### PR TITLE
fix(playbook): accept flat (name-as-field) pipeline shape

### DIFF
--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -503,7 +503,10 @@ mod tests {
             args: None,
             vars: None,
             r#loop: None,
-            tool: ToolDefinition::Pipeline(vec![fetch_task, transform_task]),
+            tool: ToolDefinition::Pipeline(vec![
+                crate::playbook::types::PipelineItem::Nested(fetch_task),
+                crate::playbook::types::PipelineItem::Nested(transform_task),
+            ]),
             next: None,
         };
 

--- a/src/playbook/parser.rs
+++ b/src/playbook/parser.rs
@@ -138,20 +138,37 @@ fn validate_tool_definition(tool: &ToolDefinition, step_name: &str) -> AppResult
             }
 
             for (idx, task) in tasks.iter().enumerate() {
-                // Each task should have exactly one key (the label)
-                if task.len() != 1 {
-                    return Err(AppError::Validation(format!(
-                        "Step '{}': pipeline task[{}] must have exactly one labeled entry (got {})",
-                        step_name,
-                        idx,
-                        task.len()
-                    )));
-                }
+                // Normalize both YAML pipeline shapes to a (label, spec)
+                // tuple list for validation.  Flat form uses the
+                // `name` field on the spec as the label; nested form
+                // uses the single map key.
+                let entries: Vec<(String, &crate::playbook::types::ToolSpec)> = match task {
+                    crate::playbook::types::PipelineItem::Flat(spec) => {
+                        let label = spec
+                            .extra
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        vec![(label, spec)]
+                    }
+                    crate::playbook::types::PipelineItem::Nested(map) => {
+                        if map.len() != 1 {
+                            return Err(AppError::Validation(format!(
+                                "Step '{}': pipeline task[{}] must have exactly one labeled entry (got {})",
+                                step_name,
+                                idx,
+                                map.len()
+                            )));
+                        }
+                        map.iter().map(|(k, v)| (k.clone(), v)).collect()
+                    }
+                };
 
                 // Validate eval conditions in each task
-                for (label, spec) in task {
+                for (label, spec) in entries {
                     if let Some(ref eval) = spec.eval {
-                        validate_eval_conditions_for_task(eval, step_name, label)?;
+                        validate_eval_conditions_for_task(eval, step_name, &label)?;
                     }
                 }
             }

--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -239,8 +239,89 @@ pub enum ToolDefinition {
     Single(ToolSpec),
 
     /// Pipeline - list of labeled tasks.
-    /// Each item is a map with single key (label) -> tool spec.
-    Pipeline(Vec<HashMap<String, ToolSpec>>),
+    ///
+    /// Two YAML shapes are accepted on input, both map to the same
+    /// internal representation (label-as-key) before serialization
+    /// for the worker's `task_sequence` consumer:
+    ///
+    /// **Flat / name-as-field** (the dominant v10 form in e2e
+    /// fixtures: ~5 fixtures with this shape under
+    /// `repos/e2e/fixtures/playbooks/`):
+    /// ```yaml
+    /// tool:
+    /// - name: init_action
+    ///   kind: python
+    ///   input: { ... }
+    ///   code: ...
+    /// ```
+    ///
+    /// **Nested / label-as-key** (the existing Rust internal
+    /// shape, also used in some hand-written fixtures):
+    /// ```yaml
+    /// tool:
+    /// - init_action:
+    ///     kind: python
+    ///     input: { ... }
+    ///     code: ...
+    /// ```
+    ///
+    /// See `noetl/ai-meta#57` for the e2e finding that surfaced
+    /// the flat form being rejected by the strict Rust decoder.
+    Pipeline(Vec<PipelineItem>),
+}
+
+/// One item in a pipeline.  Untagged so serde tries each variant
+/// in declaration order and picks the first that decodes.
+///
+/// `Flat` is tried first because the v10 dominant form has a
+/// top-level `kind:` field (a required field on `ToolSpec`); the
+/// nested label-as-key form has no `kind:` at the top level
+/// (the key IS the label), so it cleanly falls through to
+/// `Nested`.  The serializer round-trips through the nested form
+/// so the wire shape downstream (worker's `task_sequence` consumer)
+/// stays unchanged.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum PipelineItem {
+    /// Flat shape: `{ name: "label", kind: "python", code: "...", ... }`.
+    /// The pipeline-item label lives in the `name` field; the rest of
+    /// the fields are an inline `ToolSpec`.  Stored via `ToolSpec.extra`
+    /// (the `#[serde(flatten)] HashMap` catch-all), so no schema change
+    /// is needed on ToolSpec itself.
+    Flat(ToolSpec),
+
+    /// Nested shape: `{ "label": { kind: "python", code: "...", ... } }`.
+    /// Single-key map — the key is the label, the value is the spec.
+    Nested(HashMap<String, ToolSpec>),
+}
+
+impl serde::Serialize for PipelineItem {
+    /// Normalize on the wire to the nested shape so the worker's
+    /// `task_sequence` consumer (which has historically seen only
+    /// the nested shape) doesn't have to dual-decode.  The `Flat`
+    /// form's pipeline-item label is read from `ToolSpec.extra["name"]`
+    /// if present; missing/non-string `name` falls back to the empty
+    /// string, which is the same fallback the downstream config has
+    /// always used.
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PipelineItem::Flat(spec) => {
+                let label = spec
+                    .extra
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let mut map = HashMap::new();
+                map.insert(label, spec.clone());
+                map.serialize(serializer)
+            }
+            PipelineItem::Nested(map) => map.serialize(serializer),
+        }
+    }
 }
 
 // ============================================================================
@@ -968,8 +1049,62 @@ workflow:
 
         if let ToolDefinition::Pipeline(tasks) = &step.tool {
             assert_eq!(tasks.len(), 2);
-            assert!(tasks[0].contains_key("fetch"));
-            assert!(tasks[1].contains_key("transform"));
+            // Nested form (label-as-key) — the existing back-compat shape.
+            match &tasks[0] {
+                PipelineItem::Nested(map) => assert!(map.contains_key("fetch")),
+                PipelineItem::Flat(_) => panic!("Expected Nested form for label-as-key YAML"),
+            }
+            match &tasks[1] {
+                PipelineItem::Nested(map) => assert!(map.contains_key("transform")),
+                PipelineItem::Flat(_) => panic!("Expected Nested form for label-as-key YAML"),
+            }
+        } else {
+            panic!("Expected ToolDefinition::Pipeline");
+        }
+    }
+
+    #[test]
+    fn test_parse_pipeline_with_name_as_field_shape() {
+        // noetl/ai-meta#57 — the v10 canonical fixtures write
+        // pipeline items in flat form with `name:` as a field
+        // (not as the outer label-as-key map).  Both shapes must
+        // decode into a Pipeline of the right cardinality with
+        // labels addressable downstream.
+        let yaml = r#"
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: pipeline_flat
+workflow:
+  - step: fetch_transform
+    tool:
+      - name: fetch
+        kind: http
+        url: "https://api.example.com"
+      - name: transform
+        kind: python
+        code: "result = {'ok': True}"
+"#;
+        let playbook: Playbook = serde_yaml::from_str(yaml).unwrap();
+        let step = playbook.get_step("fetch_transform").unwrap();
+        if let ToolDefinition::Pipeline(tasks) = &step.tool {
+            assert_eq!(tasks.len(), 2);
+            // Flat form — pipeline-item label lives in spec.extra["name"].
+            for (i, expected_label) in [(0usize, "fetch"), (1usize, "transform")] {
+                match &tasks[i] {
+                    PipelineItem::Flat(spec) => {
+                        let name = spec
+                            .extra
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        assert_eq!(name, expected_label);
+                    }
+                    PipelineItem::Nested(_) => {
+                        panic!("Expected Flat form for name-as-field YAML")
+                    }
+                }
+            }
         } else {
             panic!("Expected ToolDefinition::Pipeline");
         }


### PR DESCRIPTION
## Summary

Extends \`ToolDefinition::Pipeline\` to accept both YAML pipeline shapes:

- **Flat** (v10 dominant — was rejected): \`{ name: \"label\", kind: \"python\", code: ..., ... }\`
- **Nested** (existing internal shape): \`{ \"label\": { kind: \"python\", code: ..., ... } }\`

New \`PipelineItem\` untagged enum tries Flat first (matches the dominant form via its required top-level \`kind:\`), Nested second.  Custom \`Serialize\` normalises on the wire to the nested shape so the worker's \`task_sequence\` consumer is unchanged.

## Why

Surfaced during the Rust-only e2e probe (noetl/ai-meta#57) right after #57 unblocked workload threading.  5 e2e fixtures under \`repos/e2e/fixtures/playbooks/\` use the flat form, plus 3 catalog-registered fixtures (\`iterator_save_test\`, \`start_with_action\`, \`end_with_action\`).  All returned 400 with \"data did not match any variant of untagged enum ToolDefinition\".

## Test plan

- [x] \`cargo build -p noetl-server\` clean.
- [x] \`cargo test -p noetl-server --lib playbook\` — 23/24 pass.  The 1 fail is the pre-existing \`test_parse_invalid_next_reference\` on origin/main (verified via \`git stash\`; not introduced here).
- [x] \`cargo test -p noetl-server --lib engine::commands\` — 5/5 pass.
- [x] New unit test \`test_parse_pipeline_with_name_as_field_shape\` pins the flat decode.
- [x] Existing \`test_parse_playbook_with_pipeline\` still passes (back-compat).
- [x] Local kind validation: rebuilt image, reloaded, dispatched all three previously-rejected fixtures.  All three now return 200 with execution_id.  \`iterator_save_test\` advances past the dispatch boundary, runs the start step end-to-end, and reaches \`create_table\` (postgres tool, which IS registered).
- [ ] Cluster-wide CI on this branch.

## Scope

**This PR is the YAML parse layer only.**  The worker still needs a \`task_sequence\` tool in noetl-tools to actually execute the pipeline — separate sub-issue at noetl/cli#53.  Until that lands, flat-shape fixtures that reach a pipeline step will fail at the worker with \"Tool not found: task_sequence\".  Server side is sound — clients no longer get 400 on canonical YAML.

Pre-existing \`playbook::parser::tests::test_parse_invalid_next_reference\` still fails on origin/main; not introduced here.

Closes noetl/server#60
Closes noetl/ai-meta#57