### PR TITLE
fix(config): rename machine_id → server_machine_id (env: NOETL_SERVER_MACHINE_ID)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-server"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-server"
-version = "2.10.0"
+version = "2.10.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -76,9 +76,13 @@ pub struct AppConfig {
     ///
     /// Phase F R1.5 of noetl/ai-meta#49 introduced this.  See
     /// `src/snowflake.rs` for the id layout and the migration
-    /// rationale.
+    /// rationale.  The field name (`server_machine_id`) maps to
+    /// the env var `NOETL_SERVER_MACHINE_ID` via the
+    /// `envy::prefixed("NOETL_")` shape — more specific than a
+    /// bare `NOETL_MACHINE_ID` and easier to grep for in
+    /// deployment manifests.
     #[serde(default)]
-    pub machine_id: Option<u16>,
+    pub server_machine_id: Option<u16>,
 }
 
 fn default_host() -> String {
@@ -134,7 +138,7 @@ impl Default for AppConfig {
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),
             public_server_url: None,
-            machine_id: None,
+            server_machine_id: None,
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -46,10 +46,10 @@ impl AppState {
     /// * `config` - Application configuration
     /// * `nats` - Optional NATS client
     ///
-    /// Reads `machine_id` from `config.machine_id` (envy:
-    /// `NOETL_SERVER_MACHINE_ID`).  When unset, derives a 10-bit
-    /// id from the process hostname via FNV-1a — fine for local
-    /// dev; the deployment manifest should set the env var
+    /// Reads `server_machine_id` from `config.server_machine_id`
+    /// (envy: `NOETL_SERVER_MACHINE_ID`).  When unset, derives a
+    /// 10-bit id from the process hostname via FNV-1a — fine for
+    /// local dev; the deployment manifest should set the env var
     /// explicitly per replica in production.
     ///
     /// # Returns
@@ -58,21 +58,21 @@ impl AppState {
     ///
     /// # Panics
     ///
-    /// Panics if the configured `machine_id` exceeds the 10-bit
-    /// max (1023).  The caller should validate at config-load
-    /// time; this is the last-resort guard.
+    /// Panics if the configured `server_machine_id` exceeds the
+    /// 10-bit max (1023).  The caller should validate at
+    /// config-load time; this is the last-resort guard.
     pub fn new(db: DbPool, config: AppConfig, nats: Option<async_nats::Client>) -> Self {
-        let machine_id = config.machine_id.unwrap_or_else(|| {
+        let machine_id = config.server_machine_id.unwrap_or_else(|| {
             let hostname = std::env::var("HOSTNAME")
                 .or_else(|_| std::env::var("COMPUTERNAME"))
                 .unwrap_or_else(|_| "noetl-server-local".to_string());
             derive_machine_id(&hostname)
         });
         let snowflake = SnowflakeGenerator::new(machine_id)
-            .expect("machine_id must fit in 10 bits; validate config at startup");
+            .expect("server_machine_id must fit in 10 bits; validate config at startup");
         tracing::info!(
             machine_id = snowflake.machine_id(),
-            source = if config.machine_id.is_some() {
+            source = if config.server_machine_id.is_some() {
                 "NOETL_SERVER_MACHINE_ID"
             } else {
                 "derived from HOSTNAME"


### PR DESCRIPTION
## Summary

Phase F R1.5 ([noetl/server#42](https://github.com/noetl/server/pull/42)) added the snowflake machine-id config field but named it \`machine_id\`.  With \`envy::prefixed(\"NOETL_\")\` on \`AppConfig\`, that resolves to env var \`NOETL_MACHINE_ID\` — not \`NOETL_SERVER_MACHINE_ID\` as the doc comment + the noetl/server wiki [deployment-specification](https://github.com/noetl/server/wiki/deployment-specification) page documented.

## How this was caught

Starting the noetl/ops manifest update to set the env var per-replica, I checked the actual envy resolution and noticed the mismatch.  This is exactly the kind of drift the new [\`agents/rules/wiki-maintenance.md\` Rule 2a](https://github.com/noetl/ai-meta/blob/main/agents/rules/wiki-maintenance.md) discipline is supposed to catch — and it did.

## Why rename rather than re-document

Renaming the field to \`server_machine_id\` so envy reads \`NOETL_SERVER_MACHINE_ID\` is the cleaner fix:

1. **Matches the documentation** (single source of truth on the deployment-spec page).
2. **More specific env var name** — clear in shared deployment manifests where the noetl-server + noetl-worker + future bins all sit alongside.  Bare \`NOETL_MACHINE_ID\` would collide naming-wise with the worker's \`NOETL_SNOWFLAKE_NODE_ID\` family (different pattern but easy to confuse).
3. **Hasn't been deployed yet** — no env-var renaming pain because no manifest was using the wrong name.  The window to fix this is now, before R1.5 propagates further.

## Changes

- \`src/config/app.rs\`: field \`machine_id\` → \`server_machine_id\`, default value, doc comment updated to call out the envy resolution.
- \`src/state.rs\`: \`config.machine_id\` → \`config.server_machine_id\`, panic message updated.

## Version

\`v2.10.0 → v2.10.1\` (patch).

## Test plan

- [x] \`cargo build --quiet\` clean
- [x] \`cargo test --quiet --lib\` — 214/215 (the one pre-existing failure on \`playbook::parser::tests::test_parse_invalid_next_reference\` is unrelated; was already on main before this PR)

Refs noetl/ai-meta#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)