### PR TITLE
feat(crypto): envelope-encrypt credential + keychain storage — forward-only (Wallet Phase 1c/1d)

### DIFF
--- a/src/crypto/envelope.rs
+++ b/src/crypto/envelope.rs
@@ -12,12 +12,14 @@
 
 use std::sync::Arc;
 
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 use crate::crypto::encryption::Encryptor;
 use crate::crypto::keymanager::{KeyManager, WrappedDek};
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 
 /// The current envelope-encryption format version stored in `enc_version`.
 /// `0` (or NULL) means a legacy single-master-key record (pre-Phase-1).
@@ -37,6 +39,77 @@ pub struct EnvelopeRecord {
     pub enc_alg: String,
     /// Envelope format version (`ENC_VERSION`).
     pub enc_version: i16,
+}
+
+/// On-storage JSON form of an [`EnvelopeRecord`]: the bytes that go into the
+/// `data_encrypted` (TEXT) / `data` (BYTEA) column. Self-describing (carries
+/// the KEK identity + format version) so the re-encrypt / rotation job can act
+/// on it. Forward-only: there is no legacy fallback — a stored value that does
+/// not parse as this shape is an error (re-register the secret).
+#[derive(Serialize, Deserialize)]
+struct StoredEnvelope {
+    /// Envelope format version.
+    v: i16,
+    /// Content-encryption algorithm.
+    alg: String,
+    /// base64 `nonce || ciphertext`.
+    ct: String,
+    /// Wrapped DEK + the KEK that wrapped it.
+    dek: StoredDek,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredDek {
+    /// KEK provider (`local`, `gcp-kms`, …).
+    p: String,
+    /// KEK key id.
+    kid: String,
+    /// KEK key version.
+    kv: String,
+    /// base64 wrapped-DEK bytes.
+    ct: String,
+}
+
+impl EnvelopeRecord {
+    /// Serialise to the on-storage JSON string (UTF-8; safe for TEXT + BYTEA).
+    pub fn to_storage_string(&self) -> String {
+        let s = StoredEnvelope {
+            v: self.enc_version,
+            alg: self.enc_alg.clone(),
+            ct: B64.encode(&self.ciphertext),
+            dek: StoredDek {
+                p: self.wrapped.provider.clone(),
+                kid: self.wrapped.key_id.clone(),
+                kv: self.wrapped.key_version.clone(),
+                ct: B64.encode(&self.wrapped.ciphertext),
+            },
+        };
+        serde_json::to_string(&s).expect("StoredEnvelope serialises")
+    }
+
+    /// Parse an on-storage value. Errors (rather than falling back) if the
+    /// value is not a valid envelope — forward-only, no legacy path.
+    pub fn from_storage_str(raw: &str) -> AppResult<EnvelopeRecord> {
+        let s: StoredEnvelope = serde_json::from_str(raw.trim())
+            .map_err(|e| AppError::Encryption(format!("not a wallet envelope record: {e}")))?;
+        let ciphertext = B64
+            .decode(s.ct.as_bytes())
+            .map_err(|e| AppError::Encryption(format!("envelope ct base64: {e}")))?;
+        let dek_ct = B64
+            .decode(s.dek.ct.as_bytes())
+            .map_err(|e| AppError::Encryption(format!("envelope dek base64: {e}")))?;
+        Ok(EnvelopeRecord {
+            ciphertext,
+            wrapped: WrappedDek {
+                provider: s.dek.p,
+                key_id: s.dek.kid,
+                key_version: s.dek.kv,
+                ciphertext: dek_ct,
+            },
+            enc_alg: s.alg,
+            enc_version: s.v,
+        })
+    }
 }
 
 /// Seals/opens secrets with envelope encryption over a [`KeyManager`].
@@ -93,6 +166,18 @@ impl EnvelopeCipher {
         serde_json::from_slice(&bytes)
             .map_err(|e| crate::error::AppError::Encryption(format!("deserialize: {e}")))
     }
+
+    /// Seal a JSON value directly into the on-storage string form (the value to
+    /// persist in `data_encrypted` / `data`).
+    pub async fn seal_json_to_storage(&self, value: &serde_json::Value) -> AppResult<String> {
+        Ok(self.seal_json(value).await?.to_storage_string())
+    }
+
+    /// Open an on-storage value into JSON.
+    pub async fn open_storage_json(&self, raw: &str) -> AppResult<serde_json::Value> {
+        let record = EnvelopeRecord::from_storage_str(raw)?;
+        self.open_json(&record).await
+    }
 }
 
 #[cfg(test)]
@@ -145,5 +230,24 @@ mod tests {
         let c2 = cipher();
         let rec = c1.seal(b"secret").await.unwrap();
         assert!(c2.open(&rec).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn storage_string_round_trips() {
+        let c = cipher();
+        let v = serde_json::json!({"db_host": "pg", "db_password": "p@ss;'"});
+        let stored = c.seal_json_to_storage(&v).await.unwrap();
+        // Self-describing JSON carrying the format version + KEK identity.
+        assert!(stored.contains("\"v\":1"));
+        assert!(stored.contains("\"local\""));
+        let out = c.open_storage_json(&stored).await.unwrap();
+        assert_eq!(out, v);
+    }
+
+    #[tokio::test]
+    async fn non_envelope_storage_value_errors() {
+        let c = cipher();
+        // A legacy/garbage value is not a wallet envelope → error (forward-only).
+        assert!(c.open_storage_json("AAAAlegacy-base64==").await.is_err());
     }
 }

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -1,8 +1,14 @@
 //! Credential service for managing encrypted credentials.
+//!
+//! Credentials are stored under **envelope encryption** (Secrets Wallet
+//! Phase 1, noetl/ai-meta#61): each record's data is sealed with a per-record
+//! DEK that is wrapped by the KEK. The on-storage value is the self-describing
+//! envelope JSON (see `crypto::envelope`). Forward-only — there is no legacy
+//! single-master-key path; a pre-wallet record must be re-registered.
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use std::sync::Arc;
 
-use crate::crypto::Encryptor;
+use crate::crypto::{EnvelopeCipher, LocalDevKms};
 use crate::db::models::{
     CredentialCreateRequest, CredentialEntry, CredentialFilter, CredentialListResponse,
     CredentialResponse,
@@ -15,7 +21,7 @@ use crate::error::{AppError, AppResult};
 #[derive(Clone)]
 pub struct CredentialService {
     pool: DbPool,
-    encryptor: Encryptor,
+    cipher: EnvelopeCipher,
 }
 
 impl CredentialService {
@@ -24,10 +30,13 @@ impl CredentialService {
     /// # Arguments
     ///
     /// * `pool` - Database connection pool
-    /// * `encryption_key` - Base64-encoded 32-byte encryption key
+    /// * `encryption_key` - Base64-encoded 32-byte master key (the KEK for the
+    ///   in-process [`LocalDevKms`]; a KMS-backed `KeyManager` replaces it in
+    ///   Phase 2 without changing the stored record format).
     pub fn new(pool: DbPool, encryption_key: &str) -> AppResult<Self> {
-        let encryptor = Encryptor::from_base64(encryption_key)?;
-        Ok(Self { pool, encryptor })
+        let kms = LocalDevKms::from_master_key_base64(encryption_key)?;
+        let cipher = EnvelopeCipher::new(Arc::new(kms));
+        Ok(Self { pool, cipher })
     }
 
     /// Create or update a credential.
@@ -35,10 +44,9 @@ impl CredentialService {
         &self,
         request: CredentialCreateRequest,
     ) -> AppResult<CredentialResponse> {
-        // Encrypt the data, then base64-armor the AES-GCM bytes so
-        // they round-trip through the TEXT `data_encrypted` column.
-        let encrypted_bytes = self.encryptor.encrypt_json(&request.data)?;
-        let encrypted_data = BASE64.encode(&encrypted_bytes);
+        // Envelope-seal the data into the self-describing storage string
+        // (UTF-8 JSON) for the TEXT `data_encrypted` column.
+        let encrypted_data = self.cipher.seal_json_to_storage(&request.data).await?;
 
         // Check if credential already exists
         if let Some(existing) = queries::get_credential_by_name(&self.pool, &request.name).await? {
@@ -89,12 +97,9 @@ impl CredentialService {
         let entry = self.find_credential(identifier).await?;
 
         let data = if include_data {
-            // `entry.data` is the base64-armored AES-GCM blob from the
-            // TEXT column — decode back to bytes before decrypting.
-            let cipher_bytes = BASE64
-                .decode(entry.data.as_bytes())
-                .map_err(|e| AppError::Internal(format!("credential base64 decode: {e}")))?;
-            Some(self.encryptor.decrypt_json(&cipher_bytes)?)
+            // `entry.data` is the self-describing envelope JSON from the
+            // TEXT column — unwrap the DEK + decrypt.
+            Some(self.cipher.open_storage_json(&entry.data).await?)
         } else {
             None
         };

--- a/src/services/keychain.rs
+++ b/src/services/keychain.rs
@@ -1,21 +1,28 @@
 //! Keychain service for token/credential caching.
+//!
+//! The keychain is the per-execution cache of resolved secrets / minted tokens
+//! (noetl/ai-meta#61). Cached values are envelope-encrypted with the same
+//! wallet primitives as credentials (per-record DEK wrapped by the KEK) and
+//! stored as the self-describing envelope JSON. Forward-only — no legacy path.
+
+use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 
-use crate::crypto::Encryptor;
+use crate::crypto::{EnvelopeCipher, LocalDevKms};
 use crate::db::models::{
     KeychainDeleteResponse, KeychainEntrySummary, KeychainGetResponse, KeychainListResponse,
     KeychainSetRequest, KeychainSetResponse,
 };
 use crate::db::queries::keychain as queries;
 use crate::db::DbPool;
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 
 /// Service for keychain operations.
 #[derive(Clone)]
 pub struct KeychainService {
     pool: DbPool,
-    encryptor: Encryptor,
+    cipher: EnvelopeCipher,
 }
 
 impl KeychainService {
@@ -24,10 +31,12 @@ impl KeychainService {
     /// # Arguments
     ///
     /// * `pool` - Database connection pool
-    /// * `encryption_key` - Base64-encoded 32-byte encryption key
+    /// * `encryption_key` - Base64-encoded 32-byte master key (KEK for the
+    ///   in-process [`LocalDevKms`]).
     pub fn new(pool: DbPool, encryption_key: &str) -> AppResult<Self> {
-        let encryptor = Encryptor::from_base64(encryption_key)?;
-        Ok(Self { pool, encryptor })
+        let kms = LocalDevKms::from_master_key_base64(encryption_key)?;
+        let cipher = EnvelopeCipher::new(Arc::new(kms));
+        Ok(Self { pool, cipher })
     }
 
     /// Get a keychain entry.
@@ -70,8 +79,10 @@ impl KeychainService {
         // Increment access count
         queries::increment_access_count(&self.pool, entry.id).await?;
 
-        // Decrypt data
-        let data = self.encryptor.decrypt_json(&entry.data)?;
+        // Decrypt data: `entry.data` (BYTEA) holds the UTF-8 envelope JSON.
+        let stored = std::str::from_utf8(&entry.data)
+            .map_err(|e| AppError::Encryption(format!("keychain data not UTF-8: {e}")))?;
+        let data = self.cipher.open_storage_json(stored).await?;
 
         Ok(KeychainGetResponse {
             status: "found".to_string(),
@@ -103,8 +114,13 @@ impl KeychainService {
                 .map(|seconds| Utc::now() + Duration::seconds(seconds))
         });
 
-        // Encrypt data
-        let encrypted_data = self.encryptor.encrypt_json(&request.data)?;
+        // Envelope-seal data into the self-describing JSON, stored as UTF-8
+        // bytes in the BYTEA `data` column.
+        let encrypted_data = self
+            .cipher
+            .seal_json_to_storage(&request.data)
+            .await?
+            .into_bytes();
 
         // Upsert entry
         queries::upsert_keychain_entry(


### PR DESCRIPTION
## Summary

**Secrets Wallet Phase 1c/1d** (tracks noetl/ai-meta#61). Wires the Phase 1b envelope cipher (server#77) into the **live** credential + keychain write/read paths. Both `CredentialService` and `KeychainService` now store secrets under **envelope encryption** — a per-record DEK (AES-256-GCM), the DEK wrapped by the KEK (`LocalDevKms` over the master key today; GCP KMS in Phase 2).

**Forward-only — no legacy master-key path** (per direction: legacy is a placeholder for mistakes). A pre-wallet record does not read back and must be re-registered.

### Storage form (no schema migration)
The server has no migration system, so the envelope is **self-describing** within the existing column: a versioned JSON `{v,alg,ct,dek:{p,kid,kv,ct}}` in `data_encrypted` (TEXT) / `data` (BYTEA). `EnvelopeRecord::to_storage_string()` / `from_storage_str()` + `EnvelopeCipher::{seal_json_to_storage, open_storage_json}`. A non-envelope value errors (no fallback). Queryable `kek_*` columns are a later optimization.

### Changes
- `crypto/envelope.rs`: storage (de)serialisation + 2 tests (round-trip, non-envelope errors).
- `services/credential.rs`, `services/keychain.rs`: `Encryptor` → `EnvelopeCipher`; write seals, read opens.

## Tests
`cargo build` + `cargo test crypto:: services::` green (16 crypto tests incl. distinct per-record DEKs, wrong-KEK fails, storage round-trip). `cargo fmt --check` clean.

> Note: `playbook::parser::tests::test_parse_invalid_next_reference` fails on `main` independent of this change (confirmed on a clean checkout) — flagged for a separate fix.

## Validation (kind)
Build the image, deploy, **re-register credentials** (one-way cutover), confirm a new record is stored envelope-form (`{"v":1,...`) and decrypts, then run a pg_k8s fixture end-to-end. (Validation run added to this PR before merge.)

Closes noetl/server#78
Refs noetl/ai-meta#61

🤖 Generated with [Claude Code](https://claude.com/claude-code)