### PR TITLE
fix(schema): align event_type literals + catalog column names with real DB

### DIFF
--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -56,7 +56,7 @@ pub async fn insert_catalog_entry(
 pub async fn get_catalog_by_id(pool: &DbPool, id: i64) -> AppResult<Option<CatalogEntry>> {
     let entry = sqlx::query_as::<_, CatalogEntry>(
         r#"
-        SELECT id, path, kind, version, content, layout, payload, meta, created_at
+        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
         WHERE id = $1
         "#,
@@ -76,7 +76,7 @@ pub async fn get_catalog_by_path_version(
 ) -> AppResult<Option<CatalogEntry>> {
     let entry = sqlx::query_as::<_, CatalogEntry>(
         r#"
-        SELECT id, path, kind, version, content, layout, payload, meta, created_at
+        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
         WHERE path = $1 AND version = $2
         "#,
@@ -93,7 +93,7 @@ pub async fn get_catalog_by_path_version(
 pub async fn get_catalog_latest(pool: &DbPool, path: &str) -> AppResult<Option<CatalogEntry>> {
     let entry = sqlx::query_as::<_, CatalogEntry>(
         r#"
-        SELECT id, path, kind, version, content, layout, payload, meta, created_at
+        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
         WHERE path = $1
         ORDER BY version DESC
@@ -115,7 +115,7 @@ pub async fn list_catalog_entries(
     let entries = if let Some(k) = kind {
         sqlx::query_as::<_, CatalogEntry>(
             r#"
-            SELECT id, path, kind, version, content, layout, payload, meta, created_at
+            SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
             FROM noetl.catalog
             WHERE kind = $1
             ORDER BY created_at DESC
@@ -127,7 +127,7 @@ pub async fn list_catalog_entries(
     } else {
         sqlx::query_as::<_, CatalogEntry>(
             r#"
-            SELECT id, path, kind, version, content, layout, payload, meta, created_at
+            SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
             FROM noetl.catalog
             ORDER BY created_at DESC
             "#,
@@ -143,7 +143,7 @@ pub async fn list_catalog_entries(
 pub async fn get_catalog_all_versions(pool: &DbPool, path: &str) -> AppResult<Vec<CatalogEntry>> {
     let entries = sqlx::query_as::<_, CatalogEntry>(
         r#"
-        SELECT id, path, kind, version, content, layout, payload, meta, created_at
+        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
         WHERE path = $1
         ORDER BY version DESC

--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -103,6 +103,16 @@ impl ExecutionService {
                 -- timestamp as UTC and produces a TIMESTAMPTZ that
                 -- sqlx can decode into DateTime<Utc>.  See
                 -- noetl/ai-meta#49 Phase A.
+                -- Event-type values follow the dot-style convention
+                -- written by the Python noetl-server (per
+                -- ``noetl/server/api/core/events.py``):
+                -- ``playbook.initialized`` / ``playbook.completed`` /
+                -- ``playbook.failed`` / ``playbook.cancelled``.
+                -- The legacy ``playbook_started`` / ``playbook_completed``
+                -- / ``playbook_failed`` / ``playbook_cancelled`` aliases
+                -- are accepted too — see ``engine/state.rs``'s match
+                -- arms for the same dual-shape acceptance.  See
+                -- noetl/ai-meta#49 Phase A.
                 WITH execution_stats AS (
                     SELECT
                         execution_id,
@@ -111,9 +121,9 @@ impl ExecutionService {
                         MAX(CASE WHEN status IN ('COMPLETED', 'FAILED', 'CANCELLED') THEN created_at END) AT TIME ZONE 'UTC' as completed_at,
                         COUNT(*) as event_count,
                         MAX(CASE
-                            WHEN event_type = 'playbook_completed' THEN 'COMPLETED'
-                            WHEN event_type = 'playbook_failed' THEN 'FAILED'
-                            WHEN event_type = 'playbook_cancelled' THEN 'CANCELLED'
+                            WHEN event_type IN ('playbook.completed', 'playbook_completed') THEN 'COMPLETED'
+                            WHEN event_type IN ('playbook.failed', 'playbook_failed') THEN 'FAILED'
+                            WHEN event_type IN ('playbook.cancelled', 'playbook_cancelled') THEN 'CANCELLED'
                             WHEN status = 'FAILED' THEN 'FAILED'
                             ELSE 'RUNNING'
                         END) as status
@@ -187,7 +197,8 @@ impl ExecutionService {
                     context->'workload' as workload,
                     created_at AT TIME ZONE 'UTC' as created_at
                 FROM noetl.event
-                WHERE execution_id = $1 AND event_type = 'playbook_started'
+                WHERE execution_id = $1
+                  AND event_type IN ('playbook.initialized', 'playbook_started')
                 LIMIT 1
                 "#,
             )
@@ -257,9 +268,15 @@ impl ExecutionService {
         let completed_at = events
             .iter()
             .filter(|e| {
-                e.event_type == "playbook_completed"
-                    || e.event_type == "playbook_failed"
-                    || e.event_type == "playbook_cancelled"
+                matches!(
+                    e.event_type.as_str(),
+                    "playbook.completed"
+                        | "playbook_completed"
+                        | "playbook.failed"
+                        | "playbook_failed"
+                        | "playbook.cancelled"
+                        | "playbook_cancelled"
+                )
             })
             .map(|e| e.created_at)
             .max();
@@ -331,7 +348,7 @@ impl ExecutionService {
             SELECT EXISTS(
                 SELECT 1 FROM noetl.event
                 WHERE execution_id = $1
-                  AND event_type = 'playbook_cancelled'
+                  AND event_type IN ('playbook.cancelled', 'playbook_cancelled')
             )
             "#,
         )
@@ -423,7 +440,7 @@ impl ExecutionService {
             SELECT EXISTS(
                 SELECT 1 FROM noetl.event
                 WHERE execution_id = $1
-                  AND event_type = 'playbook_cancelled'
+                  AND event_type IN ('playbook.cancelled', 'playbook_cancelled')
             )
             "#,
         )
@@ -499,9 +516,9 @@ impl ExecutionService {
     fn determine_status(&self, events: &[ExecutionEvent]) -> String {
         for event in events.iter().rev() {
             match event.event_type.as_str() {
-                "playbook_completed" => return "COMPLETED".to_string(),
-                "playbook_failed" => return "FAILED".to_string(),
-                "playbook_cancelled" => return "CANCELLED".to_string(),
+                "playbook.completed" | "playbook_completed" => return "COMPLETED".to_string(),
+                "playbook.failed" | "playbook_failed" => return "FAILED".to_string(),
+                "playbook.cancelled" | "playbook_cancelled" => return "CANCELLED".to_string(),
                 _ => {}
             }
             if event.status == "FAILED" {


### PR DESCRIPTION
## Summary

Surfaced by noetl/ai-meta#49 Phase A round 3 — two more rounds of Rust-vs-Python schema convention mismatches.

### 1. event_type literals (services/execution.rs)

The Rust queries used **underscore-style** literals like \`playbook_started\` / \`playbook_completed\` / \`playbook_failed\`, but the values the Python noetl-server actually writes use **dot-style**: \`playbook.initialized\` / \`playbook.completed\` / \`playbook.failed\` / \`playbook.cancelled\`:

\`\`\`
$ psql -At -c \"SELECT event_type, count(*) FROM noetl.event
                WHERE event_type LIKE 'playbook%' GROUP BY event_type\"
playbook.completed   | 1646
playbook.failed      |  269
playbook.initialized | 2564
\`\`\`

And note **\`playbook.initialized\` ≠ \`playbook_started\`** — the Python convention uses different words too, not just a different separator.  \`GET /api/executions/{id}\` previously returned 404 because its first query was \`WHERE event_type = 'playbook_started'\` (literally zero rows).

This PR teaches all 5 affected sites in \`ExecutionService\` to accept **both** styles (mirror of the \`\"playbook_completed\" | \"playbook.completed\"\` match arms already present in \`engine/state.rs\`):

- \`list()\`'s \`WITH execution_stats\` CASE branches.
- \`get()\`'s first-event lookup (\`playbook.initialized\`/\`playbook_started\`).
- \`get()\`'s in-process \`completed_at\` filter.
- \`get_status()\`'s \`is_cancelled\` lookup.
- \`is_cancelled()\` standalone query.
- \`determine_status()\`'s match arms.

### 2. catalog column name + tz cast (db/queries/catalog.rs)

\`GET /api/catalog/list\` returned 500 because all 5 SELECT queries selected a column \`id\` that doesn't exist (real PK is \`catalog_id\`) and decoded \`created_at\` as TIMESTAMPTZ (real column is naive TIMESTAMP).

Fixed via \`catalog_id AS id\` aliasing + \`created_at AT TIME ZONE 'UTC'\` casting — same shape as the noetl/server#15 credential fix + #16 execution fix.  \`CatalogEntry\` struct stays unchanged.

## Refs

Refs noetl/ai-meta#49 Phase A

🤖 Generated with [Claude Code](https://claude.com/claude-code)