### PR TITLE
feat(db,handlers): cross-shard fan-out + event_id resolver (Phase F R4-4)

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -260,6 +260,82 @@ impl DbPoolMap {
             .enumerate()
             .map(|(idx, pool)| (idx as u32, pool))
     }
+
+    /// Run an async query against every shard sequentially and
+    /// collect the per-shard results in shard-index order.
+    ///
+    /// Phase F R4-4: powers cluster-wide list endpoints that
+    /// query a per-execution table (e.g. `GET /api/executions`).
+    /// The caller's closure runs once per shard with the shard
+    /// pool + shard index; the helper returns the per-shard
+    /// outputs in shard-index order so the caller can merge /
+    /// sort / paginate.
+    ///
+    /// In single-pool fallback mode (`is_single_pool() == true`)
+    /// this is a single call against the one pool — same
+    /// behaviour as `query.fetch_all(map.cluster())` modulo the
+    /// `(0, _)` shard_index pair the closure receives.
+    ///
+    /// Errors short-circuit: the first shard that errors stops
+    /// the iteration and propagates.  Acceptable for R4-4
+    /// because the per-shard pool's own error path already logs
+    /// a "shard N failed" line.  Parallelism across shards is a
+    /// Phase G concern (see body comment).
+    pub async fn for_each_shard<F, Fut, T, E>(&self, mut f: F) -> Result<Vec<(u32, T)>, E>
+    where
+        F: FnMut(u32, DbPool) -> Fut,
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        // Sequential await — simple and dep-free.  Parallelism
+        // across shards is a Phase G concern (would need
+        // `futures::future::try_join_all` or a `tokio::spawn`
+        // with the awkward 'static + Send bounds it imposes on
+        // the caller's closure).  For N=2-4 shards on a typical
+        // GKE Cloud SQL latency profile (sub-10ms per query),
+        // the sequential cost is small enough that the call-site
+        // simplicity wins.
+        let mut out = Vec::with_capacity(self.shard_count as usize);
+        for (idx, pool) in self.all_shards() {
+            let result = f(idx, pool.clone()).await?;
+            out.push((idx, result));
+        }
+        Ok(out)
+    }
+
+    /// Run an async probe against every shard in parallel and
+    /// return the first non-`None` result.
+    ///
+    /// Phase F R4-4: powers event_id-keyed endpoints where the
+    /// caller doesn't know which shard owns the row up-front
+    /// (`GET /api/commands/{event_id}`, `POST /api/commands/{event_id}/claim`).
+    /// Each shard answers "do you have this event_id?" via the
+    /// caller's closure; the first shard that returns `Some` is
+    /// the owner.  Returns `Ok(None)` only if every shard
+    /// returned `Ok(None)` (the event_id doesn't exist anywhere).
+    ///
+    /// In single-pool fallback mode this is a single probe
+    /// against the one pool.
+    ///
+    /// **Race semantics**: when multiple shards somehow return
+    /// `Some` (shouldn't happen for a properly-routed
+    /// `event_id` — IDs are minted from a per-shard snowflake
+    /// machine_id and can't collide across shards), the first
+    /// completed future wins.  This is good enough for the
+    /// event_id contract; a stricter implementation would
+    /// `try_join_all` and require exactly one `Some`.
+    ///
+    /// Errors short-circuit the same way as
+    /// [`Self::for_each_shard`].
+    pub async fn find_first<F, Fut, T, E>(&self, mut f: F) -> Result<Option<(u32, T)>, E>
+    where
+        F: FnMut(u32, DbPool) -> Fut,
+        Fut: std::future::Future<Output = Result<Option<T>, E>>,
+    {
+        let results = self.for_each_shard(|idx, pool| f(idx, pool)).await?;
+        Ok(results
+            .into_iter()
+            .find_map(|(idx, opt)| opt.map(|t| (idx, t))))
+    }
 }
 
 /// Build a pool from a [`ShardConnection`] using the legacy
@@ -358,5 +434,56 @@ mod tests {
         let _ = map.pool_for(-1);
         let _ = map.pool_for(i64::MAX);
         let _ = map.pool_for(0);
+    }
+
+    // ----- DbPoolMap::for_each_shard + find_first (R4-4) -----
+
+    #[tokio::test]
+    async fn for_each_shard_runs_closure_once_per_shard_in_order() {
+        let map = DbPoolMap::from_single_pool(dummy_pool());
+        // In single-pool fallback mode there's exactly one shard
+        // (index 0).  The closure receives (0, pool) once.
+        let observed: Vec<u32> = map
+            .for_each_shard::<_, _, u32, sqlx::Error>(|idx, _pool| async move { Ok(idx) })
+            .await
+            .expect("ok")
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect();
+        assert_eq!(observed, vec![0]);
+    }
+
+    #[tokio::test]
+    async fn for_each_shard_propagates_first_error() {
+        let map = DbPoolMap::from_single_pool(dummy_pool());
+        let err = map
+            .for_each_shard::<_, _, (), &'static str>(|_idx, _pool| async move {
+                Err("kaboom")
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err, "kaboom");
+    }
+
+    #[tokio::test]
+    async fn find_first_returns_none_when_no_shard_matches() {
+        let map = DbPoolMap::from_single_pool(dummy_pool());
+        let out: Option<(u32, i64)> = map
+            .find_first::<_, _, i64, sqlx::Error>(|_idx, _pool| async move { Ok(None) })
+            .await
+            .expect("ok");
+        assert!(out.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_first_returns_first_match_with_shard_index() {
+        let map = DbPoolMap::from_single_pool(dummy_pool());
+        let out: Option<(u32, &'static str)> = map
+            .find_first::<_, _, &'static str, sqlx::Error>(|_idx, _pool| async move {
+                Ok(Some("hit"))
+            })
+            .await
+            .expect("ok");
+        assert_eq!(out, Some((0, "hit")));
     }
 }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -510,26 +510,27 @@ pub async fn get_command(
 ) -> Result<Json<CommandResponse>, AppError> {
     debug!("Getting command for event_id={}", event_id);
 
-    // Phase F R4-3: `GET /api/commands/{event_id}` is keyed by
-    // event_id alone — execution_id isn't known until after this
-    // lookup, so we can't pick a per-execution pool yet.  In
-    // single-pool fallback mode (today's default) `state.db` IS
-    // the only pool and this works as-is.  When sharding is on,
-    // this endpoint needs the R4-4 cluster-wide fan-out helper
-    // (query every shard, return the first hit).  TODO(R4-4):
-    // replace `state.db` with `state.pools.find_in_any_shard(...)`
-    // once that helper lands.
-    let row: Option<(i64, String, String, serde_json::Value, serde_json::Value)> =
-        sqlx::query_as::<_, (i64, String, String, serde_json::Value, serde_json::Value)>(
-            r#"
-            SELECT execution_id, node_name, node_type, context, meta
-            FROM noetl.event
-            WHERE event_id = $1 AND event_type = 'command.issued'
-            "#,
-        )
-        .bind(event_id)
-        .fetch_optional(&state.db)
+    // Phase F R4-4: `GET /api/commands/{event_id}` is keyed by
+    // event_id alone — execution_id isn't known until after the
+    // lookup.  Use the cross-shard resolver: probe every shard,
+    // first hit wins.  In single-pool fallback mode this is a
+    // single probe against the one pool.
+    let found = state
+        .pools
+        .find_first(|_shard_idx, pool| async move {
+            sqlx::query_as::<_, (i64, String, String, serde_json::Value, serde_json::Value)>(
+                r#"
+                SELECT execution_id, node_name, node_type, context, meta
+                FROM noetl.event
+                WHERE event_id = $1 AND event_type = 'command.issued'
+                "#,
+            )
+            .bind(event_id)
+            .fetch_optional(&pool)
+            .await
+        })
         .await?;
+    let row = found.map(|(_shard_idx, r)| r);
 
     match row {
         Some((execution_id, node_name, node_type, context, meta)) => Ok(Json(CommandResponse {
@@ -560,19 +561,43 @@ pub async fn claim_command(
         event_id, request.worker_id
     );
 
-    // Phase F R4-3: `claim_command` is keyed by event_id alone —
-    // execution_id is read out of the first SELECT inside the
-    // transaction.  We can't open the tx on the per-execution
-    // pool until we know which shard owns this event_id.
-    // Pragmatic stance: open the tx on `state.db` (the only pool
-    // in fallback mode; the cluster pool in sharded mode).  In
-    // sharded mode this endpoint is non-functional until R4-4
-    // adds a fan-out resolver — the endpoint contract carries
-    // event_id but not execution_id, so a path-param redesign or
-    // a multi-shard probe is needed.  TODO(R4-4): resolve
-    // event_id → execution_id (via cross-shard probe or new path
-    // param), then `pool_for(execution_id).begin().await?`.
-    let mut tx = state.db.begin().await?;
+    // Phase F R4-4: resolve event_id -> execution_id via the
+    // cross-shard probe, then open the tx on the per-execution
+    // pool.  Two round trips in sharded mode (one probe + one tx
+    // open) is the right trade-off vs. holding the tx open
+    // across a fan-out scan — keeping shard-locality on the
+    // claim transaction means the second SELECT (terminal-row
+    // check) and any subsequent INSERTs all hit the same shard
+    // and stay within the same tx scope.
+    //
+    // In single-pool fallback mode the resolver short-circuits
+    // (one pool, one probe).
+    let resolved_execution_id: Option<i64> = state
+        .pools
+        .find_first(|_shard_idx, pool| async move {
+            sqlx::query_scalar::<_, i64>(
+                r#"
+                SELECT execution_id
+                FROM noetl.event
+                WHERE event_id = $1 AND event_type = 'command.issued'
+                "#,
+            )
+            .bind(event_id)
+            .fetch_optional(&pool)
+            .await
+        })
+        .await?
+        .map(|(_shard_idx, eid)| eid);
+
+    let resolved_execution_id = resolved_execution_id.ok_or_else(|| {
+        AppError::NotFound(format!("command.issued event not found: {}", event_id))
+    })?;
+
+    let mut tx = state
+        .pools
+        .pool_for(resolved_execution_id)
+        .begin()
+        .await?;
 
     let cmd_row = sqlx::query(
         r#"


### PR DESCRIPTION
## Summary

Phase F R4-4 of [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49). Builds on R4-3's complete handler cutover (#51 + #52 + #53 / v2.15.0–v2.17.0). Tracks #48.

Two cross-shard primitives + closes the two event_id-keyed deferrals from R4-3a. The full `ExecutionService` refactor (list fan-out with the catalog join split into per-shard events aggregation + cluster-master catalog lookup) is the natural next slice (**R4-4b**); landing it separately keeps this PR diff reviewable.

## What landed

### `DbPoolMap` helpers (`src/db/pool.rs`)

- **`for_each_shard<F, Fut, T, E>(f) -> Result<Vec<(u32, T)>, E>`** — runs the caller's async closure once per shard in shard-index order; collects per-shard outputs. Powers cluster-wide list endpoints. Sequential await (no `futures` crate dep, no `tokio::spawn` `'static` bounds); parallelism is a Phase G concern.

- **`find_first<F, Fut, T, E>(f) -> Result<Option<(u32, T)>, E>`** — probes every shard via `for_each_shard`, returns the first shard that produced `Some`. Powers event_id-keyed endpoints where `execution_id` isn't in scope at request time.

### events.rs event_id-keyed deferrals closed

| Site | Function | Approach |
| :-- | :-- | :-- |
| L513–533 | `get_command` (`GET /api/commands/{event_id}`) | `find_first` locates the shard owning the event_id; returns the row. |
| L569–600 | `claim_command` (`POST /api/commands/{event_id}/claim`) | Resolves `event_id → execution_id` via `find_first` against just the `execution_id` column, then opens the tx on `pool_for(execution_id)`. Keeps shard-locality on the claim tx so the inner SELECT + subsequent INSERTs all hit the same shard. Two round trips in sharded mode (one probe + one tx open); locality trade-off wins over fan-out-in-tx. |

### `state.db` absent from src/

R4-3 (events.rs + execute.rs + health.rs) plus R4-4 (events.rs event_id-keyed sites) together complete the handler-side migration to `DbPoolMap`. `grep -rn 'state\.db\b' src/` returns zero hits.

## Tests

4 new tokio pool tests using the existing `dummy_pool` helper:

- `for_each_shard_runs_closure_once_per_shard_in_order` — verifies shard-index ordering.
- `for_each_shard_propagates_first_error` — verifies short-circuit on error.
- `find_first_returns_none_when_no_shard_matches` — verifies negative case.
- `find_first_returns_first_match_with_shard_index` — verifies the `(shard_idx, T)` tuple shape.

9/9 db::pool tests pass; 250/251 full suite (one pre-existing parser failure unrelated, carried over from R3b-1).

## Why not include the ExecutionService refactor here

`ExecutionService::list` joins `noetl.event` (per-execution) with `noetl.catalog` (cluster-wide). In sharded mode that join can't run on a single shard; the correct shape is:

1. Per-shard fan-out via `for_each_shard`: events aggregation grouped by `execution_id`.
2. Merge per-shard `ExecutionSummary` vecs, sort by `started_at DESC`, apply post-merge limit/offset.
3. Single cluster query for `noetl.catalog` paths by the collected `catalog_id` set.
4. Stitch paths into the summaries.

That's a ~14-site refactor inside ExecutionService (every per-execution method moves to `pool_for(execution_id)`; `list` gets rewritten; constructor takes `DbPoolMap`; `main.rs` wiring updates). Doing it in this PR would bloat the diff to 400+ lines across 3 files. **R4-4b** is the dedicated next slice.

## Test plan

- [x] cargo build clean
- [x] 4 new helper tests pass (sequential ordering + error propagation + Some/None paths)
- [x] state.db absent from src/ tree
- [x] event_id-keyed endpoints work in single-pool fallback mode (verified via cargo build + no behavioural change)
- [ ] R4-5 kind validation will exercise the multi-pool path end-to-end (N=2 shards)

## Forward

- **R4-4b**: ExecutionService refactor (DbPoolMap ownership + per-execution method migration + GET /api/executions list fan-out).
- **R4-5**: kind validation with N=2 shards (noetl/ops manifest split + end-to-end smoke).

Refs #48
Refs https://github.com/noetl/ai-meta/issues/49