### PR TITLE
fix(credential): SQL column is data_encrypted not data

### DIFF
--- a/src/db/queries/credential.rs
+++ b/src/db/queries/credential.rs
@@ -16,7 +16,8 @@ pub async fn insert_credential(
 ) -> AppResult<i64> {
     let result: (i64,) = sqlx::query_as(
         r#"
-        INSERT INTO noetl.credential (name, type, data, meta, tags, description)
+        INSERT INTO noetl.credential
+            (name, type, data_encrypted, meta, tags, description)
         VALUES ($1, $2, $3, $4, $5, $6)
         RETURNING id
         "#,
@@ -46,7 +47,12 @@ pub async fn update_credential(
     sqlx::query(
         r#"
         UPDATE noetl.credential
-        SET type = $2, data = $3, meta = $4, tags = $5, description = $6, updated_at = NOW()
+        SET type = $2,
+            data_encrypted = $3,
+            meta = $4,
+            tags = $5,
+            description = $6,
+            updated_at = NOW()
         WHERE id = $1
         "#,
     )
@@ -66,7 +72,8 @@ pub async fn update_credential(
 pub async fn get_credential_by_id(pool: &DbPool, id: i64) -> AppResult<Option<CredentialEntry>> {
     let entry = sqlx::query_as::<_, CredentialEntry>(
         r#"
-        SELECT id, name, type, data, meta, tags, description, created_at, updated_at
+        SELECT id, name, type, data_encrypted AS data,
+               meta, tags, description, created_at, updated_at
         FROM noetl.credential
         WHERE id = $1
         "#,
@@ -85,7 +92,8 @@ pub async fn get_credential_by_name(
 ) -> AppResult<Option<CredentialEntry>> {
     let entry = sqlx::query_as::<_, CredentialEntry>(
         r#"
-        SELECT id, name, type, data, meta, tags, description, created_at, updated_at
+        SELECT id, name, type, data_encrypted AS data,
+               meta, tags, description, created_at, updated_at
         FROM noetl.credential
         WHERE name = $1
         "#,
@@ -108,7 +116,8 @@ pub async fn list_credentials(
             let pattern = format!("%{}%", q);
             sqlx::query_as::<_, CredentialEntry>(
                 r#"
-                SELECT id, name, type, data, meta, tags, description, created_at, updated_at
+                SELECT id, name, type, data_encrypted AS data,
+                       meta, tags, description, created_at, updated_at
                 FROM noetl.credential
                 WHERE type = $1 AND (name ILIKE $2 OR description ILIKE $2)
                 ORDER BY created_at DESC
@@ -122,7 +131,8 @@ pub async fn list_credentials(
         (Some(t), None) => {
             sqlx::query_as::<_, CredentialEntry>(
                 r#"
-                SELECT id, name, type, data, meta, tags, description, created_at, updated_at
+                SELECT id, name, type, data_encrypted AS data,
+                       meta, tags, description, created_at, updated_at
                 FROM noetl.credential
                 WHERE type = $1
                 ORDER BY created_at DESC
@@ -136,7 +146,8 @@ pub async fn list_credentials(
             let pattern = format!("%{}%", q);
             sqlx::query_as::<_, CredentialEntry>(
                 r#"
-                SELECT id, name, type, data, meta, tags, description, created_at, updated_at
+                SELECT id, name, type, data_encrypted AS data,
+                       meta, tags, description, created_at, updated_at
                 FROM noetl.credential
                 WHERE name ILIKE $1 OR description ILIKE $1
                 ORDER BY created_at DESC
@@ -149,7 +160,8 @@ pub async fn list_credentials(
         (None, None) => {
             sqlx::query_as::<_, CredentialEntry>(
                 r#"
-                SELECT id, name, type, data, meta, tags, description, created_at, updated_at
+                SELECT id, name, type, data_encrypted AS data,
+                       meta, tags, description, created_at, updated_at
                 FROM noetl.credential
                 ORDER BY created_at DESC
                 "#,


### PR DESCRIPTION
## Summary

Surfaced by noetl/ai-meta#49 Phase A parity harness — \`GET /api/credentials\` returns HTTP 500 with:

\`\`\`
Database error: column \"data\" does not exist
\`\`\`

The actual \`noetl.credential\` schema has these columns:

\`\`\`
id, name, type, data_encrypted, schema, meta, tags,
description, created_at, updated_at
\`\`\`

All 8 SQL strings in \`src/db/queries/credential.rs\` referenced a column named \`data\` that doesn't exist.

## What changes

- **INSERT**: writes to \`data_encrypted\` (not \`data\`).
- **UPDATE**: sets \`data_encrypted = $3\` (not \`data = $3\`).
- **All 6 SELECT statements**: select \`data_encrypted AS data\` so the existing \`CredentialEntry\` struct's \`pub data: Vec<u8>\` field continues to deserialize without a struct change.

## Follow-up still needed (separate PR)

This unblocks the column lookup but a deeper type-mismatch error surfaces underneath:

\`\`\`
error occurred while decoding column \"data\": mismatched types;
Rust type \`alloc::vec::Vec<u8>\` (as SQL type \`BYTEA\`) is not
compatible with SQL type \`TEXT\`
\`\`\`

The Python server stores the credential data as **plain JSON text** in a \`text\` column (not encrypted bytes despite the column name).  Sampling shows:

\`\`\`
length(data_encrypted) | substring
1290                   | {\"access_token\": \"0b6a6fc78c40
250                    | {\"account_id\": \"DU8027814\", \"b
144                    | {\"db_host\": \"postgres.postgres
\`\`\`

That's a deeper concern that needs deciding: should the Rust server treat \`data_encrypted\` as \`String\` containing JSON?  Or should the Python server actually encrypt?  Tracked as a follow-up under #49 Phase A.

## Refs

Refs noetl/ai-meta#49 Phase A

🤖 Generated with [Claude Code](https://claude.com/claude-code)