### PR TITLE
fix(execute): playbook workload reaches all steps via input alias + merge

### DIFF
--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -87,9 +87,33 @@ pub async fn execute(
     // immediately and retries stay idempotent.
     let execution_id = state.snowflake.generate()?;
 
-    // Build workload from payload
-    let workload = serde_json::to_value(&request.payload)
-        .map_err(|e| AppError::Internal(format!("Failed to serialize payload: {}", e)))?;
+    // Build the effective workload by merging playbook YAML
+    // `workload:` defaults with the request's `payload:` overrides.
+    // The orchestrator persists this as the `workload` key on the
+    // `playbook_started` event; ExecutionState::handle_event reads
+    // it back on every subsequent orchestrator pass so downstream
+    // steps see the same workload the start step did.
+    //
+    // Without this merge, the playbook YAML's `workload:` defaults
+    // never reached anything past the start step:
+    // generate_initial_commands does its own merge (below) for the
+    // start step's command context, but the playbook_started event
+    // captured only the request payload — so when state.workload is
+    // hydrated from that event, downstream steps' build_context
+    // returned an empty `{}` and Jinja templates referencing
+    // workload fields rendered to None.  See noetl/ai-meta#56.
+    let mut merged_workload = serde_json::Map::new();
+    if let Some(playbook_workload) = &playbook.workload {
+        if let serde_json::Value::Object(map) = playbook_workload {
+            for (k, v) in map {
+                merged_workload.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    for (k, v) in &request.payload {
+        merged_workload.insert(k.clone(), v.clone());
+    }
+    let workload = serde_json::Value::Object(merged_workload);
 
     // Emit playbook_started event
     let start_event_id = emit_playbook_started_event(

--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -145,8 +145,24 @@ pub struct ToolSpec {
     #[serde(default)]
     pub libs: Option<serde_json::Value>,
 
-    /// Default arguments.
-    #[serde(default)]
+    /// Default arguments / inputs passed to the tool runtime.
+    ///
+    /// The canonical NoETL v10 playbook YAML writes this as
+    /// `input:` at the step's `tool:` block.  The Rust internal
+    /// name stays `args` because that's what the noetl-tools
+    /// registry's `ToolConfig` consumes (PythonTool, ShellTool,
+    /// etc. expose this to user code as `args` / `globals()` /
+    /// shell env).  The serde alias means both forms decode into
+    /// the same field; `input:` is the form playbooks should
+    /// write, `args:` stays accepted for back-compat with
+    /// existing fixtures.
+    ///
+    /// Without the alias, `input:` is silently dropped by serde,
+    /// the worker's Python wrapper's `globals().update(args)`
+    /// gets an empty dict, and any user code referencing the
+    /// workload by name (e.g. `print(f"hello {message}")`) raises
+    /// `NameError`.  See noetl/ai-meta#56 for the e2e finding.
+    #[serde(default, alias = "input")]
     pub args: Option<serde_json::Value>,
 
     /// Python code (for python tool).
@@ -1023,6 +1039,52 @@ workflow:
         let call = ToolCall::from_spec(&spec);
         assert_eq!(call.kind, ToolKind::Python);
         assert!(call.config.contains_key("code"));
+    }
+
+    #[test]
+    fn test_tool_spec_accepts_input_alias_for_args() {
+        // Canonical NoETL v10 playbook YAML writes `input:` on the
+        // tool block.  Without the serde alias, this is silently
+        // dropped and the worker's Python wrapper's
+        // `globals().update(args)` gets an empty dict.  See
+        // noetl/ai-meta#56 — surfaced via hello_world e2e on the
+        // Rust-only stack: `NameError: name 'message' is not
+        // defined` because `input: { message: "{{ message }}" }`
+        // never reached the wrapper.
+        let yaml = r#"
+kind: python
+input:
+  message: "Hello World"
+  count: 42
+code: |
+  print(f"hello {message}")
+"#;
+        let spec: ToolSpec = serde_yaml::from_str(yaml).unwrap();
+        let args = spec.args.clone().expect("input alias should decode into args");
+        assert_eq!(args.get("message").and_then(|v| v.as_str()), Some("Hello World"));
+        assert_eq!(args.get("count").and_then(|v| v.as_i64()), Some(42));
+
+        let call = ToolCall::from_spec(&spec);
+        let call_args = call
+            .config
+            .get("args")
+            .expect("ToolCall::from_spec should propagate args");
+        assert_eq!(call_args.get("message").and_then(|v| v.as_str()), Some("Hello World"));
+    }
+
+    #[test]
+    fn test_tool_spec_accepts_args_field_directly() {
+        // Back-compat: existing fixtures that use `args:` keep
+        // working alongside the new `input:` alias.
+        let yaml = r#"
+kind: python
+args:
+  x: 10
+code: "print(x * 2)"
+"#;
+        let spec: ToolSpec = serde_yaml::from_str(yaml).unwrap();
+        let args = spec.args.expect("args field decodes");
+        assert_eq!(args.get("x").and_then(|v| v.as_i64()), Some(10));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two interlocking fixes that make canonical NoETL v10 playbooks work end-to-end on the Rust-only stack.

1. **\`ToolSpec.args\`** accepts \`input\` as a serde alias.  The v10 playbook YAML writes \`tool.input: { ... }\`; the Rust ToolSpec only knew \`args\` and silently dropped the unknown field.  Frequency in e2e fixtures: 446 \`input:\` occurrences vs 37 \`args:\`.
2. **\`emit_playbook_started_event\`** now merges \`playbook.workload\` (YAML defaults) with \`request.payload\` (overrides) before recording the event.  Without this, downstream steps' \`build_context()\` returned \`{}\` because \`state.workload\` was hydrated from an event that only carried the request payload — even though \`generate_initial_commands\` already did the right merge for the start step's command context.

## Why

Surfaced via the hello_world e2e on the Rust-only stack (Python deployments scaled to 0, after noetl/server#57 unblocked event emission).  The script \`print(f\"HELLO_WORLD: {message}\")\` printed:
- Before any fix: \`NameError: name 'message' is not defined\` (input dropped).
- Input alias alone: \`HELLO_WORLD: None\` (input field present but workload empty).
- Both fixes: **\`HELLO_WORLD: Hello World\`** (workload reaches the runtime).

The Python implementation handles both natively (Pydantic v2 lax handling + Python's permissive dict merging), so the drift was invisible until the Rust-only stack ran end-to-end.

## Test plan

- [x] \`cargo build -p noetl-server\` clean.
- [x] \`cargo test -p noetl-server --lib playbook::types\` — 11/11 pass including 2 new ones (\`test_tool_spec_accepts_input_alias_for_args\`, \`test_tool_spec_accepts_args_field_directly\`).
- [x] \`cargo test -p noetl-server --lib handlers::execute\` — 2/2 pass.
- [x] Rebuilt \`localhost/noetl-server-rust:dev\`, \`kind load\`, rolled out.
- [x] Dispatched \`noetl exec tests/fixtures/playbooks/hello_world\` against the Rust server on the Rust-only stack.  Event log:
      \`playbook_started\` → \`start.command.completed=success\` → \`step.enter.test_step\` → \`test_step.command.completed=success\` → \`playbook.completed\`.
      test_step stdout: \`HELLO_WORLD: Hello World\`.
- [ ] Cluster-wide CI on this branch.

Pre-existing \`playbook::parser::tests::test_parse_invalid_next_reference\` still fails on origin/main; not introduced here.

Closes noetl/server#58
Closes noetl/ai-meta#56