### PR TITLE
feat(orchestrator): wire trigger_orchestrator + persist_engine_command (Phase D R2)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -598,9 +598,14 @@ pub async fn claim_command(
     }
 
     let claim_event_id = generate_snowflake_id_with_tx(&mut tx).await?;
+    // Constraint-compliant `{status, context}` envelope — see
+    // noetl/server#29 for why `{kind, data}` was rejected.  The
+    // explicit claim path was missed in v2.4.3 because the load
+    // smoke only exercised handle_event; Phase D Round 2's
+    // multi-step kind validation surfaced it.
     let claim_result = serde_json::json!({
-        "kind": "data",
-        "data": {
+        "status": "RUNNING",
+        "context": {
             "command_id": command_id,
             "worker_id": request.worker_id,
         }
@@ -682,10 +687,19 @@ pub async fn handle_batch_events(
         let event_id = generate_snowflake_id_with_tx(&mut tx).await?;
         let status = event_status_from_name(&item.event_type);
 
-        let result_obj_raw = serde_json::json!({
-            "kind": "data",
-            "data": item.payload,
-        });
+        // Constraint-compliant `{status, context}` envelope per
+        // noetl/server#29.  Same shape rule as build_result_object
+        // in handle_event_inner: `context` only when payload is
+        // an object; otherwise emit `{status}` alone.
+        let mut result_map = serde_json::Map::new();
+        result_map.insert(
+            "status".to_string(),
+            serde_json::Value::String(status.to_string()),
+        );
+        if let serde_json::Value::Object(_) = item.payload {
+            result_map.insert("context".to_string(), item.payload.clone());
+        }
+        let result_obj_raw = serde_json::Value::Object(result_map);
         let result_obj = sanitize_sensitive_data(&result_obj_raw);
 
         let mut meta_obj = serde_json::json!({
@@ -728,6 +742,32 @@ pub async fn handle_batch_events(
     }
 
     tx.commit().await?;
+
+    // Trigger orchestrator for any command.completed in the batch
+    // whose step is not the playbook's terminal `end` block.  Mirrors
+    // the call site in `handle_event` above; runs once per qualifying
+    // event so a batch with multiple completions can still advance
+    // multi-step playbooks.  Errors are logged and swallowed so a
+    // bad-state evaluation doesn't fail the whole batch ingest.
+    for (idx, item) in request.events.iter().enumerate() {
+        if item.event_type == "command.completed" && item.step.to_lowercase() != "end" {
+            let trigger_event_id = event_ids[idx];
+            match trigger_orchestrator(&state, execution_id, trigger_event_id).await {
+                Ok(cmds) => {
+                    info!(
+                        "Orchestrator (batch) generated {} commands for execution {} step {}",
+                        cmds, execution_id, item.step
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Orchestrator error in batch for execution {} step {}: {}",
+                        execution_id, item.step, e
+                    );
+                }
+            }
+        }
+    }
 
     Ok(Json(BatchEventResponse {
         status: "ok".to_string(),
@@ -910,20 +950,251 @@ fn event_status_from_name(event_name: &str) -> &'static str {
 }
 
 /// Trigger orchestrator for workflow progression.
+///
+/// Phase D Round 2 of noetl/ai-meta#49 — wires the previously-
+/// stubbed orchestrator to the real
+/// [`crate::engine::WorkflowOrchestrator::evaluate`] pipeline.
+///
+/// Pipeline:
+///
+/// 1. Load all `noetl.event` rows for this execution (sorted by
+///    `event_id` so [`WorkflowState::from_events`] reconstructs
+///    state in the canonical order).
+/// 2. Resolve `catalog_id` from one of the events, load the
+///    playbook YAML, parse to [`Playbook`].
+/// 3. Call `orchestrator.evaluate(&events, &playbook,
+///    Some("command.completed"))`.
+/// 4. For each [`EventToEmit`] returned (e.g. `step.enter` rows
+///    for the next step), insert into `noetl.event`.
+/// 5. For each [`engine::Command`] returned, look up the matching
+///    [`Step`] in the playbook and call
+///    [`crate::handlers::execute::persist_engine_command`] —
+///    which inserts the `command.issued` event, the
+///    `noetl.command` row, and publishes the NATS notification
+///    (same code path the `/api/execute` first-command uses, so
+///    the wire format stays consistent).
+/// 6. If `result.should_complete` is set, emit a final
+///    `playbook.completed` or `playbook.failed` event so
+///    downstream consumers can observe terminal state.
+///
+/// `trigger_event_id` is the `event_id` of the event that
+/// triggered this evaluation pass (usually the `command.completed`
+/// row).  It's used as the `parent_event_id` for newly-inserted
+/// events so the event log forms a proper causal chain.
 async fn trigger_orchestrator(
-    _state: &AppState,
+    state: &AppState,
     execution_id: i64,
     trigger_event_id: i64,
 ) -> AppResult<i32> {
-    // This would be a full orchestrator implementation
-    // For now, just log and return 0
+    use crate::engine::WorkflowOrchestrator;
+    use sqlx::Row;
+
     debug!(
-        "Would trigger orchestrator for execution={}, trigger_event={}",
-        execution_id, trigger_event_id
+        execution_id,
+        trigger_event_id, "trigger_orchestrator: loading events"
     );
 
-    // TODO: Load playbook, reconstruct state from events, evaluate next steps
-    Ok(0)
+    // 1. Load all events for this execution.
+    //
+    // `attempt` is stored inside `meta` JSONB (no dedicated column on
+    // noetl.event today — same shape Python projector uses), so we
+    // source it via `meta->>'attempt'` cast to int.
+    let rows = sqlx::query(
+        r#"
+        SELECT event_id, execution_id, catalog_id,
+               parent_event_id, parent_execution_id,
+               event_type, node_id, node_name, node_type, status,
+               context, meta, result, worker_id,
+               NULLIF(meta->>'attempt', '')::int AS attempt,
+               created_at
+        FROM noetl.event
+        WHERE execution_id = $1
+        ORDER BY event_id ASC
+        "#,
+    )
+    .bind(execution_id)
+    .fetch_all(&state.db)
+    .await?;
+
+    let events: Vec<crate::db::models::Event> = rows
+        .into_iter()
+        .map(|r| crate::db::models::Event {
+            id: r.try_get("event_id").unwrap_or(0),
+            execution_id: r.try_get("execution_id").unwrap_or(0),
+            catalog_id: r.try_get("catalog_id").unwrap_or(0),
+            event_id: r.try_get("event_id").unwrap_or(0),
+            parent_event_id: r.try_get("parent_event_id").ok(),
+            parent_execution_id: r.try_get("parent_execution_id").ok(),
+            event_type: r.try_get("event_type").unwrap_or_default(),
+            node_id: r.try_get("node_id").ok(),
+            node_name: r.try_get("node_name").ok(),
+            node_type: r.try_get("node_type").ok(),
+            status: r.try_get("status").unwrap_or_default(),
+            context: r.try_get("context").ok(),
+            meta: r.try_get("meta").ok(),
+            result: r.try_get("result").ok(),
+            worker_id: r.try_get("worker_id").ok(),
+            attempt: r.try_get("attempt").ok(),
+            created_at: r.try_get("created_at").unwrap_or_else(|_| chrono::Utc::now()),
+        })
+        .collect();
+
+    if events.is_empty() {
+        debug!(execution_id, "No events to evaluate — orchestrator exit early");
+        return Ok(0);
+    }
+
+    // 2. Look up catalog_id + playbook content.
+    let catalog_id = events
+        .iter()
+        .find_map(|e| {
+            if e.catalog_id > 0 {
+                Some(e.catalog_id)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            AppError::Internal(format!(
+                "No catalog_id found in events for execution {execution_id}"
+            ))
+        })?;
+
+    let playbook_yaml: String = sqlx::query_scalar(
+        "SELECT content FROM noetl.catalog WHERE catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| {
+        AppError::Internal(format!(
+            "Failed to load playbook for catalog_id {catalog_id}: {e}"
+        ))
+    })?;
+    let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
+
+    // 3. Evaluate.
+    let orchestrator = WorkflowOrchestrator::new();
+    let result = orchestrator
+        .evaluate(&events, &playbook, Some("command.completed"))
+        .map_err(|e| AppError::Internal(format!("Orchestrator evaluate failed: {e}")))?;
+
+    info!(
+        execution_id,
+        trigger_event_id,
+        new_commands = result.commands.len(),
+        new_events = result.events_to_emit.len(),
+        should_complete = result.should_complete,
+        "Orchestrator evaluate complete"
+    );
+
+    // 4. Emit pure events (step.enter etc.) before issuing new
+    //    commands so the causal chain is correct.
+    for emit in &result.events_to_emit {
+        let event_id = generate_snowflake_id(state).await?;
+        let event_status = if emit.status.is_empty() {
+            "STARTED".to_string()
+        } else {
+            emit.status.clone()
+        };
+
+        // Compose the constraint-compliant {status, context} result
+        // envelope when context is present, else {status} alone.
+        let result_obj = match &emit.context {
+            Some(serde_json::Value::Object(_)) => serde_json::json!({
+                "status": event_status,
+                "context": emit.context.clone().unwrap(),
+            }),
+            _ => serde_json::json!({"status": event_status}),
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO noetl.event (
+                event_id, execution_id, catalog_id, event_type,
+                node_id, node_name, status, result, meta, created_at, parent_event_id
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            "#,
+        )
+        .bind(event_id)
+        .bind(execution_id)
+        .bind(catalog_id)
+        .bind(&emit.event_type)
+        .bind(emit.node_name.as_deref())
+        .bind(emit.node_name.as_deref())
+        .bind(&event_status)
+        .bind(&result_obj)
+        .bind(serde_json::json!({"emitted_by": "orchestrator"}))
+        .bind(chrono::Utc::now())
+        .bind(trigger_event_id)
+        .execute(&state.db)
+        .await?;
+    }
+
+    // 5. Issue new commands via the shared persist + publish helper.
+    let mut commands_generated = 0i32;
+    for command in &result.commands {
+        let step = playbook.get_step(&command.step_name).ok_or_else(|| {
+            AppError::Internal(format!(
+                "Orchestrator returned command for unknown step '{}'",
+                command.step_name
+            ))
+        })?;
+
+        let render_context: std::collections::HashMap<String, serde_json::Value> =
+            command.context.clone().unwrap_or_default();
+
+        crate::handlers::execute::persist_engine_command(
+            state,
+            execution_id,
+            catalog_id,
+            trigger_event_id,
+            step,
+            command,
+            &render_context,
+            &playbook,
+        )
+        .await?;
+        commands_generated += 1;
+    }
+
+    // 6. Emit terminal playbook event when the orchestrator says so.
+    if result.should_complete {
+        let (event_type, status) = match &result.completion_status {
+            Some(cs) if cs.status == "FAILED" => ("playbook.failed", "FAILED"),
+            _ => ("playbook.completed", "COMPLETED"),
+        };
+        let event_id = generate_snowflake_id(state).await?;
+        let terminal_meta = serde_json::to_value(&result.completion_status).unwrap_or_default();
+        sqlx::query(
+            r#"
+            INSERT INTO noetl.event (
+                event_id, execution_id, catalog_id, event_type,
+                node_id, node_name, status, result, meta, created_at, parent_event_id
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            "#,
+        )
+        .bind(event_id)
+        .bind(execution_id)
+        .bind(catalog_id)
+        .bind(event_type)
+        .bind("playbook")
+        .bind("playbook")
+        .bind(status)
+        .bind(serde_json::json!({"status": status}))
+        .bind(terminal_meta)
+        .bind(chrono::Utc::now())
+        .bind(trigger_event_id)
+        .execute(&state.db)
+        .await?;
+        info!(
+            execution_id,
+            terminal_event = %event_type,
+            "Orchestrator marked execution as terminal"
+        );
+    }
+
+    Ok(commands_generated)
 }
 
 #[cfg(test)]

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -241,6 +241,123 @@ async fn emit_playbook_started_event(
     Ok(event_id)
 }
 
+/// Persist one engine-generated command + its `command.issued`
+/// event + its NATS notification.
+///
+/// Used both by `generate_initial_commands` (the `/api/execute`
+/// path that publishes the first command) and by
+/// `trigger_orchestrator` in `events.rs` (the state-machine path
+/// that publishes follow-up commands after `command.completed`
+/// events).  The helper is `pub(crate)` so the events module can
+/// call it without duplicating the wire-format logic that
+/// noetl/ai-meta#49 phases B+C+D-R1 carefully established.
+///
+/// `step` is read for `args` (which the worker copies into the
+/// tool config) and the canonical `step` name.  `command.tool`
+/// supplies the rendered tool kind + config.  The function
+/// generates a fresh `event_id` snowflake for the `command.issued`
+/// row, derives `command_id` from `(execution_id, step, event_id)`,
+/// and threads the notification through NATS via the path-based
+/// routing scheme.
+///
+/// Returns the new `event_id` so callers can attribute downstream
+/// events back to this command.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn persist_engine_command(
+    state: &AppState,
+    execution_id: i64,
+    catalog_id: i64,
+    parent_event_id: i64,
+    step: &crate::playbook::types::Step,
+    command: &crate::engine::commands::Command,
+    render_context: &HashMap<String, serde_json::Value>,
+    playbook: &crate::playbook::types::Playbook,
+) -> AppResult<i64> {
+    let event_id = generate_snowflake_id(state).await?;
+    let command_id = format!("{}:{}:{}", execution_id, step.step, event_id);
+
+    let cmd_args = match &step.args {
+        Some(map) => serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})),
+        None => serde_json::json!({}),
+    };
+    let cmd_context = serde_json::json!({
+        "tool_config": command.tool.config,
+        "args": cmd_args,
+        "render_context": render_context,
+    });
+
+    let cmd_meta = serde_json::json!({
+        "command_id": command_id,
+        "step": step.step,
+        "tool_kind": command.tool.kind,
+        "max_attempts": 3,
+        "attempt": 1,
+        "execution_id": execution_id.to_string(),
+        "catalog_id": catalog_id.to_string(),
+        "actionable": true,
+    });
+
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.event (
+            event_id, execution_id, catalog_id, event_type,
+            node_id, node_name, node_type, status,
+            context, meta, parent_event_id, created_at
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+        )
+        "#,
+    )
+    .bind(event_id)
+    .bind(execution_id)
+    .bind(catalog_id)
+    .bind("command.issued")
+    .bind(&step.step)
+    .bind(&step.step)
+    .bind(command.tool.kind.as_str())
+    .bind("PENDING")
+    .bind(&cmd_context)
+    .bind(&cmd_meta)
+    .bind(parent_event_id)
+    .bind(chrono::Utc::now())
+    .execute(&state.db)
+    .await?;
+
+    if let Err(e) = insert_command_row(
+        state,
+        execution_id,
+        event_id,
+        catalog_id,
+        parent_event_id,
+        &step.step,
+        command.tool.kind.as_str(),
+        &cmd_context,
+        &cmd_meta,
+    )
+    .await
+    {
+        tracing::warn!(
+            error = %e,
+            execution_id,
+            event_id,
+            "Failed to insert noetl.command row (non-fatal — event log is source of truth)"
+        );
+    }
+
+    publish_command_notification(
+        state,
+        execution_id,
+        event_id,
+        &command_id,
+        &step.step,
+        command.tool.kind.as_str(),
+        playbook,
+    )
+    .await?;
+
+    Ok(event_id)
+}
+
 /// Generate initial commands for the start step.
 #[allow(clippy::too_many_arguments)]
 async fn generate_initial_commands(
@@ -290,110 +407,17 @@ async fn generate_initial_commands(
         None,
     )?;
 
-    // Generate event_id for command.issued
-    let event_id = generate_snowflake_id(state).await?;
-    let command_id = format!("{}:{}:{}", execution_id, start_step.step, event_id);
-
-    // Build context for command execution.
-    //
-    // `start_step.args` is `Option<HashMap<String, Value>>`.  We
-    // emit it as `args: {}` when unset, not `args: null`, because
-    // the worker's command-handling path (`command::execute_command`
-    // in `repos/worker/src/executor/`) copies a missing tool-side
-    // `args` from the top-level `args` key.  A `null` there
-    // surfaces inside the tool config and serde rejects it as
-    // "expected a map" when deserialising into `HashMap`.  Mirror
-    // Python's empty-map default (the Python server emits
-    // `input: {}` here — same intent, slightly different key
-    // naming that future Phase D work will reconcile).
-    let cmd_args = match &start_step.args {
-        Some(map) => serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})),
-        None => serde_json::json!({}),
-    };
-    let cmd_context = serde_json::json!({
-        "tool_config": command.tool.config,
-        "args": cmd_args,
-        "render_context": context,
-    });
-
-    let cmd_meta = serde_json::json!({
-        "command_id": command_id,
-        "step": start_step.step,
-        "tool_kind": command.tool.kind,
-        "max_attempts": 3,
-        "attempt": 1,
-        "execution_id": execution_id.to_string(),
-        "catalog_id": catalog_id.to_string(),
-        "actionable": true,
-    });
-
-    // Insert command.issued event
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            event_id, execution_id, catalog_id, event_type,
-            node_id, node_name, node_type, status,
-            context, meta, parent_event_id, created_at
-        ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
-        )
-        "#,
-    )
-    .bind(event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind("command.issued")
-    .bind(&start_step.step)
-    .bind(&start_step.step)
-    .bind(command.tool.kind.as_str())
-    .bind("PENDING")
-    .bind(&cmd_context)
-    .bind(&cmd_meta)
-    .bind(parent_event_id)
-    .bind(chrono::Utc::now())
-    .execute(&state.db)
-    .await?;
-
-    // Mirror noetl.command for replay + observability parity with
-    // the Python server.  The worker reads command details from
-    // noetl.event today (the `command.issued` row), so this insert
-    // isn't strictly required for the worker to claim — but the
-    // Python server populates the row and downstream tooling
-    // (replay, dashboards) expects it.  Best-effort: a failure
-    // here is logged but doesn't fail the execution (the event-log
-    // row is the source of truth).
-    if let Err(e) = insert_command_row(
+    // Persist + publish via the shared helper so the same wire-format
+    // logic feeds both the /api/execute path (this function) and the
+    // orchestrator-triggered transitions in events.rs::trigger_orchestrator.
+    persist_engine_command(
         state,
         execution_id,
-        event_id,
         catalog_id,
         parent_event_id,
-        &start_step.step,
-        command.tool.kind.as_str(),
-        &cmd_context,
-        &cmd_meta,
-    )
-    .await
-    {
-        tracing::warn!(
-            error = %e,
-            execution_id,
-            event_id,
-            "Failed to insert noetl.command row (non-fatal — event log is source of truth)"
-        );
-    }
-
-    // Publish the command notification to NATS so the worker pool
-    // claims the work.  Without this, the `command.issued` event
-    // sits in noetl.event but no worker hears about it — exactly
-    // the noetl/server#26 failure mode.
-    publish_command_notification(
-        state,
-        execution_id,
-        event_id,
-        &command_id,
-        &start_step.step,
-        command.tool.kind.as_str(),
+        start_step,
+        &command,
+        &context,
         playbook,
     )
     .await?;


### PR DESCRIPTION
## Summary

Phase D Round 2 of the Rust-server parity port (Refs noetl/server#22, noetl/ai-meta#49) — wires the existing \`WorkflowOrchestrator\` scaffold into the event-ingest pipeline so multi-step playbooks transition end-to-end.

* \`trigger_orchestrator\` (\`events.rs\`) rewritten from stub to full impl: loads events, parses playbook, calls \`WorkflowOrchestrator::evaluate\`, persists \`OrchestrationResult.events_to_emit\` + commands via the new \`persist_engine_command\` helper, and emits the terminal \`playbook.completed\` / \`playbook.failed\` event.
* \`persist_engine_command\` (\`execute.rs\`) extracted as \`pub(crate)\` so \`/api/execute\` initial commands and orchestrator follow-up commands share one wire-format path. \`generate_initial_commands\` now delegates to it.
* Both \`handle_event\` and \`handle_batch_events\` invoke the orchestrator on \`command.completed\` when \`step != \"end\"\`. The batch arm matters because the Rust worker uses the batch endpoint for terminal events — without this, \`command.completed\` never advanced the state machine.
* \`trigger_orchestrator\` SELECT sources \`attempt\` from \`NULLIF(meta->>'attempt','')::int\` — \`noetl.event\` has no \`attempt\` column; the value lives in \`meta\` JSONB.
* \`claim_command\` result envelope flipped to constraint-compliant \`{status, context}\` shape (noetl/server#29 follow-through that was also tripping kind validation).

## Kind validation

Registered \`tests/fixtures/r2_two_step\` (2-step linear \`start → second → end\` playbook). Ran end-to-end via \`POST /api/execute\` on \`noetl-server-rust\` in \`kind-noetl\`. Event log shows the full lifecycle including the terminal \`playbook.completed\`:

\`\`\`
playbook_started
command.issued(start)        → command.claimed(start) → command.started(start)
call.done(start)             → command.completed(start)
step.enter(second)           → command.issued(second)
command.claimed(second)      → command.started(second)
call.done(second)            → command.completed(second)
playbook.completed
\`\`\`

Server log confirms the orchestrator branch fired:
\`Orchestrator (batch) generated N commands for execution ... step start\`.

## Known follow-up (not in this PR)

Both Rust + Python workers consume the shared NATS subject in kind today, so each step shows two claim cycles in the event log. The terminal lifecycle still converges; tracking under noetl/ai-meta#49 routing follow-up.

## Test plan

- [x] \`cargo build --release\` clean (incremental — no new clippy warnings on the touched modules)
- [x] Kind: rebuild + reload \`noetl-server-rust\` image, redeploy, port-forward, submit fresh execution, verify event log ends at \`playbook.completed\`
- [ ] Reviewers: confirm \`persist_engine_command\` arg layout (it's \`pub(crate)\` and intentionally takes already-rendered \`render_context\` so the helper stays orchestrator-agnostic)

Refs noetl/server#22
Refs noetl/ai-meta#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)