### PR TITLE
fix(ci): trigger release-server after semantic-release tags + grant permissions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -6,7 +6,23 @@ on:
       - main
 
 permissions:
+  # `contents: write` — semantic-release pushes the version bump +
+  # CHANGELOG commit + tag back to main.
   contents: write
+  # `actions: write` — required for the "Trigger release-server
+  # workflow" step (added below) to call
+  # `gh workflow run release.yml`.  Without this, the dispatch
+  # returns HTTP 403 "Resource not accessible by integration"
+  # and the pipeline silently leaves the newly-bumped version
+  # unpublished on crates.io.  Same permission set noetl/cli +
+  # noetl/worker use.
+  actions: write
+  # `issues: write` + `pull-requests: write` — semantic-release's
+  # GitHub plugin posts a successComment on the PR / closing
+  # comment on the resolved issue.  Required when those comments
+  # are enabled in .releaserc.json.
+  issues: write
+  pull-requests: write
 
 jobs:
   release:
@@ -20,6 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release
+        id: semantic
         uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 24.2.3
@@ -30,3 +47,23 @@ jobs:
             conventional-changelog-conventionalcommits@8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub Actions safeguard: tags created by GITHUB_TOKEN do not
+      # trigger workflows (prevents recursion).  The `release-server`
+      # workflow is configured to run on `push: tags: ['v*']` but a
+      # tag pushed by the semantic-release-action via GITHUB_TOKEN
+      # won't fire it.  Explicitly dispatch it here so each new
+      # version reaches the crate / image / GitHub Release flow.
+      #
+      # Same pattern as noetl/cli + noetl/worker.  Without this step,
+      # noetl-server 2.0.0 was tagged but not published to crates.io
+      # (release-server had to be dispatched manually).
+      - name: Trigger release-server workflow
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)"
+          gh workflow run release.yml --ref main -f version="${VERSION}"


### PR DESCRIPTION
## Summary

Same bug noetl/worker had pre-PRs [#4](https://github.com/noetl/worker/pull/4) + [#5](https://github.com/noetl/worker/pull/5).

After [PR #6 (EE-2)](https://github.com/noetl/server/pull/6) merged, semantic-release bumped \`noetl-server\` to 2.0.0 and tagged \`v2.0.0\`, but \`release-server\` did **not** auto-fire — GitHub Actions safeguards prevent \`GITHUB_TOKEN\`-created tags from triggering workflows (the \`on: push: tags: ['v*']\` handler).

**Symptom**: noetl-server 2.0.0 exists as a tag + GitHub Release but is **not** on crates.io (still at 1.0.3 there).

## Fix

Mirrors the noetl/worker pattern verbatim:

1. **Permissions block extended**:
   - \`actions: write\` — required for the \`gh workflow run\` dispatch
   - \`issues: write\` + \`pull-requests: write\` — semantic-release's GitHub plugin successComment / closing-comment hooks

2. **New \"Trigger release-server workflow\" step** added after the \`semantic-release-action\` step, gated by \`steps.semantic.outputs.new_release_published == 'true'\`.  Reads VERSION from Cargo.toml and dispatches \`release.yml\` via \`gh workflow run\`.

After this PR merges, every future server release on a \`feat:\` / \`fix:\` / \`feat!:\` merge auto-publishes to crates.io without manual intervention.

## Catch-up for stuck v2.0.0

This PR doesn't fix the existing v2.0.0 tag.  After merging:

\`\`\`bash
gh workflow run release.yml --repo noetl/server --ref main -f version=2.0.0
\`\`\`

(I'll run that immediately after the merge.)

## Verification

- The same fix is in production on noetl/cli (since R-1.2 PR-1) and noetl/worker (since #4 + #5).  Both auto-publish reliably on every \`feat:\` / \`fix:\` merge.

Refs noetl/ai-meta#30 — Appendix H umbrella.
Refs noetl/worker#4 + #5 — the same fix pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)