### PR TITLE
Phase B R1: prometheus metrics surface + instrument POST /api/events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1281,7 @@ dependencies = [
  "dotenvy",
  "envy",
  "minijinja",
+ "prometheus",
  "rand 0.8.6",
  "regex",
  "reqwest",
@@ -1561,6 +1568,27 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quinn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ sysinfo = "0.33"
 # Regex (for ui_schema inline-directive scanning, etc.)
 regex = "1"
 
+# Prometheus metrics surface — exposed at GET /metrics per
+# agents/rules/observability.md (Principle 1, Principle 2).
+prometheus = "0.13"
+
 [dev-dependencies]
 tokio-test = "0.4"
 # Process-global env var tests serialise via #[serial] so concurrent

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -210,7 +210,38 @@ pub struct CommandResponse {
 ///
 /// Worker reports completion with result (inline or ref).
 /// Engine evaluates case/when/then and generates next commands.
+///
+/// Instrumented per
+/// [`agents/rules/observability.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/observability.md)
+/// Principle 1: a counter (`noetl_events_ingested_total{event_type,status}`)
+/// and histogram (`noetl_event_ingest_duration_seconds{event_type}`) are
+/// recorded on every dispatch.  See [`handle_event_inner`] for the body
+/// of the handler.
 pub async fn handle_event(
+    state: State<AppState>,
+    request: Json<EventRequest>,
+) -> Result<Json<EventResponse>, AppError> {
+    let event_type_for_metrics = request.0.event_type.clone();
+    let started_at = std::time::Instant::now();
+
+    let result = handle_event_inner(state, request).await;
+
+    let status_label = if result.is_ok() { "ok" } else { "error" };
+    let duration_seconds = started_at.elapsed().as_secs_f64();
+    crate::metrics::record_event_ingest(
+        &event_type_for_metrics,
+        status_label,
+        duration_seconds,
+    );
+
+    result
+}
+
+/// Inner body of [`handle_event`] — same logic, no instrumentation.
+///
+/// Split out so the wrapper can record metrics on both Ok and Err
+/// paths without coupling the body to the recording call.
+async fn handle_event_inner(
     State(state): State<AppState>,
     Json(request): Json<EventRequest>,
 ) -> Result<Json<EventResponse>, AppError> {

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -1,6 +1,11 @@
 //! Health check endpoints for the NoETL Control Plane API.
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::db::pool::health_check as db_health_check;
@@ -142,6 +147,40 @@ pub async fn pool_status(State(state): State<AppState>) -> Json<PoolStatusRespon
     })
 }
 
+/// Prometheus metrics endpoint.
+///
+/// `GET /metrics`
+///
+/// Returns the text-exposition format documented at
+/// <https://prometheus.io/docs/instrumenting/exposition_formats/>.
+/// Routed only when `disable_metrics` is `false` in
+/// [`AppConfig`].  Per
+/// [`agents/rules/observability.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/observability.md)
+/// Principles 1+2, every substantive code change ships a
+/// counter/histogram alongside the implementation; this endpoint
+/// is the surface those metrics are scraped from.
+pub async fn metrics() -> Response {
+    match crate::metrics::gather_text() {
+        Ok(text) => (
+            StatusCode::OK,
+            [(
+                header::CONTENT_TYPE,
+                "text/plain; version=0.0.4; charset=utf-8",
+            )],
+            text,
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to gather Prometheus metrics");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to render metrics: {e}"),
+            )
+                .into_response()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,5 +189,24 @@ mod tests {
     async fn test_health_check() {
         let response = health_check().await;
         assert_eq!(response.status, "ok");
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint_returns_ok() {
+        // Ensure at least one observation exists in the registry so
+        // the response is non-trivial.  This also covers the happy
+        // path of `gather_text` end-to-end through the handler.
+        crate::metrics::record_event_ingest("test.metrics_endpoint", "ok", 0.001);
+        let response = metrics().await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            content_type.contains("text/plain"),
+            "expected text/plain, got: {content_type}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod db;
 pub mod engine;
 pub mod error;
 pub mod handlers;
+pub mod metrics;
 pub mod nats;
 pub mod playbook;
 pub mod result_ext;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,17 @@ fn build_router(
         .allow_headers(Any);
 
     // Health check routes (no auth required)
-    let health_routes = Router::new()
+    let mut health_routes = Router::new()
         .route("/health", get(handlers::health_check))
         .route("/api/health", get(handlers::api_health))
-        .route("/api/pool/status", get(handlers::health::pool_status))
-        .with_state(state.clone());
+        .route("/api/pool/status", get(handlers::health::pool_status));
+    // Prometheus metrics endpoint — gated by AppConfig.disable_metrics
+    // per agents/rules/observability.md.  Default-on; ingress / netpol
+    // can restrict reach in prod.
+    if !state.config.disable_metrics {
+        health_routes = health_routes.route("/metrics", get(handlers::health::metrics));
+    }
+    let health_routes = health_routes.with_state(state.clone());
 
     // Catalog routes
     let catalog_routes = Router::new()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,194 @@
+//! Prometheus metrics surface for the NoETL control plane.
+//!
+//! Follows `agents/rules/observability.md` Principles 1 and 2:
+//!
+//! - Every substantive change ships a counter and/or histogram
+//!   alongside the code (Principle 1).
+//! - Counters / histograms / gauges scale; per-event INFO logs
+//!   do not (Principle 2).
+//!
+//! The registry is global (`OnceLock<Registry>`) so any module
+//! can record without threading a handle through `AppState`.
+//! `gather_text()` renders the registry into the standard
+//! Prometheus text exposition format used by `/metrics`.
+//!
+//! ## Per-endpoint conventions
+//!
+//! - **Counters** are named with a trailing `_total` suffix
+//!   (Prometheus convention).
+//! - **Histograms** are named with a unit suffix
+//!   (`_seconds`, `_bytes`, etc.) — never raw.
+//! - **Labels** are low-cardinality enums (`event_type`,
+//!   `status`).  `execution_id` is NEVER a label (cardinality
+//!   blows up the registry); it lives on tracing spans only
+//!   per Principle 4.
+//!
+//! ## Round 1 surface (this file, this PR)
+//!
+//! - `noetl_events_ingested_total{event_type, status}` —
+//!   counter; one increment per `POST /api/events` call.
+//! - `noetl_event_ingest_duration_seconds{event_type}` —
+//!   histogram; the wall-clock time spent inside the handler.
+//!
+//! Future rounds add counters/histograms for the other write
+//! endpoints (catalog/register, credentials, keychain,
+//! worker/pool/register, worker/pool/heartbeat).  See
+//! noetl/server#21.
+
+use std::sync::OnceLock;
+
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder};
+
+/// Bucket boundaries for the event-ingest histogram (seconds).
+///
+/// Spans the 1ms–10s range an event-ingest call could plausibly
+/// take (DB write + optional engine call + result-store fallback).
+/// Wider buckets at the tail capture the rare slow paths without
+/// overweighting the high-percentile estimate.
+const EVENT_INGEST_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// Global registry — lazily initialised on first `registry()` call.
+fn registry() -> &'static Registry {
+    static REG: OnceLock<Registry> = OnceLock::new();
+    REG.get_or_init(Registry::new)
+}
+
+/// Counter: `POST /api/events` calls bucketed by event type and status.
+pub fn events_ingested_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_events_ingested_total",
+                "Total events accepted by POST /api/events (incremented once per handler call, whether the body persisted or errored).",
+            ),
+            &["event_type", "status"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Histogram: wall-clock time spent inside the `POST /api/events` handler.
+pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
+    static M: OnceLock<HistogramVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let hist = HistogramVec::new(
+            HistogramOpts::new(
+                "noetl_event_ingest_duration_seconds",
+                "Wall-clock time spent inside POST /api/events.",
+            )
+            .buckets(EVENT_INGEST_BUCKETS.to_vec()),
+            &["event_type"],
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(hist.clone()))
+            .expect("histogram registration must succeed");
+        hist
+    })
+}
+
+/// Record a single `POST /api/events` outcome.
+///
+/// `event_type` is the wire event_type from the request
+/// (`"playbook.initialized"`, `"command.claimed"`, etc.).
+/// `status` is `"ok"` on the success path, `"error"` on any
+/// `Err` return.  `duration_seconds` is wall-clock time
+/// inside the handler.
+pub fn record_event_ingest(event_type: &str, status: &str, duration_seconds: f64) {
+    events_ingested_total()
+        .with_label_values(&[event_type, status])
+        .inc();
+    event_ingest_duration_seconds()
+        .with_label_values(&[event_type])
+        .observe(duration_seconds);
+}
+
+/// Render the global registry as Prometheus text-exposition
+/// format.  Used by the `GET /metrics` handler.
+pub fn gather_text() -> Result<String, prometheus::Error> {
+    let encoder = TextEncoder::new();
+    let metric_families = registry().gather();
+    encoder.encode_to_string(&metric_families)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // The registry is process-global, so all tests share state.
+    // We assert on the rendered text after at least one observation
+    // — the test order is `serial_test`-coordinated by the global
+    // registry's internal locks (counters are thread-safe).
+
+    #[test]
+    fn registry_initializes_once() {
+        let a = registry() as *const Registry;
+        let b = registry() as *const Registry;
+        assert_eq!(a, b, "registry() must return the same instance");
+    }
+
+    #[test]
+    fn counter_increments_by_label_set() {
+        events_ingested_total()
+            .with_label_values(&["test.counter_increments", "ok"])
+            .inc();
+        events_ingested_total()
+            .with_label_values(&["test.counter_increments", "ok"])
+            .inc();
+        let value = events_ingested_total()
+            .with_label_values(&["test.counter_increments", "ok"])
+            .get();
+        assert!(value >= 2, "expected at least 2 increments, got {value}");
+    }
+
+    #[test]
+    fn histogram_observes_duration() {
+        event_ingest_duration_seconds()
+            .with_label_values(&["test.histogram_observes"])
+            .observe(0.123);
+        // We can't read the histogram value directly via the public
+        // API, but we can confirm the gathered output mentions it.
+        let text = gather_text().expect("gather_text must succeed");
+        assert!(
+            text.contains("test.histogram_observes"),
+            "expected histogram label in text:\n{text}"
+        );
+    }
+
+    #[test]
+    fn gather_text_contains_metric_names() {
+        record_event_ingest("test.gather_text", "ok", 0.05);
+        let text = gather_text().expect("gather_text must succeed");
+        assert!(
+            text.contains("noetl_events_ingested_total"),
+            "expected counter name in text:\n{text}"
+        );
+        assert!(
+            text.contains("noetl_event_ingest_duration_seconds"),
+            "expected histogram name in text:\n{text}"
+        );
+    }
+
+    #[test]
+    fn record_event_ingest_handles_both_statuses() {
+        record_event_ingest("test.both_statuses", "ok", 0.01);
+        record_event_ingest("test.both_statuses", "error", 0.02);
+        let text = gather_text().expect("gather_text must succeed");
+        assert!(text.contains("test.both_statuses"));
+        // Both label sets should be present.
+        assert!(
+            text.contains("status=\"ok\""),
+            "expected status=ok label in text:\n{text}"
+        );
+        assert!(
+            text.contains("status=\"error\""),
+            "expected status=error label in text:\n{text}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First concrete step of [noetl/server#21](https://github.com/noetl/server/issues/21) (Phase B of noetl/ai-meta#49).  Adds the foundation for "verify under load":

- Global Prometheus registry with lazy-init counters/histograms (`src/metrics.rs`, 5 unit tests).
- \`GET /metrics\` route returning the text-exposition format, gated by the existing \`AppConfig.disable_metrics\` knob.
- \`POST /api/events\` split into wrapper + inner so the wrapper can record \`noetl_events_ingested_total{event_type, status}\` and \`noetl_event_ingest_duration_seconds{event_type}\` on both Ok and Err paths.

Per \`agents/rules/observability.md\` Principles 1, 2, and 4: \`_total\` / \`_seconds\` suffix conventions, low-cardinality labels only, \`execution_id\` stays on tracing spans (never a Prometheus label).

## Test plan

- [x] \`cargo build --release\` — clean
- [x] \`cargo test --release --lib\` — 179/180 pass (one pre-existing failure on \`main\`)
- [x] Kind validation: rebuilt + reloaded image, drove 3x \`POST /api/events\`, scraped \`/metrics\`:
      \`\`\`
      noetl_events_ingested_total{event_type="step.enter",status="error"} 3
      noetl_event_ingest_duration_seconds_bucket{event_type="step.enter",le="0.1"} 3
      \`\`\`

## Round-2 follow-up

The other 5 Phase B POST endpoints in #21 (catalog/register, credentials, keychain, worker/pool/register, worker/pool/heartbeat) get their instrumentation in the next round.

Refs noetl/server#21
Refs noetl/ai-meta#49