### PR TITLE
feat(events): server adopts noetl-events as canonical envelope (EE-4 PR 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,8 +1279,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "noetl-events"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fec7b09050dcac7d4a69b54ed5632373cf43db7db401047a1e17d8877e3d0bf"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "noetl-server"
-version = "2.8.3"
+version = "2.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1281,6 +1305,7 @@ dependencies = [
  "dotenvy",
  "envy",
  "minijinja",
+ "noetl-events",
  "prometheus",
  "rand 0.8.6",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-server"
-version = "2.8.3"
+version = "2.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"
@@ -20,6 +20,24 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+
+# Shared event envelope (noetl/ai-meta#49 EE-4): the canonical
+# `ExecutorEvent` shape lives in the dedicated `noetl-events` crate
+# extracted from `noetl-executor::events` in noetl/cli#49 + #50.
+# Server takes a direct dep so the wire format the worker emits
+# (via `noetl-executor::events::ExecutorEvent`) and the wire format
+# the server's `POST /api/events` handler accepts as `EventRequest`
+# are anchored to a single source of truth — instead of being held
+# in sync by hand-aligned doc comments + parallel tests.
+#
+# The server's `EventRequest` legitimately carries extra fields
+# the canonical envelope doesn't expose (`result_kind`, `result_uri`,
+# `event_ids`, `actionable`, `informative`) and wire-encodes
+# `execution_id` / `event_id` as `String` for JSON-number precision
+# in browser clients, so it remains a distinct type.  The dep wires
+# in `From<ExecutorEvent>` / `TryFrom<&EventRequest>` conversions +
+# a wire-compat test that proves the shared subset round-trips.
+noetl-events = "0.1"
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "uuid", "json"] }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -19,16 +19,35 @@ use crate::state::AppState;
 
 /// Worker event request.
 ///
-/// R-1.2 PR-EE-2: aligned with the executor's `ExecutorEvent`
-/// shape per the cross-repo event envelope reconciliation tracked
-/// on noetl/ai-meta#30.  The legacy `name` field is renamed to
-/// `event_type` with a `#[serde(alias = "name")]` so existing
-/// worker / CLI clients sending `name` continue to deserialize
-/// without breakage during the migration window.  The new
-/// optional fields (`event_id`, `status`, `created_at`) align
-/// with `noetl_executor::events::ExecutorEvent 0.3.1`; producers
-/// that don't populate them get sensible server-side fallbacks
-/// (DB-side snowflake_id() for `event_id`, name-derived `status`,
+/// The shared subset of fields with the canonical
+/// [`noetl_events::ExecutorEvent`] envelope (from the
+/// `noetl-events` crate published off
+/// [noetl/cli](https://github.com/noetl/cli)) — `execution_id`,
+/// `step`, `event_type` (with `name` alias), `payload`/`context`,
+/// `meta`, `worker_id`, `event_id`, `status`, `created_at` — is
+/// wire-format compatible.  The wire-compat test
+/// `wire_compat_round_trips_shared_subset_with_executor_event`
+/// guards this property.  EE-4 (noetl/ai-meta#49) extracted the
+/// shared envelope into the dedicated `noetl-events` crate and
+/// added a direct dep on it here so the wire shape has a single
+/// source of truth instead of being held in sync by hand-aligned
+/// doc comments.
+///
+/// `EventRequest` keeps several server-only fields beyond the
+/// canonical envelope: `result_kind`, `result_uri`, `event_ids`
+/// (drive the constraint-compliant `{status, reference}` /
+/// `{status, context}` result shape per noetl/server#29);
+/// `actionable`, `informative` (control orchestrator dispatch +
+/// log-only persistence).  Wire-encodes `execution_id` /
+/// `event_id` as `String` for JSON-number precision in browser
+/// clients, vs the envelope's `i64` — the `From` / `TryFrom`
+/// impls below handle the conversion at the boundary.
+///
+/// Pre-EE-2 (`name`-field) worker / CLI clients keep working via
+/// `#[serde(alias = "name")]`; producers that omit
+/// `event_id` / `status` / `created_at` get sensible server-side
+/// fallbacks (DB-side `snowflake_id()` for `event_id`, the
+/// name-derived `status` returned by `event_status_from_name`,
 /// `Utc::now()` for `created_at`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventRequest {
@@ -101,6 +120,82 @@ fn default_result_kind() -> String {
 
 fn default_true() -> bool {
     true
+}
+
+/// Project the canonical `noetl_events::ExecutorEvent` envelope (the
+/// shape every NoETL Rust producer emits through `EventSink`) into
+/// the server's wire request shape.
+///
+/// Server-only fields (`result_kind`, `result_uri`, `event_ids`,
+/// `actionable`, `informative`) get the same defaults the handler
+/// applies when a producer omits them.  `execution_id` + `event_id`
+/// flip to `String` because that's the wire format the server has
+/// always exposed to browser clients (JSON-number precision).
+impl From<noetl_events::ExecutorEvent> for EventRequest {
+    fn from(ev: noetl_events::ExecutorEvent) -> Self {
+        Self {
+            execution_id: ev.execution_id.to_string(),
+            step: ev.step,
+            event_type: ev.event_type,
+            payload: ev.context,
+            meta: ev.meta,
+            worker_id: ev.worker_id,
+            result_kind: default_result_kind(),
+            result_uri: None,
+            event_ids: None,
+            actionable: true,
+            informative: true,
+            event_id: ev.event_id.map(|id| id.to_string()),
+            status: Some(ev.status),
+            created_at: Some(ev.created_at),
+        }
+    }
+}
+
+/// Inverse of [`From<noetl_events::ExecutorEvent>`].  `TryFrom`
+/// rather than `From` because the wire-shape `String` execution_id
+/// and `String` event_id can fail to parse — the server returns 400
+/// in that case in the actual handler.  Server-only fields
+/// (`result_kind`, `result_uri`, `event_ids`, `actionable`,
+/// `informative`) drop on the floor here — the canonical envelope
+/// doesn't model them.  When `status` / `created_at` are absent on
+/// the request, the conversion fills them with the same fallbacks
+/// the handler uses (`event_status_from_name`, `Utc::now()`).
+impl TryFrom<&EventRequest> for noetl_events::ExecutorEvent {
+    type Error = anyhow::Error;
+
+    fn try_from(req: &EventRequest) -> std::result::Result<Self, Self::Error> {
+        let execution_id: i64 = req.execution_id.parse().map_err(|e| {
+            anyhow::anyhow!(
+                "execution_id {:?} not parseable as i64: {e}",
+                req.execution_id
+            )
+        })?;
+        let event_id = req
+            .event_id
+            .as_deref()
+            .map(|s| s.parse::<i64>())
+            .transpose()
+            .map_err(|e| {
+                anyhow::anyhow!("event_id {:?} not parseable as i64: {e}", req.event_id)
+            })?;
+        let status = req
+            .status
+            .clone()
+            .unwrap_or_else(|| event_status_from_name(&req.event_type).to_string());
+        let created_at = req.created_at.unwrap_or_else(chrono::Utc::now);
+        Ok(Self {
+            execution_id,
+            event_type: req.event_type.clone(),
+            step: req.step.clone(),
+            status,
+            created_at,
+            context: req.payload.clone(),
+            event_id,
+            worker_id: req.worker_id.clone(),
+            meta: req.meta.clone(),
+        })
+    }
 }
 
 /// Response for event handling.
@@ -1453,5 +1548,117 @@ mod tests {
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("step1"));
         assert!(json.contains("python"));
+    }
+
+    // ---- EE-4 (noetl/ai-meta#49) wire-compat with noetl-events --------
+    //
+    // The server's `EventRequest` and the canonical
+    // `noetl_events::ExecutorEvent` share a subset of fields that
+    // make up the wire envelope every NoETL Rust producer emits.
+    // The four tests below pin the round-trip semantics so a future
+    // change to either type that breaks compat fails the build
+    // here instead of in a kind-validation cycle.
+
+    #[test]
+    fn ee4_executor_event_converts_into_event_request() {
+        let executor_event = noetl_events::ExecutorEvent {
+            execution_id: 478775660589088776,
+            event_type: "command.completed".to_string(),
+            step: "fetch_calendar".to_string(),
+            status: "COMPLETED".to_string(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-05-31T03:14:15Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            context: serde_json::json!({"items": 42}),
+            event_id: Some(478775660589088777),
+            worker_id: Some("worker-prod-7".to_string()),
+            meta: Some(serde_json::json!({"attempts": 2})),
+        };
+        let req: EventRequest = executor_event.clone().into();
+        // String wire format for browser precision.
+        assert_eq!(req.execution_id, "478775660589088776");
+        assert_eq!(req.event_id.as_deref(), Some("478775660589088777"));
+        // Shared subset round-trips field-for-field.
+        assert_eq!(req.event_type, executor_event.event_type);
+        assert_eq!(req.step, executor_event.step);
+        assert_eq!(req.status.as_deref(), Some(executor_event.status.as_str()));
+        assert_eq!(req.created_at, Some(executor_event.created_at));
+        assert_eq!(req.payload, executor_event.context);
+        assert_eq!(req.worker_id, executor_event.worker_id);
+        assert_eq!(req.meta, executor_event.meta);
+        // Server-only fields take handler defaults.
+        assert_eq!(req.result_kind, "data");
+        assert!(req.result_uri.is_none());
+        assert!(req.event_ids.is_none());
+        assert!(req.actionable);
+        assert!(req.informative);
+    }
+
+    #[test]
+    fn ee4_event_request_converts_into_executor_event() {
+        let req = EventRequest {
+            execution_id: "478775660589088776".to_string(),
+            step: "fetch_calendar".to_string(),
+            event_type: "command.completed".to_string(),
+            payload: serde_json::json!({"items": 42}),
+            meta: Some(serde_json::json!({"attempts": 2})),
+            worker_id: Some("worker-prod-7".to_string()),
+            result_kind: "data".to_string(),
+            result_uri: None,
+            event_ids: None,
+            actionable: true,
+            informative: true,
+            event_id: Some("478775660589088777".to_string()),
+            status: Some("COMPLETED".to_string()),
+            created_at: Some(
+                chrono::DateTime::parse_from_rfc3339("2026-05-31T03:14:15Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            ),
+        };
+        let ev: noetl_events::ExecutorEvent =
+            (&req).try_into().expect("convert with explicit fields");
+        assert_eq!(ev.execution_id, 478775660589088776_i64);
+        assert_eq!(ev.event_id, Some(478775660589088777_i64));
+        assert_eq!(ev.status, "COMPLETED");
+        assert_eq!(ev.created_at, req.created_at.unwrap());
+        assert_eq!(ev.context, req.payload);
+        assert_eq!(ev.worker_id, req.worker_id);
+        assert_eq!(ev.meta, req.meta);
+    }
+
+    #[test]
+    fn ee4_try_from_event_request_fills_defaults_for_missing_status_and_created_at() {
+        // Producers that don't stamp `status` / `created_at` are
+        // valid on the wire; the conversion must apply the same
+        // fallbacks the handler uses, so callers building an
+        // `ExecutorEvent` for downstream emit don't see surprises.
+        let mut req = test_request_skeleton();
+        req.event_type = "command.completed".to_string();
+        req.status = None;
+        req.created_at = None;
+        let ev: noetl_events::ExecutorEvent =
+            (&req).try_into().expect("convert with defaults");
+        assert_eq!(ev.status, "COMPLETED"); // name-derived fallback
+        // created_at falls back to now(); just assert it's non-zero
+        // and recent enough to be sane.
+        let age = chrono::Utc::now() - ev.created_at;
+        assert!(age.num_seconds() >= 0 && age.num_seconds() < 60);
+    }
+
+    #[test]
+    fn ee4_try_from_event_request_rejects_non_numeric_execution_id() {
+        // The wire shape is "stringified i64".  Anything else is a
+        // bug at the producer; the conversion surfaces it instead of
+        // silently dropping the event into the log with execution_id=0.
+        let req = EventRequest {
+            execution_id: "not-a-number".to_string(),
+            ..test_request_skeleton()
+        };
+        let err = noetl_events::ExecutorEvent::try_from(&req).unwrap_err();
+        assert!(
+            err.to_string().contains("execution_id"),
+            "error should mention the field name: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

EE-4 (noetl/ai-meta#49) carved the wire-format `ExecutorEvent`
envelope out of `noetl-executor::events` into the dedicated
[`noetl-events`](https://crates.io/crates/noetl-events) crate in
noetl/cli#49 + #50.  This PR is the third and final round on the
noetl-server side: take a direct dep on the published 0.1.0 crate
and wire in conversions between the canonical envelope and the
server's `EventRequest`.

## Why this isn't a literal struct swap

The server's `EventRequest` legitimately carries a strictly larger
field set than the canonical envelope:

| Field                                          | EventRequest | ExecutorEvent |
| :--                                            | :--:         | :--:          |
| `execution_id`                                 | `String`     | `i64`         |
| `step`, `event_type`, `meta`, `worker_id`      | ✓            | ✓             |
| `payload` (alias `context`)                    | ✓            | `context`     |
| `event_id`                                     | `String?`    | `i64?`        |
| `status`, `created_at`                         | `Option`     | required      |
| `result_kind`, `result_uri`, `event_ids`       | ✓            | —             |
| `actionable`, `informative`                    | ✓            | —             |

`result_kind` / `result_uri` / `event_ids` drive the constraint-
compliant `{status, reference}` / `{status, context}` result shape
per noetl/server#29; `actionable` / `informative` control
orchestrator dispatch + log-only persistence.  Wire-encoding
`execution_id` / `event_id` as `String` is the JSON-number-
precision concession to browser clients.

So "replace EventRequest with a thin wrapper around ExecutorEvent"
wasn't the right shape; the two types stay distinct but the
SHARED SUBSET is now anchored to a single source of truth via
`From<ExecutorEvent>` + `TryFrom<&EventRequest>` impls in
`src/handlers/events.rs`.

## Wire-compat guard

Four new tests in the `events` module:

- \`ee4_executor_event_converts_into_event_request\` — canonical
  envelope projects into EventRequest with server-only fields
  taking handler defaults.
- \`ee4_event_request_converts_into_executor_event\` — full-
  fidelity round-trip back to the envelope.
- \`ee4_try_from_event_request_fills_defaults_for_missing_status_and_created_at\`
  — when producers omit \`status\` / \`created_at\`, the conversion
  applies the same fallbacks the live handler uses
  (\`event_status_from_name\`, \`Utc::now()\`).
- \`ee4_try_from_event_request_rejects_non_numeric_execution_id\`
  — the wire shape is "stringified i64"; anything else surfaces
  as an error instead of silently dropping the event into the
  log with \`execution_id=0\`.

If a future change to either type breaks the shared subset, the
build fails here instead of in a kind-validation cycle.

Updated the \`EventRequest\` doc comment to cite \`noetl-events\`
as the canonical envelope spec, rather than the historical
"R-1.2 PR-EE-2 aligned with the executor's ExecutorEvent shape"
phrasing that left the alignment as a doc-comment promise.

## Version

Server bumps to 2.9.0 — minor-semver: new dependency
(\`noetl-events = "0.1"\`), no public-API change.

## Behavior

No behavior changes in the live \`POST /api/events\` /
\`POST /api/events/batch\` handlers — the new conversions are
infrastructure callers can use to thread the canonical envelope
through downstream code in follow-up work.  No current call site
consumes them yet, so this PR is safe to ship without a kind
validation pass (per \`agents/rules/deployment-validation.md\`
exceptions: dev-only scaffold change that doesn't alter the
binary's runtime behaviour).

## EE-4 fully shipped

- PR 1 ([noetl/cli#49](https://github.com/noetl/cli/pull/49)) — extract \`noetl-events\` workspace crate.
- PR 2 ([noetl/cli#50](https://github.com/noetl/cli/pull/50)) — publish \`noetl-events 0.1.0\` + bump \`noetl-executor 0.4.0\` to crates.io.
- PR 3 (this PR)                                                  — noetl-server adopts \`noetl-events\`.

Refs noetl/ai-meta#49

## Test plan

- [x] \`cargo build --quiet\` — clean
- [x] \`cargo test --quiet --lib handlers::events\` — 17/17 pass (4 new + 13 pre-existing)
- [x] \`cargo test --quiet\` — 204/205 pass; the one failure (\`playbook::parser::tests::test_parse_invalid_next_reference\`) is pre-existing on \`main\`, unrelated to this PR
- [ ] No kind validation needed — no runtime behavior change (see "Behavior" above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)