### PR TITLE
feat(orchestrator): step.loop iterator fan-out + state aggregation (Phase D R3b)

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -14,9 +14,35 @@ use crate::db::models::Event;
 use crate::error::{AppError, AppResult};
 use crate::playbook::types::{Playbook, Step};
 
-use super::commands::{Command, CommandBuilder};
+use super::commands::{Command, CommandBuilder, IteratorMetadata};
 use super::evaluator::ConditionEvaluator;
 use super::state::{ExecutionState, WorkflowState};
+
+/// Merge iterator metadata into the step-enter context so
+/// `state.apply_event` can stamp `iterations_expected` (and a
+/// readable iterator name) onto the resulting `StepInfo` during
+/// state reconstruction.  `with_params` is the existing transition
+/// context (if any); the helper returns a new JSON object that
+/// includes both that AND the iteration keys.
+fn merge_iteration_context(
+    with_params: Option<serde_json::Value>,
+    iterations_expected: i32,
+    iterator_var: &str,
+) -> serde_json::Value {
+    let mut obj = match with_params {
+        Some(serde_json::Value::Object(m)) => m,
+        _ => serde_json::Map::new(),
+    };
+    obj.insert(
+        "iterations_expected".to_string(),
+        serde_json::json!(iterations_expected),
+    );
+    obj.insert(
+        "iterator_var".to_string(),
+        serde_json::Value::String(iterator_var.to_string()),
+    );
+    serde_json::Value::Object(obj)
+}
 
 /// Result of orchestration evaluation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -413,6 +439,107 @@ impl WorkflowOrchestrator {
                         continue;
                     }
 
+                    // R3b iterator fan-out: if the landed step
+                    // declares `step.loop`, evaluate the loop
+                    // expression and emit one command per item.  The
+                    // single `step.enter` event carries
+                    // `iterations_expected` in its context so state
+                    // reconstruction can aggregate per-iteration
+                    // `command.completed` events into one
+                    // step-level completion (see
+                    // `state.rs::apply_event`).  Sequential and
+                    // parallel modes both fan out the same way at
+                    // this layer; concurrency is shaped downstream
+                    // by the worker pool.
+                    if let Some(loop_cfg) = current_step.r#loop.as_ref() {
+                        let items = self
+                            .evaluator
+                            .evaluate_loop(&loop_cfg.in_expr, &current_ctx)?;
+                        let total: usize = items.len();
+
+                        if total == 0 {
+                            // Empty collection — emit step.enter with
+                            // total=0 + a synthetic step.exit so
+                            // downstream transitions still fire.  No
+                            // command dispatched.
+                            info!(
+                                "Iterator step '{}' produced empty collection — short-circuiting",
+                                current_step_name
+                            );
+                            let enter_ctx = merge_iteration_context(
+                                current_with_params.clone(),
+                                0i32,
+                                &loop_cfg.iterator,
+                            );
+                            events_to_emit.push(EventToEmit {
+                                event_type: "step.enter".to_string(),
+                                node_name: Some(current_step_name.clone()),
+                                status: "ENTERED".to_string(),
+                                context: Some(enter_ctx),
+                                result: None,
+                                error: None,
+                            });
+                            events_to_emit.push(EventToEmit {
+                                event_type: "step.exit".to_string(),
+                                node_name: Some(current_step_name.clone()),
+                                status: "COMPLETED".to_string(),
+                                context: None,
+                                result: Some(serde_json::Value::Array(vec![])),
+                                error: None,
+                            });
+                            continue;
+                        }
+
+                        info!(
+                            "Fanning out {} iterations for step '{}' (iterator='{}')",
+                            total, current_step_name, loop_cfg.iterator
+                        );
+
+                        // One `step.enter` carries the total so
+                        // state.apply_event can stamp
+                        // iterations_expected onto the StepInfo.
+                        let enter_ctx = merge_iteration_context(
+                            current_with_params.clone(),
+                            total as i32,
+                            &loop_cfg.iterator,
+                        );
+                        events_to_emit.push(EventToEmit {
+                            event_type: "step.enter".to_string(),
+                            node_name: Some(current_step_name.clone()),
+                            status: "ENTERED".to_string(),
+                            context: Some(enter_ctx),
+                            result: None,
+                            error: None,
+                        });
+
+                        // One command per item via
+                        // build_iteration_command (which injects
+                        // `<iterator>`, `_index`, `_total` into the
+                        // command's render context).
+                        for (idx, item) in items.into_iter().enumerate() {
+                            let iter_meta = IteratorMetadata {
+                                parent_execution_id: state.execution_id,
+                                iterator_step: current_step_name.clone(),
+                                item_var: loop_cfg.iterator.clone(),
+                                item,
+                                index: idx,
+                                total,
+                            };
+                            let command = self.command_builder.build_iteration_command(
+                                0,
+                                state.execution_id,
+                                state.catalog_id,
+                                0,
+                                current_step,
+                                &current_ctx,
+                                iter_meta,
+                            )?;
+                            commands.push(command);
+                        }
+
+                        continue;
+                    }
+
                     info!("Transitioning to step: {}", current_step_name);
 
                     // Create step.enter event for the step we landed
@@ -794,6 +921,154 @@ mod tests {
             .iter()
             .any(|e| e.event_type == "step.skipped");
         assert!(!skipped, "should NOT emit step.skipped when guard passes");
+    }
+
+    #[test]
+    fn test_step_loop_fans_out_iterations() {
+        // Playbook: start → looped (loop.in=[1,2,3]) → end.
+        // Expectation: orchestrator emits one step.enter(looped)
+        // carrying iterations_expected=3 in context, and dispatches
+        // three commands (one per item) each with iterator metadata.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step("start", Some("looped"));
+        let mut looped = make_step("looped", Some("end"));
+        looped.r#loop = Some(crate::playbook::types::Loop {
+            in_expr: "{{ [1, 2, 3] }}".to_string(),
+            iterator: "n".to_string(),
+            spec: None,
+        });
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {},
+                    "path": "test",
+                    "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "loop_test".to_string(),
+                path: Some("test/loop".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, looped, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .unwrap();
+
+        // Three iteration commands.
+        assert_eq!(
+            result.commands.len(),
+            3,
+            "expected 3 iteration commands, got {}",
+            result.commands.len()
+        );
+        // All carry iterator metadata.
+        for (idx, cmd) in result.commands.iter().enumerate() {
+            let iter = cmd.iterator.as_ref().expect("iterator metadata present");
+            assert_eq!(iter.index, idx);
+            assert_eq!(iter.total, 3);
+            assert_eq!(iter.iterator_step, "looped");
+            assert_eq!(iter.item_var, "n");
+        }
+        // Exactly one step.enter, with iterations_expected=3.
+        let enters: Vec<_> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.enter")
+            .collect();
+        assert_eq!(enters.len(), 1);
+        assert_eq!(enters[0].node_name.as_deref(), Some("looped"));
+        let enter_ctx = enters[0].context.as_ref().unwrap();
+        assert_eq!(
+            enter_ctx.get("iterations_expected").and_then(|v| v.as_i64()),
+            Some(3)
+        );
+        assert_eq!(
+            enter_ctx.get("iterator_var").and_then(|v| v.as_str()),
+            Some("n")
+        );
+    }
+
+    #[test]
+    fn test_step_loop_empty_collection_short_circuits() {
+        // Loop expression evaluates to []; orchestrator should
+        // emit step.enter (iterations_expected=0) AND a synthetic
+        // step.exit so transitions downstream still fire.  No
+        // commands dispatched.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step("start", Some("looped"));
+        let mut looped = make_step("looped", Some("end"));
+        looped.r#loop = Some(crate::playbook::types::Loop {
+            in_expr: "{{ [] }}".to_string(),
+            iterator: "x".to_string(),
+            spec: None,
+        });
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {},
+                    "path": "test",
+                    "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "loop_empty".to_string(),
+                path: Some("test/loop_empty".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, looped, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .unwrap();
+        assert!(
+            result.commands.is_empty(),
+            "empty collection should dispatch no commands"
+        );
+        let types: Vec<&str> = result
+            .events_to_emit
+            .iter()
+            .map(|e| e.event_type.as_str())
+            .collect();
+        assert!(types.contains(&"step.enter"));
+        assert!(types.contains(&"step.exit"));
     }
 
     #[test]

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -102,6 +102,42 @@ pub struct StepInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<DateTime<Utc>>,
     pub attempt: i32,
+
+    // -------- Iterator fan-out (Phase D R3b) --------
+    //
+    // A step with `step.loop` fans out into N iteration commands at
+    // dispatch time.  The orchestrator emits ONE `step.enter` (which
+    // records `iterations_expected` here) and N `command.issued`
+    // events, each with a per-iteration `command_id` of the shape
+    // `<exec>:<step>:<event>:i<index>` and `iteration_index` in
+    // meta.  Workers that act on those commands echo `command_id`
+    // forward in their emitted events but do NOT necessarily echo
+    // `iteration_index` (worker contract is per-command, not
+    // per-iteration), so `apply_event` deduplicates `command.completed`
+    // events by `command_id` instead of by iteration_index.  The
+    // step's `state` flips to `Completed` once we've seen
+    // `iterations_expected` distinct command_ids complete.
+    //
+    // Non-looped steps leave these at their defaults and behave
+    // exactly as before.
+    /// Total iterations expected when the step is a `step.loop` step.
+    /// `None` for non-looped steps; set from the `step.enter` event
+    /// context at fan-out time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iterations_expected: Option<i32>,
+
+    /// Distinct iteration command_ids observed as `command.completed`
+    /// (dedup so a dual-worker race emitting two `command.completed`
+    /// for the same command_id only counts once).  Always empty for
+    /// non-looped steps.
+    #[serde(default, skip_serializing_if = "std::collections::HashSet::is_empty")]
+    pub iteration_command_ids: std::collections::HashSet<String>,
+
+    /// Per-iteration result payloads collected in dispatch order.
+    /// Used to assemble the aggregate result the next step sees in
+    /// its render context.  Empty for non-looped steps.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub iteration_results: Vec<serde_json::Value>,
 }
 
 impl StepInfo {
@@ -115,7 +151,21 @@ impl StepInfo {
             entered_at: None,
             completed_at: None,
             attempt: 0,
+            iterations_expected: None,
+            iteration_command_ids: std::collections::HashSet::new(),
+            iteration_results: Vec::new(),
         }
+    }
+
+    /// True if this step was dispatched as a `step.loop` fan-out.
+    pub fn is_iterator(&self) -> bool {
+        self.iterations_expected.is_some()
+    }
+
+    /// Number of distinct iterations that have completed.  Always
+    /// `0` for non-iterator steps.
+    pub fn iterations_completed(&self) -> i32 {
+        self.iteration_command_ids.len() as i32
     }
 }
 
@@ -138,6 +188,37 @@ pub struct WorkflowState {
     pub completed_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_execution_id: Option<i64>,
+}
+
+/// Pull a `command_id` out of an event row.  Workers echo
+/// `command_id` forward through their emitted events; depending on
+/// the lifecycle slot it may live on `meta`, on `result.context`
+/// (constraint-compliant envelope), or — in older shapes — on
+/// `result.data`.  Returns the first match.  Used by R3b iterator
+/// state aggregation to deduplicate `command.completed` events.
+fn extract_command_id(event: &Event) -> Option<String> {
+    if let Some(meta) = &event.meta {
+        if let Some(s) = meta.get("command_id").and_then(|v| v.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    if let Some(result) = &event.result {
+        if let Some(s) = result
+            .get("context")
+            .and_then(|c| c.get("command_id"))
+            .and_then(|v| v.as_str())
+        {
+            return Some(s.to_string());
+        }
+        if let Some(s) = result
+            .get("data")
+            .and_then(|d| d.get("command_id"))
+            .and_then(|v| v.as_str())
+        {
+            return Some(s.to_string());
+        }
+    }
+    None
 }
 
 impl WorkflowState {
@@ -243,6 +324,19 @@ impl WorkflowState {
                         .or_insert_with(|| StepInfo::new(name));
                     step.state = StepState::Entered;
                     step.entered_at = Some(event.created_at);
+                    // R3b iterator fan-out: orchestrator stamps the
+                    // iteration total into the step.enter event
+                    // context so state reconstruction knows how many
+                    // command.completed events to wait for before
+                    // marking the step truly Completed.  Plain steps
+                    // omit this key and behave as before.
+                    if let Some(context) = &event.context {
+                        if let Some(total) =
+                            context.get("iterations_expected").and_then(|v| v.as_i64())
+                        {
+                            step.iterations_expected = Some(total as i32);
+                        }
+                    }
                 }
             }
             "command.issued" => {
@@ -281,9 +375,51 @@ impl WorkflowState {
                         .steps
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
-                    step.state = StepState::Completed;
-                    step.completed_at = Some(event.created_at);
-                    step.result = event.result.clone();
+
+                    // R3b iterator-aware completion: if this step is
+                    // a loop step (iterations_expected set), count
+                    // each distinct `command_id` (sourced from meta
+                    // or result.context) toward completion.  Workers
+                    // emit multiple events per command (claimed →
+                    // started → call.done → completed), and a
+                    // dual-worker race may even emit two
+                    // `command.completed` events for the same
+                    // command_id — both are deduped by the HashSet.
+                    // Only flip state to Completed once we've seen
+                    // `iterations_expected` distinct command_ids
+                    // complete.  Non-iterator steps continue to
+                    // complete on the first command.completed.
+                    if let Some(expected) = step.iterations_expected {
+                        let command_id = extract_command_id(event);
+                        if let Some(cid) = command_id {
+                            // First time we've seen this iteration?
+                            // Append its result in arrival order.
+                            if step.iteration_command_ids.insert(cid) {
+                                if let Some(result) = event.result.clone() {
+                                    step.iteration_results.push(result);
+                                }
+                            }
+                        }
+                        if step.iterations_completed() >= expected {
+                            step.state = StepState::Completed;
+                            step.completed_at = Some(event.created_at);
+                            // Aggregate result = list of per-iteration
+                            // results in arrival order (may not match
+                            // dispatch index in parallel mode — see
+                            // R3b follow-up).
+                            step.result = Some(serde_json::Value::Array(
+                                step.iteration_results.clone(),
+                            ));
+                        }
+                        // Mid-iteration: leave step.state at whatever
+                        // command.started / command.claimed last set
+                        // it to so `is_step_completed` returns false.
+                    } else {
+                        // Plain (non-iterator) step.
+                        step.state = StepState::Completed;
+                        step.completed_at = Some(event.created_at);
+                        step.result = event.result.clone();
+                    }
                 }
             }
             "command.failed" | "action_failed" | "step_failed" => {
@@ -540,5 +676,135 @@ mod tests {
             state.steps.get("step1").unwrap().state,
             StepState::Completed
         );
+    }
+
+    #[test]
+    fn test_iterator_step_aggregates_completion() {
+        // Simulate the events an iterator step produces:
+        //   step.enter (iterations_expected=3)
+        //   command.completed (iteration_index=0)
+        //   command.completed (iteration_index=1)
+        //   command.completed (iteration_index=2)
+        //
+        // The step's state stays "not completed" until all 3
+        // iterations land, then flips to Completed with an
+        // aggregated array result.
+        let mut state = WorkflowState::new(1, 1);
+
+        let mut enter = make_event("step.enter", Some("looped"));
+        enter.context = Some(serde_json::json!({
+            "iterations_expected": 3,
+            "iterator_var": "item",
+        }));
+        state.apply_event(&enter);
+        let after_enter = state.steps.get("looped").unwrap();
+        assert_eq!(after_enter.state, StepState::Entered);
+        assert_eq!(after_enter.iterations_expected, Some(3));
+        assert_eq!(after_enter.iterations_completed(), 0);
+
+        for (idx, payload) in [(0, "a"), (1, "b"), (2, "c")] {
+            let mut ev = make_event("command.completed", Some("looped"));
+            ev.meta = Some(serde_json::json!({
+                "command_id": format!("e:looped:0:i{}", idx),
+                "iteration_index": idx,
+                "iteration_total": 3,
+            }));
+            ev.result = Some(serde_json::json!({ "value": payload }));
+            state.apply_event(&ev);
+        }
+
+        let info = state.steps.get("looped").unwrap();
+        assert_eq!(info.state, StepState::Completed);
+        assert_eq!(info.iterations_completed(), 3);
+        // Aggregate result is the per-iteration array in arrival order.
+        let agg = info.result.as_ref().unwrap();
+        assert_eq!(agg.as_array().map(|a| a.len()), Some(3));
+        let values: Vec<String> = agg
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.get("value").unwrap().as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(values, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_iterator_step_dedupes_duplicate_command_completed() {
+        // Two `command.completed` events for the same command_id
+        // (dual-worker race) should NOT double-count the iteration.
+        let mut state = WorkflowState::new(1, 1);
+        let mut enter = make_event("step.enter", Some("looped"));
+        enter.context = Some(serde_json::json!({
+            "iterations_expected": 2,
+        }));
+        state.apply_event(&enter);
+
+        for _ in 0..2 {
+            let mut ev = make_event("command.completed", Some("looped"));
+            ev.meta = Some(serde_json::json!({
+                "command_id": "e:looped:0:i0",
+            }));
+            ev.result = Some(serde_json::json!({"i": 0}));
+            state.apply_event(&ev);
+        }
+        // Only 1 distinct command_id seen.
+        let info = state.steps.get("looped").unwrap();
+        assert_eq!(info.iterations_completed(), 1);
+        assert_ne!(info.state, StepState::Completed);
+
+        // Now the second iteration's command_id completes.
+        let mut ev = make_event("command.completed", Some("looped"));
+        ev.meta = Some(serde_json::json!({
+            "command_id": "e:looped:0:i1",
+        }));
+        ev.result = Some(serde_json::json!({"i": 1}));
+        state.apply_event(&ev);
+        let info = state.steps.get("looped").unwrap();
+        assert_eq!(info.iterations_completed(), 2);
+        assert_eq!(info.state, StepState::Completed);
+    }
+
+    #[test]
+    fn test_iterator_step_partial_completion_stays_running() {
+        // Two of three iterations done — step should NOT be
+        // Completed yet (state is whatever the last event left it
+        // at, but `is_step_completed` returns false).
+        let mut state = WorkflowState::new(1, 1);
+
+        let mut enter = make_event("step.enter", Some("looped"));
+        enter.context = Some(serde_json::json!({
+            "iterations_expected": 3,
+        }));
+        state.apply_event(&enter);
+
+        for idx in 0..2 {
+            let mut ev = make_event("command.completed", Some("looped"));
+            ev.meta = Some(serde_json::json!({
+                "command_id": format!("e:looped:0:i{}", idx),
+            }));
+            ev.result = Some(serde_json::json!({"i": idx}));
+            state.apply_event(&ev);
+        }
+
+        let info = state.steps.get("looped").unwrap();
+        assert_ne!(info.state, StepState::Completed);
+        assert_eq!(info.iterations_completed(), 2);
+        assert!(!state.is_step_completed("looped"));
+    }
+
+    #[test]
+    fn test_plain_step_unaffected_by_iterator_logic() {
+        // A plain step (no iterations_expected) continues to
+        // complete on the first command.completed, same as before.
+        let mut state = WorkflowState::new(1, 1);
+        state.apply_event(&make_event("step.enter", Some("plain")));
+        let mut ev = make_event("command.completed", Some("plain"));
+        ev.result = Some(serde_json::json!({"ok": true}));
+        state.apply_event(&ev);
+        let info = state.steps.get("plain").unwrap();
+        assert_eq!(info.state, StepState::Completed);
+        assert_eq!(info.iterations_expected, None);
+        assert_eq!(info.iterations_completed(), 0);
+        assert_eq!(info.result, Some(serde_json::json!({"ok": true})));
     }
 }

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -274,7 +274,21 @@ pub(crate) async fn persist_engine_command(
     playbook: &crate::playbook::types::Playbook,
 ) -> AppResult<i64> {
     let event_id = generate_snowflake_id(state).await?;
-    let command_id = format!("{}:{}:{}", execution_id, step.step, event_id);
+
+    // R3b iterator fan-out: include the iteration index in
+    // command_id so each per-iteration command row has a unique
+    // identifier (the noetl.command primary key is per-execution
+    // command_id), and the worker can correlate its emitted events
+    // back to the right iteration.  Plain steps keep the
+    // pre-existing 3-segment shape `<exec>:<step>:<event>`.
+    let command_id = if let Some(iter) = command.iterator.as_ref() {
+        format!(
+            "{}:{}:{}:i{}",
+            execution_id, step.step, event_id, iter.index
+        )
+    } else {
+        format!("{}:{}:{}", execution_id, step.step, event_id)
+    };
 
     let cmd_args = match &step.args {
         Some(map) => serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})),
@@ -286,7 +300,12 @@ pub(crate) async fn persist_engine_command(
         "render_context": render_context,
     });
 
-    let cmd_meta = serde_json::json!({
+    // Base meta — extended below with iteration_index/_total for
+    // iterator commands so `state.apply_event` (Phase D R3b state
+    // aggregation) sees the per-event iteration index on the
+    // matching `command.completed` row when the worker echoes
+    // meta forward.
+    let mut cmd_meta = serde_json::json!({
         "command_id": command_id,
         "step": step.step,
         "tool_kind": command.tool.kind,
@@ -296,6 +315,26 @@ pub(crate) async fn persist_engine_command(
         "catalog_id": catalog_id.to_string(),
         "actionable": true,
     });
+    if let Some(iter) = command.iterator.as_ref() {
+        if let serde_json::Value::Object(ref mut map) = cmd_meta {
+            map.insert(
+                "iteration_index".to_string(),
+                serde_json::json!(iter.index),
+            );
+            map.insert(
+                "iteration_total".to_string(),
+                serde_json::json!(iter.total),
+            );
+            map.insert(
+                "iterator_step".to_string(),
+                serde_json::json!(iter.iterator_step.clone()),
+            );
+            map.insert(
+                "item_var".to_string(),
+                serde_json::json!(iter.item_var.clone()),
+            );
+        }
+    }
 
     sqlx::query(
         r#"


### PR DESCRIPTION
## Summary

Phase D Round 3b of the Rust-server parity port (Refs noetl/server#22, noetl/ai-meta#49) — **step.loop iterator fan-out + state aggregation**. Second of three Phase D R3 control-flow rounds (R3a conditionals shipped in #32; R3b iterators here; R3c parallel next).

### What landed

**Orchestrator fan-out** (`engine/orchestrator.rs`): when the transition path picks a `next_step` with `step.loop` set, it evaluates `loop.in_expr` via the existing `Evaluator::evaluate_loop`, emits ONE `step.enter` (carrying `iterations_expected` in context), and dispatches one `CommandBuilder::build_iteration_command` per item — each with `IteratorMetadata` filled in. Empty collection emits `step.enter` + a synthetic `step.exit` and short-circuits.

**State aggregation** (`engine/state.rs`): `StepInfo` gains `iterations_expected`, `iteration_command_ids` (HashSet), and `iteration_results` (Vec). `apply_event` for `command.completed` is now iterator-aware: when `iterations_expected` is Some, it extracts the iteration's `command_id` from event meta / result.context and **deduplicates** against `iteration_command_ids` so a dual-worker race emitting two `command.completed` for the same iteration only counts once. The step's state flips to `Completed` only once `iteration_command_ids.len() >= iterations_expected`. Plain non-iterator steps complete on the first `command.completed`, same as before.

**Iteration command persistence** (`handlers/execute.rs::persist_engine_command`): when `command.iterator` is `Some`, includes `iteration_index` / `iteration_total` / `iterator_step` / `item_var` in `cmd_meta` and makes `command_id` unique per iteration (`<exec>:<step>:<event>:i<index>`).

### Tests

5 new unit tests, **28/28 engine tests pass**:

- `test_step_loop_fans_out_iterations` — static `[1, 2, 3]` loop expr produces one `step.enter` + 3 iteration commands with correct `IteratorMetadata` (index, total, iterator_step, item_var).
- `test_step_loop_empty_collection_short_circuits` — empty `in_expr` produces `step.enter` + `step.exit`, no commands.
- `test_iterator_step_aggregates_completion` — 3 `command.completed` with distinct `command_id`s flip step to `Completed` and produce aggregate array result.
- `test_iterator_step_partial_completion_stays_running` — 2 of 3 leave state ≠ `Completed`, `is_step_completed` false.
- `test_iterator_step_dedupes_duplicate_command_completed` — two `command.completed` for the same `command_id` (dual-worker race) only count once.

### Kind validation (partial — known gaps for follow-up)

\`tests/fixtures/r3b_iterator\` registered (3-step playbook \`start → looped → end\` with \`loop.in=[1,2,3]\`). Submitted via \`/api/execute\` on \`noetl-server-rust\` in \`kind-noetl\`.

**Orchestrator path validated:** server log confirms \`Fanning out 3 iterations for step 'looped' (iterator='item')\` and 3 distinct iteration command notifications publish to NATS with command_ids ending \`:i0\` / \`:i1\` / \`:i2\`. Worker pulls all 3 from NATS and claims them.

**End-to-end completion gated on TWO separate gaps (NOT in scope for this PR):**

1. **Worker doesn't inject iteration variables into the Python tool's runtime scope.** \`CommandBuilder::build_iteration_command\` puts \`item\`, \`_index\`, \`_total\` into the command's **render** context (for Jinja templating), but the worker's Python execution sees \`NameError: name 'item' is not defined\`. Needs a noetl/worker-side change to inject iter context into Python globals before exec.

2. **Subsequent batch.events from the worker for iteration \`command.completed\` lifecycle don't appear to re-trigger \`trigger_orchestrator\`** — only the initial \`start.command.completed\` triggers. Root cause not yet found; may relate to how the Rust worker batches lifecycle events. State aggregation infrastructure is in place + unit-tested; once trigger fires for each iteration, completion drains correctly.

Both gaps will be tracked as Phase D R3b-2 (worker iteration injection) and R3b-3 (trigger investigation) follow-up issues. The infrastructure landed here is what the e2e completion will be built on top of.

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release --lib engine\` → 28/28 pass
- [x] Kind: rebuild + reload \`noetl-server-rust\`, register fixture, submit execution; verify orchestrator fans out N commands with correct iterator metadata
- [ ] Reviewers: confirm the dedup-by-command_id approach is the right semantic (alternative would be to look up iteration_index from prior \`command.issued\` events, but that requires preserving order during state reconstruction).

Refs noetl/server#22
Refs noetl/ai-meta#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)