### PR TITLE
fix(orchestrator): guard skip-chain target against re-dispatch on re-trigger

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -453,6 +453,35 @@ impl WorkflowOrchestrator {
                         continue;
                     }
 
+                    // R3a skip-chain re-entry guard: after walking
+                    // forward through one or more skipped steps, the
+                    // chain target may itself already be Completed
+                    // or running.  Without this guard, every
+                    // subsequent command.completed event for any
+                    // later step in the workflow re-triggers the
+                    // orchestrator, which re-evaluates `start`'s
+                    // transitions, walks the skip chain again, and
+                    // emits a fresh step.enter + command.issued for
+                    // the chain target.  Surfaced by Phase D R3a
+                    // re-validation after noetl/ai-meta#53 unblocked
+                    // multi-trigger paths — the chain target was
+                    // `tail`, which got re-issued on every
+                    // tail.command.completed.
+                    if state.is_step_done(&current_step_name) {
+                        debug!(
+                            "Skip-chain target '{}' already done, suppressing re-dispatch",
+                            current_step_name
+                        );
+                        continue;
+                    }
+                    if state.running_steps().contains(&current_step_name.as_str()) {
+                        debug!(
+                            "Skip-chain target '{}' already running, suppressing re-dispatch",
+                            current_step_name
+                        );
+                        continue;
+                    }
+
                     // R3b iterator fan-out: if the landed step
                     // declares `step.loop`, evaluate the loop
                     // expression and emit one command per item.  The


### PR DESCRIPTION
## Summary

Surfaced during the Phase D R3 **end-to-end re-validation** after [noetl/ai-meta#53](https://github.com/noetl/ai-meta/issues/53) unblocked the dual-trigger path (server #35 + worker #41 — Rust worker now correctly routes lifecycle events back to the Rust server, so multi-step orchestrator triggers fire on every command.completed).

The R3a skip-chain (orchestrator detects \`step.when=false\`, emits \`step.skipped\`, walks forward through the skipped step's \`next.arcs\` until landing on a step whose guard passes) had per-step "already done / already running" guards for the direct \`next_step\` transition path but **NOT** for the chain target after the inline walk.

## The bug

On the **first** orchestrator pass after \`start\` completed, the skip-chain dispatched the chain target normally (e.g. \`tail\`). But on **every subsequent** \`command.completed\` (e.g. tail's own completion, or any later step's completion), the orchestrator re-iterated \`state.steps\`, found \`start\` still Completed, re-evaluated start's \`next.arcs\` → middle (skipped) → tail, and emitted a fresh \`step.enter(tail)\` + \`command.issued(tail)\`.

Kind validation surfaced this as ~7 \`step.skipped(middle)\` events and ~7 redundant \`tail\` dispatches before the playbook eventually completed.

## The fix

Mirror the existing guards at the top of the per-result loop. After the skip-chain walks forward to \`current_step_name\`, check:

\`\`\`rust
if state.is_step_done(&current_step_name) {
    debug!("Skip-chain target '{}' already done, suppressing re-dispatch", current_step_name);
    continue;
}
if state.running_steps().contains(&current_step_name.as_str()) {
    debug!("Skip-chain target '{}' already running, suppressing re-dispatch", current_step_name);
    continue;
}
\`\`\`

If either is true, \`continue\` so the chain target isn't re-issued.

## Tests

Existing 31 engine tests still pass. The R3a unit tests (\`test_step_when_guard_skips_step\`, \`test_step_when_guard_passes_dispatches_step\`) cover the single-trigger path and stay green. End-to-end kind validation now produces ONE \`step.skipped(middle)\` + ONE tail dispatch + \`playbook.completed\` (modulo the dual-worker race that produces a single extra \`step.skipped\`).

## End-to-end results (with this fix + #35 + worker #41)

| Fixture | Result |
|---|---|
| \`tests/fixtures/r2_two_step\` | ✅ \`playbook.completed\` |
| \`tests/fixtures/r3a_conditional\` (skip_middle=false) | ✅ \`playbook.completed\` |
| \`tests/fixtures/r3a_conditional\` (skip_middle=true) | ✅ \`step.skipped(middle) → playbook.completed\` |
| \`tests/fixtures/r3c_parallel\` | ✅ \`playbook.completed\` |

All four with both Rust + Python worker pools running (no manual scale-to-zero workarounds).

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release --lib engine\` → 31/31 pass
- [x] Kind: 4 fixtures (R2, R3a×2, R3c) all reach \`playbook.completed\` cleanly
- [ ] Reviewers: confirm the guard placement — added after \`should_dispatch\` check + before the iterator-fan-out branch.

Refs noetl/ai-meta#49
Refs noetl/ai-meta#53

🤖 Generated with [Claude Code](https://claude.com/claude-code)