### PR TITLE
fix(rust-stack): v10 control-flow playbooks run end-to-end (6 commits)

### DIFF
--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -10,9 +10,14 @@ use crate::error::AppResult;
 /// matches the column type and avoids the sqlx decode mismatch that
 /// surfaced during noetl/ai-meta#49 Phase A ui_schema validation.
 pub async fn get_next_version(pool: &DbPool, path: &str) -> AppResult<i16> {
+    // `smallint + integer-literal` returns `INT4` in Postgres, so we cast
+    // the entire expression back to `smallint` to match the `i16` binding
+    // the sqlx decoder expects.  Without the outer cast sqlx errors with
+    // `Rust type 'i16' (as SQL type 'INT2') is not compatible with SQL
+    // type 'INT4'`.
     let result: Option<(i16,)> = sqlx::query_as(
         r#"
-        SELECT COALESCE(MAX(version), 0)::smallint + 1
+        SELECT (COALESCE(MAX(version), 0)::smallint + 1)::smallint
         FROM noetl.catalog
         WHERE path = $1
         "#,

--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -41,11 +41,15 @@ pub async fn insert_catalog_entry(
     payload: Option<&serde_json::Value>,
     meta: Option<&serde_json::Value>,
 ) -> AppResult<i64> {
+    // `noetl.catalog` has no `id` column — the PK is `catalog_id`.
+    // Older code returned `id`, which would 500 with `column "id" does
+    // not exist` at runtime.  Same alias-vs-column drift as the
+    // v2.1.5 catalog `list` fix and the comment on get_catalog_by_id.
     let result: (i64,) = sqlx::query_as(
         r#"
         INSERT INTO noetl.catalog (path, kind, version, content, layout, payload, meta)
         VALUES ($1, $2, $3, $4, $5, $6, $7)
-        RETURNING id
+        RETURNING catalog_id
         "#,
     )
     .bind(path)

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -256,6 +256,17 @@ impl WorkflowOrchestrator {
         // would falsely mark the playbook done while the other
         // branches are still running.
         let mut reached_end = false;
+        // Steps already dispatched in THIS pass.  `is_step_done` /
+        // `running_steps` read from the events DB, so two sibling
+        // arcs whose `next_step` resolves to the same target would
+        // otherwise both queue commands in the same orchestrator
+        // round (neither has a persisted event yet).  Track here so
+        // the second arc skips dispatch.  Surfaced as part of the
+        // `end`-step-with-action fix (noetl/ai-meta#54): parallel
+        // branches converging on `end` would double-queue without
+        // this guard.
+        let mut dispatched_in_pass: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         // command.failed gets its own dedicated short-circuit path
         // BEFORE the transition-trigger filter — a failed step must
@@ -376,7 +387,26 @@ impl WorkflowOrchestrator {
                     if next_step_name == "end" {
                         debug!("Branch reached 'end'; deferring completion decision");
                         reached_end = true;
-                        continue;
+
+                        // If `end` is defined as a real step in the
+                        // workflow (the canonical v10 shape — an
+                        // aggregator that may carry its own cleanup
+                        // tool), fall through to the normal dispatch
+                        // path below so the end step's action runs.
+                        // Without this, every `end:` step with a
+                        // `tool:` block (e.g. `test_end_with_action`'s
+                        // cleanup Python) was silently skipped — the
+                        // orchestrator went straight to
+                        // `playbook.completed` without executing the
+                        // end step.
+                        //
+                        // Skip dispatch only when `end` is not a
+                        // defined step (legacy "pure terminal" case);
+                        // `reached_end_quiescent` then handles the
+                        // completion transition.
+                        if !steps.contains_key("end") {
+                            continue;
+                        }
                     }
 
                     // Get next step definition
@@ -396,6 +426,16 @@ impl WorkflowOrchestrator {
 
                     if state.running_steps().contains(&next_step_name.as_str()) {
                         debug!("Step '{}' already running, skipping", next_step_name);
+                        continue;
+                    }
+
+                    // Same-pass dedup: a sibling arc may have just
+                    // queued a command for this step in this round.
+                    if dispatched_in_pass.contains(next_step_name) {
+                        debug!(
+                            "Step '{}' already dispatched in this pass, skipping",
+                            next_step_name
+                        );
                         continue;
                     }
 
@@ -676,6 +716,7 @@ impl WorkflowOrchestrator {
                     )?;
 
                     commands.push(command);
+                    dispatched_in_pass.insert(current_step_name.clone());
                 }
             }
         }
@@ -1498,9 +1539,13 @@ mod tests {
     }
 
     #[test]
-    fn test_parallel_all_branches_done_completes() {
-        // Both branches completed and both routed to `end` — the
-        // orchestrator's deferred completion should fire.
+    fn test_parallel_all_branches_done_dispatches_end_once() {
+        // Both branches completed and both routed to `end`.  With
+        // the noetl/ai-meta#54 fix, `end` is now a real dispatchable
+        // step (not a pure terminal sentinel) — the orchestrator
+        // queues a single command for it, and same-pass dedup
+        // prevents the second branch's arc from double-dispatching.
+        // Completion happens later, on `end`'s own command.completed.
         let orchestrator = WorkflowOrchestrator::new();
 
         let start = make_step_with_parallel_next("start", &["branch_a", "branch_b"]);
@@ -1544,9 +1589,70 @@ mod tests {
             .evaluate(&events, &playbook, Some("command.completed"))
             .unwrap();
 
+        assert_eq!(
+            result.commands.len(),
+            1,
+            "end step must be dispatched exactly once, not duplicated by sibling arcs"
+        );
+        assert!(
+            !result.should_complete,
+            "should not complete until end's own command.completed lands"
+        );
+    }
+
+    #[test]
+    fn test_parallel_all_branches_plus_end_completed_finalises() {
+        // Follow-on round: once `end`'s own command.completed is in
+        // the event log, check_completion fires and the workflow
+        // terminates with status COMPLETED.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step_with_parallel_next("start", &["branch_a", "branch_b"]);
+        let branch_a = make_step("branch_a", Some("end"));
+        let branch_b = make_step("branch_b", Some("end"));
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {}, "path": "test", "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+            make_event("step.enter", Some("branch_a")),
+            make_event("command.completed", Some("branch_a")),
+            make_event("step.enter", Some("branch_b")),
+            make_event("command.completed", Some("branch_b")),
+            make_event("step.enter", Some("end")),
+            make_event("command.completed", Some("end")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "parallel_done_end".to_string(),
+                path: Some("test/parallel_done_end".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, branch_a, branch_b, end],
+        };
+
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .unwrap();
+
         assert!(
             result.should_complete,
-            "both branches done + both at end ⇒ complete"
+            "all branches done + end's own command.completed ⇒ COMPLETED"
         );
         assert_eq!(
             result.completion_status.as_ref().map(|c| c.status.as_str()),

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -708,16 +708,66 @@ fn extract_user_data(result: &serde_json::Value) -> Option<serde_json::Value> {
         .and_then(|v| v.get("context"))
         .and_then(|v| v.get("data"));
     if let Some(data) = inner {
-        return Some(data.clone());
+        return Some(flatten_task_sequence_data(data));
     }
     // Single-layer wrappers (e.g. {status, context}).
     if let Some(ctx) = result.get("context") {
         if let Some(data) = ctx.get("data") {
-            return Some(data.clone());
+            return Some(flatten_task_sequence_data(data));
         }
         return Some(ctx.clone());
     }
     Some(result.clone())
+}
+
+/// Flatten task_sequence's label-keyed result map so that the
+/// user-facing `{{ step.field }}` references resolve.
+///
+/// Every v10 step uses the `tool: [...]` list shape, which the
+/// server wraps as a `task_sequence` pipeline even when the step
+/// has a single tool.  `task_sequence` then aggregates the
+/// sub-task results as `{label1: <data1>, label2: <data2>, ...}`,
+/// so the unwrapped envelope data ends up as
+/// `{init_action: {data: {executed: true}, status, message}}`
+/// rather than the user-assigned dict the YAML template
+/// expects (`{data: {executed: true}, status, message}`).
+///
+/// Strategy: when `data` is a non-empty object whose values are
+/// ALL objects (the task_sequence labeled-results signature),
+/// merge each task's fields at the top level — last-task-wins on
+/// key collisions, matching the `_prev` convention inside the
+/// pipeline.  The original labeled shape is preserved so
+/// `{{ step.label.field }}` references still work alongside the
+/// flat `{{ step.field }}` form.
+///
+/// For non-task_sequence data (a single tool that wasn't wrapped,
+/// or a tool that returned a scalar / array / mixed map) this is
+/// a no-op — the returned value equals the input.
+fn flatten_task_sequence_data(data: &serde_json::Value) -> serde_json::Value {
+    let map = match data.as_object() {
+        Some(m) if !m.is_empty() => m,
+        _ => return data.clone(),
+    };
+    // Heuristic: labeled-results shape has every value as an
+    // object.  A user-assigned dict that happens to be
+    // `{data: ..., status: ...}` has scalar / string values for
+    // some keys, so this won't accidentally merge it.
+    let all_objects = map.values().all(|v| v.is_object());
+    if !all_objects {
+        return data.clone();
+    }
+    // Build merged shape: labeled-keys at top + flat keys from
+    // each task's value.  Iterate in insertion order so the last
+    // task's keys win on collision (matches `_prev`).
+    let mut merged = map.clone();
+    for value in map.values() {
+        if let serde_json::Value::Object(task_map) = value {
+            for (k, v) in task_map {
+                merged.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    serde_json::Value::Object(merged)
 }
 
 #[cfg(test)]

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1199,4 +1199,68 @@ mod tests {
         // Workload still at top level (from earlier build_context behavior).
         assert_eq!(ctx.get("temp").and_then(|v| v.as_i64()), Some(30));
     }
+
+    #[test]
+    fn test_extract_user_data_flattens_task_sequence_wrap() {
+        // Real e2e payload from `test_start_with_action`'s call.done
+        // event on the Rust kind cluster (Phase F R5).  task_sequence
+        // wraps the single Python tool's result under the tool's
+        // label (`init_action`), so the unwrapped envelope `data` is
+        // `{init_action: {data: {executed: true}, ...}}` rather than
+        // the user's assigned dict.  After the flatten:
+        //   - `start.init_action.data.executed` still works (back-compat)
+        //   - `start.data.executed` ALSO works (the YAML template's expectation)
+        let envelope = serde_json::json!({
+            "status": "COMPLETED",
+            "context": {
+                "call_index": 0,
+                "command_id": "321180039523602432:start:321180039552962560",
+                "result": {
+                    "status": "success",
+                    "context": {
+                        "data": {
+                            "init_action": {
+                                "data": {
+                                    "executed": true,
+                                    "input": {"test_value": "hello"}
+                                },
+                                "message": "Start step executed with action type",
+                                "status": "success"
+                            }
+                        },
+                        "duration_ms": 79,
+                        "exit_code": 0,
+                        "status": "success",
+                        "stderr": "",
+                        "stdout": ""
+                    }
+                }
+            }
+        });
+        let unwrapped = extract_user_data(&envelope).expect("envelope unwraps");
+        // Flat reference — the failing YAML template path:
+        assert_eq!(
+            unwrapped
+                .get("data")
+                .and_then(|v| v.get("executed"))
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "start.data.executed must resolve after flatten"
+        );
+        assert_eq!(
+            unwrapped.get("status").and_then(|v| v.as_str()),
+            Some("success"),
+            "start.status must resolve after flatten"
+        );
+        // Labeled reference — back-compat:
+        assert_eq!(
+            unwrapped
+                .get("init_action")
+                .and_then(|v| v.get("data"))
+                .and_then(|v| v.get("executed"))
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "start.init_action.data.executed must still resolve"
+        );
+    }
 }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -639,12 +639,16 @@ async fn handle_event_inner(
     // steps stalled the execution forever because the orchestrator
     // never got a chance to emit `playbook.failed`).
     //
-    // The `step != "end"` guard stays in place: the sentinel `end`
-    // step's completion fires its own `playbook.completed` path on
-    // the orchestrator's natural-completion branch.
-    let should_trigger_orchestrator = (request.event_type == "command.completed"
-        || request.event_type == "command.failed")
-        && request.step.to_lowercase() != "end";
+    // The earlier `step != "end"` guard treated `end` as a sentinel
+    // whose completion fired playbook.completed implicitly.  After
+    // the noetl/ai-meta#54 orchestrator change (end is a real step
+    // with its own `tool:` block), end's command.completed MUST
+    // trigger the orchestrator — that's the pass where
+    // `check_completion` sees end as done and emits
+    // `playbook.completed`.  Without this trigger the playbook
+    // stalled at `command.completed [end]` with no terminal event.
+    let should_trigger_orchestrator =
+        request.event_type == "command.completed" || request.event_type == "command.failed";
     if should_trigger_orchestrator {
         match trigger_orchestrator(&state, execution_id, event_id).await {
             Ok(cmds) => {
@@ -1057,14 +1061,16 @@ pub async fn handle_batch_events(
 
     tx.commit().await?;
 
-    // Trigger orchestrator for any command.completed in the batch
-    // whose step is not the playbook's terminal `end` block.  Mirrors
-    // the call site in `handle_event` above; runs once per qualifying
+    // Trigger orchestrator for any command.completed in the batch,
+    // including end (end is now a real dispatched step per
+    // noetl/ai-meta#54 — its command.completed is the trigger that
+    // makes check_completion emit playbook.completed).  Mirrors the
+    // call site in `handle_event` above; runs once per qualifying
     // event so a batch with multiple completions can still advance
     // multi-step playbooks.  Errors are logged and swallowed so a
     // bad-state evaluation doesn't fail the whole batch ingest.
     for (idx, item) in request.events.iter().enumerate() {
-        if item.event_type == "command.completed" && item.step.to_lowercase() != "end" {
+        if item.event_type == "command.completed" {
             let trigger_event_id = event_ids[idx];
             match trigger_orchestrator(&state, execution_id, trigger_event_id).await {
                 Ok(cmds) => {

--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -134,15 +134,15 @@ pub struct ToolSpec {
 
     /// Tool-level flow control (canonical format).
     /// Evaluated after tool execution.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eval: Option<Vec<EvalEntry>>,
 
     /// Authentication configuration.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<serde_json::Value>,
 
     /// Libraries/dependencies.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub libs: Option<serde_json::Value>,
 
     /// Default arguments / inputs passed to the tool runtime.
@@ -162,43 +162,43 @@ pub struct ToolSpec {
     /// gets an empty dict, and any user code referencing the
     /// workload by name (e.g. `print(f"hello {message}")`) raises
     /// `NameError`.  See noetl/ai-meta#56 for the e2e finding.
-    #[serde(default, alias = "input")]
+    #[serde(default, alias = "input", skip_serializing_if = "Option::is_none")]
     pub args: Option<serde_json::Value>,
 
     /// Python code (for python tool).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
 
     /// URL (for http tool).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
     /// HTTP method (for http tool).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
 
     /// Query/SQL (for database tools).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 
     /// Command (for database/shell tools).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
 
     /// Connection string or credential reference.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection: Option<String>,
 
     /// HTTP params.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<HashMap<String, serde_json::Value>>,
 
     /// HTTP headers.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
 
     /// Output selection strategy (for result externalization).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_select: Option<serde_json::Value>,
 
     /// Additional tool-specific configuration.

--- a/src/template/jinja.rs
+++ b/src/template/jinja.rs
@@ -4,7 +4,7 @@
 //! supporting variables, filters, and control structures.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use minijinja::{value::ValueKind, Environment, Error, ErrorKind, Value};
+use minijinja::{value::ValueKind, Environment, Error, ErrorKind, UndefinedBehavior, Value};
 use std::collections::HashMap;
 
 use crate::error::{AppError, AppResult};
@@ -24,6 +24,20 @@ impl TemplateRenderer {
     /// Create a new template renderer with custom filters.
     pub fn new() -> Self {
         let mut env = Environment::new();
+
+        // Allow `{{ undefined.attribute }}` style chains to resolve
+        // to undefined rather than throwing.  The default `Lenient`
+        // behaviour fails attribute access on an undefined parent —
+        // so a template like
+        //   `{{ ctx.from_start | default(start.data.executed) }}`
+        // throws "undefined value" when `ctx` isn't populated (e.g.
+        // arc `set:` block isn't processed), even though the
+        // `default()` filter would otherwise catch the missing
+        // value.  `Chainable` returns undefined for the missing
+        // attribute, lets `default()` see it, and matches the
+        // Python reference impl's permissive Jinja2 behavior.
+        // See noetl/ai-meta#54 Phase F R5 e2e finding.
+        env.set_undefined_behavior(UndefinedBehavior::Chainable);
 
         // Add custom filters
         env.add_filter("b64encode", filter_b64encode);


### PR DESCRIPTION
## Summary

Phase F R5 e2e validation drove the v10 control-flow fixtures
(`test_start_with_action`, `test_end_with_action`) through the
Rust-only kind cluster (Rust server + Rust worker, Python scaled to
0).  Each surfaced a distinct gap in the Rust stack's playbook
execution path.  This PR lands all seven:

| # | Commit | Fix |
|---|--------|-----|
| 1 | `52d8ca9` | catalog `get_next_version`: cast `smallint+1` back to `smallint` (Postgres promotes to INT4, sqlx rejected the `i16` decode → register 500'd) |
| 2 | `0763c81` | catalog `insert_catalog_entry`: `RETURNING catalog_id` not `id` (no `id` column → 500) |
| 3 | `d673be0` | `ToolSpec` Option fields `skip_serializing_if` — absent fields serialized as `null`, broke PythonConfig's `HashMap` deserialize (`invalid type: null, expected a map`) |
| 4 | `e1e71ee` | orchestrator: `end` step with a `tool:` block now dispatches its action (was silently skipped); task_sequence label-keyed result flatten; intra-pass dispatch dedup for parallel branches converging on `end` |
| 5 | `d9cebe3` | template: `UndefinedBehavior::Chainable` so `{{ ctx.x \| default(step.y) }}` resolves when `ctx` is undefined (default `Lenient` failed attribute access before `default()` ran); + e2e flatten unit test |
| 6 | `a50d718` | events: trigger orchestrator on `end`'s `command.completed` so `check_completion` emits `playbook.completed` (the `step != "end"` gate left the playbook with no terminal event) |

## Validation

Both fixtures reach `playbook.completed` (status COMPLETED), 19
events each, full chain `start → process(_data) → end →
playbook.completed`.  Data-flow proven end-to-end:

- `start_with_action`: `process` step's result carries
  `from_start: true` — the arc `set: {ctx.from_start: '{{ start.data.executed }}'}`
  captured start's output and `process` read it back.
- `end_with_action`: end's cleanup tool executed with
  `"Cleanup performed on temp_session_12345"`, `cleaned_up: true` —
  `ctx.temp_table` threaded from `process_data` to the terminal
  step's action.

## Test plan

- [x] `cargo check` + `cargo test --lib engine` (39 engine tests pass)
- [x] Both control-flow fixtures reach `playbook.completed` on the
  Rust-only kind cluster
- [ ] Reviewer-side: rebuild + redeploy, re-run both fixtures

Closes #68
Refs noetl/ai-meta#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)