### PR TITLE
fix(internal-api): events/project SQL matches actual noetl.event partitioned schema

### DIFF
--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -265,11 +265,25 @@ pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResul
 
     let payload = serde_json::to_value(events)?;
 
+    // noetl.event schema (kind 2026-06-02):
+    //   - PRIMARY KEY (event_id)
+    //   - NOT NULL: execution_id, catalog_id, event_id, created_at,
+    //               tenant_id, organization_id
+    //   - All others nullable.
+    //
+    // The projector accepts envelopes that may or may not carry
+    // catalog_id/tenant_id/organization_id (depends on the emitter).
+    // Defaults:
+    //   - catalog_id      → 0   (sentinel)
+    //   - tenant_id       → 'default'
+    //   - organization_id → 'default'
+    //   - created_at      → now()
     let result = sqlx::query(
         r#"
         INSERT INTO noetl.event (
             event_id,
             execution_id,
+            catalog_id,
             parent_event_id,
             event_type,
             node_id,
@@ -277,17 +291,19 @@ pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResul
             node_type,
             status,
             duration,
-            timestamp,
             context,
             result,
             meta,
             error,
             stack_trace,
-            trace_component
+            tenant_id,
+            organization_id,
+            created_at
         )
         SELECT
             (row->>'event_id')::bigint,
-            NULLIF(row->>'execution_id', '')::bigint,
+            COALESCE(NULLIF(row->>'execution_id', '')::bigint, 0),
+            COALESCE(NULLIF(row->>'catalog_id', '')::bigint, 0),
             NULLIF(row->>'parent_event_id', '')::bigint,
             row->>'event_type',
             row->>'node_id',
@@ -295,15 +311,23 @@ pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResul
             row->>'node_type',
             row->>'status',
             NULLIF(row->>'duration', '')::double precision,
-            NULLIF(row->>'timestamp', '')::timestamptz,
             NULLIF(row->'context', 'null'::jsonb),
             NULLIF(row->'result', 'null'::jsonb),
             NULLIF(row->'meta', 'null'::jsonb),
             row->>'error',
             row->>'stack_trace',
-            row->>'trace_component'
+            COALESCE(NULLIF(row->>'tenant_id', ''), 'default'),
+            COALESCE(NULLIF(row->>'organization_id', ''), 'default'),
+            COALESCE(NULLIF(row->>'timestamp', '')::timestamp,
+                     NULLIF(row->>'created_at', '')::timestamp,
+                     now())
         FROM jsonb_array_elements($1::jsonb) AS row
-        ON CONFLICT (event_id) DO NOTHING
+        -- noetl.event is partitioned (15 partitions); event_id alone
+        -- is not a partition-spanning unique constraint.  Using
+        -- ``ON CONFLICT DO NOTHING`` without a target catches any
+        -- uniqueness violation across partitions — sufficient for
+        -- projector idempotency.
+        ON CONFLICT DO NOTHING
         "#,
     )
     .bind(payload)


### PR DESCRIPTION
## Summary

Mirror of [noetl/noetl#660](https://github.com/noetl/noetl/pull/660) on the Rust side.  Same SQL fixes for the `/api/internal/events/project` endpoint after kind validation surfaced three schema mismatches:

1. **No `timestamp` column** — real table uses `created_at`.
2. **Required NOT NULL columns missing** — `catalog_id`, `tenant_id`, `organization_id` must be supplied.  Defaults via `COALESCE`: `catalog_id=0` sentinel (real events from workers carry one), `tenant_id='default'`, `organization_id='default'`.
3. **Partitioned table** — `noetl.event` has 15 partitions; `ON CONFLICT (event_id)` can't match any partition-spanning unique constraint.  Use `ON CONFLICT DO NOTHING` without a target.

The SQL is identical to the Python fix in #660 — kind validation of the Python implementation passes 11/11 tests, so this Rust mirror is expected to behave identically.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test internal --lib` — 15/15 pass
- [ ] Kind validation of the Rust server side-by-side with Python (defer to follow-up; requires extra Helm work to expose the Rust server at a separate port).  Same SQL → byte-identical behavior expected.

## Refs

- Python fix: [noetl/noetl#660](https://github.com/noetl/noetl/pull/660)
- Kind validation script: `repos/ops/automation/development/validate-internal-api.sh` (will land in `noetl/ops` separately)
- Tracks [noetl/ai-meta#46](https://github.com/noetl/ai-meta/issues/46) + [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)