### PR TITLE
feat(handlers): cut health.rs over to DbPoolMap (Phase F R4-3c)

### DIFF
--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -85,7 +85,12 @@ pub async fn health_check() -> Json<HealthCheckResponse> {
 /// - `200 OK` with detailed health status if all services are healthy
 /// - `503 Service Unavailable` if any critical service is unhealthy
 pub async fn api_health(State(state): State<AppState>) -> (StatusCode, Json<ApiHealthResponse>) {
-    let db_healthy = db_health_check(&state.db).await;
+    // Phase F R4-3c: probe the cluster pool — that's the
+    // "can this replica answer at all" check.  Per-shard health
+    // is a separate concern (a future /api/health/shards endpoint
+    // would iterate state.pools.all_shards() and probe each); not
+    // needed for the basic readiness signal.
+    let db_healthy = db_health_check(state.pools.cluster()).await;
 
     let nats_status = if state.has_nats() {
         Some("connected".to_string())
@@ -124,8 +129,16 @@ pub async fn api_health(State(state): State<AppState>) -> (StatusCode, Json<ApiH
 ///
 /// `GET /api/pool/status`
 pub async fn pool_status(State(state): State<AppState>) -> Json<PoolStatusResponse> {
-    let pool_size = u32::try_from(state.db.size()).unwrap_or(u32::MAX);
-    let pool_available = u32::try_from(state.db.num_idle()).unwrap_or(u32::MAX);
+    // Phase F R4-3c: report cluster pool stats here.  In
+    // single-pool fallback mode (NOETL_SHARDS empty) the cluster
+    // handle IS the only pool, so the numbers are unchanged from
+    // pre-R4.  In sharded mode this endpoint surfaces just the
+    // cluster pool — per-shard pool utilization belongs on
+    // /metrics (per-shard gauge labels) or a follow-up
+    // /api/pool/status/shards endpoint.
+    let cluster = state.pools.cluster();
+    let pool_size = u32::try_from(cluster.size()).unwrap_or(u32::MAX);
+    let pool_available = u32::try_from(cluster.num_idle()).unwrap_or(u32::MAX);
     let pool_max = pool_size.max(pool_available);
     let pool_min = 0;
     let active = pool_size.saturating_sub(pool_available);


### PR DESCRIPTION
## Summary

Phase F R4-3c of [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49). Third + final slice of R4-3 (per-execution handler cutover) on top of R4-3a (events.rs, #51 / v2.15.0) and R4-3b (execute.rs, #52 / v2.16.0). Tracks #48.

`health.rs` cutover. 3 `state.db` call sites, all cluster-wide.

## Sites migrated (3)

| Site | Function | Pool |
| :-- | :-- | :-- |
| L88 | `api_health` — `db_health_check` for `GET /api/health` | **`cluster()`** |
| L132 | `pool_status` — `pool.size()` for `GET /api/pool/status` | **`cluster()`** |
| L133 | `pool_status` — `pool.num_idle()` for the same endpoint | **`cluster()`** |

`state.db` is now absent from `health.rs`.

## Future per-shard health (called out in comments)

Per-shard health probing is a separate concern from this PR:

- **Basic readiness** (`/api/health`): the cluster probe covers "can this replica answer at all". Sufficient signal for Kubernetes liveness/readiness probes.
- **Per-shard health** (future `/api/health/shards`): iterate `state.pools.all_shards()` and probe each. Useful for ops dashboards; not needed for the readiness gate.
- **Per-shard pool utilization** (future): belongs on `/metrics` (per-shard gauge labels) or `/api/pool/status/shards`.

Inline comments at both sites point at the future endpoints so the next operator knows where to extend.

## R4-3 complete

After this PR merges, only **2** `state.db` sites remain in the entire codebase — both in `events.rs`, both event_id-keyed (`get_command` + `claim_command`), both explicitly tagged with `TODO(R4-4)` markers. R4-4 introduces the cluster-wide fan-out resolver (or path-param redesign) that closes those out.

| Slice | File | Status |
| :-- | :-- | :-- |
| R4-3a | events.rs | ✅ #51 → v2.15.0 |
| R4-3b | execute.rs | ✅ #52 → v2.16.0 |
| R4-3c | health.rs | this PR |

## Tests

- `cargo build` clean.
- 20/20 R4 unit tests still pass.
- `cargo test --lib`: 246/247 pass. The one failure (`playbook::parser::tests::test_parse_invalid_next_reference`) is the same pre-existing parser failure carried over from R3b-1, unrelated.

## Next

**R4-4**: cluster-wide list fan-out (`GET /api/executions` merges paginated views across `state.pools.all_shards()`) plus the two event_id-keyed deferrals from R4-3a.

Then R4-5: kind validation with N=2 shards (noetl/ops manifest split + end-to-end smoke).

## Test plan

- [x] cargo build clean
- [x] 20 R4 unit tests pass
- [x] state.db absent from health.rs after the cutover
- [x] R4-3 complete across all three files (events.rs + execute.rs + health.rs)
- [ ] R4-5 kind validation will exercise the multi-pool path end-to-end

Refs #48
Refs https://github.com/noetl/ai-meta/issues/49