### PR TITLE
feat(handlers): cut execute.rs over to DbPoolMap (Phase F R4-3b)

### DIFF
--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -128,23 +128,23 @@ pub async fn execute(
 /// Resolve catalog entry from path or catalog_id.
 async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResult<(i64, String)> {
     if let Some(catalog_id) = request.catalog_id {
-        // Lookup by catalog_id
+        // Lookup by catalog_id (Phase F R4-3: noetl.catalog is cluster-wide)
         let entry = sqlx::query_as::<_, (i64, String)>(
             "SELECT catalog_id, path FROM noetl.catalog WHERE catalog_id = $1",
         )
         .bind(catalog_id)
-        .fetch_optional(&state.db)
+        .fetch_optional(state.pools.cluster())
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Catalog entry not found: {}", catalog_id)))?;
 
         Ok(entry)
     } else if let Some(path) = &request.path {
-        // Lookup by path (latest version)
+        // Lookup by path (latest version; Phase F R4-3: cluster-wide)
         let entry = sqlx::query_as::<_, (i64, String)>(
             "SELECT catalog_id, path FROM noetl.catalog WHERE path = $1 ORDER BY version DESC LIMIT 1",
         )
         .bind(path)
-        .fetch_optional(&state.db)
+        .fetch_optional(state.pools.cluster())
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Playbook not found: {}", path)))?;
 
@@ -159,12 +159,13 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
 /// Get playbook YAML from catalog.
 async fn get_playbook_yaml(state: &AppState, catalog_id: i64) -> AppResult<String> {
     // Try to get content first (raw YAML), fall back to payload (JSON)
+    // Phase F R4-3: noetl.catalog is cluster-wide.
     let row: (Option<String>, Option<serde_json::Value>) =
         sqlx::query_as::<_, (Option<String>, Option<serde_json::Value>)>(
             "SELECT content, payload FROM noetl.catalog WHERE catalog_id = $1",
         )
         .bind(catalog_id)
-        .fetch_optional(&state.db)
+        .fetch_optional(state.pools.cluster())
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Catalog entry not found: {}", catalog_id)))?;
 
@@ -229,7 +230,7 @@ async fn emit_playbook_started_event(
     .bind(&context)
     .bind(&meta)
     .bind(chrono::Utc::now())
-    .execute(&state.db)
+    .execute(state.pools.pool_for(execution_id))
     .await?;
 
     Ok(event_id)
@@ -353,7 +354,7 @@ pub(crate) async fn persist_engine_command(
     .bind(&cmd_meta)
     .bind(parent_event_id)
     .bind(chrono::Utc::now())
-    .execute(&state.db)
+    .execute(state.pools.pool_for(execution_id))
     .await?;
 
     if let Err(e) = insert_command_row(
@@ -505,7 +506,7 @@ async fn insert_command_row(
     .bind(context)
     .bind(meta)
     .bind(parent_event_id)
-    .execute(&state.db)
+    .execute(state.pools.pool_for(execution_id))
     .await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Phase F R4-3b of [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49). Second slice of R4-3 (per-execution handler cutover) on top of R4-3a (events.rs, #51 / v2.15.0). Tracks #48.

`execute.rs` cutover. 6 `state.db` call sites, cleanly split by table family.

## Sites migrated (6)

| Site | Function | Table | Pool |
| :-- | :-- | :-- | :-- |
| L136 | `resolve_catalog` by catalog_id | `noetl.catalog` | **`cluster()`** |
| L147 | `resolve_catalog` by path | `noetl.catalog` | **`cluster()`** |
| L167 | `get_playbook_yaml` content/payload | `noetl.catalog` | **`cluster()`** |
| L232 | `playbook_started` event INSERT | `noetl.event` | `pool_for(execution_id)` |
| L356 | `command.issued` event INSERT (per command) | `noetl.event` | `pool_for(execution_id)` |
| L508 | command row INSERT (`insert_command_row`) | `noetl.command` | `pool_for(execution_id)` |

`state.db` no longer appears in `execute.rs`.

## Single-pool fallback verification

Same shape as R4-3a — when `NOETL_SHARDS` is empty, `pool_for(execution_id)` / `cluster()` / `state.db` all resolve to the same `DbPool` handle via `DbPoolMap::from_single_pool`. Behaviour bit-identical to pre-R4.

## Tests

- `cargo build` clean.
- 20/20 R4 unit tests still pass.
- `cargo test --lib`: 246/247 pass. The one failure (`playbook::parser::tests::test_parse_invalid_next_reference`) is the same pre-existing parser failure carried over from R3b-1, unrelated.

## Next

**R4-3c**: `health.rs` cutover (3 sites; health check + pool stats; all cluster-wide → `cluster()`). Final slice of R4-3.

Then R4-4 (cluster-wide list fan-out + the event_id-keyed deferrals from R4-3a) → R4-5 (kind validation with N=2 shards).

## Test plan

- [x] cargo build clean
- [x] 20 R4 unit tests pass
- [x] 3 catalog reads → cluster(); 3 per-execution writes → pool_for
- [x] state.db absent from execute.rs after the cutover
- [ ] R4-5 kind validation will exercise the multi-pool path end-to-end

Refs #48
Refs https://github.com/noetl/ai-meta/issues/49