### PR TITLE
fix(orchestrator): R3b iterator end-to-end — args injection + state reconstruction

### DIFF
--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -132,7 +132,32 @@ impl CommandBuilder {
         iter_context.insert("_total".to_string(), serde_json::json!(iterator.total));
 
         // Build tool command from definition with iterator context
-        let tool_command = self.build_tool_from_definition(&step.tool, &iter_context)?;
+        let mut tool_command = self.build_tool_from_definition(&step.tool, &iter_context)?;
+
+        // Phase D R3b-2: also inject the iteration variables into
+        // the tool's `args` map.  The worker's Python tool exposes
+        // `args` keys as Python globals via `globals().update(args)`
+        // — without this, a `step.loop` over `items: [1,2,3]` with
+        // a Python tool referencing `item` / `_index` / `_total`
+        // raises `NameError: name 'item' is not defined` on the
+        // worker side.  Other tool kinds (shell, http, duckdb)
+        // also benefit from getting the iter vars in `args` for the
+        // same Jinja-rendering reason — keys with templates like
+        // `{{ item }}` rendered earlier resolve correctly, but raw
+        // references in tool-specific runtimes (Python globals,
+        // shell `$item`, etc.) need the literal binding.  Safe for
+        // tools without an `args` convention — the field just goes
+        // unused.
+        if let Some(serde_json::Value::Object(cfg)) = tool_command.config.as_mut() {
+            let args_entry = cfg
+                .entry("args".to_string())
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            if let serde_json::Value::Object(args) = args_entry {
+                args.insert(iterator.item_var.clone(), iterator.item.clone());
+                args.insert("_index".to_string(), serde_json::json!(iterator.index));
+                args.insert("_total".to_string(), serde_json::json!(iterator.total));
+            }
+        }
 
         Ok(Command {
             command_id,
@@ -396,9 +421,17 @@ mod tests {
             .unwrap();
 
         assert!(command.iterator.is_some());
-        let iter = command.iterator.unwrap();
+        let iter = command.iterator.as_ref().unwrap();
         assert_eq!(iter.index, 2);
         assert_eq!(iter.total, 5);
+
+        // Phase D R3b-2: tool.config.args must carry the iteration
+        // variables so the worker's Python tool sees them as globals.
+        let tool_cfg = command.tool.config.as_ref().expect("tool config present");
+        let args = tool_cfg.get("args").expect("args injected");
+        assert_eq!(args.get("item"), Some(&serde_json::json!("test_value")));
+        assert_eq!(args.get("_index"), Some(&serde_json::json!(2)));
+        assert_eq!(args.get("_total"), Some(&serde_json::json!(5)));
     }
 
     #[test]

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -325,17 +325,37 @@ impl WorkflowState {
                     step.state = StepState::Entered;
                     step.entered_at = Some(event.created_at);
                     // R3b iterator fan-out: orchestrator stamps the
-                    // iteration total into the step.enter event
-                    // context so state reconstruction knows how many
+                    // iteration total onto the step.enter event so
+                    // state reconstruction knows how many
                     // command.completed events to wait for before
-                    // marking the step truly Completed.  Plain steps
-                    // omit this key and behave as before.
-                    if let Some(context) = &event.context {
-                        if let Some(total) =
-                            context.get("iterations_expected").and_then(|v| v.as_i64())
-                        {
-                            step.iterations_expected = Some(total as i32);
-                        }
+                    // marking the step truly Completed.  The
+                    // orchestrator emits `EventToEmit { context:
+                    // Some(...) }`, which `trigger_orchestrator`
+                    // persists by wrapping it inside the
+                    // constraint-compliant `{status, context}`
+                    // result envelope (per noetl/server#29) — so
+                    // the canonical storage location is
+                    // `event.result.context.iterations_expected`.
+                    // Older callers may have populated the event
+                    // row's `context` column directly; we accept
+                    // both shapes.  Workers' own per-iteration
+                    // step.enter events don't carry this key and
+                    // leave the previously-set value alone.
+                    let total = event
+                        .result
+                        .as_ref()
+                        .and_then(|r| r.get("context"))
+                        .and_then(|c| c.get("iterations_expected"))
+                        .and_then(|v| v.as_i64())
+                        .or_else(|| {
+                            event
+                                .context
+                                .as_ref()
+                                .and_then(|c| c.get("iterations_expected"))
+                                .and_then(|v| v.as_i64())
+                        });
+                    if let Some(total) = total {
+                        step.iterations_expected = Some(total as i32);
                     }
                 }
             }
@@ -789,6 +809,107 @@ mod tests {
         let info = state.steps.get("looped").unwrap();
         assert_ne!(info.state, StepState::Completed);
         assert_eq!(info.iterations_completed(), 2);
+        assert!(!state.is_step_completed("looped"));
+    }
+
+    #[test]
+    fn test_iterator_partial_with_worker_step_exit_does_not_complete() {
+        // Reproduces the R3b kind-val symptom: orchestrator emits
+        // step.enter(iterations_expected=3), 3 command.issued events
+        // fire, then ONE iteration's worker lifecycle arrives
+        // (command.claimed/started + worker's step.enter + call.done
+        // + step.exit + command.completed).  The looped step must
+        // NOT be marked Completed after only 1 iteration, even
+        // though step.exit AND command.completed both go through
+        // the iteration-aware match arm and both carry the same
+        // command_id in result.context.
+        let mut state = WorkflowState::new(1, 1);
+
+        // 1. Orchestrator's initial step.enter — populates
+        //    iterations_expected.  In production the orchestrator
+        //    persists this via `trigger_orchestrator`, which wraps
+        //    `EventToEmit.context` in a `{status, context}` result
+        //    envelope (per noetl/server#29's chk_event_result_shape
+        //    constraint).  So the canonical storage location is
+        //    `event.result.context.iterations_expected`, NOT the
+        //    event row's `context` column.  Earlier tests used the
+        //    `event.context` shape; we accept both via the
+        //    apply_event fallback, so this test uses the
+        //    production shape.
+        let mut enter = make_event("step.enter", Some("looped"));
+        enter.result = Some(serde_json::json!({
+            "status": "ENTERED",
+            "context": {
+                "iterations_expected": 3,
+                "iterator_var": "item",
+            },
+        }));
+        state.apply_event(&enter);
+
+        // 2. Three command.issued events — each with a distinct
+        //    per-iteration command_id in meta.
+        for idx in 0..3 {
+            let mut ev = make_event("command.issued", Some("looped"));
+            ev.meta = Some(serde_json::json!({
+                "command_id": format!("exec:looped:e0:i{}", idx),
+                "iteration_index": idx,
+                "iteration_total": 3,
+            }));
+            state.apply_event(&ev);
+        }
+
+        // 3. One iteration's worker lifecycle (only iter i2).
+        let cid = "exec:looped:e0:i2".to_string();
+        let mut claimed = make_event("command.claimed", Some("looped"));
+        claimed.meta = Some(serde_json::json!({"command_id": cid}));
+        state.apply_event(&claimed);
+
+        let mut started = make_event("command.started", Some("looped"));
+        started.meta = Some(serde_json::json!({"command_id": cid}));
+        state.apply_event(&started);
+
+        // Worker's per-iteration step.enter — no iterations_expected
+        // in context, so iterations_expected must stay Some(3).
+        let mut worker_enter = make_event("step.enter", Some("looped"));
+        worker_enter.context = Some(serde_json::json!({"status": "started"}));
+        state.apply_event(&worker_enter);
+
+        // call.done — not in any match arm, no state change.
+        let call_done = make_event("call.done", Some("looped"));
+        state.apply_event(&call_done);
+
+        // step.exit — IS in the command.completed arm.  Carries
+        // command_id in result.context.
+        let mut step_exit = make_event("step.exit", Some("looped"));
+        step_exit.result = Some(serde_json::json!({
+            "status": "COMPLETED",
+            "context": { "command_id": cid.clone(), "status": "COMPLETED" }
+        }));
+        state.apply_event(&step_exit);
+
+        // command.completed — same command_id (dedupes via HashSet).
+        let mut completed = make_event("command.completed", Some("looped"));
+        completed.result = Some(serde_json::json!({
+            "status": "COMPLETED",
+            "context": { "command_id": cid.clone(), "worker_id": "w" }
+        }));
+        state.apply_event(&completed);
+
+        let info = state.steps.get("looped").unwrap();
+        assert_eq!(info.iterations_expected, Some(3));
+        assert_eq!(
+            info.iterations_completed(),
+            1,
+            "only ONE distinct command_id observed across step.exit + command.completed; \
+             iteration_command_ids = {:?}",
+            info.iteration_command_ids
+        );
+        assert_ne!(
+            info.state,
+            StepState::Completed,
+            "looped must NOT be Completed after only 1 of 3 iterations; state = {:?}",
+            info.state
+        );
         assert!(!state.is_step_completed("looped"));
     }
 


### PR DESCRIPTION
## Summary

Two fixes that together drain the **R3b iterator path end-to-end** on the Rust server.  Phase D R3 e2e is now fully closed across conditionals + iterators + parallel.

### Fix 1 — \`engine/commands.rs::build_iteration_command\` injects iter vars into \`tool.config.args\`

Previously the iterator vars (\`item_var\`, \`_index\`, \`_total\`) went into the command's **render context** (for Jinja templating of tool fields like \`url\` or \`command\`), but the worker's Python tool exposes \`args\` keys as Python globals via \`globals().update(args)\`.  A \`step.loop\` over \`items: [1, 2, 3]\` with a Python tool referencing \`item\` raised \`NameError: name 'item' is not defined\`.

The fix adds an \`if let Some(serde_json::Value::Object(cfg)) = tool_command.config.as_mut()\` block after \`build_tool_from_definition\` that inserts the three iteration keys into \`cfg.args\`.  Safe for tool kinds that don't use \`args\` — the field just goes unused.

### Fix 2 — \`engine/state.rs\` step.enter handler reads \`iterations_expected\` from \`result.context\`

The canonical storage shape: \`trigger_orchestrator\` (events.rs) wraps \`EventToEmit.context\` in a \`{status, context}\` result envelope per noetl/server#29's \`chk_event_result_shape\` constraint.  So the orchestrator's \`iterations_expected\` is stored at \`event.result.context.iterations_expected\`, **not** the event row's \`context\` column.

My old handler read only \`event.context.iterations_expected\` → \`iterations_expected\` was never set → command.completed for each iteration fell into the "plain step" else-branch and marked the step Completed on the FIRST iteration → orchestrator transitioned to \`end\` → \`playbook.completed\` fired prematurely after 1 of 3 iterations.

The fix tries \`event.result.context.iterations_expected\` first, then falls back to \`event.context\` for backwards compatibility.

## Tests

**32/32 engine tests pass.**  New test \`test_iterator_partial_with_worker_step_exit_does_not_complete\` simulates the exact kind-val event sequence (orchestrator step.enter + 3 command.issued + 1 iteration's worker lifecycle: claimed/started/worker-step.enter/call.done/step.exit/command.completed) and asserts state stays not-Completed after only 1 of 3 iterations.  Existing \`test_build_iteration_command\` gains assertions on the injected \`args\`.

## Kind validation end-to-end

With both Rust + Python worker pools running (no manual workarounds):

| Fixture | Result |
|---|---|
| \`tests/fixtures/r2_two_step\` | ✅ \`playbook.completed\` |
| \`tests/fixtures/r3a_conditional\` (skip_middle=false) | ✅ \`playbook.completed\` |
| \`tests/fixtures/r3a_conditional\` (skip_middle=true) | ✅ \`step.skipped(middle) → playbook.completed\` |
| \`tests/fixtures/r3c_parallel\` | ✅ \`playbook.completed\` |
| **\`tests/fixtures/r3b_iterator\` [NEW]** | ✅ **3 × \`command.completed(looped) → playbook.completed\`** |

All 3 iterations of \`r3b_iterator\` complete BEFORE the terminal \`playbook.completed\` event fires.  **Phase D R3 e2e is now fully closed.**

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release --lib engine\` → 32/32 pass
- [x] Kind: 3-iteration \`step.loop\` over \`[1, 2, 3]\` reaches \`playbook.completed\` after all 3 iterations
- [ ] Reviewers: the args-injection mutates \`tool_command.config\` in-place after \`build_tool_from_definition\`.  Confirm this is the right layer (vs. doing it inside \`build_tool_command\`) — the current placement keeps the injection localized to iteration commands without touching the generic tool-command path.

Refs noetl/ai-meta#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)