### PR TITLE
feat(crypto): GCP Cloud KMS KeyManager + runtime provider selection (Wallet Phase 2)

### DIFF
--- a/src/crypto/kms_gcp.rs
+++ b/src/crypto/kms_gcp.rs
@@ -1,0 +1,267 @@
+//! GCP Cloud KMS key manager (Secrets Wallet Phase 2, noetl/ai-meta#61).
+//!
+//! Implements [`KeyManager`] over **Google Cloud KMS**: `wrap_dek` /
+//! `unwrap_dek` become Cloud KMS `:encrypt` / `:decrypt` calls on a symmetric
+//! crypto key. The KEK never leaves Cloud KMS — only the wrapped DEK is ever
+//! held in the process.
+//!
+//! Auth uses **ambient GKE Workload Identity**: a short-lived access token is
+//! fetched from the instance metadata server (per `execution-model.md`'s
+//! already-in-place-trust rule — no bootstrap secret stored in the wallet).
+//! The transport is the Cloud KMS REST API over `reqwest` (no heavy gRPC
+//! dependency).
+//!
+//! Selection is runtime (`NOETL_KMS_PROVIDER=gcp-kms` + `NOETL_GCP_KMS_KEY=<resource>`);
+//! the default stays [`super::LocalDevKms`] so kind / dev keep working.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::crypto::keymanager::{KeyManager, WrappedDek};
+use crate::error::{AppError, AppResult};
+
+const PROVIDER: &str = "gcp-kms";
+const DEFAULT_KMS_ENDPOINT: &str = "https://cloudkms.googleapis.com/v1";
+const DEFAULT_METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+/// GCP Cloud KMS-backed key manager.
+pub struct GcpKms {
+    http: reqwest::Client,
+    /// The symmetric crypto key resource: `projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>`.
+    key_name: String,
+    kms_endpoint: String,
+    metadata_token_url: String,
+    token: Arc<Mutex<Option<CachedToken>>>,
+}
+
+struct CachedToken {
+    value: String,
+    expires_at: Instant,
+}
+
+#[derive(Deserialize)]
+struct MetadataToken {
+    access_token: String,
+    expires_in: u64,
+}
+
+#[derive(Deserialize)]
+struct EncryptResponse {
+    /// The key VERSION used, e.g. `.../cryptoKeys/<k>/cryptoKeyVersions/<v>`.
+    #[serde(default)]
+    name: String,
+    ciphertext: String,
+}
+
+#[derive(Deserialize)]
+struct DecryptResponse {
+    plaintext: String,
+}
+
+impl GcpKms {
+    /// Build from a Cloud KMS crypto-key resource name.
+    pub fn new(key_name: &str) -> AppResult<Self> {
+        if !key_name.contains("/cryptoKeys/") {
+            return Err(AppError::Encryption(format!(
+                "NOETL_GCP_KMS_KEY must be a Cloud KMS cryptoKey resource \
+                 (projects/.../cryptoKeys/<key>), got '{key_name}'"
+            )));
+        }
+        Ok(Self {
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .map_err(|e| AppError::Encryption(format!("kms http client: {e}")))?,
+            key_name: key_name.to_string(),
+            kms_endpoint: DEFAULT_KMS_ENDPOINT.to_string(),
+            metadata_token_url: DEFAULT_METADATA_TOKEN_URL.to_string(),
+            token: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    /// Fetch (and cache) a Workload-Identity access token from the metadata
+    /// server. Refreshed when within 60s of expiry.
+    async fn access_token(&self) -> AppResult<String> {
+        let mut guard = self.token.lock().await;
+        if let Some(tok) = guard.as_ref() {
+            if tok.expires_at > Instant::now() {
+                return Ok(tok.value.clone());
+            }
+        }
+        let resp = self
+            .http
+            .get(&self.metadata_token_url)
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await
+            .map_err(|e| AppError::Encryption(format!("kms metadata token request: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(AppError::Encryption(format!(
+                "kms metadata token: HTTP {}",
+                resp.status().as_u16()
+            )));
+        }
+        let body: MetadataToken = resp
+            .json()
+            .await
+            .map_err(|e| AppError::Encryption(format!("kms metadata token decode: {e}")))?;
+        let ttl = body.expires_in.saturating_sub(60).max(1);
+        *guard = Some(CachedToken {
+            value: body.access_token.clone(),
+            expires_at: Instant::now() + Duration::from_secs(ttl),
+        });
+        Ok(body.access_token)
+    }
+}
+
+/// Pure: the Cloud KMS `:encrypt` request body for a DEK.
+fn encrypt_body(dek: &[u8]) -> serde_json::Value {
+    serde_json::json!({ "plaintext": B64.encode(dek) })
+}
+
+/// Pure: the Cloud KMS `:decrypt` request body for a wrapped DEK.
+fn decrypt_body(ciphertext: &[u8]) -> serde_json::Value {
+    serde_json::json!({ "ciphertext": B64.encode(ciphertext) })
+}
+
+/// Pure: parse an `:encrypt` response into (wrapped-dek bytes, key version).
+fn parse_encrypt(body: &EncryptResponse) -> AppResult<(Vec<u8>, String)> {
+    let ct = B64
+        .decode(body.ciphertext.as_bytes())
+        .map_err(|e| AppError::Encryption(format!("kms encrypt ciphertext base64: {e}")))?;
+    // The version is the trailing `cryptoKeyVersions/<v>` segment, if present.
+    let version = body
+        .name
+        .rsplit("cryptoKeyVersions/")
+        .next()
+        .filter(|v| !v.is_empty() && *v != body.name)
+        .unwrap_or("primary")
+        .to_string();
+    Ok((ct, version))
+}
+
+#[async_trait]
+impl KeyManager for GcpKms {
+    async fn wrap_dek(&self, dek: &[u8]) -> AppResult<WrappedDek> {
+        let token = self.access_token().await?;
+        let url = format!("{}/{}:encrypt", self.kms_endpoint, self.key_name);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(token)
+            .json(&encrypt_body(dek))
+            .send()
+            .await
+            .map_err(|e| AppError::Encryption(format!("kms encrypt request: {e}")))?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(AppError::Encryption(format!(
+                "kms encrypt: HTTP {status} {}",
+                detail.chars().take(200).collect::<String>()
+            )));
+        }
+        let body: EncryptResponse = resp
+            .json()
+            .await
+            .map_err(|e| AppError::Encryption(format!("kms encrypt decode: {e}")))?;
+        let (ciphertext, version) = parse_encrypt(&body)?;
+        Ok(WrappedDek {
+            provider: PROVIDER.to_string(),
+            key_id: self.key_name.clone(),
+            key_version: version,
+            ciphertext,
+        })
+    }
+
+    async fn unwrap_dek(&self, wrapped: &WrappedDek) -> AppResult<zeroize::Zeroizing<Vec<u8>>> {
+        if wrapped.provider != PROVIDER {
+            return Err(AppError::Encryption(format!(
+                "GcpKms cannot unwrap a DEK from provider '{}'",
+                wrapped.provider
+            )));
+        }
+        let token = self.access_token().await?;
+        // Decrypt against the cryptoKey (Cloud KMS selects the version from the
+        // ciphertext); `wrapped.key_id` is that cryptoKey resource name.
+        let url = format!("{}/{}:decrypt", self.kms_endpoint, wrapped.key_id);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(token)
+            .json(&decrypt_body(&wrapped.ciphertext))
+            .send()
+            .await
+            .map_err(|e| AppError::Encryption(format!("kms decrypt request: {e}")))?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let detail = resp.text().await.unwrap_or_default();
+            return Err(AppError::Encryption(format!(
+                "kms decrypt: HTTP {status} {}",
+                detail.chars().take(200).collect::<String>()
+            )));
+        }
+        let body: DecryptResponse = resp
+            .json()
+            .await
+            .map_err(|e| AppError::Encryption(format!("kms decrypt decode: {e}")))?;
+        let pt = B64
+            .decode(body.plaintext.as_bytes())
+            .map_err(|e| AppError::Encryption(format!("kms decrypt plaintext base64: {e}")))?;
+        Ok(zeroize::Zeroizing::new(pt))
+    }
+
+    fn provider(&self) -> &str {
+        PROVIDER
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_cryptokey_resource() {
+        assert!(GcpKms::new("projects/p/locations/l/keyRings/r").is_err());
+        assert!(GcpKms::new("projects/p/locations/l/keyRings/r/cryptoKeys/k").is_ok());
+    }
+
+    #[test]
+    fn encrypt_body_is_base64_plaintext() {
+        let b = encrypt_body(b"\x00\x01\x02");
+        assert_eq!(b["plaintext"], B64.encode([0u8, 1, 2]));
+    }
+
+    #[test]
+    fn decrypt_body_is_base64_ciphertext() {
+        let b = decrypt_body(b"\xff\xfe");
+        assert_eq!(b["ciphertext"], B64.encode([255u8, 254]));
+    }
+
+    #[test]
+    fn parse_encrypt_extracts_version_and_bytes() {
+        let r = EncryptResponse {
+            name: "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/7".to_string(),
+            ciphertext: B64.encode(b"wrapped"),
+        };
+        let (ct, ver) = parse_encrypt(&r).unwrap();
+        assert_eq!(ct, b"wrapped");
+        assert_eq!(ver, "7");
+    }
+
+    #[test]
+    fn parse_encrypt_defaults_version_when_absent() {
+        let r = EncryptResponse {
+            name: String::new(),
+            ciphertext: B64.encode(b"x"),
+        };
+        let (_ct, ver) = parse_encrypt(&r).unwrap();
+        assert_eq!(ver, "primary");
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -7,7 +7,93 @@
 pub mod encryption;
 pub mod envelope;
 pub mod keymanager;
+pub mod kms_gcp;
 
 pub use encryption::{decrypt, encrypt, Encryptor};
 pub use envelope::{EnvelopeCipher, EnvelopeRecord, ENC_ALG, ENC_VERSION};
 pub use keymanager::{KeyManager, LocalDevKms, WrappedDek};
+pub use kms_gcp::GcpKms;
+
+use std::sync::Arc;
+
+use crate::error::{AppError, AppResult};
+
+/// Build the configured KEK key manager (Secrets Wallet, noetl/ai-meta#61).
+///
+/// `provider` selects the backend:
+/// - `local` (default) — [`LocalDevKms`] wraps DEKs with the in-process
+///   AES-256-GCM master key. The dev / kind / single-node KEK.
+/// - `gcp-kms` — [`GcpKms`] wraps DEKs via Google Cloud KMS (the KEK never
+///   leaves Cloud KMS); requires `gcp_kms_key` (a cryptoKey resource name).
+///
+/// New KMS providers (AWS, Azure, Vault) add an arm here behind the same
+/// [`KeyManager`] trait — the stored record format is unchanged.
+pub fn build_key_manager(
+    provider: &str,
+    master_key_base64: &str,
+    gcp_kms_key: Option<&str>,
+) -> AppResult<Arc<dyn KeyManager>> {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        "" | "local" => Ok(Arc::new(LocalDevKms::from_master_key_base64(
+            master_key_base64,
+        )?)),
+        "gcp-kms" | "gcp" => {
+            let key = gcp_kms_key.ok_or_else(|| {
+                AppError::Encryption(
+                    "NOETL_KMS_PROVIDER=gcp-kms requires NOETL_GCP_KMS_KEY (a Cloud KMS \
+                     cryptoKey resource: projects/.../cryptoKeys/<key>)"
+                        .to_string(),
+                )
+            })?;
+            Ok(Arc::new(GcpKms::new(key)?))
+        }
+        other => Err(AppError::Encryption(format!(
+            "unknown NOETL_KMS_PROVIDER '{other}' (expected 'local' or 'gcp-kms')"
+        ))),
+    }
+}
+
+/// Build the wallet's [`EnvelopeCipher`] from environment-configured KMS
+/// settings (`NOETL_KMS_PROVIDER`, `NOETL_GCP_KMS_KEY`) + the master key.
+pub fn build_envelope_cipher(master_key_base64: &str) -> AppResult<EnvelopeCipher> {
+    let provider = std::env::var("NOETL_KMS_PROVIDER").unwrap_or_else(|_| "local".to_string());
+    let gcp_key = std::env::var("NOETL_GCP_KMS_KEY").ok();
+    let km = build_key_manager(&provider, master_key_base64, gcp_key.as_deref())?;
+    tracing::info!(kms_provider = %km.provider(), "Wallet KEK provider initialized");
+    Ok(EnvelopeCipher::new(km))
+}
+
+#[cfg(test)]
+mod factory_tests {
+    use super::*;
+    use crate::crypto::Encryptor;
+
+    #[test]
+    fn defaults_to_local() {
+        let key = Encryptor::generate_key_base64();
+        let km = build_key_manager("local", &key, None).unwrap();
+        assert_eq!(km.provider(), "local");
+        // Empty provider also defaults to local.
+        let km2 = build_key_manager("", &key, None).unwrap();
+        assert_eq!(km2.provider(), "local");
+    }
+
+    #[test]
+    fn gcp_requires_key() {
+        let key = Encryptor::generate_key_base64();
+        assert!(build_key_manager("gcp-kms", &key, None).is_err());
+        let km = build_key_manager(
+            "gcp-kms",
+            &key,
+            Some("projects/p/locations/l/keyRings/r/cryptoKeys/k"),
+        )
+        .unwrap();
+        assert_eq!(km.provider(), "gcp-kms");
+    }
+
+    #[test]
+    fn unknown_provider_errors() {
+        let key = Encryptor::generate_key_base64();
+        assert!(build_key_manager("vault-xyz", &key, None).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,10 +501,14 @@ async fn main() -> anyhow::Result<()> {
     // ids take a clone of `state.snowflake` (an `Arc`).
     let state = AppState::new(db_pool.clone(), pools, app_config.clone(), nats_client);
 
-    // Create services
+    // Create services. The wallet's envelope cipher is built once over the
+    // configured KEK provider (NOETL_KMS_PROVIDER: `local` default, or
+    // `gcp-kms` over Cloud KMS — noetl/ai-meta#61 Phase 2) and shared between
+    // the credential and keychain services.
     let catalog_service = CatalogService::new(db_pool.clone());
-    let credential_service = CredentialService::new(db_pool.clone(), &encryption_key)?;
-    let keychain_service = KeychainService::new(db_pool.clone(), &encryption_key)?;
+    let wallet_cipher = noetl_server::crypto::build_envelope_cipher(&encryption_key)?;
+    let credential_service = CredentialService::new(db_pool.clone(), wallet_cipher.clone());
+    let keychain_service = KeychainService::new(db_pool.clone(), wallet_cipher);
     // Phase F R4-4b: ExecutionService now takes the DbPoolMap so
     // its per-execution methods route via pool_for(execution_id)
     // and `list()` fan-outs via for_each_shard.  In single-pool

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -6,9 +6,7 @@
 //! envelope JSON (see `crypto::envelope`). Forward-only — there is no legacy
 //! single-master-key path; a pre-wallet record must be re-registered.
 
-use std::sync::Arc;
-
-use crate::crypto::{EnvelopeCipher, LocalDevKms};
+use crate::crypto::EnvelopeCipher;
 use crate::db::models::{
     CredentialCreateRequest, CredentialEntry, CredentialFilter, CredentialListResponse,
     CredentialResponse,
@@ -27,16 +25,11 @@ pub struct CredentialService {
 impl CredentialService {
     /// Create a new credential service.
     ///
-    /// # Arguments
-    ///
-    /// * `pool` - Database connection pool
-    /// * `encryption_key` - Base64-encoded 32-byte master key (the KEK for the
-    ///   in-process [`LocalDevKms`]; a KMS-backed `KeyManager` replaces it in
-    ///   Phase 2 without changing the stored record format).
-    pub fn new(pool: DbPool, encryption_key: &str) -> AppResult<Self> {
-        let kms = LocalDevKms::from_master_key_base64(encryption_key)?;
-        let cipher = EnvelopeCipher::new(Arc::new(kms));
-        Ok(Self { pool, cipher })
+    /// `cipher` is the wallet's [`EnvelopeCipher`], built once at startup over
+    /// the configured KEK provider (`crypto::build_envelope_cipher`) — local
+    /// master key in dev, GCP Cloud KMS in production.
+    pub fn new(pool: DbPool, cipher: EnvelopeCipher) -> Self {
+        Self { pool, cipher }
     }
 
     /// Create or update a credential.

--- a/src/services/keychain.rs
+++ b/src/services/keychain.rs
@@ -5,11 +5,9 @@
 //! wallet primitives as credentials (per-record DEK wrapped by the KEK) and
 //! stored as the self-describing envelope JSON. Forward-only — no legacy path.
 
-use std::sync::Arc;
-
 use chrono::{Duration, Utc};
 
-use crate::crypto::{EnvelopeCipher, LocalDevKms};
+use crate::crypto::EnvelopeCipher;
 use crate::db::models::{
     KeychainDeleteResponse, KeychainEntrySummary, KeychainGetResponse, KeychainListResponse,
     KeychainSetRequest, KeychainSetResponse,
@@ -28,15 +26,10 @@ pub struct KeychainService {
 impl KeychainService {
     /// Create a new keychain service.
     ///
-    /// # Arguments
-    ///
-    /// * `pool` - Database connection pool
-    /// * `encryption_key` - Base64-encoded 32-byte master key (KEK for the
-    ///   in-process [`LocalDevKms`]).
-    pub fn new(pool: DbPool, encryption_key: &str) -> AppResult<Self> {
-        let kms = LocalDevKms::from_master_key_base64(encryption_key)?;
-        let cipher = EnvelopeCipher::new(Arc::new(kms));
-        Ok(Self { pool, cipher })
+    /// `cipher` is the wallet's [`EnvelopeCipher`] (shared with the credential
+    /// service), built once over the configured KEK provider.
+    pub fn new(pool: DbPool, cipher: EnvelopeCipher) -> Self {
+        Self { pool, cipher }
     }
 
     /// Get a keychain entry.


### PR DESCRIPTION
## Summary

**Secrets Wallet Phase 2** (tracks noetl/ai-meta#61). The KEK can now live in **Google Cloud KMS** instead of the process — the chosen primary KMS. No change to the stored record format (Phase 1's self-describing envelope blob is provider-agnostic).

### `GcpKms` (`crypto/kms_gcp.rs`)
- `wrap_dek` / `unwrap_dek` → Cloud KMS REST `:encrypt` / `:decrypt` on a symmetric cryptoKey. The KEK never leaves Cloud KMS; only the wrapped DEK is held in-process.
- Auth: **ambient GKE Workload Identity** — short-lived access token from the instance metadata server (cached, refreshed near expiry). No bootstrap secret stored (per `execution-model.md` already-in-place-trust).
- Transport: `reqwest` (no gRPC dependency). Pure request/response helpers, 5 unit tests.

### Provider selection (`crypto::build_key_manager` / `build_envelope_cipher`)
Runtime, env-driven: `local` (default — `LocalDevKms` over the master key) or `gcp-kms` (`NOETL_KMS_PROVIDER` + `NOETL_GCP_KMS_KEY`). New providers (AWS/Azure/Vault) add one arm. 3 factory tests.

### Service wiring
`CredentialService` + `KeychainService` now take the shared `EnvelopeCipher`, built once in `main` over the configured provider.

## Tests / validation
- `cargo test crypto:: services::` green (24 crypto tests). `fmt` + `clippy` clean.
- **kind** stays on the `local` provider → no behavior change; the regression check (creds decrypt + fixtures) is re-run on this image.
- **GCP KMS round-trip can't run on kind** (needs a real GCP project + Workload Identity). Operator validation on GKE: set `NOETL_KMS_PROVIDER=gcp-kms` + `NOETL_GCP_KMS_KEY=projects/.../cryptoKeys/<k>`, grant the KSA `roles/cloudkms.cryptoKeyEncrypterDecrypter`, register a credential, confirm decrypt. (Deployment-spec wiki note to follow.)

Closes noetl/server#80
Refs noetl/ai-meta#61

🤖 Generated with [Claude Code](https://claude.com/claude-code)