### PR TITLE
feat(state): wire DbPoolMap into AppState (Phase F R4-2)

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,4 +7,4 @@ pub mod models;
 pub mod pool;
 pub mod queries;
 
-pub use pool::{create_pool, DbPool};
+pub use pool::{create_pool, DbPool, DbPoolMap};

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -192,6 +192,23 @@ impl DbPoolMap {
         })
     }
 
+    /// Build a single-pool fallback [`DbPoolMap`] from an
+    /// already-created [`DbPool`].  Sync constructor for callers
+    /// (tests, the legacy `main.rs` path) that already have a
+    /// pool in hand and don't want to re-resolve `ShardingConfig`.
+    ///
+    /// The result behaves identically to the single-pool branch
+    /// of [`DbPoolMap::new`]: one shard whose pool is also the
+    /// cluster pool; every accessor returns `pool`.
+    pub fn from_single_pool(pool: DbPool) -> Self {
+        Self {
+            shards: Arc::new(vec![pool.clone()]),
+            cluster: pool,
+            shard_count: 1,
+            single_pool_mode: true,
+        }
+    }
+
     /// Number of shard pools configured.  Always `>= 1`.
     pub fn shard_count(&self) -> u32 {
         self.shard_count
@@ -297,5 +314,49 @@ mod tests {
         assert_eq!(shard_for(42, 1), 0);
         assert_eq!(shard_for(9_999_999_999, 1), 0);
         assert_eq!(shard_for(-1, 1), 0);
+    }
+
+    // ----- DbPoolMap::from_single_pool (R4-2) ---------------------------------
+
+    // The `from_single_pool` constructor lets `AppState::new_legacy`
+    // (Phase F R4-2) wrap an already-created `DbPool` without
+    // re-resolving `ShardingConfig`.  These tests don't need a
+    // live Postgres — they exercise the struct shape only.
+    // Building a `PgPool` without connecting requires sqlx's
+    // `PgPoolOptions::connect_lazy_with`; we use that to fabricate
+    // a dummy pool whose accessor identity we then verify.
+
+    fn dummy_pool() -> DbPool {
+        use sqlx::postgres::PgConnectOptions;
+        PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy_with(PgConnectOptions::new().host("localhost"))
+    }
+
+    #[tokio::test]
+    async fn from_single_pool_marks_fallback_mode() {
+        let pool = dummy_pool();
+        let map = DbPoolMap::from_single_pool(pool);
+        assert!(map.is_single_pool());
+        assert_eq!(map.shard_count(), 1);
+        // pool_for must short-circuit and not hash; the value
+        // we return for any execution_id is the only pool.
+        // (We don't compare the pool by identity here — sqlx
+        // doesn't expose Arc internals — but we do verify
+        // `shard_count() == 1` and that `all_shards()` yields
+        // exactly one entry.)
+        assert_eq!(map.all_shards().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn from_single_pool_pool_for_does_not_panic_on_negative_eid() {
+        // Regression guard: `shard_for(-1, 1)` short-circuits to
+        // 0; pool_for indexes into `shards[0]`.  Make sure the
+        // single-pool path is safe for the i64-extreme inputs
+        // the R3b drift-guard exercises.
+        let map = DbPoolMap::from_single_pool(dummy_pool());
+        let _ = map.pool_for(-1);
+        let _ = map.pool_for(i64::MAX);
+        let _ = map.pool_for(0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,10 @@
 //!     let app_config = AppConfig::from_env()?;
 //!     let db_config = DatabaseConfig::from_env()?;
 //!     let db_pool = create_pool(&db_config).await?;
-//!     let state = AppState::new(db_pool, app_config, None);
+//!     // Single-pool fallback shim — production main.rs builds
+//!     // the DbPoolMap from ShardingConfig::from_env() for the
+//!     // sharded path; test / example code uses new_legacy.
+//!     let state = AppState::new_legacy(db_pool, app_config, None);
 //!     // ... build and run server
 //!     Ok(())
 //! }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use noetl_server::{
-    config::{AppConfig, DatabaseConfig},
-    db::{create_pool, DbPool},
+    config::{AppConfig, DatabaseConfig, ShardingConfig},
+    db::{create_pool, DbPool, DbPoolMap},
     handlers,
     services::{
         CatalogService, CredentialService, ExecutionService, KeychainService, RuntimeService,
@@ -410,8 +410,34 @@ async fn main() -> anyhow::Result<()> {
         "Configuration loaded"
     );
 
-    // Create database connection pool
+    // Create database connection pool (legacy single pool — kept
+    // as the cluster-wide pool in DbPoolMap's fallback branch
+    // and as `AppState.db` for handlers that haven't migrated
+    // to the pool map yet, per R4-2).
     let db_pool = create_pool(&db_config).await?;
+
+    // Phase F R4-2 of noetl/ai-meta#49: load sharding config
+    // and build the DbPoolMap.  When NOETL_SHARDS is empty
+    // (today's default), DbPoolMap::new short-circuits to a
+    // single-pool fallback that wraps `db_pool` itself —
+    // behaviour bit-identical to pre-R4 single-host deployments.
+    let sharding_config = ShardingConfig::from_env().unwrap_or_else(|e| {
+        tracing::warn!(
+            error = %e,
+            "Failed to parse NOETL_SHARDS / NOETL_CLUSTER_DSN; falling back to single-pool mode"
+        );
+        ShardingConfig::default()
+    });
+    let pools = if sharding_config.is_disabled() {
+        DbPoolMap::from_single_pool(db_pool.clone())
+    } else {
+        DbPoolMap::new(&db_config, &sharding_config).await?
+    };
+    tracing::info!(
+        shard_count = pools.shard_count(),
+        single_pool_mode = pools.is_single_pool(),
+        "Database pool map ready"
+    );
 
     // Connect to NATS (optional)
     let nats_client = connect_nats(&app_config).await;
@@ -423,7 +449,7 @@ async fn main() -> anyhow::Result<()> {
     // (Phase F R1.5 of noetl/ai-meta#49) is initialized once and
     // shared with the services below.  Services that need to mint
     // ids take a clone of `state.snowflake` (an `Arc`).
-    let state = AppState::new(db_pool.clone(), app_config.clone(), nats_client);
+    let state = AppState::new(db_pool.clone(), pools, app_config.clone(), nats_client);
 
     // Create services
     let catalog_service = CatalogService::new(db_pool.clone());

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,7 @@
 //! passed to all handlers via Axum's state management.
 
 use crate::config::AppConfig;
-use crate::db::DbPool;
+use crate::db::{DbPool, DbPoolMap};
 use crate::sharding::ShardConfig;
 use crate::snowflake::{derive_machine_id, SnowflakeGenerator};
 use std::sync::Arc;
@@ -15,8 +15,43 @@ use std::sync::Arc;
 /// It is wrapped in an `Arc` and passed to handlers via Axum's state.
 #[derive(Clone)]
 pub struct AppState {
-    /// Database connection pool
+    /// Legacy database connection pool.
+    ///
+    /// In single-pool fallback mode (Phase F R4-1's
+    /// `NOETL_SHARDS` empty), this IS the only pool — every
+    /// handler that hasn't migrated to [`Self::pools`] uses it.
+    /// In sharded mode, `db` is the cluster-wide pool (the
+    /// always-master pool for catalog / credential / keychain /
+    /// runtime / etc.) so handlers that read cluster-wide tables
+    /// keep working without R4-3 touching them.
+    ///
+    /// Phase F R4-3 migrates per-execution call sites to
+    /// `self.pools.pool_for(execution_id)`.  Until that round
+    /// lands, every handler reads from `db` regardless of which
+    /// table they touch — which is correct in fallback mode
+    /// (one pool everywhere) and incorrect-but-tolerated in
+    /// sharded mode (per-execution tables would still go to the
+    /// cluster master; this is why the kind validation in R4-5
+    /// only fires after R4-3 ships).
     pub db: DbPool,
+
+    /// Sharded pool map — N per-shard pools + 1 cluster pool.
+    ///
+    /// Phase F R4-2 of
+    /// [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49)
+    /// added this.  Use [`DbPoolMap::pool_for`] for per-execution
+    /// tables (`event`, `command`, `execution`, `outbox`,
+    /// `transient`, `stage`, `frame`, `projection`,
+    /// `projection_snapshot`, `result_ref`) and
+    /// [`DbPoolMap::cluster`] for cluster-wide tables
+    /// (`catalog`, `credential`, `keychain`, `runtime`,
+    /// `schedule`, `resource`, `manifest`, `manifest_part`).
+    ///
+    /// In single-pool fallback mode (NOETL_SHARDS empty), every
+    /// accessor returns the same pool as [`Self::db`] — handlers
+    /// that opt into `pools` get bit-identical behaviour to the
+    /// legacy path.
+    pub pools: DbPoolMap,
 
     /// Application configuration
     pub config: Arc<AppConfig>,
@@ -53,7 +88,13 @@ impl AppState {
     ///
     /// # Arguments
     ///
-    /// * `db` - Database connection pool
+    /// * `db` - Legacy database connection pool (kept for handlers
+    ///   not yet migrated to [`Self::pools`] — see field doc).
+    /// * `pools` - Sharded pool map.  In single-pool fallback
+    ///   mode this is constructed from the same `db` connection
+    ///   via [`DbPoolMap::new`] with an empty [`crate::config::ShardingConfig`];
+    ///   callers should use [`AppState::new_legacy`] when they
+    ///   don't have a separate `ShardingConfig` to pass.
     /// * `config` - Application configuration
     /// * `nats` - Optional NATS client
     ///
@@ -72,7 +113,12 @@ impl AppState {
     /// Panics if the configured `server_machine_id` exceeds the
     /// 10-bit max (1023).  The caller should validate at
     /// config-load time; this is the last-resort guard.
-    pub fn new(db: DbPool, config: AppConfig, nats: Option<async_nats::Client>) -> Self {
+    pub fn new(
+        db: DbPool,
+        pools: DbPoolMap,
+        config: AppConfig,
+        nats: Option<async_nats::Client>,
+    ) -> Self {
         let machine_id = config.server_machine_id.unwrap_or_else(|| {
             let hostname = std::env::var("HOSTNAME")
                 .or_else(|_| std::env::var("COMPUTERNAME"))
@@ -117,12 +163,32 @@ impl AppState {
 
         Self {
             db,
+            pools,
             config: Arc::new(config),
             nats: nats.map(Arc::new),
             snowflake: Arc::new(snowflake),
             shard: Arc::new(shard),
             start_time: std::time::Instant::now(),
         }
+    }
+
+    /// Convenience constructor for tests + paths that haven't
+    /// loaded a [`ShardingConfig`] yet.  Wraps the legacy `db`
+    /// pool in a single-pool [`DbPoolMap`] (no per-shard pools,
+    /// no separate cluster pool — the same `db` handle covers
+    /// every accessor).
+    ///
+    /// `main.rs` uses the full [`AppState::new`] with a pool map
+    /// built from [`ShardingConfig::from_env`] so the production
+    /// path honors `NOETL_SHARDS` if set.  Test code that
+    /// already has a `DbPool` in hand uses this shim.
+    pub fn new_legacy(
+        db: DbPool,
+        config: AppConfig,
+        nats: Option<async_nats::Client>,
+    ) -> Self {
+        let pools = DbPoolMap::from_single_pool(db.clone());
+        Self::new(db, pools, config, nats)
     }
 
     /// Get the server uptime in seconds.


### PR DESCRIPTION
## Summary

Phase F R4-2 of [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49). Builds on R4-1's pool layer (#49 / v2.13.0). Tracks #48.

Wires `DbPoolMap` into `AppState`. **No handler call-site changes.** Handlers continue to read from `state.db` (the legacy pool) — that field is preserved exactly. R4-3 (next round) cuts over per-execution handlers to `state.pools.pool_for(execution_id)`.

## What landed

### `AppState` (`src/state.rs`)

- New `pools: DbPoolMap` field alongside the existing `db: DbPool`.
- `AppState::new` takes the pool map as a fourth argument.
- New `AppState::new_legacy(db, config, nats)` shim wraps an already-created pool in a single-pool `DbPoolMap` — for tests / examples that don't have a `ShardingConfig`.

### `DbPoolMap` (`src/db/pool.rs`)

- New sync constructor `DbPoolMap::from_single_pool(pool)`. Lets `AppState::new_legacy` (and any other caller with a pool already in hand) skip the async `DbPoolMap::new` path. Behavior identical to the single-pool fallback branch of the async constructor.

### `main.rs`

- Load `ShardingConfig::from_env()`; build `DbPoolMap::new(&db_config, &sharding_config)` when sharded, `from_single_pool(db_pool.clone())` when not.
- Pass the map into `AppState::new` as the new fourth arg.
- Log shard count + single-pool mode on startup so the routing topology is visible in the server's first log lines.

### Lib doc example (`src/lib.rs`)

- Update the doc-comment quickstart to use `new_legacy` since the 3-arg `new` signature is gone.

### `db` module (`src/db/mod.rs`)

- Re-export `DbPoolMap` alongside `DbPool` and `create_pool`.

## Why the legacy `db` field stays

R4-2 deliberately leaves `state.db` as the legacy pool (= the cluster-wide pool in sharded mode, = the only pool in fallback mode). That field is read by ~70 call sites and a single PR rewriting all of them would be reviewer-hostile and risky.

R4-3 does the disciplined cutover:
- Per-execution handlers (events, commands, executions, variables, internal/outbox) → `state.pools.pool_for(execution_id)`.
- Cluster-wide handlers (catalog, credential, keychain, runtime) → `state.pools.cluster()` (which equals `state.db` in single-pool mode, but tells the reader which intent applies).
- The `db` field gets eventually removed in R4-3 or R4-4 once every reader has migrated.

This staging keeps each PR's diff small enough to review properly.

## Testing

- 2 new pool tests using sqlx `connect_lazy_with` + `#[tokio::test]` (sqlx needs the runtime even for lazy construction):
  - `from_single_pool_marks_fallback_mode` — verifies `is_single_pool() == true`, `shard_count() == 1`, `all_shards()` yields one entry.
  - `from_single_pool_pool_for_does_not_panic_on_negative_eid` — regression guard for the i64-extreme inputs (`-1`, `i64::MAX`, `0`) the R3b drift-guard exercises.
- 20/20 R4 tests pass (12 R4-1 config + 5 R4-1 pool + 2 R4-2 pool + 1 existing alias test).
- `cargo build` clean.
- `cargo test --lib`: 246/247 pass. The one failure (`playbook::parser::tests::test_parse_invalid_next_reference`) is the same pre-existing parser failure unrelated to R4 (carried over from R3b-1).

## Single-pool fallback verification

When `NOETL_SHARDS` is empty / unset:
- `main.rs` builds `DbPoolMap::from_single_pool(db_pool.clone())` instead of `DbPoolMap::new`.
- The map's three accessors (`pool_for`, `cluster`, `all_shards`) all return / iterate the same `db_pool` handle.
- `state.db` is also the same handle.
- Existing handlers (which read `state.db`) see no change.

## Next rounds

- **R4-3**: per-execution handler cutover (~12 handler files).
- **R4-4**: `GET /api/executions` cluster-wide list fan-out using `all_shards()`.
- **R4-5**: kind validation with N=2 shards (noetl/ops manifest split).

## Test plan

- [x] cargo build clean
- [x] 20 R4 tests pass (R4-1 + R4-2)
- [x] AppState::new_legacy shim verified for the test/example path
- [x] main.rs sharded path compiles (live shard validation deferred to R4-5)
- [ ] R4-5 kind validation will exercise the multi-pool path end-to-end

Refs #48
Refs https://github.com/noetl/ai-meta/issues/49