### PR TITLE
Phase A round 4: remove /api/runtimes for Python parity

### DIFF
--- a/src/handlers/runtime.rs
+++ b/src/handlers/runtime.rs
@@ -98,7 +98,11 @@ pub async fn list_pools(
 
 /// List all runtimes.
 ///
-/// GET /api/runtimes
+/// GET /api/runtimes (route unwired pending Python parity backport — see
+/// noetl/ai-meta#49 Phase A round 4 + the follow-up issue tracking the
+/// `/api/runtimes` Python addition).  Handler retained so re-wiring is a
+/// one-line `main.rs` edit when Python lands the equivalent endpoint.
+#[allow(dead_code)]
 pub async fn list_all(
     State(service): State<RuntimeService>,
     Query(query): Query<ListRuntimesQuery>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,11 @@ fn build_router(
             post(handlers::runtime::heartbeat),
         )
         .route("/api/worker/pools", get(handlers::runtime::list_pools))
-        .route("/api/runtimes", get(handlers::runtime::list_all))
+        // NOTE: `/api/runtimes` (no-filter list) was a Rust-side innovation
+        // with no Python equivalent — removed for Phase A parity per #49
+        // constraint #2 ("byte-identical contracts during migration").
+        // Handler `runtime::list_all` retained for the eventual Python-side
+        // backport; see noetl/server follow-up issue.
         .with_state(runtime_service);
 
     // Database routes


### PR DESCRIPTION
## Summary

- Removes the \`/api/runtimes\` route registration (Rust-side
  innovation with no Python equivalent).
- Retains the \`runtime::list_all\` handler with \`#[allow(dead_code)]\`
  for the eventual Python backport.
- Closes one of the two Phase A round 3 parity findings.

## Why

Per noetl/ai-meta#49 constraint #2 ("byte-identical contracts during
migration"), Rust shouldn't expose endpoints Python doesn't have.
The Python server has only \`/api/worker/pools\` (filtered to
\`kind=worker_pool\`).  No client calls \`/api/runtimes\` today (grep
across the worker, CLI, tools, gateway repos returned no hits).

## Companion work

The other Phase A round 3 finding (\`/api/catalog/{path}/ui_schema\`
returning 404 on Rust) is a larger port — tracked as #18.

## Test plan

- [x] \`cargo build --release\` — clean compile
- [x] \`cargo test --release\` — 147/148 pass (one pre-existing
  failure on \`main\`: \`playbook::parser::tests::test_parse_invalid_next_reference\`)
- [ ] Kind validation: rebuild image, redeploy, run parity harness
      — verified post-merge during ai-meta pointer bump

Refs noetl/ai-meta#49