### PR TITLE
feat(internal-api): mirror /api/internal/* endpoints from Python noetl-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sqlx",
+ "subtle",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",
@@ -2094,6 +2096,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ minijinja = { version = "2.5", features = ["loader"] }
 aes-gcm = "0.10"
 base64 = "0.22"
 rand = "0.8"
+# Constant-time comparison for bearer-token auth — see
+# src/handlers/internal.rs (the `/api/internal/*` route gate).
+subtle = "2.6"
 
 # Utilities
 uuid = { version = "1", features = ["serde", "v4"] }
@@ -56,6 +59,10 @@ sysinfo = "0.33"
 
 [dev-dependencies]
 tokio-test = "0.4"
+# Process-global env var tests serialise via #[serial] so concurrent
+# test threads don't race on NOETL_INTERNAL_API_TOKEN; see
+# src/handlers/internal.rs tests.
+serial_test = "3"
 
 [[bin]]
 name = "noetl-control-plane"

--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -1,0 +1,407 @@
+//! HTTP handlers for the `/api/internal/*` route family.
+//!
+//! Mirror of the Python implementation in
+//! `repos/noetl/noetl/server/api/internal/` (noetl/noetl v4.10.0).
+//! Tracks noetl/server#11 → noetl/ai-meta#49 Phase C.
+//!
+//! All routes are gated by `RequireInternalApiToken` — a bearer-token
+//! extractor that pulls the expected token from the
+//! `NOETL_INTERNAL_API_TOKEN` env var and constant-time-compares it to
+//! the request's `Authorization: Bearer <token>` header.  System
+//! worker pool playbooks carry the token via their K8s ServiceAccount
+//! Secret; user playbooks don't have it and get 403.
+
+use std::env;
+
+use axum::{
+    extract::{FromRequestParts, State},
+    http::{request::Parts, StatusCode},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
+use tracing::{debug, info, warn};
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::services::internal as svc;
+
+const TOKEN_ENV: &str = "NOETL_INTERNAL_API_TOKEN";
+
+// ===========================================================================
+// Auth extractor
+// ===========================================================================
+
+/// Axum extractor that validates the bearer token before the handler
+/// runs.  Returns `(StatusCode, String)` errors that axum maps to
+/// HTTP responses; the handler never sees an unauthenticated request.
+///
+/// Failure modes (mirror the Python side):
+///
+/// - 503 `Service Unavailable` if `NOETL_INTERNAL_API_TOKEN` is unset
+///   or empty in the server env.  Intentional — no permissive default
+///   for a privileged surface.
+/// - 403 `Forbidden` if the `Authorization` header is missing, malformed
+///   (no `Bearer` scheme), or the token doesn't match.
+#[derive(Debug)]
+pub struct RequireInternalApiToken;
+
+impl<S> FromRequestParts<S> for RequireInternalApiToken
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, String);
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        // 1. Server config — token env var must be set.
+        let expected = match env::var(TOKEN_ENV) {
+            Ok(value) if !value.trim().is_empty() => value,
+            _ => {
+                warn!(
+                    "Internal API called but {} is not set; rejecting with 503.",
+                    TOKEN_ENV
+                );
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "Internal API not configured: {} env var unset on the server. \
+                         Set it to the system worker pool's ServiceAccount token before \
+                         calling /api/internal/* endpoints.",
+                        TOKEN_ENV
+                    ),
+                ));
+            }
+        };
+
+        // 2. Authorization header — must exist.
+        let header = match parts.headers.get("authorization") {
+            Some(v) => v,
+            None => {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    "Internal API requires Authorization header with Bearer token.".to_string(),
+                ));
+            }
+        };
+        let header_value = header.to_str().map_err(|_| {
+            (
+                StatusCode::FORBIDDEN,
+                "Internal API Authorization header is not valid ASCII.".to_string(),
+            )
+        })?;
+
+        // 3. Bearer scheme + non-empty token.
+        let mut parts_iter = header_value.splitn(2, ' ');
+        let scheme = parts_iter.next().unwrap_or("");
+        let token = parts_iter.next().unwrap_or("").trim();
+        if !scheme.eq_ignore_ascii_case("bearer") || token.is_empty() {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Internal API requires 'Bearer <token>' Authorization scheme.".to_string(),
+            ));
+        }
+
+        // 4. Constant-time comparison — never use == on secrets.
+        let provided = token.as_bytes();
+        let expected_bytes = expected.as_bytes();
+        if provided.len() != expected_bytes.len()
+            || !bool::from(provided.ct_eq(expected_bytes))
+        {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Invalid service-account token for /api/internal/*.".to_string(),
+            ));
+        }
+
+        Ok(RequireInternalApiToken)
+    }
+}
+
+// ===========================================================================
+// Request/response shapes — byte-identical to the Python side
+// ===========================================================================
+
+#[derive(Debug, Deserialize, Default)]
+pub struct OutboxClaimRequest {
+    #[serde(default = "default_claim_limit")]
+    pub limit: i64,
+}
+
+fn default_claim_limit() -> i64 {
+    100
+}
+
+#[derive(Debug, Serialize)]
+pub struct OutboxClaimResponse {
+    pub rows: Vec<svc::OutboxRow>,
+    pub claimed: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OutboxMarkPublishedRequest {
+    pub outbox_ids: Vec<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OutboxMarkPublishedResponse {
+    pub marked: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OutboxMarkFailedRequest {
+    pub outbox_id: i64,
+    pub error: String,
+    #[serde(default = "default_attempts")]
+    pub attempts: i32,
+    #[serde(default = "default_max_delay_seconds")]
+    pub max_delay_seconds: i32,
+}
+
+fn default_attempts() -> i32 {
+    1
+}
+
+fn default_max_delay_seconds() -> i32 {
+    300
+}
+
+#[derive(Debug, Serialize)]
+pub struct OutboxMarkFailedResponse {
+    pub marked: bool,
+    pub available_at_in: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OutboxPendingCountResponse {
+    pub pending: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventsProjectRequest {
+    pub events: Vec<svc::EventEnvelope>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EventsProjectResponse {
+    pub projected: i64,
+    pub duplicates: i64,
+}
+
+// ===========================================================================
+// Route handlers
+// ===========================================================================
+
+/// `POST /api/internal/outbox/claim`
+///
+/// Claim a batch of PENDING/FAILED outbox rows and mark them IN_FLIGHT.
+/// Replaces the direct-DB call from today's Python publisher.
+#[tracing::instrument(skip(pool, _token), fields(limit = request.limit))]
+pub async fn outbox_claim(
+    State(pool): State<DbPool>,
+    _token: RequireInternalApiToken,
+    Json(request): Json<OutboxClaimRequest>,
+) -> AppResult<Json<OutboxClaimResponse>> {
+    let rows = svc::claim_batch(&pool, request.limit).await?;
+    let claimed = rows.len() as i64;
+    debug!(claimed, "outbox/claim done");
+    Ok(Json(OutboxClaimResponse { rows, claimed }))
+}
+
+/// `POST /api/internal/outbox/mark-published`
+///
+/// Mark a batch of outbox rows PUBLISHED.  Idempotent.
+#[tracing::instrument(skip(pool, _token), fields(count = request.outbox_ids.len()))]
+pub async fn outbox_mark_published(
+    State(pool): State<DbPool>,
+    _token: RequireInternalApiToken,
+    Json(request): Json<OutboxMarkPublishedRequest>,
+) -> AppResult<Json<OutboxMarkPublishedResponse>> {
+    if request.outbox_ids.is_empty() {
+        return Err(crate::error::AppError::BadRequest(
+            "outbox_ids must not be empty".to_string(),
+        ));
+    }
+    let marked = svc::mark_published_batch(&pool, &request.outbox_ids).await?;
+    debug!(marked, "outbox/mark-published done");
+    Ok(Json(OutboxMarkPublishedResponse { marked }))
+}
+
+/// `POST /api/internal/outbox/mark-failed`
+///
+/// Mark a single outbox row FAILED with exponential backoff.
+#[tracing::instrument(
+    skip(pool, _token),
+    fields(outbox_id = request.outbox_id, attempts = request.attempts)
+)]
+pub async fn outbox_mark_failed(
+    State(pool): State<DbPool>,
+    _token: RequireInternalApiToken,
+    Json(request): Json<OutboxMarkFailedRequest>,
+) -> AppResult<Json<OutboxMarkFailedResponse>> {
+    if request.error.is_empty() {
+        return Err(crate::error::AppError::BadRequest(
+            "error must not be empty".to_string(),
+        ));
+    }
+    let delay = svc::mark_failed_row(
+        &pool,
+        request.outbox_id,
+        &request.error,
+        request.attempts,
+        request.max_delay_seconds,
+    )
+    .await?;
+    info!(delay_seconds = delay, "outbox/mark-failed applied");
+    Ok(Json(OutboxMarkFailedResponse {
+        marked: true,
+        available_at_in: delay,
+    }))
+}
+
+/// `GET /api/internal/outbox/pending-count`
+///
+/// KEDA HTTP scaler trigger source.
+#[tracing::instrument(skip(pool, _token))]
+pub async fn outbox_pending_count(
+    State(pool): State<DbPool>,
+    _token: RequireInternalApiToken,
+) -> AppResult<Json<OutboxPendingCountResponse>> {
+    let pending = svc::pending_count(&pool).await?;
+    Ok(Json(OutboxPendingCountResponse { pending }))
+}
+
+/// `POST /api/internal/events/project`
+///
+/// Batch-INSERT events into `noetl.event`.  Idempotent via
+/// `ON CONFLICT (event_id) DO NOTHING`.
+#[tracing::instrument(skip(pool, _token), fields(batch_size = request.events.len()))]
+pub async fn events_project(
+    State(pool): State<DbPool>,
+    _token: RequireInternalApiToken,
+    Json(request): Json<EventsProjectRequest>,
+) -> AppResult<Json<EventsProjectResponse>> {
+    if request.events.is_empty() {
+        return Err(crate::error::AppError::BadRequest(
+            "events must not be empty".to_string(),
+        ));
+    }
+    let (projected, duplicates) = svc::project_events(&pool, &request.events).await?;
+    info!(projected, duplicates, "events/project done");
+    Ok(Json(EventsProjectResponse {
+        projected,
+        duplicates,
+    }))
+}
+
+// ===========================================================================
+// Tests — auth extractor (the only logic that doesn't need a real DB)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::extract::FromRequestParts;
+    use axum::http::{Request, StatusCode};
+
+    /// Helper to invoke the extractor without a router around it.
+    async fn run_extractor(
+        env_token: Option<&str>,
+        header: Option<&str>,
+    ) -> Result<RequireInternalApiToken, (StatusCode, String)> {
+        // Save + override the env var (tests run sequentially-isolated via
+        // the `serial_test` pattern would be cleaner; here we accept the
+        // small risk because each test sets + removes its own value).
+        match env_token {
+            Some(v) => unsafe { env::set_var(TOKEN_ENV, v) },
+            None => unsafe { env::remove_var(TOKEN_ENV) },
+        }
+
+        let mut builder = Request::builder().method("GET").uri("/test");
+        if let Some(h) = header {
+            builder = builder.header("authorization", h);
+        }
+        let req = builder.body(Body::empty()).unwrap();
+        let (mut parts, _body) = req.into_parts();
+
+        let result = <RequireInternalApiToken as FromRequestParts<()>>::from_request_parts(
+            &mut parts,
+            &(),
+        )
+        .await;
+
+        unsafe { env::remove_var(TOKEN_ENV) };
+        result
+    }
+
+    // Tests touch the process-global ``NOETL_INTERNAL_API_TOKEN``
+    // env var — they must run sequentially or one test's setenv races
+    // another's getenv.  ``#[serial]`` from ``serial_test`` serialises
+    // these without forcing the whole suite to single-threaded mode.
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejects_when_env_unset() {
+        let err = run_extractor(None, Some("Bearer foo")).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(err.1.contains(TOKEN_ENV));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejects_when_env_blank() {
+        let err = run_extractor(Some("   "), Some("Bearer foo"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejects_when_no_authorization_header() {
+        let err = run_extractor(Some("secret-123"), None).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+        assert!(err.1.contains("Bearer"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejects_non_bearer_scheme() {
+        let err = run_extractor(Some("secret-123"), Some("Basic secret-123"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejects_wrong_token() {
+        let err = run_extractor(Some("secret-123"), Some("Bearer wrong"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn accepts_valid_token() {
+        let result = run_extractor(Some("secret-123"), Some("Bearer secret-123")).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn accepts_valid_token_case_insensitive_scheme() {
+        let result = run_extractor(Some("secret-123"), Some("bearer secret-123")).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn rejects_empty_token_after_bearer() {
+        let err = run_extractor(Some("secret-123"), Some("Bearer "))
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod events;
 pub mod execute;
 pub mod executions;
 pub mod health;
+pub mod internal;
 pub mod keychain;
 pub mod runtime;
 pub mod system;

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,6 +196,36 @@ fn build_router(
         )
         .with_state(db_pool.clone());
 
+    // Internal API — system worker pool only.  Gated by the
+    // ``RequireInternalApiToken`` extractor in
+    // ``handlers::internal`` which constant-time-compares the
+    // request bearer token to ``NOETL_INTERNAL_API_TOKEN``.  Mirror of
+    // the Python implementation in
+    // ``repos/noetl/noetl/server/api/internal/`` (noetl v4.10.0).
+    // Tracks noetl/server#11 → noetl/ai-meta#49 Phase C.
+    let internal_routes = Router::new()
+        .route(
+            "/api/internal/outbox/claim",
+            post(handlers::internal::outbox_claim),
+        )
+        .route(
+            "/api/internal/outbox/mark-published",
+            post(handlers::internal::outbox_mark_published),
+        )
+        .route(
+            "/api/internal/outbox/mark-failed",
+            post(handlers::internal::outbox_mark_failed),
+        )
+        .route(
+            "/api/internal/outbox/pending-count",
+            get(handlers::internal::outbox_pending_count),
+        )
+        .route(
+            "/api/internal/events/project",
+            post(handlers::internal::events_project),
+        )
+        .with_state(db_pool.clone());
+
     // System monitoring routes
     let system_routes = Router::new()
         .route("/api/status", get(handlers::system::get_status))
@@ -234,6 +264,7 @@ fn build_router(
         .merge(variable_routes)
         .merge(runtime_routes)
         .merge(database_routes)
+        .merge(internal_routes)
         .merge(system_routes)
         .merge(dashboard_routes)
         .layer(TraceLayer::new_for_http())

--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -1,0 +1,370 @@
+//! Service logic for the `/api/internal/*` endpoint family.
+//!
+//! These endpoints are called by the system worker pool's playbooks
+//! (`system/outbox_publisher`, `system/projector`) instead of the
+//! playbooks touching `noetl.*` tables directly.  Per the
+//! data-access-boundary rule
+//! (`agents/rules/data-access-boundary.md` in ai-meta): NoETL platform
+//! data is server-API only.
+//!
+//! Contract mirrors the Python implementation in
+//! `repos/noetl/noetl/server/api/internal/service.py` byte-for-byte —
+//! the system pool's playbooks must work against either server during
+//! migration.  Tracks noetl/server#11 → noetl/ai-meta#49 Phase C.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::types::JsonValue;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+
+// ---------------------------------------------------------------------------
+// Outbox claim
+// ---------------------------------------------------------------------------
+
+/// One outbox row returned by `claim_batch`.
+///
+/// Mirrors the columns the Python `claim_outbox_batch` returns; the
+/// system playbook iterates over these rows and publishes each
+/// `payload` to NATS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboxRow {
+    pub outbox_id: i64,
+    pub event_id: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    pub payload: JsonValue,
+    #[serde(default = "default_payload_codec")]
+    pub payload_codec: String,
+    #[serde(default)]
+    pub attempts: i32,
+}
+
+fn default_payload_codec() -> String {
+    "arrow-feather".to_string()
+}
+
+/// Claim a batch of PENDING/FAILED outbox rows and mark them
+/// IN_FLIGHT.
+///
+/// Mirrors the SQL in `noetl.core.outbox.claim_outbox_batch`:
+/// `WITH ready AS (SELECT ... FOR UPDATE SKIP LOCKED) UPDATE ...
+/// RETURNING ...`.  The CTE + skip-locked combo lets multiple system
+/// pool workers race the same outbox without blocking each other.
+pub async fn claim_batch(pool: &DbPool, limit: i64) -> AppResult<Vec<OutboxRow>> {
+    let limit = limit.clamp(1, 1000);
+
+    let rows = sqlx::query_as::<_, (i64, i64, Option<i64>, Option<String>, JsonValue, String, i32)>(
+        r#"
+        WITH ready AS (
+            SELECT outbox_id
+            FROM noetl.outbox
+            WHERE status IN ('PENDING', 'FAILED')
+              AND available_at <= now()
+            ORDER BY outbox_id
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE noetl.outbox o
+        SET status = 'IN_FLIGHT',
+            attempts = attempts + 1,
+            locked_at = now(),
+            updated_at = now()
+        FROM ready
+        WHERE o.outbox_id = ready.outbox_id
+        RETURNING o.outbox_id, o.event_id, o.execution_id, o.subject,
+                  o.payload, o.payload_codec, o.attempts
+        "#,
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(outbox_id, event_id, execution_id, subject, payload, payload_codec, attempts)| {
+                OutboxRow {
+                    outbox_id,
+                    event_id,
+                    execution_id,
+                    subject,
+                    payload,
+                    payload_codec,
+                    attempts,
+                }
+            },
+        )
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Outbox mark published
+// ---------------------------------------------------------------------------
+
+/// Mark a batch of outbox rows PUBLISHED.
+///
+/// Idempotent: re-marking an already-PUBLISHED row is a no-op
+/// (the UPDATE just won't match).  Returns the count of rows actually
+/// updated.
+pub async fn mark_published_batch(pool: &DbPool, outbox_ids: &[i64]) -> AppResult<i64> {
+    if outbox_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let result = sqlx::query(
+        r#"
+        UPDATE noetl.outbox
+        SET status = 'PUBLISHED',
+            published_at = now(),
+            updated_at = now(),
+            last_error = NULL
+        WHERE outbox_id = ANY($1)
+        "#,
+    )
+    .bind(outbox_ids)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() as i64)
+}
+
+// ---------------------------------------------------------------------------
+// Outbox mark failed
+// ---------------------------------------------------------------------------
+
+/// Mark a single outbox row FAILED with exponential backoff.
+///
+/// Backoff formula mirrors `noetl.core.outbox.mark_outbox_failed`:
+/// `delay = min(max_delay_seconds, 2 ** min(8, max(0, attempts - 1)))`.
+/// Returns the computed delay so the system playbook can surface it.
+pub async fn mark_failed_row(
+    pool: &DbPool,
+    outbox_id: i64,
+    error: &str,
+    attempts: i32,
+    max_delay_seconds: i32,
+) -> AppResult<i64> {
+    let clamped_exponent = (attempts - 1).clamp(0, 8);
+    let raw_delay: i64 = 1i64 << clamped_exponent;
+    let delay_seconds = raw_delay.min(max_delay_seconds as i64);
+
+    // Truncate the error to the same 2000-char limit the Python side uses.
+    let truncated_error: String = error.chars().take(2000).collect();
+
+    sqlx::query(
+        r#"
+        UPDATE noetl.outbox
+        SET status = 'FAILED',
+            available_at = now() + ($1 || ' seconds')::interval,
+            last_error = $2,
+            updated_at = now()
+        WHERE outbox_id = $3
+        "#,
+    )
+    .bind(delay_seconds.to_string())
+    .bind(truncated_error)
+    .bind(outbox_id)
+    .execute(pool)
+    .await?;
+
+    Ok(delay_seconds)
+}
+
+// ---------------------------------------------------------------------------
+// Outbox pending count
+// ---------------------------------------------------------------------------
+
+/// Count outbox rows currently eligible for claim.
+///
+/// KEDA HTTP scaler reads this; keep it fast.  Returns rows in PENDING
+/// or FAILED with `available_at <= now()`.  IN_FLIGHT / PUBLISHED rows
+/// excluded.
+pub async fn pending_count(pool: &DbPool) -> AppResult<i64> {
+    let row: (i64,) = sqlx::query_as(
+        r#"
+        SELECT count(*)
+        FROM noetl.outbox
+        WHERE status IN ('PENDING', 'FAILED')
+          AND available_at <= now()
+        "#,
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
+}
+
+// ---------------------------------------------------------------------------
+// Events projector
+// ---------------------------------------------------------------------------
+
+/// One event envelope as the projector receives it.
+///
+/// Tolerates extra fields via `#[serde(flatten)]` on `extra` — the
+/// projector must be loose-coupled with the event emitter (worker,
+/// executor, server).  Required fields mirror what the projector's
+/// batch INSERT writes.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EventEnvelope {
+    pub event_id: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stack_trace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_component: Option<String>,
+    /// Catch-all for extra fields the emitter sends that the projector
+    /// doesn't currently care about.  Preserves the
+    /// `model_config={"extra": "allow"}` semantics from the Python side.
+    #[serde(flatten, default)]
+    pub extra: std::collections::BTreeMap<String, JsonValue>,
+}
+
+/// Project a batch of events into `noetl.event`.
+///
+/// Idempotent via `ON CONFLICT (event_id) DO NOTHING`.  Re-projecting
+/// the same `event_id` is a no-op.  Returns `(projected, duplicates)`
+/// where `projected` is the number of rows actually inserted and
+/// `duplicates` is the number skipped via ON CONFLICT.
+///
+/// Mirrors the SQL pattern in
+/// `repos/noetl/noetl/server/api/internal/service.py::project_events`
+/// — single-statement batch INSERT via `jsonb_array_elements` over the
+/// payload.
+pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResult<(i64, i64)> {
+    if events.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let payload = serde_json::to_value(events)?;
+
+    let result = sqlx::query(
+        r#"
+        INSERT INTO noetl.event (
+            event_id,
+            execution_id,
+            parent_event_id,
+            event_type,
+            node_id,
+            node_name,
+            node_type,
+            status,
+            duration,
+            timestamp,
+            context,
+            result,
+            meta,
+            error,
+            stack_trace,
+            trace_component
+        )
+        SELECT
+            (row->>'event_id')::bigint,
+            NULLIF(row->>'execution_id', '')::bigint,
+            NULLIF(row->>'parent_event_id', '')::bigint,
+            row->>'event_type',
+            row->>'node_id',
+            row->>'node_name',
+            row->>'node_type',
+            row->>'status',
+            NULLIF(row->>'duration', '')::double precision,
+            NULLIF(row->>'timestamp', '')::timestamptz,
+            NULLIF(row->'context', 'null'::jsonb),
+            NULLIF(row->'result', 'null'::jsonb),
+            NULLIF(row->'meta', 'null'::jsonb),
+            row->>'error',
+            row->>'stack_trace',
+            row->>'trace_component'
+        FROM jsonb_array_elements($1::jsonb) AS row
+        ON CONFLICT (event_id) DO NOTHING
+        "#,
+    )
+    .bind(payload)
+    .execute(pool)
+    .await?;
+
+    let projected = result.rows_affected() as i64;
+    let duplicates = (events.len() as i64 - projected).max(0);
+    Ok((projected, duplicates))
+}
+
+// ---------------------------------------------------------------------------
+// Tests — backoff math (the only logic that doesn't need a real DB)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    /// Verify the exponential-backoff math matches the Python side's
+    /// `min(max_delay, 2 ** min(8, max(0, attempts-1)))`.
+    fn compute_delay(attempts: i32, max_delay: i32) -> i64 {
+        let clamped_exponent = (attempts - 1).clamp(0, 8);
+        let raw_delay: i64 = 1i64 << clamped_exponent;
+        raw_delay.min(max_delay as i64)
+    }
+
+    #[test]
+    fn backoff_attempts_1_is_1s() {
+        assert_eq!(compute_delay(1, 300), 1);
+    }
+
+    #[test]
+    fn backoff_attempts_2_is_2s() {
+        assert_eq!(compute_delay(2, 300), 2);
+    }
+
+    #[test]
+    fn backoff_attempts_5_is_16s() {
+        assert_eq!(compute_delay(5, 300), 16);
+    }
+
+    #[test]
+    fn backoff_attempts_9_clamps_to_max() {
+        // 2^8 = 256, capped at max=300 → 256.
+        assert_eq!(compute_delay(9, 300), 256);
+    }
+
+    #[test]
+    fn backoff_attempts_20_clamps_to_max() {
+        // 2^min(8, 19) = 2^8 = 256, capped at max=300 → 256.
+        assert_eq!(compute_delay(20, 300), 256);
+    }
+
+    #[test]
+    fn backoff_respects_max_delay_lower_than_2_pow_8() {
+        // 2^min(8, 4) = 2^4 = 16, but max=10 → 10.
+        assert_eq!(compute_delay(5, 10), 10);
+    }
+
+    #[test]
+    fn backoff_attempts_0_is_1s() {
+        // attempts-1 clamps at 0 → 2^0 = 1.
+        assert_eq!(compute_delay(0, 300), 1);
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod catalog;
 pub mod credential;
 pub mod event;
 pub mod execution;
+pub mod internal;
 pub mod keychain;
 pub mod runtime;
 


### PR DESCRIPTION
## Summary

- Rust mirror of [noetl/noetl#659](https://github.com/noetl/noetl/pull/659) (Python noetl-server v4.10.0).  System worker pool playbooks now work against either Python or Rust server — byte-identical contract.
- 5 new HTTP endpoints under `/api/internal/*` for the system pool's `system/outbox_publisher` + `system/projector` playbooks.
- Bearer-token auth gate (`RequireInternalApiToken` extractor) — constant-time comparison via `subtle::ConstantTimeEq`; 403 on bad/missing, 503 if `NOETL_INTERNAL_API_TOKEN` env unset.

Closes [noetl/server#11](https://github.com/noetl/server/issues/11) · Refs [noetl/ai-meta#49 Phase C](https://github.com/noetl/ai-meta/issues/49) · Refs [noetl/ai-meta#46 Phase 1.a Rust side](https://github.com/noetl/ai-meta/issues/46)

## Endpoints

| Method | Path | Replaces |
|---|---|---|
| POST | `/api/internal/outbox/claim` | `noetl.core.outbox.claim_outbox_batch` direct call |
| POST | `/api/internal/outbox/mark-published` | `mark_outbox_published` |
| POST | `/api/internal/outbox/mark-failed` | `mark_outbox_failed` (exponential backoff in `available_at`) |
| GET | `/api/internal/outbox/pending-count` | NEW — KEDA HTTP scaler trigger source |
| POST | `/api/internal/events/project` | Python projector batch INSERT (via `jsonb_array_elements` + `ON CONFLICT DO NOTHING`) |

## Module layout

```
src/services/internal.rs    DB logic — claim/mark/project/count + types
src/handlers/internal.rs    5 route handlers + bearer-token extractor + request/response shapes
src/main.rs                 internal_routes registered between database_routes and system_routes
```

## Test plan

- [x] `cargo build` clean
- [x] `cargo test internal` — **15/15 pass**
  - Auth gate (8 cases, `#[serial_test::serial]` because env-var-touching): unset env, blank env, no Authorization, non-Bearer scheme, wrong token, valid token, case-insensitive scheme, empty token after Bearer
  - Backoff math (7 cases): attempts 0/1/2/5/9/20 + custom max_delay
- [x] My new code is clippy-clean (pre-existing warnings in other files are not from this change)
- [ ] Kind validation (next session, per `agents/rules/deployment-validation.md`):
  - Rebuild Rust server image with this branch; load into kind; set `NOETL_INTERNAL_API_TOKEN` env
  - Curl-test all 5 endpoints against a real outbox row + event with the same diff harness as the Python side; expect byte-identical responses

## New deps

- `subtle = "2.6"` — constant-time bearer-token comparison.  Never use `==` on secrets.
- `serial_test = "3"` (dev-dep) — process-global env-var tests serialise via `#[serial]` so concurrent test threads don't race.

## Contract preservation

The system pool's playbooks deploy against EITHER server during migration.  Every request/response shape here matches the Python side byte-for-byte:

- `OutboxClaimRequest{limit: i64=100}` ↔ Python `OutboxClaimRequest{limit: int=100}`
- `OutboxClaimResponse{rows: Vec<OutboxRow>, claimed: i64}` ↔ Python `OutboxClaimResponse{rows: list[OutboxRow], claimed: int}`
- `OutboxRow{outbox_id, event_id, execution_id?, subject?, payload, payload_codec="arrow-feather", attempts}` ↔ same fields, same types
- `OutboxMarkPublishedRequest{outbox_ids: Vec<i64>}` ↔ same
- `OutboxMarkFailedRequest{outbox_id, error, attempts=1, max_delay_seconds=300}` ↔ same
- `OutboxPendingCountResponse{pending: i64}` ↔ same
- `EventEnvelope` with all 16 fields + `#[serde(flatten)]` for extra fields ↔ Python's `model_config={"extra": "allow"}`

Any divergence will be caught by the kind diff harness when it runs.

## Out of scope

- Per-endpoint Prometheus metrics — the Rust server doesn't have a `prometheus` registry yet; deferred to a follow-up PR.  `tracing::instrument` spans + structured logs added in this PR cover the observability surface for now.
- Sharding (#49 Phase F) — endpoints accept whatever `execution_id` comes in; sharded routing is a separate layer above.
- noetl/server wiki page documenting the API contract — defer to a follow-up after this lands so both Python + Rust pages can cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)