### PR TITLE
feat(crypto): envelope-encryption core — KeyManager + LocalDevKms + EnvelopeCipher (Wallet Phase 1b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "async-nats",
+ "async-trait",
  "axum",
  "base64",
  "chrono",
@@ -1326,6 +1327,7 @@ dependencies = [
  "tracing-subscriber",
  "twox-hash",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ minijinja = { version = "2.5", features = ["loader"] }
 aes-gcm = "0.10"
 base64 = "0.22"
 rand = "0.8"
+async-trait = "0.1"
+zeroize = "1"
 # Constant-time comparison for bearer-token auth — see
 # src/handlers/internal.rs (the `/api/internal/*` route gate).
 subtle = "2.6"

--- a/src/crypto/envelope.rs
+++ b/src/crypto/envelope.rs
@@ -1,0 +1,149 @@
+//! Envelope encryption for the secrets wallet (Phase 1, noetl/ai-meta#61).
+//!
+//! [`EnvelopeCipher::seal`] generates a fresh per-record DEK, AES-256-GCM
+//! encrypts the plaintext under it, then wraps the DEK with the configured
+//! [`KeyManager`]'s KEK. [`EnvelopeCipher::open`] reverses it. The plaintext
+//! DEK is zeroized after each operation; only the ciphertext + the wrapped DEK
+//! (+ metadata) are persisted.
+//!
+//! The persisted shape is [`EnvelopeRecord`]; the DB layer (Phase 1c/1d) maps
+//! its fields onto the `*_encrypted` / `wrapped_dek` / `kek_*` / `enc_*`
+//! columns on `noetl.credential` and `noetl.keychain`.
+
+use std::sync::Arc;
+
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use crate::crypto::encryption::Encryptor;
+use crate::crypto::keymanager::{KeyManager, WrappedDek};
+use crate::error::AppResult;
+
+/// The current envelope-encryption format version stored in `enc_version`.
+/// `0` (or NULL) means a legacy single-master-key record (pre-Phase-1).
+pub const ENC_VERSION: i16 = 1;
+/// The content-encryption algorithm stored in `enc_alg`.
+pub const ENC_ALG: &str = "AES-256-GCM";
+
+/// A sealed secret: ciphertext + the wrapped DEK + algorithm metadata. This is
+/// the unit the storage layer persists and the wallet reads back.
+#[derive(Clone, Debug)]
+pub struct EnvelopeRecord {
+    /// `nonce || AES-256-GCM(dek, plaintext)` (the `Encryptor` wire format).
+    pub ciphertext: Vec<u8>,
+    /// The DEK, wrapped by the KEK.
+    pub wrapped: WrappedDek,
+    /// Content-encryption algorithm (`AES-256-GCM`).
+    pub enc_alg: String,
+    /// Envelope format version (`ENC_VERSION`).
+    pub enc_version: i16,
+}
+
+/// Seals/opens secrets with envelope encryption over a [`KeyManager`].
+#[derive(Clone)]
+pub struct EnvelopeCipher {
+    km: Arc<dyn KeyManager>,
+}
+
+impl EnvelopeCipher {
+    pub fn new(km: Arc<dyn KeyManager>) -> Self {
+        Self { km }
+    }
+
+    /// The KEK provider id (`local`, `gcp-kms`, …) for logging / audit.
+    pub fn provider(&self) -> &str {
+        self.km.provider()
+    }
+
+    /// Encrypt `plaintext`: fresh DEK → AES-256-GCM → wrap the DEK.
+    pub async fn seal(&self, plaintext: &[u8]) -> AppResult<EnvelopeRecord> {
+        // Per-record 256-bit DEK; zeroized on drop.
+        let mut dek = Zeroizing::new(vec![0u8; 32]);
+        rand::thread_rng().fill_bytes(dek.as_mut_slice());
+
+        let cipher = Encryptor::from_bytes(&dek)?;
+        let ciphertext = cipher.encrypt(plaintext)?;
+        let wrapped = self.km.wrap_dek(&dek).await?;
+
+        Ok(EnvelopeRecord {
+            ciphertext,
+            wrapped,
+            enc_alg: ENC_ALG.to_string(),
+            enc_version: ENC_VERSION,
+        })
+    }
+
+    /// Decrypt an [`EnvelopeRecord`]: unwrap the DEK → AES-256-GCM decrypt.
+    pub async fn open(&self, record: &EnvelopeRecord) -> AppResult<Vec<u8>> {
+        let dek = self.km.unwrap_dek(&record.wrapped).await?;
+        let cipher = Encryptor::from_bytes(&dek)?;
+        cipher.decrypt(&record.ciphertext)
+    }
+
+    /// Convenience: seal a JSON value (serialised compactly).
+    pub async fn seal_json(&self, value: &serde_json::Value) -> AppResult<EnvelopeRecord> {
+        let bytes = serde_json::to_vec(value)
+            .map_err(|e| crate::error::AppError::Encryption(format!("serialize: {e}")))?;
+        self.seal(&bytes).await
+    }
+
+    /// Convenience: open into a JSON value.
+    pub async fn open_json(&self, record: &EnvelopeRecord) -> AppResult<serde_json::Value> {
+        let bytes = self.open(record).await?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| crate::error::AppError::Encryption(format!("deserialize: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::keymanager::LocalDevKms;
+
+    fn cipher() -> EnvelopeCipher {
+        let key = Encryptor::generate_key_base64();
+        let km = LocalDevKms::from_master_key_base64(&key).unwrap();
+        EnvelopeCipher::new(Arc::new(km))
+    }
+
+    #[tokio::test]
+    async fn seal_open_round_trips() {
+        let c = cipher();
+        let pt = b"super-secret-password";
+        let rec = c.seal(pt).await.unwrap();
+        assert_eq!(rec.enc_version, ENC_VERSION);
+        assert_eq!(rec.enc_alg, ENC_ALG);
+        // Ciphertext is not the plaintext, and the wrapped DEK is present.
+        assert_ne!(rec.ciphertext, pt);
+        assert!(!rec.wrapped.ciphertext.is_empty());
+        let out = c.open(&rec).await.unwrap();
+        assert_eq!(out, pt);
+    }
+
+    #[tokio::test]
+    async fn two_seals_use_distinct_deks() {
+        let c = cipher();
+        let a = c.seal(b"x").await.unwrap();
+        let b = c.seal(b"x").await.unwrap();
+        // Different per-record DEKs → different wrapped DEKs and ciphertexts.
+        assert_ne!(a.wrapped.ciphertext, b.wrapped.ciphertext);
+        assert_ne!(a.ciphertext, b.ciphertext);
+    }
+
+    #[tokio::test]
+    async fn seal_open_json() {
+        let c = cipher();
+        let v = serde_json::json!({"db_host": "pg", "db_password": "p@ss"});
+        let rec = c.seal_json(&v).await.unwrap();
+        let out = c.open_json(&rec).await.unwrap();
+        assert_eq!(out, v);
+    }
+
+    #[tokio::test]
+    async fn record_from_another_kek_does_not_open() {
+        let c1 = cipher();
+        let c2 = cipher();
+        let rec = c1.seal(b"secret").await.unwrap();
+        assert!(c2.open(&rec).await.is_err());
+    }
+}

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -1,0 +1,144 @@
+//! Key management for envelope encryption (Secrets Wallet Phase 1,
+//! noetl/ai-meta#61).
+//!
+//! The wallet uses **envelope encryption**: each secret record is encrypted
+//! with a per-record **data-encryption key (DEK)**, and the DEK is itself
+//! encrypted ("wrapped") by a **key-encryption key (KEK)** held in a key
+//! manager (a KMS in production, or [`LocalDevKms`] in dev/kind). Only the
+//! wrapped DEK is stored beside the ciphertext; the plaintext DEK exists in
+//! memory only for the duration of an encrypt/decrypt and is zeroized after.
+//!
+//! This module defines the [`KeyManager`] trait (the KEK boundary) and the
+//! in-process [`LocalDevKms`] implementation that wraps DEKs with the server's
+//! AES-256-GCM master key. Real KMS providers (GCP Cloud KMS, AWS KMS, Azure
+//! Key Vault, Vault Transit) implement the same trait in Phase 2.
+
+use async_trait::async_trait;
+use zeroize::Zeroizing;
+
+use crate::crypto::encryption::Encryptor;
+use crate::error::{AppError, AppResult};
+
+/// A DEK that has been wrapped (encrypted) by a [`KeyManager`]'s KEK, plus the
+/// metadata needed to identify which KEK (provider / key / version) wrapped it
+/// so it can be unwrapped later — even after a key rotation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WrappedDek {
+    /// KEK provider id, e.g. `local`, `gcp-kms`, `aws-kms`, `azure-kv`, `vault`.
+    pub provider: String,
+    /// KEK identifier within the provider (a key resource name / alias).
+    pub key_id: String,
+    /// KEK version that wrapped this DEK (for rotation-aware unwrap).
+    pub key_version: String,
+    /// The wrapped (KEK-encrypted) DEK bytes.
+    pub ciphertext: Vec<u8>,
+}
+
+/// The KEK boundary. Implementations wrap/unwrap DEKs; the plaintext DEK never
+/// leaves the caller, and a KMS-backed implementation never exposes the KEK.
+#[async_trait]
+pub trait KeyManager: Send + Sync {
+    /// Wrap (encrypt) a freshly-generated 32-byte DEK with the current KEK.
+    async fn wrap_dek(&self, dek: &[u8]) -> AppResult<WrappedDek>;
+
+    /// Unwrap (decrypt) a previously-wrapped DEK. The returned bytes are
+    /// zeroized on drop.
+    async fn unwrap_dek(&self, wrapped: &WrappedDek) -> AppResult<Zeroizing<Vec<u8>>>;
+
+    /// Provider id stored alongside records (`local`, `gcp-kms`, …).
+    fn provider(&self) -> &str;
+}
+
+/// In-process key manager that wraps DEKs with the server's AES-256-GCM master
+/// key (the `NOETL_ENCRYPTION_KEY`, now fail-closed per Phase 1a). This is the
+/// dev / kind / single-node KEK. It is **not** a real KMS — the KEK lives in
+/// the process — but it gives envelope encryption (per-record DEKs, rotatable
+/// by re-wrapping) without an external dependency, and the master key can be
+/// supplied from a mounted secret. Production swaps in a KMS-backed
+/// [`KeyManager`] in Phase 2 without touching the record format.
+pub struct LocalDevKms {
+    kek: Encryptor,
+    key_id: String,
+    key_version: String,
+}
+
+impl LocalDevKms {
+    /// Build a `LocalDevKms` from a base64-encoded 32-byte master key (the
+    /// resolved `NOETL_ENCRYPTION_KEY`).
+    pub fn from_master_key_base64(master_key_base64: &str) -> AppResult<Self> {
+        let kek = Encryptor::from_base64(master_key_base64)?;
+        Ok(Self {
+            kek,
+            key_id: "env:NOETL_ENCRYPTION_KEY".to_string(),
+            key_version: "v1".to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl KeyManager for LocalDevKms {
+    async fn wrap_dek(&self, dek: &[u8]) -> AppResult<WrappedDek> {
+        let ciphertext = self.kek.encrypt(dek)?;
+        Ok(WrappedDek {
+            provider: "local".to_string(),
+            key_id: self.key_id.clone(),
+            key_version: self.key_version.clone(),
+            ciphertext,
+        })
+    }
+
+    async fn unwrap_dek(&self, wrapped: &WrappedDek) -> AppResult<Zeroizing<Vec<u8>>> {
+        if wrapped.provider != "local" {
+            return Err(AppError::Encryption(format!(
+                "LocalDevKms cannot unwrap a DEK from provider '{}'",
+                wrapped.provider
+            )));
+        }
+        let dek = self.kek.decrypt(&wrapped.ciphertext)?;
+        Ok(Zeroizing::new(dek))
+    }
+
+    fn provider(&self) -> &str {
+        "local"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kms() -> LocalDevKms {
+        let key = Encryptor::generate_key_base64();
+        LocalDevKms::from_master_key_base64(&key).unwrap()
+    }
+
+    #[tokio::test]
+    async fn wrap_unwrap_round_trips() {
+        let km = kms();
+        let dek = Encryptor::generate_key(); // 32 bytes
+        let wrapped = km.wrap_dek(&dek).await.unwrap();
+        assert_eq!(wrapped.provider, "local");
+        // The wrapped bytes are NOT the plaintext DEK.
+        assert_ne!(wrapped.ciphertext, dek);
+        let unwrapped = km.unwrap_dek(&wrapped).await.unwrap();
+        assert_eq!(unwrapped.as_slice(), dek.as_slice());
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_a_different_kek_fails() {
+        let km1 = kms();
+        let km2 = kms(); // different master key
+        let dek = Encryptor::generate_key();
+        let wrapped = km1.wrap_dek(&dek).await.unwrap();
+        assert!(km2.unwrap_dek(&wrapped).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_foreign_provider() {
+        let km = kms();
+        let dek = Encryptor::generate_key();
+        let mut wrapped = km.wrap_dek(&dek).await.unwrap();
+        wrapped.provider = "gcp-kms".to_string();
+        assert!(km.unwrap_dek(&wrapped).await.is_err());
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,7 +1,13 @@
 //! Cryptography module for the NoETL Control Plane.
 //!
-//! Provides AES-GCM encryption for credential data.
+//! Provides AES-GCM encryption for credential data, plus envelope encryption
+//! (per-record DEK wrapped by a KEK) for the secrets wallet — see
+//! [`envelope`] + [`keymanager`] (noetl/ai-meta#61).
 
 pub mod encryption;
+pub mod envelope;
+pub mod keymanager;
 
 pub use encryption::{decrypt, encrypt, Encryptor};
+pub use envelope::{EnvelopeCipher, EnvelopeRecord, ENC_ALG, ENC_VERSION};
+pub use keymanager::{KeyManager, LocalDevKms, WrappedDek};


### PR DESCRIPTION
## Summary

**Secrets Wallet Phase 1b** (tracks noetl/ai-meta#61 — [design](https://github.com/noetl/ai-meta/wiki/Umbrella-Secrets-Wallet)). The crypto foundation for envelope encryption. Each secret will be encrypted with a per-record **DEK**, and the DEK is wrapped by a **KEK** held in a `KeyManager`. This PR is the **library core only** — no DB or service wiring yet (Phase 1c/1d).

### `src/crypto/keymanager.rs`
- `KeyManager` async trait — the KEK boundary: `wrap_dek` / `unwrap_dek` + `provider()`.
- `WrappedDek { provider, key_id, key_version, ciphertext }` — carries the KEK identity so a DEK can be unwrapped even after rotation.
- `LocalDevKms` — wraps DEKs with the server's AES-256-GCM master key (the `NOETL_ENCRYPTION_KEY`, now fail-closed per Phase 1a). The dev / kind / single-node KEK; GCP Cloud KMS / AWS KMS / Azure Key Vault / Vault Transit implement the same trait in **Phase 2** without changing the record format.

### `src/crypto/envelope.rs`
- `EnvelopeCipher` over `Arc<dyn KeyManager>`: `seal` (fresh per-record DEK → AES-256-GCM → wrap the DEK) / `open`, plus `seal_json` / `open_json`.
- `EnvelopeRecord { ciphertext, wrapped, enc_alg, enc_version }` — the unit the storage layer (Phase 1c/1d) maps onto the `*_encrypted` / `wrapped_dek` / `kek_*` / `enc_*` columns.
- DEKs are `zeroize::Zeroizing` (zeroed on drop).

## Tests (8, all green)

round-trip seal/open, **distinct per-record DEKs** (two seals of the same plaintext differ), wrong-KEK fails to open, JSON round-trip, foreign-provider rejected, wrap/unwrap round-trip, unwrap-with-different-KEK fails. `cargo build` + `cargo test crypto::` (14 pass) + `cargo fmt --check` + `cargo clippy` clean.

## Next (separate PRs on #61)
- **1c** — schema migration: `wrapped_dek` / `kek_*` / `enc_*` columns on `noetl.credential` + `noetl.keychain` (nullable, back-compat).
- **1d** — wire `EnvelopeCipher` into `CredentialService` + `KeychainService` (new records `enc_version=1`; read path handles legacy `enc_version` 0/NULL).
- **1e** — re-encrypt migration job for existing records.

`feat:` → minor release; the module is additive and unused at runtime until 1d.

Closes noetl/server#76
Refs noetl/ai-meta#61

🤖 Generated with [Claude Code](https://claude.com/claude-code)