### PR TITLE
feat(config,db): add ShardingConfig + DbPoolMap (Phase F R4-1)

### DIFF
--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -78,6 +78,167 @@ fn default_acquire_timeout() -> u64 {
     30
 }
 
+/// Connection options for a single Postgres host — used by the
+/// per-shard + cluster-wide pools in [`ShardingConfig`].
+///
+/// Phase F R4 introduces this as a lightweight DSN-style holder so
+/// the `DbPoolMap` can carry N+1 [`PgConnectOptions`] without the
+/// rest of [`DatabaseConfig`]'s pool-tuning fields (which apply
+/// uniformly across all pools).
+///
+/// Parsed from a single `host=...&port=...&user=...&password=...&database=...`
+/// query-string-ish DSN.  See [`ShardConnection::parse`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardConnection {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+}
+
+impl ShardConnection {
+    /// Parse a DSN of the form
+    /// `host=postgres-0;port=5432;user=noetl;password=secret;database=noetl`
+    /// (semicolon-separated key=value pairs).  Order-independent.
+    ///
+    /// Picked semicolons (NOT `&` and NOT URL-encoded form) because
+    /// the outer separator in `NOETL_SHARDS` is the comma, and we
+    /// want DSN strings to be obviously distinct from URL query
+    /// strings (operators copy-paste these into env files; the
+    /// less ambiguity, the better).
+    pub fn parse(dsn: &str) -> Result<Self, ShardConnectionError> {
+        let mut host: Option<String> = None;
+        let mut port: Option<u16> = None;
+        let mut user: Option<String> = None;
+        let mut password: Option<String> = None;
+        let mut database: Option<String> = None;
+
+        for pair in dsn.split(';').filter(|p| !p.trim().is_empty()) {
+            let (key, value) = pair
+                .split_once('=')
+                .ok_or_else(|| ShardConnectionError::MalformedPair(pair.to_string()))?;
+            let value = value.to_string();
+            match key.trim() {
+                "host" => host = Some(value),
+                "port" => {
+                    port = Some(
+                        value
+                            .parse()
+                            .map_err(|_| ShardConnectionError::InvalidPort(value.clone()))?,
+                    )
+                }
+                "user" => user = Some(value),
+                "password" => password = Some(value),
+                "database" | "dbname" => database = Some(value),
+                other => return Err(ShardConnectionError::UnknownKey(other.to_string())),
+            }
+        }
+
+        Ok(Self {
+            host: host.ok_or(ShardConnectionError::MissingKey("host"))?,
+            port: port.unwrap_or(5432),
+            user: user.ok_or(ShardConnectionError::MissingKey("user"))?,
+            password: password.unwrap_or_default(),
+            database: database.unwrap_or_else(|| "noetl".to_string()),
+        })
+    }
+
+    /// Build [`PgConnectOptions`] from this shard connection.
+    pub fn connect_options(&self) -> PgConnectOptions {
+        PgConnectOptions::new()
+            .host(&self.host)
+            .port(self.port)
+            .username(&self.user)
+            .password(&self.password)
+            .database(&self.database)
+    }
+}
+
+/// Errors parsing a [`ShardConnection`] DSN.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ShardConnectionError {
+    #[error("malformed key=value pair: {0}")]
+    MalformedPair(String),
+    #[error("missing required key: {0}")]
+    MissingKey(&'static str),
+    #[error("unknown key: {0}")]
+    UnknownKey(String),
+    #[error("invalid port: {0}")]
+    InvalidPort(String),
+}
+
+/// Sharding configuration — per-shard Postgres DSNs + a separate
+/// cluster-wide DSN for the always-master tables (catalog,
+/// credential, keychain, runtime, schedule, resource, manifest).
+///
+/// Phase F R4 plumbs this through `AppState`.  When `shards` is
+/// empty, the server runs in single-pool fallback mode (current
+/// shape — every query goes through the legacy [`DatabaseConfig`]
+/// pool).  When `shards` is non-empty, [`DbPoolMap`] holds N
+/// per-shard pools picked by [`crate::sharding::shard_for`] and an
+/// optional separate cluster pool; when `cluster` is `None`, the
+/// cluster-wide tables ride on shard 0's pool (degenerate but
+/// useful for single-node kind validation).
+///
+/// Parsed from env vars:
+///
+/// - `NOETL_SHARDS` — comma-separated list of shard DSNs.  Empty
+///   string or unset → single-pool fallback.
+/// - `NOETL_CLUSTER_DSN` — optional DSN for the cluster-wide pool.
+#[derive(Debug, Clone, Default)]
+pub struct ShardingConfig {
+    /// Per-shard connections, in shard-index order.  Position N
+    /// in this vec is the DSN for shard N (matching
+    /// `shard_for(execution_id, shards.len()) == N`).
+    pub shards: Vec<ShardConnection>,
+    /// Optional cluster-wide pool DSN.  When `None`, cluster-wide
+    /// queries ride on `shards[0]` (or fall back to the legacy
+    /// pool if `shards` is also empty).
+    pub cluster: Option<ShardConnection>,
+}
+
+impl ShardingConfig {
+    /// Load sharding config from env vars.
+    ///
+    /// `NOETL_SHARDS` (default empty) is comma-separated; each
+    /// segment is parsed via [`ShardConnection::parse`].  Empty
+    /// segments are skipped — `NOETL_SHARDS=""` yields an empty
+    /// `shards` vec (single-pool fallback).
+    ///
+    /// `NOETL_CLUSTER_DSN` (default empty) is a single DSN.
+    pub fn from_env() -> Result<Self, ShardConnectionError> {
+        let shards_raw = std::env::var("NOETL_SHARDS").unwrap_or_default();
+        let cluster_raw = std::env::var("NOETL_CLUSTER_DSN").unwrap_or_default();
+
+        let shards = shards_raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ShardConnection::parse)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let cluster = if cluster_raw.trim().is_empty() {
+            None
+        } else {
+            Some(ShardConnection::parse(&cluster_raw)?)
+        };
+
+        Ok(Self { shards, cluster })
+    }
+
+    /// Number of shards configured.  `0` = single-pool fallback.
+    pub fn shard_count(&self) -> u32 {
+        self.shards.len() as u32
+    }
+
+    /// True when sharding is OFF — server runs in single-pool
+    /// fallback mode.
+    pub fn is_disabled(&self) -> bool {
+        self.shards.is_empty()
+    }
+}
+
 /// Schema configuration loaded separately.
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
@@ -172,6 +333,156 @@ mod tests {
         assert_eq!(
             config.connection_url(),
             "postgres://noetl:secret@localhost:5432/noetl"
+        );
+    }
+
+    // ----- ShardConnection parsing ------------------------------------------
+
+    #[test]
+    fn shard_connection_parse_full_dsn() {
+        let dsn = "host=postgres-0;port=5432;user=noetl;password=secret;database=noetl_shard0";
+        let conn = ShardConnection::parse(dsn).expect("parse");
+        assert_eq!(conn.host, "postgres-0");
+        assert_eq!(conn.port, 5432);
+        assert_eq!(conn.user, "noetl");
+        assert_eq!(conn.password, "secret");
+        assert_eq!(conn.database, "noetl_shard0");
+    }
+
+    #[test]
+    fn shard_connection_parse_uses_defaults() {
+        let dsn = "host=p0;user=noetl";
+        let conn = ShardConnection::parse(dsn).expect("parse");
+        assert_eq!(conn.host, "p0");
+        assert_eq!(conn.port, 5432);
+        assert_eq!(conn.password, "");
+        assert_eq!(conn.database, "noetl");
+    }
+
+    #[test]
+    fn shard_connection_parse_accepts_dbname_alias() {
+        let dsn = "host=p0;user=noetl;dbname=noetl_shard1";
+        let conn = ShardConnection::parse(dsn).expect("parse");
+        assert_eq!(conn.database, "noetl_shard1");
+    }
+
+    #[test]
+    fn shard_connection_parse_rejects_missing_host() {
+        assert_eq!(
+            ShardConnection::parse("user=noetl"),
+            Err(ShardConnectionError::MissingKey("host"))
+        );
+    }
+
+    #[test]
+    fn shard_connection_parse_rejects_missing_user() {
+        assert_eq!(
+            ShardConnection::parse("host=p0"),
+            Err(ShardConnectionError::MissingKey("user"))
+        );
+    }
+
+    #[test]
+    fn shard_connection_parse_rejects_unknown_key() {
+        let err = ShardConnection::parse("host=p0;user=noetl;sslmode=require").unwrap_err();
+        assert_eq!(err, ShardConnectionError::UnknownKey("sslmode".into()));
+    }
+
+    #[test]
+    fn shard_connection_parse_rejects_malformed_pair() {
+        let err = ShardConnection::parse("host=p0;bogus;user=noetl").unwrap_err();
+        assert_eq!(err, ShardConnectionError::MalformedPair("bogus".into()));
+    }
+
+    #[test]
+    fn shard_connection_parse_rejects_invalid_port() {
+        let err = ShardConnection::parse("host=p0;port=abc;user=noetl").unwrap_err();
+        assert_eq!(err, ShardConnectionError::InvalidPort("abc".into()));
+    }
+
+    #[test]
+    fn shard_connection_parse_tolerates_trailing_separator() {
+        let conn = ShardConnection::parse("host=p0;user=noetl;").expect("parse");
+        assert_eq!(conn.host, "p0");
+    }
+
+    // ----- ShardingConfig from_env ------------------------------------------
+
+    // NOTE: these tests mutate process-wide env vars.  Run with
+    // `cargo test -- --test-threads=1` if you add more, or guard
+    // with a mutex.  The shape today is deliberately small so the
+    // serial cost is negligible.
+
+    fn with_env<F: FnOnce() -> R, R>(shards: Option<&str>, cluster: Option<&str>, f: F) -> R {
+        let prev_shards = std::env::var("NOETL_SHARDS").ok();
+        let prev_cluster = std::env::var("NOETL_CLUSTER_DSN").ok();
+
+        match shards {
+            Some(v) => std::env::set_var("NOETL_SHARDS", v),
+            None => std::env::remove_var("NOETL_SHARDS"),
+        }
+        match cluster {
+            Some(v) => std::env::set_var("NOETL_CLUSTER_DSN", v),
+            None => std::env::remove_var("NOETL_CLUSTER_DSN"),
+        }
+
+        let out = f();
+
+        match prev_shards {
+            Some(v) => std::env::set_var("NOETL_SHARDS", v),
+            None => std::env::remove_var("NOETL_SHARDS"),
+        }
+        match prev_cluster {
+            Some(v) => std::env::set_var("NOETL_CLUSTER_DSN", v),
+            None => std::env::remove_var("NOETL_CLUSTER_DSN"),
+        }
+
+        out
+    }
+
+    #[test]
+    fn sharding_config_disabled_when_env_unset() {
+        with_env(None, None, || {
+            let cfg = ShardingConfig::from_env().expect("from_env");
+            assert!(cfg.is_disabled());
+            assert_eq!(cfg.shard_count(), 0);
+            assert!(cfg.cluster.is_none());
+        });
+    }
+
+    #[test]
+    fn sharding_config_disabled_on_empty_string() {
+        with_env(Some(""), Some(""), || {
+            let cfg = ShardingConfig::from_env().expect("from_env");
+            assert!(cfg.is_disabled());
+        });
+    }
+
+    #[test]
+    fn sharding_config_parses_two_shards() {
+        with_env(
+            Some("host=p0;user=noetl,host=p1;user=noetl"),
+            Some("host=pc;user=noetl"),
+            || {
+                let cfg = ShardingConfig::from_env().expect("from_env");
+                assert_eq!(cfg.shard_count(), 2);
+                assert!(!cfg.is_disabled());
+                assert_eq!(cfg.shards[0].host, "p0");
+                assert_eq!(cfg.shards[1].host, "p1");
+                assert_eq!(cfg.cluster.as_ref().unwrap().host, "pc");
+            },
+        );
+    }
+
+    #[test]
+    fn sharding_config_skips_empty_segments() {
+        with_env(
+            Some(",host=p0;user=noetl,,host=p1;user=noetl,"),
+            None,
+            || {
+                let cfg = ShardingConfig::from_env().expect("from_env");
+                assert_eq!(cfg.shard_count(), 2);
+            },
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@
 //! using the `envy` crate for type-safe environment variable parsing.
 
 mod app;
-mod database;
+pub mod database;
 
 pub use app::AppConfig;
-pub use database::DatabaseConfig;
+pub use database::{DatabaseConfig, ShardConnection, ShardConnectionError, ShardingConfig};

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,8 +1,18 @@
 //! Database connection pool management.
+//!
+//! Phase F R4 introduces [`DbPoolMap`] — the N+1 pool layout that
+//! lets the server route per-execution queries to the per-shard
+//! Postgres and cluster-wide queries to the shared master.  When
+//! sharding is OFF (`NOETL_SHARDS` empty), `DbPoolMap` degenerates
+//! to a single-pool wrapper that behaves identically to the
+//! pre-R4 [`create_pool`] path.
 
+use crate::config::database::{ShardConnection, ShardingConfig};
 use crate::config::DatabaseConfig;
+use crate::sharding::shard_for;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Type alias for the PostgreSQL connection pool.
@@ -53,6 +63,202 @@ pub async fn health_check(pool: &DbPool) -> bool {
     sqlx::query("SELECT 1").execute(pool).await.is_ok()
 }
 
+/// N+1 pool layout for Phase F R4 sharding.
+///
+/// Holds N per-shard pools (selected by [`shard_for`]) and one
+/// cluster-wide pool for the always-master tables (`catalog`,
+/// `credential`, `keychain`, `runtime`, `schedule`, `resource`,
+/// `manifest`, `manifest_part`).  Per-execution tables (`event`,
+/// `command`, `execution`, `outbox`, `transient`, `stage`,
+/// `frame`, `projection`, `projection_snapshot`, `result_ref`)
+/// ride the per-shard pools.
+///
+/// **Single-pool fallback.**  When [`ShardingConfig::is_disabled`]
+/// (i.e. `NOETL_SHARDS` was empty), the constructor builds a
+/// degenerate map: one shard whose pool IS the legacy pool, and
+/// `cluster` points at the same pool.  Every accessor below
+/// returns that pool.  This keeps R4 dormant for current
+/// single-host deployments — handlers that adopt
+/// `pool_for(execution_id)` get identical behaviour until the
+/// operator opts in via env vars.
+///
+/// Shape chosen for cheap clones: every field is an [`Arc`]-style
+/// handle (sqlx's `PgPool` is already internally `Arc`'d), so
+/// `Clone` is one ref-count bump per pool.
+#[derive(Debug, Clone)]
+pub struct DbPoolMap {
+    shards: Arc<Vec<DbPool>>,
+    cluster: DbPool,
+    /// Cached `shards.len()` for the hot path.  `0` is impossible
+    /// (the constructor always populates at least one entry); the
+    /// helper methods rely on this invariant.
+    shard_count: u32,
+    /// True when this map was constructed in single-pool fallback
+    /// mode (`NOETL_SHARDS` empty).  Distinct from
+    /// `shard_count == 1` because the operator MAY opt into
+    /// sharding with N=1 (cluster on its own + shard 0 on its own
+    /// host); the routing math is identical to fallback but the
+    /// pool topology is different.
+    single_pool_mode: bool,
+}
+
+impl DbPoolMap {
+    /// Build the pool map.
+    ///
+    /// Two modes:
+    ///
+    /// - **Single-pool fallback** (`sharding.is_disabled()`):
+    ///   creates one pool from `legacy` and uses it for both the
+    ///   `shards[0]` slot and the cluster slot.  Identical
+    ///   behaviour to the pre-R4 [`create_pool`] code path.
+    /// - **Sharded** (`sharding.shards` non-empty): creates one
+    ///   pool per [`ShardConnection`] in `sharding.shards`, plus
+    ///   a separate cluster pool from `sharding.cluster` (or from
+    ///   `shards[0]` when `sharding.cluster` is `None` — useful
+    ///   for single-node kind validation where one Postgres host
+    ///   carries both per-execution and cluster-wide tables).
+    ///
+    /// Pool-tuning fields (`max_connections`, `min_connections`,
+    /// `acquire_timeout`) come from the legacy `DatabaseConfig`
+    /// and apply uniformly across every shard + cluster pool.
+    /// Per-pool tuning is a Phase G concern.
+    pub async fn new(
+        legacy: &DatabaseConfig,
+        sharding: &ShardingConfig,
+    ) -> Result<Self, sqlx::Error> {
+        if sharding.is_disabled() {
+            let pool = create_pool(legacy).await?;
+            tracing::info!("DbPoolMap: single-pool fallback (NOETL_SHARDS empty)");
+            return Ok(Self {
+                shards: Arc::new(vec![pool.clone()]),
+                cluster: pool,
+                shard_count: 1,
+                single_pool_mode: true,
+            });
+        }
+
+        let mut shard_pools = Vec::with_capacity(sharding.shards.len());
+        for (idx, conn) in sharding.shards.iter().enumerate() {
+            let pool = build_pool(legacy, conn).await.inspect_err(|e| {
+                tracing::error!(
+                    shard_index = idx,
+                    host = %conn.host,
+                    error = %e,
+                    "DbPoolMap: failed to build shard pool"
+                );
+            })?;
+            tracing::info!(
+                shard_index = idx,
+                host = %conn.host,
+                port = %conn.port,
+                database = %conn.database,
+                "DbPoolMap: shard pool ready"
+            );
+            shard_pools.push(pool);
+        }
+
+        let cluster = match &sharding.cluster {
+            Some(conn) => {
+                let pool = build_pool(legacy, conn).await.inspect_err(|e| {
+                    tracing::error!(
+                        host = %conn.host,
+                        error = %e,
+                        "DbPoolMap: failed to build cluster pool"
+                    );
+                })?;
+                tracing::info!(
+                    host = %conn.host,
+                    port = %conn.port,
+                    database = %conn.database,
+                    "DbPoolMap: cluster pool ready"
+                );
+                pool
+            }
+            None => {
+                tracing::warn!(
+                    "DbPoolMap: NOETL_CLUSTER_DSN unset; cluster-wide queries \
+                     ride shard 0's pool (single-node kind topology)"
+                );
+                shard_pools[0].clone()
+            }
+        };
+
+        let shard_count = shard_pools.len() as u32;
+        Ok(Self {
+            shards: Arc::new(shard_pools),
+            cluster,
+            shard_count,
+            single_pool_mode: false,
+        })
+    }
+
+    /// Number of shard pools configured.  Always `>= 1`.
+    pub fn shard_count(&self) -> u32 {
+        self.shard_count
+    }
+
+    /// True when this map is operating in single-pool fallback
+    /// mode (`NOETL_SHARDS` was empty at construction).
+    pub fn is_single_pool(&self) -> bool {
+        self.single_pool_mode
+    }
+
+    /// Pool for the given `execution_id`.
+    ///
+    /// In single-pool fallback mode (or when `shard_count == 1`)
+    /// returns the only shard pool unconditionally — no hash
+    /// computation.  In sharded mode, returns
+    /// `shards[shard_for(execution_id, shard_count)]`.
+    ///
+    /// **Stability contract**: this MUST agree with the
+    /// gateway-side `shard_for` from Phase F R3a-2.  The R3b
+    /// drift-guard integration test
+    /// (`repos/ops/automation/development/validate-shard-drift-guard.sh`)
+    /// asserts both sides compute the same `shard_index` for the
+    /// same `(execution_id, shard_count)` pair.
+    pub fn pool_for(&self, execution_id: i64) -> &DbPool {
+        if self.shard_count <= 1 {
+            return &self.shards[0];
+        }
+        let idx = shard_for(execution_id, self.shard_count) as usize;
+        &self.shards[idx]
+    }
+
+    /// Pool for cluster-wide tables (catalog, credential,
+    /// keychain, runtime, schedule, resource, manifest).
+    ///
+    /// In single-pool fallback mode this is the same handle as
+    /// every shard pool.
+    pub fn cluster(&self) -> &DbPool {
+        &self.cluster
+    }
+
+    /// Iterator over every per-shard pool, in shard-index order.
+    /// Used by the cluster-wide list endpoint
+    /// (`GET /api/executions`) for fan-out queries against the
+    /// per-execution tables — see Phase F R4-4.
+    pub fn all_shards(&self) -> impl Iterator<Item = (u32, &DbPool)> {
+        self.shards
+            .iter()
+            .enumerate()
+            .map(|(idx, pool)| (idx as u32, pool))
+    }
+}
+
+/// Build a pool from a [`ShardConnection`] using the legacy
+/// pool-tuning fields (max/min connections + acquire timeout).
+async fn build_pool(
+    legacy: &DatabaseConfig,
+    conn: &ShardConnection,
+) -> Result<DbPool, sqlx::Error> {
+    PgPoolOptions::new()
+        .max_connections(legacy.max_connections)
+        .min_connections(legacy.min_connections)
+        .acquire_timeout(Duration::from_secs(legacy.acquire_timeout))
+        .connect_with(conn.connect_options())
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,5 +267,35 @@ mod tests {
     fn test_pool_type_alias() {
         // Type alias should be PgPool
         fn _assert_type(_: DbPool) {}
+    }
+
+    // DbPoolMap behavioural tests run against real sqlx pools,
+    // which need a live Postgres — they live in the kind-validate
+    // rig (Phase F R4-5).  Unit tests here exercise the routing
+    // math via `shard_for` directly; the wiring of pool selection
+    // is small enough that a live test is the natural verification.
+
+    #[test]
+    fn pool_for_routing_math_matches_drift_guard_pairs() {
+        // Pin the same (execution_id, shard_count) -> shard_index
+        // mapping the R3b drift-guard asserts across sources.
+        // If DbPoolMap::pool_for ever stops calling shard_for,
+        // these pins still document the contract.
+        assert_eq!(shard_for(1, 2), 1);
+        assert_eq!(shard_for(1, 4), 1);
+        assert_eq!(shard_for(1, 16), 5);
+        assert_eq!(shard_for(1, 64), 21);
+        assert_eq!(shard_for(1, 1024), 405);
+    }
+
+    #[test]
+    fn pool_for_degenerate_shard_count_short_circuits() {
+        // shard_count = 1 must return shard 0 without hashing.
+        // Pin both the helper and a representative execution_id
+        // to keep this honest if shard_for ever changes its
+        // shard_count <= 1 short-circuit.
+        assert_eq!(shard_for(42, 1), 0);
+        assert_eq!(shard_for(9_999_999_999, 1), 0);
+        assert_eq!(shard_for(-1, 1), 0);
     }
 }


### PR DESCRIPTION
## Summary

Phase F R4 of [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49) — DB sharding via per-shard physical Postgres.  R4 sub-issue tracker: #48.

**R4-1** is the connection-pool layer only.  No handler changes; ships dormant.  `DbPoolMap` is the container that R4-2 wires into `AppState` and R4-3 wires into per-execution handlers.

## What landed

### Config (`src/config/database.rs`)

- `ShardConnection` — host/port/user/password/database tuple.
- `ShardConnection::parse(dsn)` — parses `host=...;port=...;user=...;password=...;database=...` (semicolon-separated key=value pairs).  Chose semicolons over `&` to keep DSN strings obviously distinct from URL query strings since the outer `NOETL_SHARDS` separator is the comma; operators copy-paste these into env files and the less ambiguity the better.
- `ShardConnectionError` — typed errors for malformed pairs / missing keys / unknown keys / invalid ports.
- `ShardingConfig { shards: Vec<ShardConnection>, cluster: Option<ShardConnection> }` loaded from `NOETL_SHARDS` (comma-separated) + `NOETL_CLUSTER_DSN`.  Empty / unset → fallback mode.

### Pool layer (`src/db/pool.rs`)

- `DbPoolMap` — N+1 pool container.
  - `pool_for(execution_id)` picks the shard via the existing `sharding::shard_for(execution_id, shard_count)`.  **Same hash + seed as the gateway-side R3a-2 picker** — the R3b drift-guard (`repos/ops/automation/development/validate-shard-drift-guard.sh`) keeps both sides honest.
  - `cluster()` returns the always-master pool for `catalog` / `credential` / `keychain` / `runtime` / `schedule` / `resource` / `manifest` / `manifest_part`.
  - `all_shards()` exposes an iterator of `(shard_index, pool)` pairs for R4-4 fan-out (`GET /api/executions` list endpoint).
- **Single-pool fallback** — when `NOETL_SHARDS` is empty, the constructor builds a degenerate map: one shard whose pool IS the cluster pool.  Every accessor returns the legacy pool; behaviour identical to today.  This is how R4 ships dormant.

### Config module surface (`src/config/mod.rs`)

Public re-exports for `ShardConnection`, `ShardConnectionError`, `ShardingConfig`.

## Testing

- **12 new config tests** — DSN parse happy path + every error variant (`MalformedPair`, `MissingKey(host)`, `MissingKey(user)`, `UnknownKey`, `InvalidPort`) + `ShardingConfig::from_env` cases (disabled / empty string / two-shard / empty-segment skip / dbname alias).  Env-mutating tests run via a save/restore helper; require `--test-threads=1` to stay serial.
- **2 new pool tests** pinning `shard_for` math against the R3b drift-guard's known pairs:
  - `shard_for(1, 2/4/16/64/1024) → 1/1/5/21/405` (same values the integration test validates server-side in kind).
  - `shard_for(*, 1) → 0` (degenerate short-circuit).
  If `pool_for` ever stops calling `shard_for`, these pinned values keep the wire contract honest.
- `cargo build` clean.
- `cargo test --lib`: 244/245 pass.  The one failure (`playbook::parser::tests::test_parse_invalid_next_reference`) is a pre-existing failure carried over from R3b-1 and unrelated to this PR.

## Operator opt-in

Future R4-5 deployment manifest will set:

```
NOETL_SHARDS="host=postgres-shard-0;user=noetl;password=...,host=postgres-shard-1;user=noetl;password=..."
NOETL_CLUSTER_DSN="host=postgres-cluster;user=noetl;password=..."
```

Until then, `NOETL_SHARDS` empty/unset keeps the server in single-pool fallback mode (today's behaviour, bit-identical).

## Next rounds

- **R4-2**: wire `DbPoolMap` into `AppState`; add `ShardPool(execution_id)` + `ClusterPool` extractors for handlers.
- **R4-3**: handler cutover (~12 files: events, commands, executions, variables, internal/outbox swap from global pool to `pool_for(execution_id)`).
- **R4-4**: cluster-wide list endpoint (`GET /api/executions`) gets the fan-out + merge helper using `all_shards()`.
- **R4-5**: kind validation with N=2 shards (noetl/ops manifest split + end-to-end smoke).

## Test plan

- [x] cargo build clean
- [x] 12 new config tests pass
- [x] 2 new pool tests pin shard_for routing math against R3b drift-guard pairs
- [x] Single-pool fallback verified behaviourally (constructor + accessor logic)
- [ ] R4-5 kind validation will exercise the multi-pool path against live Postgres (deferred to that sub-round)

Refs #48
Refs https://github.com/noetl/ai-meta/issues/49