### PR TITLE
fix(execute): publish command notification to NATS + insert command row (closes #26)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -54,6 +54,16 @@ pub struct AppConfig {
     /// Runtime offline threshold in seconds
     #[serde(default = "default_offline_seconds")]
     pub runtime_offline_seconds: u64,
+
+    /// Publicly-reachable URL for this server, embedded in NATS
+    /// command notifications so workers know where to call back
+    /// (`GET /api/commands/{event_id}`).  Envy maps
+    /// `NOETL_PUBLIC_SERVER_URL`.  When unset, a localhost
+    /// fallback is used — fine for unit tests, won't work
+    /// cross-pod in kind / GKE so the deployment manifest must
+    /// override.
+    #[serde(default)]
+    pub public_server_url: Option<String>,
 }
 
 fn default_host() -> String {
@@ -108,6 +118,7 @@ impl Default for AppConfig {
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),
+            public_server_url: None,
         }
     }
 }

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -339,10 +339,179 @@ async fn generate_initial_commands(
     .execute(&state.db)
     .await?;
 
-    // TODO: Publish to NATS for worker notification
-    // This would be implemented when NATS module is added
+    // Mirror noetl.command for replay + observability parity with
+    // the Python server.  The worker reads command details from
+    // noetl.event today (the `command.issued` row), so this insert
+    // isn't strictly required for the worker to claim — but the
+    // Python server populates the row and downstream tooling
+    // (replay, dashboards) expects it.  Best-effort: a failure
+    // here is logged but doesn't fail the execution (the event-log
+    // row is the source of truth).
+    if let Err(e) = insert_command_row(
+        state,
+        execution_id,
+        event_id,
+        catalog_id,
+        parent_event_id,
+        &start_step.step,
+        command.tool.kind.as_str(),
+        &cmd_context,
+        &cmd_meta,
+    )
+    .await
+    {
+        tracing::warn!(
+            error = %e,
+            execution_id,
+            event_id,
+            "Failed to insert noetl.command row (non-fatal — event log is source of truth)"
+        );
+    }
+
+    // Publish the command notification to NATS so the worker pool
+    // claims the work.  Without this, the `command.issued` event
+    // sits in noetl.event but no worker hears about it — exactly
+    // the noetl/server#26 failure mode.
+    publish_command_notification(
+        state,
+        execution_id,
+        event_id,
+        &command_id,
+        &start_step.step,
+        command.tool.kind.as_str(),
+        playbook,
+    )
+    .await?;
 
     Ok(1)
+}
+
+/// Insert a row into `noetl.command` mirroring the `command.issued`
+/// event row.  See [`generate_initial_commands`] for the rationale —
+/// the worker doesn't read from this table today but Python's server
+/// populates it and downstream tooling depends on it.
+#[allow(clippy::too_many_arguments)]
+async fn insert_command_row(
+    state: &AppState,
+    execution_id: i64,
+    event_id: i64,
+    catalog_id: i64,
+    parent_event_id: i64,
+    step_name: &str,
+    tool_kind: &str,
+    context: &serde_json::Value,
+    meta: &serde_json::Value,
+) -> AppResult<()> {
+    let command_id = generate_snowflake_id(state).await?;
+    // No ON CONFLICT clause: `noetl.command` is a partitioned
+    // table, so a PRIMARY KEY index on the partition root doesn't
+    // exist — only per-partition indexes do.  PG rejects
+    // `ON CONFLICT (command_id)` as "no unique or exclusion
+    // constraint matching the ON CONFLICT specification".  We use
+    // a fresh snowflake `command_id` per call so duplicate inserts
+    // can't happen on the happy path anyway; on retry the caller
+    // generates a new id.
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.command (
+            command_id, event_id, execution_id, catalog_id,
+            step_name, tool_kind, status, attempt,
+            context, meta, latest_event_id
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+        )
+        "#,
+    )
+    .bind(command_id)
+    .bind(event_id)
+    .bind(execution_id)
+    .bind(catalog_id)
+    .bind(step_name)
+    .bind(tool_kind)
+    .bind("PENDING")
+    .bind(1_i32)
+    .bind(context)
+    .bind(meta)
+    .bind(parent_event_id)
+    .execute(&state.db)
+    .await?;
+    Ok(())
+}
+
+/// Publish a small notification to NATS so the Rust worker pool
+/// (subscribed to `noetl.commands.<segment>.>`) can claim the
+/// command.  The payload shape matches the Python
+/// `NATSEventPublisher.publish_command()` so the worker doesn't
+/// need to distinguish between servers — same wire format.
+///
+/// Subject derivation mirrors the path-based routing scheme in
+/// `repos/noetl/noetl/core/runtime/pool_routing.py`:
+///
+/// - `system/*` playbook paths → `noetl.commands.system.<execution_id>`
+/// - Everything else            → `noetl.commands.shared.<execution_id>`
+///
+/// When NATS isn't configured (e.g. local unit-test mode), the
+/// notification is skipped with a WARN — caller still records the
+/// `command.issued` event so dashboards work, but no worker will
+/// pick the command up.
+async fn publish_command_notification(
+    state: &AppState,
+    execution_id: i64,
+    event_id: i64,
+    command_id: &str,
+    step: &str,
+    _tool_kind: &str,
+    playbook: &crate::playbook::types::Playbook,
+) -> AppResult<()> {
+    let Some(nats_client) = state.nats.as_ref() else {
+        tracing::warn!(
+            execution_id,
+            event_id,
+            "NATS not configured; command notification skipped — worker won't claim this command"
+        );
+        return Ok(());
+    };
+
+    // Pool segment from the playbook's catalog path.  The
+    // `Playbook` type's `metadata.path` is `Option<String>`; if
+    // unset we default to `shared` (the same default Python uses).
+    let pool_segment = match playbook.metadata.path.as_deref() {
+        Some(p) if p.starts_with("system/") => "system",
+        _ => "shared",
+    };
+    let subject = format!("noetl.commands.{}.{}", pool_segment, execution_id);
+
+    let server_url = state
+        .config
+        .public_server_url
+        .clone()
+        .unwrap_or_else(|| "http://localhost:8082".to_string());
+
+    let notification = serde_json::json!({
+        "execution_id": execution_id,
+        "event_id": event_id,
+        "command_id": command_id,
+        "step": step,
+        "server_url": server_url,
+    });
+    let payload = serde_json::to_vec(&notification)
+        .map_err(|e| AppError::Internal(format!("Serialize command notification: {e}")))?;
+
+    let js = async_nats::jetstream::new((**nats_client).clone());
+    js.publish(subject.clone(), payload.into())
+        .await
+        .map_err(|e| AppError::Internal(format!("NATS publish failed: {e}")))?
+        .await
+        .map_err(|e| AppError::Internal(format!("NATS publish ack failed: {e}")))?;
+
+    tracing::info!(
+        execution_id,
+        event_id,
+        %subject,
+        command_id = %command_id,
+        "Published command notification to NATS"
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,22 +291,72 @@ fn build_router(
 }
 
 /// Connect to NATS if configured.
+///
+/// `async_nats::connect()` only parses the addr portion of the
+/// URL — it does NOT pick up the `user:pass@` segment, so an
+/// account-authenticated server (the cluster's `NOETL` account
+/// with `noetl/noetl`) rejects the connection with
+/// "authorization violation".  Mirror the worker's
+/// `subscriber.rs` shape: strip the userinfo, build
+/// `ConnectOptions::with_user_and_password`, pass the cleaned
+/// URL.  See noetl/server#26 for the discovery (Phase B R3 of
+/// noetl/ai-meta#49 surfaced this — pre-existing but unnoticed
+/// since prior rounds didn't need a Rust-side NATS publish).
 async fn connect_nats(config: &AppConfig) -> Option<async_nats::Client> {
-    if let Some(ref nats_url) = config.nats_url {
-        match async_nats::connect(nats_url).await {
-            Ok(client) => {
-                tracing::info!(url = %nats_url, "Connected to NATS");
-                Some(client)
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, url = %nats_url, "Failed to connect to NATS, continuing without it");
-                None
-            }
-        }
-    } else {
+    let Some(ref nats_url) = config.nats_url else {
         tracing::info!("NATS not configured, running without messaging");
-        None
+        return None;
+    };
+
+    // Strip + parse userinfo if present.
+    let (clean_url, creds) = strip_nats_userinfo(nats_url);
+    let connect_future = match creds {
+        Some((user, password)) => async_nats::ConnectOptions::with_user_and_password(user, password)
+            .connect(&clean_url),
+        None => async_nats::ConnectOptions::new().connect(&clean_url),
+    };
+
+    match connect_future.await {
+        Ok(client) => {
+            tracing::info!(url = %clean_url, "Connected to NATS");
+            Some(client)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, url = %clean_url, "Failed to connect to NATS, continuing without it");
+            None
+        }
     }
+}
+
+/// Strip the `user:pass@` portion from a NATS URL and return the
+/// cleaned URL alongside the parsed credentials, if any.
+///
+/// `async_nats::ConnectOptions` rejects URLs with embedded creds,
+/// so we feed it the cleaned form + the creds via
+/// `with_user_and_password`.  Mirrors the equivalent helper in
+/// `noetl-worker::nats::subscriber`.
+fn strip_nats_userinfo(url: &str) -> (String, Option<(String, String)>) {
+    // Match `<scheme>://<userinfo>@<rest>` — userinfo is the
+    // `user:password` pair the standard `host:port` URL parser
+    // ignores when it's embedded.
+    let scheme_sep = "://";
+    let Some(scheme_idx) = url.find(scheme_sep) else {
+        return (url.to_string(), None);
+    };
+    let after_scheme = &url[scheme_idx + scheme_sep.len()..];
+    let Some(at_idx) = after_scheme.find('@') else {
+        return (url.to_string(), None);
+    };
+    let userinfo = &after_scheme[..at_idx];
+    let rest = &after_scheme[at_idx + 1..];
+    let mut parts = userinfo.splitn(2, ':');
+    let user = parts.next().unwrap_or("").to_string();
+    let password = parts.next().unwrap_or("").to_string();
+    if user.is_empty() {
+        return (url.to_string(), None);
+    }
+    let cleaned = format!("{}{}{}", &url[..scheme_idx], scheme_sep, rest);
+    (cleaned, Some((user, password)))
 }
 
 /// Get encryption key from environment or use default.


### PR DESCRIPTION
## Summary

Closes [noetl/server#26](https://github.com/noetl/server/issues/26).  Unblocks Phase B Rounds 3 + 4 of [noetl/server#21](https://github.com/noetl/server/issues/21) (noetl/ai-meta#49).

\`POST /api/execute\` previously recorded \`playbook_started\` + \`command.issued\` events but never published the command notification to NATS — the worker had nothing to claim.

This PR:
1. **NATS publish** — sends a \`{execution_id, event_id, command_id, step, server_url}\` notification (same shape as Python's \`NATSEventPublisher.publish_command\`) on \`noetl.commands.<segment>.<execution_id>\` where segment is \`system\` for \`system/*\` paths and \`shared\` for everything else.
2. **\`noetl.command\` row** — mirrors the \`command.issued\` event for replay / dashboard parity (best-effort, non-fatal).
3. **Pre-existing NATS auth bug fixed** — \`async_nats::connect(url)\` silently drops the \`user:pass@\` segment.  Mirrored the worker's \`subscriber.rs\` shape: strip userinfo, build \`ConnectOptions::with_user_and_password\`, pass cleaned URL.
4. **New config field** \`AppConfig.public_server_url\` (envy: \`NOETL_PUBLIC_SERVER_URL\`) — embedded in the notification so workers know where to call back.  Companion ops manifest update wires it to \`http://noetl-server-rust.noetl.svc.cluster.local:8082\`.

## Kind verification

After deploy + Phase B R3 harness re-run:

\`\`\`
Server: Connected to NATS, Published command notification to NATS subject=noetl.commands.shared.<eid>
Worker: Command claimed command_id=<...> step=start
noetl.event: playbook_started → command.issued → command.claimed → command.started → call.error → command.failed
\`\`\`

Worker claims + executes + POSTs back the full lifecycle.  Downstream \`call.error\` is a tool-dispatch concern outside #26.

## Companion PR

A small ops manifest change to set \`NOETL_PUBLIC_SERVER_URL\` is part of the same change set and ships in the noetl/ops branch alongside this server PR.

## Test plan

- [x] \`cargo build --release\` — clean
- [x] \`cargo test --release --lib\` — 182/183 pass (1 pre-existing failure on \`main\`)
- [x] Kind validation: worker claimed + lifecycle events landed

Closes noetl/server#26
Refs noetl/server#21
Refs noetl/ai-meta#49