### PR TITLE
fix(template): defer task_sequence _prev/_results refs at command build

### DIFF
--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -181,11 +181,28 @@ impl CommandBuilder {
         match tool {
             ToolDefinition::Single(spec) => self.build_tool_command(spec, context),
             ToolDefinition::Pipeline(tasks) => {
-                // For pipelines, create a task_sequence tool command
-                // The worker will execute each task in sequence
+                // For pipelines, create a task_sequence tool command.
+                // The worker dispatches each sub-task through the
+                // task_sequence tool, which re-renders every sub-task's
+                // config against its own context (the command's
+                // render_context PLUS the runtime `_prev` / `_results`
+                // it injects per task).  So we render `{{ pg_auth }}`,
+                // `{{ item }}`, `{{ execution_id }}`, step results, etc.
+                // now (the worker's keychain-alias resolution needs the
+                // credential alias resolved to a string), but we must
+                // PRESERVE `{{ _prev.* }}` / `{{ _results.* }}` — those
+                // are undefined at command-build time and (with the
+                // Chainable undefined behavior) would otherwise render
+                // to empty strings, producing malformed sub-task configs
+                // (e.g. empty SQL VALUES).  See noetl/server#72 /
+                // noetl/ai-meta#54.
                 let pipeline_config = serde_json::to_value(tasks).ok();
                 let config = if let Some(cfg) = pipeline_config {
-                    Some(self.renderer.render_value(&cfg, context)?)
+                    Some(self.renderer.render_value_deferring(
+                        &cfg,
+                        context,
+                        &["_prev", "_results"],
+                    )?)
                 } else {
                     None
                 };

--- a/src/template/jinja.rs
+++ b/src/template/jinja.rs
@@ -161,6 +161,75 @@ impl TemplateRenderer {
         }
     }
 
+    /// Render a nested structure, but **preserve** any `{{ ... }}`
+    /// expression that references one of `deferred_roots` as a
+    /// whole-word identifier.
+    ///
+    /// Used for `task_sequence` pipeline configs: `_prev` / `_results`
+    /// are RUNTIME values the task_sequence tool injects per sub-task,
+    /// so their references must survive the server's command-build
+    /// render and reach the worker verbatim.  Everything else (the
+    /// `{{ pg_auth }}` credential alias, `{{ item }}`, `{{ execution_id }}`,
+    /// step results, …) renders now, so the worker's keychain-alias
+    /// resolution still sees a resolved alias string.  See
+    /// noetl/server#72 / noetl/ai-meta#54.
+    pub fn render_value_deferring(
+        &self,
+        value: &serde_json::Value,
+        context: &HashMap<String, serde_json::Value>,
+        deferred_roots: &[&str],
+    ) -> AppResult<serde_json::Value> {
+        match value {
+            serde_json::Value::String(s) => {
+                self.render_to_value_deferring(s, context, deferred_roots)
+            }
+            serde_json::Value::Object(map) => {
+                let mut result = serde_json::Map::new();
+                for (k, v) in map {
+                    // Object KEYS are never deferred-bearing in practice;
+                    // render normally.
+                    let rendered_key = self.render(k, context)?;
+                    let rendered_value =
+                        self.render_value_deferring(v, context, deferred_roots)?;
+                    result.insert(rendered_key, rendered_value);
+                }
+                Ok(serde_json::Value::Object(result))
+            }
+            serde_json::Value::Array(arr) => {
+                let result: Result<Vec<_>, _> = arr
+                    .iter()
+                    .map(|v| self.render_value_deferring(v, context, deferred_roots))
+                    .collect();
+                Ok(serde_json::Value::Array(result?))
+            }
+            _ => Ok(value.clone()),
+        }
+    }
+
+    /// Render a single template string while preserving `{{ ... }}`
+    /// blocks that reference a deferred root.  When no deferred block
+    /// is present this is exactly `render_to_value`.  When one IS
+    /// present the result stays a JSON string carrying the
+    /// partially-rendered template (task_sequence renders the rest).
+    fn render_to_value_deferring(
+        &self,
+        template: &str,
+        context: &HashMap<String, serde_json::Value>,
+        deferred_roots: &[&str],
+    ) -> AppResult<serde_json::Value> {
+        let (protected, stash) = protect_deferred(template, deferred_roots);
+        if stash.is_empty() {
+            // Nothing deferred — preserve the normal JSON-coercion path.
+            return self.render_to_value(template, context);
+        }
+        let rendered = self.render(&protected, context)?;
+        let restored = restore_deferred(&rendered, &stash);
+        // The restored string still holds unresolved `{{ _prev/_results }}`
+        // templates, so it can't be a finished JSON value — keep it as a
+        // string for task_sequence to render at dispatch time.
+        Ok(serde_json::Value::String(restored))
+    }
+
     /// Evaluate a condition expression.
     pub fn evaluate_condition(
         &self,
@@ -185,6 +254,82 @@ impl TemplateRenderer {
 /// Check if a string contains Jinja2 template syntax.
 fn contains_template_syntax(s: &str) -> bool {
     (s.contains("{{") && s.contains("}}")) || (s.contains("{%") && s.contains("%}"))
+}
+
+/// True when `word` appears in `haystack` delimited by non-identifier
+/// chars on both sides (ASCII-alphanumeric or `_`).  Used to detect
+/// whether a `{{ ... }}` expression references a deferred root like
+/// `_prev` without false-matching e.g. `my_prev`.
+fn contains_word(haystack: &str, word: &str) -> bool {
+    if word.is_empty() {
+        return false;
+    }
+    let bytes = haystack.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(word) {
+        let abs = start + pos;
+        let before_ok = abs == 0 || !is_ident(bytes[abs - 1]);
+        let after = abs + word.len();
+        let after_ok = after >= bytes.len() || !is_ident(bytes[after]);
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+/// Replace each `{{ ... }}` block that references one of `roots`
+/// (whole-word) with a unique null-delimited placeholder, returning
+/// the masked template + the (placeholder, original-block) pairs to
+/// restore afterwards.  `{%` statement blocks are left untouched —
+/// the deferred vars only appear in `{{ }}` value expressions in
+/// practice.
+fn protect_deferred(template: &str, roots: &[&str]) -> (String, Vec<(String, String)>) {
+    if roots.is_empty() || !template.contains("{{") {
+        return (template.to_string(), Vec::new());
+    }
+    let mut out = String::with_capacity(template.len());
+    let mut stash: Vec<(String, String)> = Vec::new();
+    let mut rest = template;
+    while let Some(open) = rest.find("{{") {
+        // Emit everything before the block verbatim.
+        out.push_str(&rest[..open]);
+        let after_open = &rest[open..];
+        match after_open.find("}}") {
+            Some(close_rel) => {
+                let close = close_rel + 2; // include the closing `}}`
+                let block = &after_open[..close];
+                let inner = &block[2..block.len() - 2];
+                if roots.iter().any(|r| contains_word(inner, r)) {
+                    let placeholder = format!("\u{0}NOETL_DEFER_{}\u{0}", stash.len());
+                    out.push_str(&placeholder);
+                    stash.push((placeholder, block.to_string()));
+                } else {
+                    out.push_str(block);
+                }
+                rest = &after_open[close..];
+            }
+            None => {
+                // Unterminated `{{` — emit the remainder and stop.
+                out.push_str(after_open);
+                rest = "";
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    (out, stash)
+}
+
+/// Restore the original `{{ ... }}` blocks masked by `protect_deferred`.
+fn restore_deferred(rendered: &str, stash: &[(String, String)]) -> String {
+    let mut out = rendered.to_string();
+    for (placeholder, original) in stash {
+        out = out.replace(placeholder.as_str(), original);
+    }
+    out
 }
 
 /// Convert a JSON HashMap to a minijinja Value.
@@ -514,6 +659,65 @@ fn minijinja_to_json(value: &Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_contains_word_respects_boundaries() {
+        assert!(contains_word("_prev.item_name", "_prev"));
+        assert!(contains_word("foo(_prev.x) | default(1)", "_prev"));
+        assert!(contains_word("_results['save']", "_results"));
+        assert!(!contains_word("my_prev.x", "_prev"));
+        assert!(!contains_word("execution_id", "_prev"));
+    }
+
+    #[test]
+    fn test_render_value_deferring_preserves_prev_renders_rest() {
+        // The exact shape that broke iterator_save_test: an INSERT query
+        // mixing a now-resolvable `{{ execution_id }}` with runtime-only
+        // `{{ _prev.* }}` refs.  After the deferring render, execution_id
+        // is filled but _prev refs survive verbatim for task_sequence.
+        let renderer = TemplateRenderer::new();
+        let mut ctx = HashMap::new();
+        ctx.insert("execution_id".to_string(), serde_json::json!("321"));
+        ctx.insert("pg_auth".to_string(), serde_json::json!("pg_k8s"));
+
+        let cfg = serde_json::json!({
+            "save_item": {
+                "kind": "postgres",
+                "credential": "{{ pg_auth }}",
+                "query": "INSERT INTO t (id, item_name, item_value) VALUES ('{{ execution_id }}:{{ _prev.item_name }}', '{{ _prev.item_name }}', {{ _prev.item_value }})"
+            }
+        });
+
+        let out = renderer
+            .render_value_deferring(&cfg, &ctx, &["_prev", "_results"])
+            .unwrap();
+        let save = &out["save_item"];
+        // Credential alias resolved now (worker auth_alias needs it).
+        assert_eq!(save["credential"], serde_json::json!("pg_k8s"));
+        let query = save["query"].as_str().unwrap();
+        // execution_id rendered:
+        assert!(query.contains("'321:{{ _prev.item_name }}'"), "got: {query}");
+        // _prev refs preserved verbatim for task_sequence:
+        assert!(query.contains("'{{ _prev.item_name }}'"), "got: {query}");
+        assert!(query.contains("{{ _prev.item_value }})"), "got: {query}");
+        // No placeholder leaked:
+        assert!(!query.contains("NOETL_DEFER"), "placeholder leaked: {query}");
+    }
+
+    #[test]
+    fn test_render_value_deferring_no_deferred_is_normal_render() {
+        // When no _prev/_results refs are present, behaves exactly like
+        // render_value (including JSON-coercion to a real value).
+        let renderer = TemplateRenderer::new();
+        let mut ctx = HashMap::new();
+        ctx.insert("item".to_string(), serde_json::json!({"name": "item1", "value": 100}));
+        let cfg = serde_json::json!({"transform": {"args": {"item": "{{ item }}"}}});
+        let out = renderer
+            .render_value_deferring(&cfg, &ctx, &["_prev", "_results"])
+            .unwrap();
+        assert_eq!(out["transform"]["args"]["item"]["name"], serde_json::json!("item1"));
+        assert_eq!(out["transform"]["args"]["item"]["value"], serde_json::json!(100));
+    }
 
     fn make_context() -> HashMap<String, serde_json::Value> {
         let mut ctx = HashMap::new();


### PR DESCRIPTION
## Summary

The server pre-rendered the entire task_sequence pipeline config at command-build time, so `{{ _prev.* }}` / `{{ _results.* }}` (task_sequence *runtime* values) rendered against an undefined `_prev` and — since the v2.19.5 `UndefinedBehavior::Chainable` change — silently became empty strings → malformed sub-task configs (empty SQL `VALUES`).

Add `render_value_deferring(value, ctx, deferred_roots)`: renders every `{{ ... }}` block except those referencing a deferred root (whole-word), which are masked + restored verbatim.  The Pipeline branch defers `_prev` / `_results`.

Keeps worker keychain-alias resolution working — `{{ pg_auth }}` (a workload ref) still resolves to `pg_k8s` at build time; only `_prev`/`_results` survive to task_sequence.

## Test plan

- [x] `cargo test --lib template::jinja` (18/18, incl. 3 new: word-boundary, preserve-_prev-render-rest, no-deferred-is-normal)
- [ ] Reviewer-side: `iterator_save_test` reaches `playbook.completed` — `process_items` INSERTs item1/100, item2/200, item3/300 into `public.iterator_save_test` on the Rust kind stack.

Closes #72
Refs noetl/ai-meta#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)