### PR TITLE
Phase A round 5: port /api/catalog/{path}/ui_schema (closes #18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "envy",
  "minijinja",
  "rand 0.8.6",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ ctor = "0.2"
 # System info (for status endpoint)
 sysinfo = "0.33"
 
+# Regex (for ui_schema inline-directive scanning, etc.)
+regex = "1"
+
 [dev-dependencies]
 tokio-test = "0.4"
 # Process-global env var tests serialise via #[serial] so concurrent

--- a/src/db/models/catalog.rs
+++ b/src/db/models/catalog.rs
@@ -19,8 +19,13 @@ pub struct CatalogEntry {
     /// Resource kind (e.g., "Playbook", "Tool", "Model")
     pub kind: String,
 
-    /// Version number (auto-incremented per path)
-    pub version: i32,
+    /// Version number (auto-incremented per path).
+    ///
+    /// `i16` matches the Postgres `smallint` column.  Older Rust
+    /// revisions used `i32`, which caused sqlx decode failures
+    /// against the real schema — same drift as v2.1.3 (credentials
+    /// data column) and v2.1.4 (executions timestamps).
+    pub version: i16,
 
     /// Raw YAML content
     pub content: String,
@@ -68,8 +73,8 @@ pub struct CatalogRegisterResponse {
     /// Resource path
     pub path: String,
 
-    /// Version number
-    pub version: i32,
+    /// Version number (Postgres `smallint`).
+    pub version: i16,
 
     /// Catalog ID
     pub catalog_id: String,
@@ -105,8 +110,8 @@ pub struct CatalogEntryResponse {
     /// Resource kind
     pub kind: String,
 
-    /// Version number
-    pub version: i32,
+    /// Version number (Postgres `smallint`).
+    pub version: i16,
 
     /// Raw YAML content
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -5,10 +5,14 @@ use crate::db::DbPool;
 use crate::error::AppResult;
 
 /// Get the next version number for a path.
-pub async fn get_next_version(pool: &DbPool, path: &str) -> AppResult<i32> {
-    let result: Option<(i32,)> = sqlx::query_as(
+///
+/// `noetl.catalog.version` is Postgres `smallint`; using `i16` here
+/// matches the column type and avoids the sqlx decode mismatch that
+/// surfaced during noetl/ai-meta#49 Phase A ui_schema validation.
+pub async fn get_next_version(pool: &DbPool, path: &str) -> AppResult<i16> {
+    let result: Option<(i16,)> = sqlx::query_as(
         r#"
-        SELECT COALESCE(MAX(version), 0) + 1
+        SELECT COALESCE(MAX(version), 0)::smallint + 1
         FROM noetl.catalog
         WHERE path = $1
         "#,
@@ -26,7 +30,7 @@ pub async fn insert_catalog_entry(
     pool: &DbPool,
     path: &str,
     kind: &str,
-    version: i32,
+    version: i16,
     content: &str,
     layout: Option<&serde_json::Value>,
     payload: Option<&serde_json::Value>,
@@ -53,12 +57,18 @@ pub async fn insert_catalog_entry(
 }
 
 /// Get a catalog entry by ID.
+///
+/// Filters on `catalog_id` (the real PK column).  Older versions
+/// wrote `WHERE id = $1`, which would fail at runtime because the
+/// table has no `id` column — only `catalog_id` aliased as `id` in
+/// the SELECT list.  Same alias-vs-column drift as the v2.1.5
+/// catalog `list` fix.
 pub async fn get_catalog_by_id(pool: &DbPool, id: i64) -> AppResult<Option<CatalogEntry>> {
     let entry = sqlx::query_as::<_, CatalogEntry>(
         r#"
         SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
-        WHERE id = $1
+        WHERE catalog_id = $1
         "#,
     )
     .bind(id)
@@ -72,7 +82,7 @@ pub async fn get_catalog_by_id(pool: &DbPool, id: i64) -> AppResult<Option<Catal
 pub async fn get_catalog_by_path_version(
     pool: &DbPool,
     path: &str,
-    version: i32,
+    version: i16,
 ) -> AppResult<Option<CatalogEntry>> {
     let entry = sqlx::query_as::<_, CatalogEntry>(
         r#"

--- a/src/handlers/catalog.rs
+++ b/src/handlers/catalog.rs
@@ -3,13 +3,20 @@
 //! Endpoints for managing playbooks, tools, and other resources
 //! in the NoETL catalog.
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::Utc;
+use serde::Deserialize;
 
 use crate::db::models::{
     CatalogEntries, CatalogEntriesRequest, CatalogEntryRequest, CatalogEntryResponse,
     CatalogRegisterRequest, CatalogRegisterResponse,
 };
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
+use crate::services::ui_schema::{infer_ui_schema, UiSchemaResponse};
 use crate::services::CatalogService;
 
 /// Register a new catalog resource.
@@ -119,4 +126,165 @@ pub async fn get_resource(
 ) -> AppResult<Json<CatalogEntryResponse>> {
     let entry = service.get_resource(request).await?;
     Ok(Json(entry.into()))
+}
+
+/// Query parameters for the `ui_schema` endpoint.
+#[derive(Debug, Deserialize)]
+pub struct UiSchemaQuery {
+    /// Catalog version to inspect. Defaults to `"latest"` to match
+    /// the Python `noetl-server` contract.
+    #[serde(default)]
+    pub version: Option<String>,
+}
+
+/// Inferred workload form for a Playbook / Agent / Mcp resource.
+///
+/// `GET /api/catalog/{*path}` — the handler routes by suffix.  Only
+/// requests whose tail ends with `/ui_schema` are served; everything
+/// else falls through as 404.  This is the Rust port of the Python
+/// route `GET /api/catalog/{path:path}/ui_schema` (FastAPI's
+/// `{path:path}` accepts slash-bearing paths; axum's wildcard
+/// `{*tail}` is the equivalent).
+///
+/// # Path
+///
+/// - `tail`: everything after `/api/catalog/`.  Expected shape is
+///   `<catalog-path>/ui_schema` where `<catalog-path>` may contain
+///   slashes (e.g. `system/outbox_publisher/ui_schema`).
+///
+/// # Query
+///
+/// - `version`: catalog version (numeric string or `"latest"`).
+///   Defaults to `"latest"`.
+///
+/// # Response
+///
+/// `UiSchemaResponse` — see [`crate::services::ui_schema`] for the
+/// shape.  Byte-identical to the Python `noetl-server` for the same
+/// input per noetl/ai-meta#49 constraint #2.
+pub async fn ui_schema(
+    State(service): State<CatalogService>,
+    Path(tail): Path<String>,
+    Query(query): Query<UiSchemaQuery>,
+) -> AppResult<Json<UiSchemaResponse>> {
+    // The wildcard route catches all `/api/catalog/*` GETs; the
+    // ui_schema variant is the one whose tail ends with `/ui_schema`.
+    // Anything else from this route is treated as not-found so it
+    // doesn't accidentally swallow paths we haven't ported yet.
+    let suffix = "/ui_schema";
+    let Some(catalog_path) = tail.strip_suffix(suffix) else {
+        return Err(AppError::NotFound(format!(
+            "no route matched GET /api/catalog/{tail}"
+        )));
+    };
+    if catalog_path.is_empty() {
+        return Err(AppError::Validation(
+            "ui_schema path must not be empty".to_string(),
+        ));
+    }
+
+    let request = CatalogEntryRequest {
+        catalog_id: None,
+        path: Some(catalog_path.to_string()),
+        version: Some(
+            query
+                .version
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| "latest".to_string()),
+        ),
+    };
+
+    let entry = service.get_resource(request).await?;
+
+    // Parse YAML for metadata. Forgiving — if the parse fails, return
+    // empty metadata rather than 500, mirroring Python's behaviour.
+    let metadata = parse_metadata(&entry.content);
+
+    let fields = infer_ui_schema(&entry.content);
+
+    let response = UiSchemaResponse {
+        path: entry.path,
+        version: entry.version,
+        kind: entry.kind.to_lowercase(),
+        title: metadata.name,
+        description_markdown: metadata.description,
+        exposed_in_ui: metadata.exposed_in_ui,
+        fields,
+        generated_at: Utc::now(),
+    };
+    Ok(Json(response))
+}
+
+#[derive(Debug, Default)]
+struct CatalogMetadata {
+    name: Option<String>,
+    description: Option<String>,
+    exposed_in_ui: bool,
+}
+
+/// Extract the `metadata` block from a YAML document.  Returns an
+/// empty `CatalogMetadata` when the document doesn't parse or has no
+/// `metadata` mapping — matches Python's forgiving handling.
+fn parse_metadata(yaml_text: &str) -> CatalogMetadata {
+    let parsed: serde_yaml::Value = match serde_yaml::from_str(yaml_text) {
+        Ok(v) => v,
+        Err(_) => return CatalogMetadata::default(),
+    };
+    let metadata = match parsed.get("metadata") {
+        Some(serde_yaml::Value::Mapping(m)) => m,
+        _ => return CatalogMetadata::default(),
+    };
+    CatalogMetadata {
+        name: metadata
+            .get(serde_yaml::Value::String("name".to_string()))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        description: metadata
+            .get(serde_yaml::Value::String("description".to_string()))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        exposed_in_ui: metadata
+            .get(serde_yaml::Value::String("exposed_in_ui".to_string()))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_metadata_name_description_flag() {
+        let yaml = "\
+apiVersion: v1
+kind: Playbook
+metadata:
+  name: test-playbook
+  description: A test
+  exposed_in_ui: true
+workload:
+  foo: bar
+";
+        let meta = parse_metadata(yaml);
+        assert_eq!(meta.name.as_deref(), Some("test-playbook"));
+        assert_eq!(meta.description.as_deref(), Some("A test"));
+        assert!(meta.exposed_in_ui);
+    }
+
+    #[test]
+    fn parse_metadata_missing_block_returns_default() {
+        let yaml = "workload:\n  foo: bar\n";
+        let meta = parse_metadata(yaml);
+        assert!(meta.name.is_none());
+        assert!(meta.description.is_none());
+        assert!(!meta.exposed_in_ui);
+    }
+
+    #[test]
+    fn parse_metadata_malformed_yaml_returns_default() {
+        let yaml = "metadata:\n  name: 'unterminated\n";
+        let meta = parse_metadata(yaml);
+        assert!(meta.name.is_none());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,15 @@ fn build_router(
             "/api/catalog/resource",
             post(handlers::catalog::get_resource),
         )
+        // ui_schema route — wildcard tail because the Python contract
+        // `GET /api/catalog/{path:path}/ui_schema` accepts slash-bearing
+        // paths (e.g. `system/outbox_publisher`).  The handler routes
+        // by suffix: only requests whose tail ends with `/ui_schema`
+        // are served; everything else returns 404.
+        .route(
+            "/api/catalog/{*tail}",
+            get(handlers::catalog::ui_schema),
+        )
         .with_state(catalog_service);
 
     // Credential routes

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -126,7 +126,7 @@ impl CatalogService {
                         });
                 }
 
-                let version: i32 = version_str
+                let version: i16 = version_str
                     .parse()
                     .map_err(|_| AppError::Validation("Invalid version number".to_string()))?;
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod execution;
 pub mod internal;
 pub mod keychain;
 pub mod runtime;
+pub mod ui_schema;
 
 pub use catalog::CatalogService;
 pub use credential::CredentialService;

--- a/src/services/ui_schema.rs
+++ b/src/services/ui_schema.rs
@@ -1,0 +1,726 @@
+//! Workload-form inference from a playbook / agent YAML payload.
+//!
+//! Port of the Python `noetl.server.api.mcp.ui_schema` helper —
+//! kept structurally close so Rust-side output is byte-identical
+//! to the Python wire shape for the same input.
+//!
+//! Public entry point: [`infer_ui_schema`].
+//!
+//! ## Approach
+//!
+//! 1. Parse the document with `serde_yaml` for the structural shape.
+//! 2. Scan the raw text for inline `# ui:` directives next to each
+//!    workload key. The directive parser is a small regex; it
+//!    ignores anything it can't recognise so a malformed comment
+//!    never breaks registration.
+//!
+//! Supported directives (always after the key/value on the same
+//! line):
+//!
+//! - `# ui:secret` — mark the field as masked input.
+//! - `# ui:enum=[a,b,c]` — force `kind=enum` and populate options.
+//! - `# ui:credential=pg_*` — restrict to a credential picker
+//!   filtered by glob.
+//! - `# ui:description=Some help text` — per-field description.
+//!
+//! The inference is intentionally forgiving: malformed YAML or
+//! unknown directives just return an empty / less-rich schema
+//! rather than raising. Callers should treat the returned schema
+//! as a best-effort hint, not a strict contract.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// One workload field inferred from a playbook's YAML.
+///
+/// Mirrors `noetl.server.api.mcp.schema.UiSchemaField` — see that
+/// module's docstring for the inference rules.
+///
+/// Optional fields are serialized as explicit `null` rather than
+/// omitted to match the Python pydantic wire shape (which has no
+/// `exclude_none` config on this model).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UiSchemaField {
+    /// Workload key.
+    pub name: String,
+
+    /// Field kind: `string|integer|number|boolean|object|array|null|enum`.
+    pub kind: String,
+
+    /// Default value parsed from YAML.
+    #[serde(default)]
+    pub default: serde_json::Value,
+
+    /// Human-readable hint, from a `# ui:description=...` comment.
+    pub description: Option<String>,
+
+    /// True when `# ui:secret` directive is present.
+    #[serde(default)]
+    pub secret: bool,
+
+    /// Credential picker filter (e.g. `pg_*`).
+    pub credential_glob: Option<String>,
+
+    /// Enum options, when `kind=enum`.
+    pub options: Option<Vec<serde_json::Value>>,
+
+    /// Nested fields when `kind=object`.
+    pub children: Option<Vec<UiSchemaField>>,
+}
+
+/// Inferred workload form for a catalog resource (Playbook | Agent | Mcp).
+///
+/// Mirrors `noetl.server.api.mcp.schema.UiSchemaResponse`.  Optional
+/// fields are serialized as `null` (not omitted) to match the
+/// Python pydantic wire shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiSchemaResponse {
+    /// Catalog path.
+    pub path: String,
+
+    /// Catalog version inspected (Postgres `smallint`).
+    pub version: i16,
+
+    /// Resource kind (Playbook | Agent | Mcp), lower-cased.
+    pub kind: String,
+
+    /// `metadata.name` from the resource.
+    pub title: Option<String>,
+
+    /// `metadata.description` rendered as markdown source.
+    pub description_markdown: Option<String>,
+
+    /// True when `metadata.exposed_in_ui` is set on the resource.
+    #[serde(default)]
+    pub exposed_in_ui: bool,
+
+    /// Top-level workload fields.
+    #[serde(default)]
+    pub fields: Vec<UiSchemaField>,
+
+    /// When this schema was inferred.
+    pub generated_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+/// Match each `# ui:foo[=bar]` token within a line.
+///
+/// The Python version uses a `(?=(?:\s+#|\s*$))` lookahead to stop
+/// at the next directive. Rust's `regex` crate has no lookahead, but
+/// the value class `[^\n#]*` already cannot contain another `#`, so
+/// the simpler greedy form has the same behaviour (the trailing
+/// whitespace before the next `#` is just absorbed into the value
+/// and trimmed afterward).
+fn directive_inline_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"#\s*ui:(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?:\s*=\s*(?P<value>[^\n#]*))?",
+        )
+        .expect("static regex must compile")
+    })
+}
+
+/// Match the start of a top-level workload key line so we can
+/// correlate the parsed dict back to the raw text. Accepts any indent
+/// of two or more spaces so this works for the common 2-space indent
+/// and the also-valid 4-space style.
+fn top_key_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(?P<indent> {2,})(?P<name>[A-Za-z_][A-Za-z0-9_-]*)\s*:")
+            .expect("static regex must compile")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Return ordered top-level workload fields inferred from the YAML.
+///
+/// Empty list when the document has no `workload:` block, when the
+/// YAML can't be parsed, or when `workload:` isn't a mapping.
+pub fn infer_ui_schema(yaml_text: &str) -> Vec<UiSchemaField> {
+    if yaml_text.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let parsed: serde_yaml::Value = match serde_yaml::from_str(yaml_text) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let workload = match parsed.get("workload") {
+        Some(serde_yaml::Value::Mapping(m)) => m,
+        _ => return Vec::new(),
+    };
+
+    let directives = scan_inline_directives(yaml_text);
+    let mut fields = Vec::with_capacity(workload.len());
+    for (key, value) in workload {
+        let name = match key {
+            serde_yaml::Value::String(s) => s.clone(),
+            other => serde_yaml::to_string(other).unwrap_or_default().trim().to_string(),
+        };
+        let directive = directives.get(&name).cloned().unwrap_or_default();
+        fields.push(field_from_value(&name, value, &directive));
+    }
+    fields
+}
+
+// ---------------------------------------------------------------------------
+// Inline-comment scanning
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, PartialEq)]
+struct Directive {
+    secret: bool,
+    enum_options: Option<Vec<String>>,
+    credential: Option<String>,
+    description: Option<String>,
+}
+
+/// Walk the raw text once and pull `# ui:` directives per top-level
+/// workload key.
+///
+/// Returns a mapping of `key_name -> Directive` aggregated from inline
+/// comments on the same line as the key/value. Only the immediate
+/// children of `workload:` are considered — without that filter the
+/// parser would happily attach a `# ui:secret` on a nested mapping
+/// to an unrelated top-level field that happens to share the same
+/// key name. Phase 1 mirrors the Python helper exactly here.
+///
+/// Detection of "immediate child" is data-driven: the first non-empty,
+/// deeper-than-`workload:` line we see fixes `child_indent` for the
+/// rest of the block. Lines at deeper indents are skipped.
+fn scan_inline_directives(yaml_text: &str) -> HashMap<String, Directive> {
+    let mut out: HashMap<String, Directive> = HashMap::new();
+    let mut in_workload = false;
+    let mut workload_indent: i32 = -1;
+    let mut child_indent: i32 = -1;
+
+    for line in yaml_text.split('\n') {
+        let stripped = line.trim_start();
+        if stripped.is_empty() {
+            continue;
+        }
+
+        if stripped.starts_with("workload:") {
+            in_workload = true;
+            workload_indent = (line.len() - stripped.len()) as i32;
+            child_indent = -1;
+            continue;
+        }
+
+        if !in_workload {
+            continue;
+        }
+
+        let indent = (line.len() - stripped.len()) as i32;
+        if indent <= workload_indent {
+            // Left the workload block.
+            in_workload = false;
+            child_indent = -1;
+            continue;
+        }
+
+        // Establish the immediate-child indent on the first qualifying line.
+        if child_indent == -1 {
+            child_indent = indent;
+        }
+
+        // Filter strictly to the immediate children of `workload:`.
+        if indent != child_indent {
+            continue;
+        }
+
+        let Some(caps) = top_key_re().captures(line) else {
+            continue;
+        };
+        let key_name = caps.name("name").unwrap().as_str().to_string();
+        let directive = extract_directives_from_line(line);
+        if !is_empty_directive(&directive) {
+            out.insert(key_name, directive);
+        }
+    }
+    out
+}
+
+fn is_empty_directive(d: &Directive) -> bool {
+    !d.secret && d.enum_options.is_none() && d.credential.is_none() && d.description.is_none()
+}
+
+/// Pull every `# ui:foo` / `# ui:foo=bar` token from a single raw line.
+fn extract_directives_from_line(line: &str) -> Directive {
+    let mut d = Directive::default();
+    for caps in directive_inline_re().captures_iter(line) {
+        let key = caps.name("key").map(|m| m.as_str()).unwrap_or("");
+        let raw_value = caps
+            .name("value")
+            .map(|m| m.as_str().trim().to_string())
+            .unwrap_or_default();
+        match key {
+            "secret" => {
+                d.secret = true;
+            }
+            "enum" => {
+                let parsed = parse_directive_value_list(&raw_value);
+                d.enum_options = Some(parsed);
+            }
+            "credential" => {
+                if !raw_value.is_empty() {
+                    d.credential = Some(strip_quotes(&raw_value));
+                }
+            }
+            "description" => {
+                if !raw_value.is_empty() {
+                    d.description = Some(strip_quotes(&raw_value));
+                }
+            }
+            _ => {
+                // Unknown directive — silently ignored to mirror Python.
+            }
+        }
+    }
+    d
+}
+
+/// Parse the value half of a `# ui:foo=bar` directive into a list of
+/// strings. Used for `enum=[a,b,c]`. Mirrors Python's
+/// `_parse_directive_value` shape for the list case.
+fn parse_directive_value_list(text: &str) -> Vec<String> {
+    let trimmed = text.trim();
+    if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        let inner = trimmed[1..trimmed.len() - 1].trim();
+        if inner.is_empty() {
+            return Vec::new();
+        }
+        return inner
+            .split(',')
+            .map(|piece| strip_quotes(piece.trim()))
+            .filter(|s| !s.is_empty())
+            .collect();
+    }
+    // Single value, no brackets — wrap into a single-element list to
+    // match Python's behaviour: `enum_options=[value]`.
+    vec![strip_quotes(trimmed)]
+}
+
+fn strip_quotes(s: &str) -> String {
+    if s.len() >= 2 {
+        let bytes = s.as_bytes();
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'\'' && last == b'\'') || (first == b'"' && last == b'"') {
+            return s[1..s.len() - 1].to_string();
+        }
+    }
+    s.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Field construction
+// ---------------------------------------------------------------------------
+
+fn field_from_value(
+    name: &str,
+    value: &serde_yaml::Value,
+    directives: &Directive,
+) -> UiSchemaField {
+    let description = directives.description.clone();
+    let secret = directives.secret;
+    let credential_glob = directives.credential.clone();
+
+    if let Some(enum_options) = &directives.enum_options {
+        let options_json: Vec<serde_json::Value> = enum_options
+            .iter()
+            .map(|s| serde_json::Value::String(s.clone()))
+            .collect();
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "enum".to_string(),
+            default: yaml_to_json(value),
+            description,
+            secret,
+            credential_glob,
+            options: Some(options_json),
+            children: None,
+        };
+    }
+
+    // Mirror Python's type-branching: bool → boolean, integer → integer,
+    // float → number, null → null, mapping → object (recurse), sequence
+    // → array, anything else → string.
+    if value.is_bool() {
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "boolean".to_string(),
+            default: yaml_to_json(value),
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: None,
+        };
+    }
+
+    if let Some(n) = value.as_i64() {
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "integer".to_string(),
+            default: serde_json::Value::Number(serde_json::Number::from(n)),
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: None,
+        };
+    }
+    if let Some(n) = value.as_u64() {
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "integer".to_string(),
+            default: serde_json::Value::Number(serde_json::Number::from(n)),
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: None,
+        };
+    }
+    if let Some(n) = value.as_f64() {
+        // f64 → JSON number, falling back to null on NaN/inf which
+        // mirrors Python's `json.dumps` rejecting non-finite floats.
+        let default = serde_json::Number::from_f64(n)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null);
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "number".to_string(),
+            default,
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: None,
+        };
+    }
+
+    if value.is_null() {
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "null".to_string(),
+            default: serde_json::Value::Null,
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: None,
+        };
+    }
+
+    if let serde_yaml::Value::Mapping(map) = value {
+        let children: Vec<UiSchemaField> = map
+            .iter()
+            .map(|(k, v)| {
+                let child_name = match k {
+                    serde_yaml::Value::String(s) => s.clone(),
+                    other => serde_yaml::to_string(other)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string(),
+                };
+                field_from_value(&child_name, v, &Directive::default())
+            })
+            .collect();
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "object".to_string(),
+            default: yaml_to_json(value),
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: Some(children),
+        };
+    }
+
+    if value.is_sequence() {
+        return UiSchemaField {
+            name: name.to_string(),
+            kind: "array".to_string(),
+            default: yaml_to_json(value),
+            description,
+            secret,
+            credential_glob,
+            options: None,
+            children: None,
+        };
+    }
+
+    // Fallback: string (or anything else like tag).
+    UiSchemaField {
+        name: name.to_string(),
+        kind: "string".to_string(),
+        default: yaml_to_json(value),
+        description,
+        secret,
+        credential_glob,
+        options: None,
+        children: None,
+    }
+}
+
+/// Convert a `serde_yaml::Value` into a `serde_json::Value` for the
+/// `default` slot of the response. We round-trip through JSON
+/// serialisation rather than re-implementing the mapping by hand —
+/// serde handles the boolean/number/string/null/array/object cases
+/// faithfully.
+fn yaml_to_json(value: &serde_yaml::Value) -> serde_json::Value {
+    // serde_yaml + serde_json don't share a direct converter, so we
+    // round-trip through a JSON string. Safe because all YAML scalars
+    // we care about (bool / int / float / string / null) survive the
+    // round trip without surprises.
+    match serde_json::to_value(value) {
+        Ok(v) => v,
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first_field(yaml: &str) -> UiSchemaField {
+        let fields = infer_ui_schema(yaml);
+        assert_eq!(fields.len(), 1, "expected 1 field for yaml: {yaml}");
+        fields.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(infer_ui_schema("").is_empty());
+        assert!(infer_ui_schema("   ").is_empty());
+        assert!(infer_ui_schema("\n\n").is_empty());
+    }
+
+    #[test]
+    fn no_workload_block_returns_empty() {
+        let yaml = "apiVersion: v1\nkind: Playbook\nmetadata:\n  name: foo\n";
+        assert!(infer_ui_schema(yaml).is_empty());
+    }
+
+    #[test]
+    fn malformed_yaml_returns_empty() {
+        // Unbalanced quotes.
+        let yaml = "workload:\n  key: 'unterminated\n";
+        assert!(infer_ui_schema(yaml).is_empty());
+    }
+
+    #[test]
+    fn workload_not_mapping_returns_empty() {
+        let yaml = "workload: 42\n";
+        assert!(infer_ui_schema(yaml).is_empty());
+
+        let yaml = "workload:\n  - a\n  - b\n";
+        assert!(infer_ui_schema(yaml).is_empty());
+    }
+
+    #[test]
+    fn scalar_string_field() {
+        let yaml = "workload:\n  name: hello\n";
+        let f = first_field(yaml);
+        assert_eq!(f.name, "name");
+        assert_eq!(f.kind, "string");
+        assert_eq!(f.default, serde_json::json!("hello"));
+        assert!(!f.secret);
+    }
+
+    #[test]
+    fn integer_field() {
+        let yaml = "workload:\n  count: 42\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "integer");
+        assert_eq!(f.default, serde_json::json!(42));
+    }
+
+    #[test]
+    fn number_field() {
+        let yaml = "workload:\n  ratio: 3.14\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "number");
+        assert_eq!(f.default, serde_json::json!(3.14));
+    }
+
+    #[test]
+    fn boolean_field() {
+        let yaml = "workload:\n  enabled: true\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "boolean");
+        assert_eq!(f.default, serde_json::json!(true));
+    }
+
+    #[test]
+    fn null_field() {
+        let yaml = "workload:\n  empty: null\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "null");
+        assert_eq!(f.default, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn array_field() {
+        let yaml = "workload:\n  items: [1, 2, 3]\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "array");
+        assert_eq!(f.default, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn object_field_with_children() {
+        let yaml = "workload:\n  db:\n    host: localhost\n    port: 5432\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "object");
+        let children = f.children.expect("object field should have children");
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].name, "host");
+        assert_eq!(children[0].kind, "string");
+        assert_eq!(children[1].name, "port");
+        assert_eq!(children[1].kind, "integer");
+    }
+
+    #[test]
+    fn directive_secret() {
+        let yaml = "workload:\n  password: hunter2  # ui:secret\n";
+        let f = first_field(yaml);
+        assert!(f.secret);
+        assert_eq!(f.kind, "string");
+    }
+
+    #[test]
+    fn directive_description() {
+        let yaml = "workload:\n  host: localhost  # ui:description=The DB host\n";
+        let f = first_field(yaml);
+        assert_eq!(f.description.as_deref(), Some("The DB host"));
+    }
+
+    #[test]
+    fn directive_credential() {
+        let yaml = "workload:\n  alias: pg_main  # ui:credential=pg_*\n";
+        let f = first_field(yaml);
+        assert_eq!(f.credential_glob.as_deref(), Some("pg_*"));
+    }
+
+    #[test]
+    fn directive_enum() {
+        let yaml = "workload:\n  level: info  # ui:enum=[debug,info,warn,error]\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "enum");
+        let options = f.options.expect("enum should have options");
+        assert_eq!(options.len(), 4);
+        assert_eq!(options[0], serde_json::json!("debug"));
+        assert_eq!(options[3], serde_json::json!("error"));
+    }
+
+    #[test]
+    fn multiple_directives_one_line() {
+        let yaml = "workload:\n  pw: hunter2  # ui:secret # ui:description=API key\n";
+        let f = first_field(yaml);
+        assert!(f.secret);
+        assert_eq!(f.description.as_deref(), Some("API key"));
+    }
+
+    #[test]
+    fn nested_directive_does_not_leak_to_top_level() {
+        // Phase 1 deliberately ignores nested directives — a
+        // `# ui:secret` on `db.password` should NOT attach to a
+        // top-level field named `password`.
+        let yaml = "\
+workload:
+  db:
+    password: hunter2  # ui:secret
+  password: visible
+";
+        let fields = infer_ui_schema(yaml);
+        assert_eq!(fields.len(), 2);
+        let db_field = &fields[0];
+        let pw_field = &fields[1];
+        assert_eq!(db_field.kind, "object");
+        assert_eq!(pw_field.name, "password");
+        // The top-level password has no directive — Phase 1 ignores
+        // the nested secret directive on db.password.
+        assert!(!pw_field.secret);
+    }
+
+    #[test]
+    fn enum_directive_overrides_value_kind() {
+        // Even if the underlying value is a string, an enum directive
+        // forces kind=enum and populates options.
+        let yaml = "workload:\n  region: us-east-1  # ui:enum=[us-east-1,us-west-2,eu-west-1]\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "enum");
+        assert_eq!(f.default, serde_json::json!("us-east-1"));
+    }
+
+    #[test]
+    fn four_space_indent_supported() {
+        // The _TOP_KEY_RE accepts any indent of two or more spaces.
+        let yaml = "workload:\n    name: hello  # ui:description=greet\n";
+        let f = first_field(yaml);
+        assert_eq!(f.description.as_deref(), Some("greet"));
+    }
+
+    #[test]
+    fn quoted_directive_value() {
+        let yaml = "workload:\n  host: localhost  # ui:description=\"with spaces\"\n";
+        let f = first_field(yaml);
+        assert_eq!(f.description.as_deref(), Some("with spaces"));
+    }
+
+    #[test]
+    fn workload_followed_by_other_top_level_keys() {
+        // Make sure we stop scanning when workload: ends.
+        let yaml = "\
+workload:
+  name: hello  # ui:description=greet
+start:
+  secret: should-not-attach  # ui:secret
+";
+        let fields = infer_ui_schema(yaml);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].description.as_deref(), Some("greet"));
+        assert!(!fields[0].secret);
+    }
+
+    #[test]
+    fn enum_empty_brackets_returns_empty_list() {
+        let yaml = "workload:\n  level: info  # ui:enum=[]\n";
+        let f = first_field(yaml);
+        assert_eq!(f.kind, "enum");
+        assert_eq!(f.options.as_ref().map(Vec::len), Some(0));
+    }
+
+    #[test]
+    fn field_order_preserved() {
+        let yaml = "workload:\n  alpha: 1\n  beta: 2\n  gamma: 3\n";
+        let fields = infer_ui_schema(yaml);
+        let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta", "gamma"]);
+    }
+}


### PR DESCRIPTION
## Summary

- Ports the Python \`infer_ui_schema\` helper (YAML parse + inline
  \`# ui:\` directive scan + field-kind inference) to Rust.
- Wires \`GET /api/catalog/{*tail}\` returning \`UiSchemaResponse\` —
  byte-identical to Python after normalizing the ephemeral
  \`generated_at\` timestamp (noetl/ops#152 adds it to the harness's
  NORMALIZE_JQ list).
- Includes two drive-by schema fixes that the new route surfaced:
  \`version\` column is \`smallint\` (i16), not i32; and
  \`get_catalog_by_id\` was querying a column that doesn't exist
  (\`id\` instead of \`catalog_id\`).

Closes the last open Phase A endpoint of noetl/ai-meta#49.

## Verification

Pre-fix probe:
\`\`\`
==> GET /api/catalog/system/outbox_publisher/ui_schema
    Python HTTP 200    Rust HTTP 404
\`\`\`

Post-fix probe (with noetl/ops#152 timestamp normalization):
\`\`\`
==> GET /api/catalog/system/outbox_publisher/ui_schema
    Python HTTP 200    Rust HTTP 200
    PASS byte-identical after normalization
\`\`\`

## Test plan

- [x] \`cargo build --release\` — clean compile
- [x] \`cargo test --release --lib\` — 173/174 pass (one pre-existing
      failure on \`main\`: \`playbook::parser::tests::test_parse_invalid_next_reference\`);
      26 new tests for the ui_schema port all pass
- [x] Kind validation: parity harness reports PASS byte-identical
      for the new endpoint against the live \`system/outbox_publisher\`
      catalog entry

Closes noetl/server#18
Refs noetl/ai-meta#49