### PR TITLE
fix(orchestrator): emit playbook.failed on command.failed instead of stalling

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -257,6 +257,74 @@ impl WorkflowOrchestrator {
         // branches are still running.
         let mut reached_end = false;
 
+        // command.failed gets its own dedicated short-circuit path
+        // BEFORE the transition-trigger filter — a failed step must
+        // not have its next.arcs evaluated, and the orchestrator
+        // must emit `playbook.failed` once all in-flight work is
+        // drained (the existing completion path waited for every
+        // branch to reach `end`, which a failed branch never does).
+        // See noetl/ai-meta#58 for the e2e finding (control_flow_workbook
+        // stalled at `command.failed` with no terminal event).
+        if matches!(trigger_event_type, Some("command.failed")) {
+            // Detect failed steps via the durable `state` field
+            // (set by apply_event when `command.failed` or
+            // `step_failed` lands), not via `info.error.is_some()`.
+            // The error-string extraction at apply_event time only
+            // catches top-level `result.error`; many tools emit
+            // their failure context under `result.context.error`,
+            // so step.error stays None even on real failures.
+            // step.state is the reliable signal.
+            let failed_steps: Vec<String> = state
+                .steps
+                .iter()
+                .filter(|(_, info)| matches!(info.state, crate::engine::state::StepState::Failed))
+                .map(|(name, _)| name.clone())
+                .collect();
+
+            // No failed step recorded yet (race between event ingest
+            // and apply_event) — keep waiting; the next trigger
+            // round will see it.
+            if failed_steps.is_empty() {
+                return Ok(OrchestrationResult {
+                    state: ExecutionState::InProgress,
+                    commands,
+                    should_complete: false,
+                    completion_status: None,
+                    events_to_emit,
+                });
+            }
+
+            // Sibling parallel branches still running — defer the
+            // terminal decision so each in-flight branch gets to
+            // emit its own outcome event into the log.  When the
+            // last running branch finishes, that branch's
+            // command.completed or command.failed will re-trigger
+            // us and we'll re-check this condition.
+            if state.has_running_steps() {
+                return Ok(OrchestrationResult {
+                    state: ExecutionState::InProgress,
+                    commands,
+                    should_complete: false,
+                    completion_status: None,
+                    events_to_emit,
+                });
+            }
+
+            // All in-flight work drained, at least one step failed
+            // — emit the terminal playbook.failed event.
+            return Ok(OrchestrationResult {
+                state: ExecutionState::Failed,
+                commands: vec![],
+                should_complete: true,
+                completion_status: Some(CompletionStatus {
+                    status: "FAILED".to_string(),
+                    error: Some(format!("Failed steps: {}", failed_steps.join(", "))),
+                    failed_steps: Some(failed_steps),
+                }),
+                events_to_emit,
+            });
+        }
+
         // Only process transitions on completion events
         if !matches!(
             trigger_event_type,
@@ -845,6 +913,151 @@ mod tests {
         let status = result.completion_status.unwrap();
         assert_eq!(status.status, "FAILED");
         assert!(status.error.is_some());
+    }
+
+    #[test]
+    fn test_command_failed_emits_terminal_playbook_failed() {
+        // noetl/ai-meta#58 — process_in_progress used to early-return
+        // on command.failed and never emit the terminal playbook.failed
+        // event.  Execution would stall mid-flight forever.  With the
+        // fix, a command.failed trigger drains in-flight work and
+        // (when nothing is still running) marks the playbook as
+        // FAILED with the failed_steps list populated.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step("start", Some("eval_flag"));
+        let eval_flag = make_step("eval_flag", Some("end"));
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {}, "path": "test", "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+            make_event("step.enter", Some("eval_flag")),
+            {
+                let mut e = make_event("call.error", Some("eval_flag"));
+                e.result = Some(serde_json::json!({"error": "Tool not found: workbook"}));
+                e
+            },
+            {
+                let mut e = make_event("command.failed", Some("eval_flag"));
+                e.result = Some(serde_json::json!({"error": "Tool not found: workbook"}));
+                e
+            },
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "fail_terminal".to_string(),
+                path: Some("test/fail_terminal".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, eval_flag, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.failed"))
+            .unwrap();
+
+        assert!(
+            result.should_complete,
+            "command.failed must terminate the playbook when no other steps are running"
+        );
+        assert_eq!(result.state, ExecutionState::Failed);
+        let status = result
+            .completion_status
+            .expect("completion_status must be populated on terminal failure");
+        assert_eq!(status.status, "FAILED");
+        assert_eq!(status.failed_steps.as_ref().unwrap(), &vec!["eval_flag".to_string()]);
+        assert!(status
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("eval_flag"));
+    }
+
+    #[test]
+    fn test_command_failed_defers_terminal_while_sibling_running() {
+        // Parallel-branch case: branch_a fails while branch_b is
+        // still in flight.  The orchestrator must NOT mark the
+        // playbook FAILED yet — wait for branch_b to drain so the
+        // event log carries every branch's outcome.  When branch_b
+        // eventually finishes (success or failure), the next trigger
+        // round re-checks and emits the terminal event then.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step_with_parallel_next("start", &["branch_a", "branch_b"]);
+        let branch_a = make_step("branch_a", Some("end"));
+        let branch_b = make_step("branch_b", Some("end"));
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {}, "path": "test", "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+            // Both branches entered + claimed.
+            make_event("step.enter", Some("branch_a")),
+            make_event("command.issued", Some("branch_a")),
+            make_event("step.enter", Some("branch_b")),
+            make_event("command.issued", Some("branch_b")),
+            // branch_a fails; branch_b still running.
+            {
+                let mut e = make_event("call.error", Some("branch_a"));
+                e.result = Some(serde_json::json!({"error": "branch_a blew up"}));
+                e
+            },
+            {
+                let mut e = make_event("command.failed", Some("branch_a"));
+                e.result = Some(serde_json::json!({"error": "branch_a blew up"}));
+                e
+            },
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "fail_with_sibling".to_string(),
+                path: Some("test/fail_with_sibling".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, branch_a, branch_b, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.failed"))
+            .unwrap();
+
+        assert!(
+            !result.should_complete,
+            "playbook must NOT terminate while branch_b is still running"
+        );
+        // State stays InProgress for the deferred outcome.
+        assert_eq!(result.state, ExecutionState::InProgress);
     }
 
     #[test]

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -450,9 +450,28 @@ impl WorkflowState {
                         .or_insert_with(|| StepInfo::new(name));
                     step.state = StepState::Failed;
                     step.completed_at = Some(event.created_at);
-                    // Extract error from result or use status
+                    // Extract error from result.  Two shapes seen in
+                    // the wild — top-level `result.error` and the
+                    // nested `result.context.error` (the worker's
+                    // standard envelope wraps the tool's
+                    // `{status, error, ...}` output under
+                    // `result.context`).  Try the top-level form
+                    // first, then fall back to the nested form so
+                    // step.error gets populated regardless of which
+                    // tool emitted the failure.  See
+                    // noetl/ai-meta#58 for the orchestrator-side
+                    // failure-termination fix that depends on this.
                     if let Some(result) = &event.result {
-                        if let Some(error) = result.get("error").and_then(|v| v.as_str()) {
+                        let err_value = result
+                            .get("error")
+                            .and_then(|v| v.as_str())
+                            .or_else(|| {
+                                result
+                                    .get("context")
+                                    .and_then(|c| c.get("error"))
+                                    .and_then(|v| v.as_str())
+                            });
+                        if let Some(error) = err_value {
                             step.error = Some(error.to_string());
                         }
                     }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -631,8 +631,21 @@ async fn handle_event_inner(
         0
     };
 
-    // Trigger orchestrator for workflow progression on command.completed
-    if request.event_type == "command.completed" && request.step.to_lowercase() != "end" {
+    // Trigger orchestrator for workflow progression.
+    //
+    // `command.completed` advances the workflow to the next step;
+    // `command.failed` checks whether the failure should terminate
+    // the playbook (noetl/ai-meta#58 — without this trigger, failed
+    // steps stalled the execution forever because the orchestrator
+    // never got a chance to emit `playbook.failed`).
+    //
+    // The `step != "end"` guard stays in place: the sentinel `end`
+    // step's completion fires its own `playbook.completed` path on
+    // the orchestrator's natural-completion branch.
+    let should_trigger_orchestrator = (request.event_type == "command.completed"
+        || request.event_type == "command.failed")
+        && request.step.to_lowercase() != "end";
+    if should_trigger_orchestrator {
         match trigger_orchestrator(&state, execution_id, event_id).await {
             Ok(cmds) => {
                 info!(
@@ -1357,9 +1370,22 @@ async fn trigger_orchestrator(
     let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
 
     // 3. Evaluate.
+    //
+    // Resolve the real trigger event's type from the loaded events
+    // list instead of hard-coding `command.completed` — the same
+    // path serves `command.failed` triggers (noetl/ai-meta#58) and
+    // future trigger sources (e.g. `iterator_completed`,
+    // `step.exit`).  Without this lookup, a failure trigger would
+    // be misreported as a completion to the orchestrator, and the
+    // failure-termination branch would never run.
+    let trigger_event_type = events
+        .iter()
+        .find(|e| e.event_id == trigger_event_id)
+        .map(|e| e.event_type.as_str())
+        .unwrap_or("command.completed");
     let orchestrator = WorkflowOrchestrator::new();
     let result = orchestrator
-        .evaluate(&events, &playbook, Some("command.completed"))
+        .evaluate(&events, &playbook, Some(trigger_event_type))
         .map_err(|e| AppError::Internal(format!("Orchestrator evaluate failed: {e}")))?;
 
     info!(


### PR DESCRIPTION
## Summary

Four interlocking gaps made any failing playbook stall mid-flight forever:

1. **Trigger gate** in \`handlers/events.rs::handle_event\` only allowed \`command.completed\` to invoke \`trigger_orchestrator\` — failure events skipped the trigger entirely.
2. **Hard-coded trigger type** in \`trigger_orchestrator\` passed \`Some(\"command.completed\")\` to \`orchestrator.evaluate\` regardless of the actual trigger event.
3. **Early-return** in \`process_in_progress\` for any trigger not in the completion-synonym list meant failure-termination logic never ran.
4. **Error-extraction shape mismatch** in \`engine/state.rs::apply_event\` — looked for \`result.error\` (top-level) but workers emit \`result.context.error\` (nested), so \`step.error\` stayed \`None\` and the existing \`info.error.is_some()\` failure check missed real failures.

## Fix

- Extend the trigger gate to \`command.completed || command.failed\` (preserves \`step != \"end\"\` guard).
- Derive trigger_event_type from the actual trigger event's \`event_type\`.
- Dedicated \`command.failed\` short-circuit in \`process_in_progress\` BEFORE the transition filter: when any step is in \`StepState::Failed\` and no steps are running → terminal FAILED.  Failed-step detection via \`info.state == StepState::Failed\` (durable signal) instead of error-string presence.
- Parallel-branch deferral: when siblings are still running, stay InProgress and wait for them to drain so every branch's outcome lands in the event log first.
- \`state.rs::apply_event\` extracts error from \`result.context.error\` as fallback so \`step.error\` gets populated for the FAILED completion message.

## Validation

End-to-end probe in local kind on the Rust-only stack (Python deployments scaled to 0):

\`\`\`
noetl exec tests/fixtures/playbooks/control_flow_workbook
# Before this PR: event log stalled at command.failed, no terminal event.
# After this PR:  event log terminates with playbook.failed | playbook | FAILED.
\`\`\`

## Tests

- New: \`test_command_failed_emits_terminal_playbook_failed\` (single-step failure → terminal).
- New: \`test_command_failed_defers_terminal_while_sibling_running\` (parallel branch failure waits for siblings).
- All 34 existing \`engine::*\` tests still pass (12 orchestrator + 22 state).
- All 23 \`handlers::events::*\` tests still pass.

Pre-existing \`playbook::parser::tests::test_parse_invalid_next_reference\` still fails on origin/main; not introduced here.

Closes noetl/server#62
Closes noetl/ai-meta#58