### PR TITLE
fix(execution): noetl.event.created_at is TIMESTAMP, not TIMESTAMPTZ

### DIFF
--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -97,12 +97,18 @@ impl ExecutionService {
         let rows: Vec<(i64, i64, Option<String>, String, DateTime<Utc>, Option<DateTime<Utc>>, i64)> =
             sqlx::query_as(
                 r#"
+                -- noetl.event.created_at is TIMESTAMP (no tz); the
+                -- Rust struct uses DateTime<Utc> (TIMESTAMPTZ).
+                -- ``AT TIME ZONE 'UTC'`` reinterprets the naive
+                -- timestamp as UTC and produces a TIMESTAMPTZ that
+                -- sqlx can decode into DateTime<Utc>.  See
+                -- noetl/ai-meta#49 Phase A.
                 WITH execution_stats AS (
                     SELECT
                         execution_id,
                         catalog_id,
-                        MIN(created_at) as started_at,
-                        MAX(CASE WHEN status IN ('COMPLETED', 'FAILED', 'CANCELLED') THEN created_at END) as completed_at,
+                        MIN(created_at) AT TIME ZONE 'UTC' as started_at,
+                        MAX(CASE WHEN status IN ('COMPLETED', 'FAILED', 'CANCELLED') THEN created_at END) AT TIME ZONE 'UTC' as completed_at,
                         COUNT(*) as event_count,
                         MAX(CASE
                             WHEN event_type = 'playbook_completed' THEN 'COMPLETED'
@@ -172,11 +178,14 @@ impl ExecutionService {
         let info: Option<(i64, Option<i64>, Option<serde_json::Value>, DateTime<Utc>)> =
             sqlx::query_as(
                 r#"
+                -- created_at is TIMESTAMP (no tz); ``AT TIME ZONE 'UTC'``
+                -- reinterprets it as UTC so sqlx can decode into
+                -- DateTime<Utc>.  Mirror of the WITH-block in list().
                 SELECT
                     catalog_id,
                     parent_execution_id,
                     context->'workload' as workload,
-                    created_at
+                    created_at AT TIME ZONE 'UTC' as created_at
                 FROM noetl.event
                 WHERE execution_id = $1 AND event_type = 'playbook_started'
                 LIMIT 1
@@ -212,7 +221,7 @@ impl ExecutionService {
                     event_type,
                     node_name,
                     COALESCE(status, 'UNKNOWN') as status,
-                    created_at,
+                    created_at AT TIME ZONE 'UTC' as created_at,
                     result,
                     error
                 FROM noetl.event


### PR DESCRIPTION
## Summary

Surfaced by noetl/ai-meta#49 Phase A parity harness round 2.  Both \`GET /api/executions\` and \`GET /api/executions/{id}\` returned HTTP 500 with:

\`\`\`
Database error: error occurred while decoding column 4: mismatched types;
Rust type DateTime<Utc> (as SQL type TIMESTAMPTZ) is not compatible with
SQL type TIMESTAMP
\`\`\`

The \`noetl.event.created_at\` column is declared **TIMESTAMP without time zone** (confirmed via \`information_schema.columns\`), but the Rust services in \`services/execution.rs\` decode it into \`DateTime<Utc>\` (which sqlx maps to TIMESTAMPTZ).  Mismatch → 500.

## What changes

Adds \`AT TIME ZONE 'UTC'\` to the three queries in \`ExecutionService::list\` and \`ExecutionService::get\` that select \`created_at\`:

- \`list()\` — the \`WITH execution_stats\` CTE's \`MIN(created_at)\` and \`MAX(... created_at)\` aggregates.
- \`get()\` — the first-event lookup that grabs \`created_at\`.
- \`get()\` — the event-list query that selects \`created_at\` per event.

\`AT TIME ZONE 'UTC'\` reinterprets the naive timestamp as UTC and produces a TIMESTAMPTZ that decodes cleanly into \`DateTime<Utc>\`.  No Rust struct changes.

## Follow-up

The \`/api/executions/{id}/status\` endpoint returns a fundamentally different wire shape than Python (Python: \`{completed_steps: [...], variables, completion_inferred, ...}\`; Rust: \`{progress: {total_steps, completed_steps, failed_steps, ...}}\`).  That's a wire-shape decision (which side wins?) tracked under #49 Phase A.

\`/api/vars/{execution_id}\` also returns a different shape (Python: \`{count, execution_id, variables}\`; Rust: bare array \`[]\`).  Same kind of decision.

## Refs

Refs noetl/ai-meta#49 Phase A

🤖 Generated with [Claude Code](https://claude.com/claude-code)