### PR TITLE
feat(orchestrator): step.when enable guard with skip chain (Phase D R3a)

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -306,14 +306,122 @@ impl WorkflowOrchestrator {
                         }
                     }
 
-                    info!("Transitioning to step: {}", next_step_name);
+                    // Iterative `step.when` enable-guard chain.  When a
+                    // step's `when` expression evaluates false we emit
+                    // `step.skipped` instead of `step.enter`, then walk
+                    // forward to that step's own `next` arcs and try
+                    // again — repeats until we land on either a step
+                    // whose guard passes (emit step.enter + command) or
+                    // a terminal/end transition (mark completion).
+                    //
+                    // Doing this inline in the same orchestrator pass
+                    // avoids the re-trigger gymnastics that would
+                    // otherwise be needed: `step.skipped` has no
+                    // `command.completed` to fire the next round on.
+                    let mut current_step: &Step = next_step;
+                    let mut current_step_name: String = next_step_name.clone();
+                    let mut current_with_params = result.with_params.clone();
+                    let mut current_ctx = step_context;
+                    let mut should_dispatch = true;
+                    let mut hit_end = false;
+                    let mut completion: Option<CompletionStatus> = None;
 
-                    // Create step.enter event
+                    loop {
+                        let guard_ok = self
+                            .evaluator
+                            .evaluate_step_when(current_step, &current_ctx)?;
+                        if guard_ok {
+                            break;
+                        }
+
+                        info!(
+                            "Step '{}' skipped (when guard false)",
+                            current_step_name
+                        );
+                        events_to_emit.push(EventToEmit {
+                            event_type: "step.skipped".to_string(),
+                            node_name: Some(current_step_name.clone()),
+                            status: "SKIPPED".to_string(),
+                            context: current_with_params.clone(),
+                            result: None,
+                            error: None,
+                        });
+
+                        // Follow the skipped step's transitions.  Pick
+                        // the first matched arc — once we've decided
+                        // to skip, we've already committed to the
+                        // single-path chain.
+                        let chained =
+                            self.evaluator.evaluate_next(current_step, &current_ctx)?;
+                        let next_after_skip = chained
+                            .into_iter()
+                            .find(|r| r.matched && r.next_step.is_some());
+
+                        let Some(arc) = next_after_skip else {
+                            // No further transition.  Treat the skipped
+                            // step as terminal — workflow ends here
+                            // unless another step is still running.
+                            should_dispatch = false;
+                            break;
+                        };
+                        let target_name = arc.next_step.expect("matched arc has next_step");
+
+                        if target_name == "end" {
+                            hit_end = true;
+                            should_dispatch = false;
+                            completion = Some(CompletionStatus {
+                                status: "COMPLETED".to_string(),
+                                error: None,
+                                failed_steps: None,
+                            });
+                            break;
+                        }
+
+                        let Some(target_step) = steps.get(target_name.as_str()) else {
+                            warn!(
+                                "Chained next step '{}' not found in workflow",
+                                target_name
+                            );
+                            should_dispatch = false;
+                            break;
+                        };
+
+                        // Merge any with_params from the chained arc
+                        // into the context for the next iteration.
+                        if let Some(serde_json::Value::Object(params)) = &arc.with_params {
+                            for (k, v) in params {
+                                current_ctx.insert(k.clone(), v.clone());
+                            }
+                        }
+
+                        current_step = *target_step;
+                        current_step_name = target_name;
+                        current_with_params = arc.with_params;
+                    }
+
+                    if hit_end {
+                        return Ok(OrchestrationResult {
+                            state: ExecutionState::InProgress,
+                            commands: vec![],
+                            should_complete: true,
+                            completion_status: completion,
+                            events_to_emit,
+                        });
+                    }
+
+                    if !should_dispatch {
+                        continue;
+                    }
+
+                    info!("Transitioning to step: {}", current_step_name);
+
+                    // Create step.enter event for the step we landed
+                    // on (after walking the skip chain, if any).
                     events_to_emit.push(EventToEmit {
                         event_type: "step.enter".to_string(),
-                        node_name: Some(next_step_name.clone()),
+                        node_name: Some(current_step_name.clone()),
                         status: "ENTERED".to_string(),
-                        context: result.with_params.clone(),
+                        context: current_with_params,
                         result: None,
                         error: None,
                     });
@@ -324,8 +432,8 @@ impl WorkflowOrchestrator {
                         state.execution_id,
                         state.catalog_id,
                         0,
-                        next_step,
-                        &step_context,
+                        current_step,
+                        &current_ctx,
                         None,
                     )?;
 
@@ -554,6 +662,138 @@ mod tests {
         let status = result.completion_status.unwrap();
         assert_eq!(status.status, "FAILED");
         assert!(status.error.is_some());
+    }
+
+    #[test]
+    fn test_step_when_guard_skips_step() {
+        // Playbook: start → middle (when=false) → end
+        // Expectation: orchestrator emits step.skipped(middle) and
+        // walks the chain forward to `end`, completing the workflow
+        // without ever dispatching a command for `middle`.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let mut start = make_step("start", Some("middle"));
+        // start has no guard
+        start.when = None;
+        let mut middle = make_step("middle", Some("end"));
+        middle.when = Some("{{ false }}".to_string());
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {},
+                    "path": "test",
+                    "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "skip_test".to_string(),
+                path: Some("test/skip".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, middle, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .unwrap();
+
+        // No command dispatched (skip chain reached `end` directly).
+        assert!(
+            result.commands.is_empty(),
+            "skip chain should not dispatch any command, got {:?}",
+            result.commands
+        );
+        // Should complete with status=COMPLETED.
+        assert!(result.should_complete);
+        assert_eq!(
+            result.completion_status.as_ref().map(|c| c.status.as_str()),
+            Some("COMPLETED")
+        );
+        // A step.skipped event was emitted for `middle`.
+        let skipped: Vec<_> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.skipped")
+            .collect();
+        assert_eq!(skipped.len(), 1, "expected one step.skipped event");
+        assert_eq!(skipped[0].node_name.as_deref(), Some("middle"));
+    }
+
+    #[test]
+    fn test_step_when_guard_passes_dispatches_step() {
+        // Same shape but middle's when is true — orchestrator
+        // should dispatch a command for `middle` and emit
+        // step.enter(middle) (no step.skipped).
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step("start", Some("middle"));
+        let mut middle = make_step("middle", Some("end"));
+        middle.when = Some("{{ true }}".to_string());
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {},
+                    "path": "test",
+                    "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "guard_test".to_string(),
+                path: Some("test/guard".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, middle, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .unwrap();
+
+        assert_eq!(result.commands.len(), 1, "should dispatch middle");
+        let enters: Vec<_> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.enter")
+            .collect();
+        assert_eq!(enters.len(), 1);
+        assert_eq!(enters[0].node_name.as_deref(), Some("middle"));
+        let skipped = result
+            .events_to_emit
+            .iter()
+            .any(|e| e.event_type == "step.skipped");
+        assert!(!skipped, "should NOT emit step.skipped when guard passes");
     }
 
     #[test]

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -383,11 +383,22 @@ impl WorkflowState {
     pub fn build_context(&self) -> serde_json::Value {
         let mut context = serde_json::Map::new();
 
-        // Add workload variables
+        // Add workload variables.  Each key is exposed both at the
+        // top level (so `{{ skip_middle }}` works) AND under the
+        // `workload` namespace (so `{{ workload.skip_middle }}`
+        // works) — matches the Python reference shape and the
+        // generate_initial_commands path in handlers/execute.rs.
+        // Without the `workload` namespace, step.when expressions
+        // that reference `workload.X` raise an undefined-value
+        // template error during transition evaluation.
         if let Some(serde_json::Value::Object(wl)) = &self.workload {
             for (k, v) in wl {
                 context.insert(k.clone(), v.clone());
             }
+            context.insert(
+                "workload".to_string(),
+                serde_json::Value::Object(wl.clone()),
+            );
         }
 
         // Add step results under 'steps' namespace


### PR DESCRIPTION
## Summary

Phase D Round 3a of the Rust-server parity port (Refs noetl/server#22, noetl/ai-meta#49) — wires the **\`step.when\` enable guard** through the orchestrator's transition path. First of three Phase D R3 control-flow features (conditionals, iterators, parallel).

### What landed

* **\`engine/orchestrator.rs\`**: before emitting \`step.enter\` + dispatching a command for a selected \`next_step\`, evaluate \`next_step.when\` via the existing \`Evaluator::evaluate_step_when\`. If the guard returns false, emit \`step.skipped\` and walk forward to the skipped step's own next-arcs **in the same orchestrator pass** — repeats until landing on either a step whose guard passes (dispatch normally) or a terminal/\`end\` transition (mark completion).

  Inline iteration rather than re-triggering on \`step.skipped\` because the skipped step has no \`command.completed\` event to fire the next orchestration round on.

* **\`engine/state.rs build_context\`**: expose workload BOTH at the top level (\`{{ skip_middle }}\`) AND under the \`workload\` namespace (\`{{ workload.skip_middle }}\`). Mirrors the namespace shape \`generate_initial_commands\` in \`handlers/execute.rs\` already uses. Without this, any \`step.when\` expression referencing \`workload.*\` raised an undefined-value template error during transition evaluation — caught during the first kind-val pass.

### Tests

Two new orchestrator unit tests cover both branches:

* \`test_step_when_guard_skips_step\` — \`middle.when=\"{{ false }}\"\` → no command, \`step.skipped\` emitted, workflow completes via chained \`end\` transition.
* \`test_step_when_guard_passes_dispatches_step\` — \`middle.when=\"{{ true }}\"\` → command for \`middle\` dispatched, no \`step.skipped\`.

\`cargo test --release --lib engine\`: 22/22 pass.

### Kind validation

\`tests/fixtures/r3a_conditional\` — 4-step playbook \`start → middle [when: {{ not workload.skip_middle }}] → tail → end\`.

**Run 1** (\`skip_middle=false\`, execution \`641335907060024244\`):

\`\`\`
playbook_started
command.issued(start)  → command.completed(start)
step.enter(middle)     → command.issued(middle)  → command.completed(middle)
step.enter(tail)       → command.issued(tail)    → command.completed(tail)
playbook.completed
\`\`\`

**Run 2** (\`skip_middle=true\`, execution \`641335907630449592\`):

\`\`\`
playbook_started
command.issued(start)  → command.completed(start)
step.skipped(middle)                                ← new behaviour
step.enter(tail)       → command.issued(tail)      → command.completed(tail)
playbook.completed
\`\`\`

Run 2 dispatches no command for \`middle\` — the orchestrator walked the chain from \`start\` through the skipped \`middle\` directly to \`tail\` in a single pass.

## Test plan

- [x] Unit tests: \`cargo test --release --lib engine\` → 22/22 pass
- [x] Kind validation: both branches end at \`playbook.completed\` with the expected node_name sequence
- [ ] Reviewers: confirm the inline skip-chain shape vs. potential alternative (re-trigger on \`step.skipped\` event). The inline path avoids needing a synthetic \`command.completed\` for the skipped step and keeps state-machine semantics single-pass.

## Known follow-ups (not in this PR)

* Phase D R3b — iterators (\`step.loop\` fan-out via \`CommandBuilder::build_iteration_command\`)
* Phase D R3c — parallel branches (likely already works via \`NextSpec::List\` — needs a kind-val fixture)
* Dual-worker NATS subject race in kind continues (cosmetic — both Rust + Python workers consume shared subject, each step gets two claim cycles in the event log; terminal lifecycle still converges).

Refs noetl/server#22
Refs noetl/ai-meta#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)