### PR TITLE
fix(execute): emit args:{} (not args:null) in command.issued context

### DIFF
--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -294,10 +294,25 @@ async fn generate_initial_commands(
     let event_id = generate_snowflake_id(state).await?;
     let command_id = format!("{}:{}:{}", execution_id, start_step.step, event_id);
 
-    // Build context for command execution
+    // Build context for command execution.
+    //
+    // `start_step.args` is `Option<HashMap<String, Value>>`.  We
+    // emit it as `args: {}` when unset, not `args: null`, because
+    // the worker's command-handling path (`command::execute_command`
+    // in `repos/worker/src/executor/`) copies a missing tool-side
+    // `args` from the top-level `args` key.  A `null` there
+    // surfaces inside the tool config and serde rejects it as
+    // "expected a map" when deserialising into `HashMap`.  Mirror
+    // Python's empty-map default (the Python server emits
+    // `input: {}` here — same intent, slightly different key
+    // naming that future Phase D work will reconcile).
+    let cmd_args = match &start_step.args {
+        Some(map) => serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})),
+        None => serde_json::json!({}),
+    };
     let cmd_context = serde_json::json!({
         "tool_config": command.tool.config,
-        "args": start_step.args,
+        "args": cmd_args,
         "render_context": context,
     });
 


### PR DESCRIPTION
## Summary

Phase B Round 3 follow-up to [noetl/server#27](https://github.com/noetl/server/pull/27).  The kind validation after #27 surfaced a \`call.error\` event with:

\`\`\`
Configuration error: Invalid python config: invalid type: null, expected a map
\`\`\`

## Root cause

\`generate_initial_commands\` serialised \`start_step.args\` (an \`Option<HashMap<...>>\`) directly, which produces \`args: null\` when \`None\`.  The worker (\`repos/worker/src/executor/command.rs\`) copies a missing tool-side \`args\` from the top-level \`args\` key, so \`null\` ends up inside the python tool config.  Serde fails to deserialise \`null\` into \`HashMap\` with "expected a map".

## Fix

Map \`None\` → \`{}\`, \`Some(map)\` → the serialised map.  Mirrors Python's \`input: {}\` default for empty inputs.

## Verification

After this fix the Round-3 harness produces a clean lifecycle:

\`\`\`
playbook_started → command.issued → command.claimed →
command.started → call.done → command.completed
\`\`\`

Previously ended in \`call.error → command.failed\`.

\`command.issued\` context now emits \`args: {}\` (verified via SQL).

## Test plan

- [x] \`cargo build --release\` — clean
- [x] Kind validation: routing_test runs to terminal \`command.completed\`

Refs noetl/server#27, noetl/server#21, noetl/ai-meta#49