### PR TITLE
fix(catalog): emit null for optional response fields (Python parity)

### DIFF
--- a/src/db/models/catalog.rs
+++ b/src/db/models/catalog.rs
@@ -98,7 +98,16 @@ pub struct CatalogEntries {
     pub entries: Vec<CatalogEntryResponse>,
 }
 
-/// Catalog entry response (subset of fields).
+/// Catalog entry response.
+///
+/// Optional JSON-bodied fields (`content`, `layout`, `payload`,
+/// `meta`) serialize as explicit `null` (not omitted) to match
+/// the Python pydantic `CatalogEntry` wire shape — pydantic v2
+/// has no `exclude_none` config on that model, so it always
+/// emits the keys.  Omitting them on the Rust side surfaced as
+/// DIFF lines in the noetl/ai-meta#49 Phase A parity harness;
+/// same `null`-vs-omit pattern as the `UiSchemaField` fix in
+/// v2.2.0.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogEntryResponse {
     /// Catalog ID
@@ -114,15 +123,15 @@ pub struct CatalogEntryResponse {
     pub version: i16,
 
     /// Raw YAML content
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
 
+    /// Parsed layout/structure (JSON)
+    pub layout: Option<serde_json::Value>,
+
     /// Parsed payload/workload (JSON)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<serde_json::Value>,
 
     /// Additional metadata (JSON)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<serde_json::Value>,
 
     /// Creation timestamp
@@ -137,6 +146,7 @@ impl From<CatalogEntry> for CatalogEntryResponse {
             kind: entry.kind,
             version: entry.version,
             content: Some(entry.content),
+            layout: entry.layout,
             payload: entry.payload,
             meta: entry.meta,
             created_at: entry.created_at,


### PR DESCRIPTION
## Summary

Closes the catalog/list null-vs-omit drift that surfaced in the Phase A parity harness output for noetl/ai-meta#49 after v2.2.0 landed:

- Adds the missing \`layout\` field to \`CatalogEntryResponse\` (the source \`CatalogEntry\` struct had it but the response struct + \`From\` impl dropped it).
- Drops \`skip_serializing_if = "Option::is_none"\` on \`content\`, \`payload\`, \`meta\`, and the new \`layout\` so optional fields serialize as explicit \`null\` — matching Python's pydantic \`CatalogEntry\` model which has no \`exclude_none\` config.

Same null-vs-omit pattern as the \`UiSchemaField\` fix in v2.2.0.

## Verification

Before this PR:
\`\`\`
==> POST /api/catalog/list
    DIFF response drift (after normalizing ephemeral fields):
    -      "layout": null,
           "meta": { ... },
\`\`\`

After (kind-validated against live \`system/outbox_publisher\` catalog entry on the rebuilt + reloaded Rust server image):
\`\`\`
==> POST /api/catalog/list
    PASS byte-identical after normalization
==> GET /api/catalog/system/outbox_publisher/ui_schema
    PASS byte-identical after normalization
\`\`\`

ui_schema probe also still PASS — no regression.

## Test plan

- [x] \`cargo build --release\` — clean
- [x] \`cargo test --release --lib\` — 173/174 pass (one pre-existing failure on \`main\`: \`playbook::parser::tests::test_parse_invalid_next_reference\`)
- [x] Kind validation: parity harness PASS byte-identical for \`POST /api/catalog/list\`

Refs noetl/ai-meta#49