### PR TITLE
feat(secrets): execution-scoped keychain cache + keychain storage fix (Phase 3c)

### DIFF
--- a/src/db/models/keychain.rs
+++ b/src/db/models/keychain.rs
@@ -10,10 +10,8 @@ use sqlx::FromRow;
 /// Keychain entry for cached tokens/credentials.
 #[derive(Debug, Clone, FromRow)]
 pub struct KeychainEntry {
-    /// Unique keychain entry ID
-    pub id: i64,
-
-    /// Cache key (format: {keychain_name}:{catalog_id}:{scope_suffix})
+    /// Cache key (format: {keychain_name}:{catalog_id}:{scope_suffix}).
+    /// Primary key of `noetl.keychain` (the table has no surrogate `id`).
     pub cache_key: String,
 
     /// Catalog ID
@@ -29,8 +27,10 @@ pub struct KeychainEntry {
     #[sqlx(default)]
     pub execution_id: Option<i64>,
 
-    /// Encrypted token/credential data
-    pub data: Vec<u8>,
+    /// Encrypted token/credential data — the self-describing envelope JSON
+    /// string in the `data_encrypted` TEXT column (same storage form as
+    /// `noetl.credential`, Secrets Wallet Phase 1).
+    pub data_encrypted: String,
 
     /// Token expiry time
     #[sqlx(default)]
@@ -54,9 +54,6 @@ pub struct KeychainEntry {
 
     /// Creation timestamp
     pub created_at: DateTime<Utc>,
-
-    /// Last update timestamp
-    pub updated_at: DateTime<Utc>,
 }
 
 /// Request to set a keychain entry.

--- a/src/db/queries/keychain.rs
+++ b/src/db/queries/keychain.rs
@@ -40,25 +40,25 @@ pub async fn upsert_keychain_entry(
     keychain_name: &str,
     scope_type: &str,
     execution_id: Option<i64>,
-    data: &[u8],
+    data_encrypted: &str,
     expires_at: Option<DateTime<Utc>>,
     auto_renew: bool,
     renew_config: Option<&serde_json::Value>,
-) -> AppResult<i64> {
-    let result: (i64,) = sqlx::query_as(
+) -> AppResult<()> {
+    sqlx::query(
         r#"
+        -- `credential_type` + `cache_type` are NOT NULL on noetl.keychain but
+        -- aren't part of the cache contract; the 'secret' value also satisfies the cache_type CHECK ('secret'|'token') (the resolver only reads `data_encrypted`).
         INSERT INTO noetl.keychain (
-            cache_key, catalog_id, keychain_name, scope_type, execution_id,
-            data, expires_at, auto_renew, renew_config
+            cache_key, catalog_id, keychain_name, credential_type, cache_type,
+            scope_type, execution_id, data_encrypted, expires_at, auto_renew, renew_config
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        VALUES ($1, $2, $3, 'secret', 'secret', $4, $5, $6, $7, $8, $9)
         ON CONFLICT (cache_key) DO UPDATE SET
-            data = EXCLUDED.data,
+            data_encrypted = EXCLUDED.data_encrypted,
             expires_at = EXCLUDED.expires_at,
             auto_renew = EXCLUDED.auto_renew,
-            renew_config = EXCLUDED.renew_config,
-            updated_at = NOW()
-        RETURNING id
+            renew_config = EXCLUDED.renew_config
         "#,
     )
     .bind(cache_key)
@@ -66,14 +66,14 @@ pub async fn upsert_keychain_entry(
     .bind(keychain_name)
     .bind(scope_type)
     .bind(execution_id)
-    .bind(data)
+    .bind(data_encrypted)
     .bind(expires_at)
     .bind(auto_renew)
     .bind(renew_config)
-    .fetch_one(pool)
+    .execute(pool)
     .await?;
 
-    Ok(result.0)
+    Ok(())
 }
 
 /// Get a keychain entry by cache key.
@@ -83,9 +83,9 @@ pub async fn get_keychain_by_cache_key(
 ) -> AppResult<Option<KeychainEntry>> {
     let entry = sqlx::query_as::<_, KeychainEntry>(
         r#"
-        SELECT id, cache_key, catalog_id, keychain_name, scope_type, execution_id,
-               data, expires_at, auto_renew, renew_config, access_count, accessed_at,
-               created_at, updated_at
+        SELECT cache_key, catalog_id, keychain_name, scope_type, execution_id,
+               data_encrypted, expires_at, auto_renew, renew_config, access_count, accessed_at,
+               created_at
         FROM noetl.keychain
         WHERE cache_key = $1
         "#,
@@ -97,16 +97,17 @@ pub async fn get_keychain_by_cache_key(
     Ok(entry)
 }
 
-/// Increment access count and update accessed_at.
-pub async fn increment_access_count(pool: &DbPool, id: i64) -> AppResult<()> {
+/// Increment access count and update accessed_at (keyed by cache_key — the
+/// table's primary key; there is no surrogate `id`).
+pub async fn increment_access_count(pool: &DbPool, cache_key: &str) -> AppResult<()> {
     sqlx::query(
         r#"
         UPDATE noetl.keychain
         SET access_count = access_count + 1, accessed_at = NOW()
-        WHERE id = $1
+        WHERE cache_key = $1
         "#,
     )
-    .bind(id)
+    .bind(cache_key)
     .execute(pool)
     .await?;
 
@@ -135,9 +136,9 @@ pub async fn list_keychain_by_catalog(
 ) -> AppResult<Vec<KeychainEntry>> {
     let entries = sqlx::query_as::<_, KeychainEntry>(
         r#"
-        SELECT id, cache_key, catalog_id, keychain_name, scope_type, execution_id,
-               data, expires_at, auto_renew, renew_config, access_count, accessed_at,
-               created_at, updated_at
+        SELECT cache_key, catalog_id, keychain_name, scope_type, execution_id,
+               data_encrypted, expires_at, auto_renew, renew_config, access_count, accessed_at,
+               created_at
         FROM noetl.keychain
         WHERE catalog_id = $1
         ORDER BY created_at DESC

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,10 +81,7 @@ fn build_router(
         // paths (e.g. `system/outbox_publisher`).  The handler routes
         // by suffix: only requests whose tail ends with `/ui_schema`
         // are served; everything else returns 404.
-        .route(
-            "/api/catalog/{*tail}",
-            get(handlers::catalog::ui_schema),
-        )
+        .route("/api/catalog/{*tail}", get(handlers::catalog::ui_schema))
         .with_state(catalog_service);
 
     // Credential routes
@@ -325,8 +322,9 @@ async fn connect_nats(config: &AppConfig) -> Option<async_nats::Client> {
     // Strip + parse userinfo if present.
     let (clean_url, creds) = strip_nats_userinfo(nats_url);
     let connect_future = match creds {
-        Some((user, password)) => async_nats::ConnectOptions::with_user_and_password(user, password)
-            .connect(&clean_url),
+        Some((user, password)) => {
+            async_nats::ConnectOptions::with_user_and_password(user, password).connect(&clean_url)
+        }
         None => async_nats::ConnectOptions::new().connect(&clean_url),
     };
 
@@ -507,8 +505,12 @@ async fn main() -> anyhow::Result<()> {
     // the credential and keychain services.
     let catalog_service = CatalogService::new(db_pool.clone());
     let wallet_cipher = noetl_server::crypto::build_envelope_cipher(&encryption_key)?;
-    let credential_service = CredentialService::new(db_pool.clone(), wallet_cipher.clone());
-    let keychain_service = KeychainService::new(db_pool.clone(), wallet_cipher);
+    // Keychain is the execution-scoped cache for credential resolution
+    // (Secrets Wallet Phase 3c), so it is built first + shared into the
+    // credential service.
+    let keychain_service = KeychainService::new(db_pool.clone(), wallet_cipher.clone());
+    let credential_service =
+        CredentialService::new(db_pool.clone(), wallet_cipher, keychain_service.clone());
     // Phase F R4-4b: ExecutionService now takes the DbPoolMap so
     // its per-execution methods route via pool_for(execution_id)
     // and `list()` fan-outs via for_each_shard.  In single-pool

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -13,7 +13,7 @@ use chrono::Utc;
 use crate::crypto::EnvelopeCipher;
 use crate::db::models::{
     CredentialCreateRequest, CredentialEntry, CredentialFilter, CredentialListResponse,
-    CredentialResponse,
+    CredentialResponse, KeychainSetRequest,
 };
 use crate::db::queries::catalog as catalog_queries;
 use crate::db::queries::credential as queries;
@@ -21,12 +21,23 @@ use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::playbook::types::Playbook;
 use crate::secrets::{build_secret_provider, resolve_keychain_entry};
+use crate::services::keychain::KeychainService;
+
+/// TTL (seconds) for a keychain-resolved secret cached after a provider fetch.
+/// Execution-scoped, so it's also cleaned up when the execution ends; the TTL
+/// just bounds staleness if the underlying secret rotates mid-run.
+const KEYCHAIN_CACHE_TTL_SECS: i64 = 600;
+
+/// Cache scope for resolved keychain secrets: `local` keys the entry by
+/// `{alias}:{catalog_id}:{execution_id}` (see `queries::keychain::build_cache_key`).
+const KEYCHAIN_CACHE_SCOPE: &str = "local";
 
 /// Service for credential operations.
 #[derive(Clone)]
 pub struct CredentialService {
     pool: DbPool,
     cipher: EnvelopeCipher,
+    keychain: KeychainService,
 }
 
 impl CredentialService {
@@ -34,9 +45,14 @@ impl CredentialService {
     ///
     /// `cipher` is the wallet's [`EnvelopeCipher`], built once at startup over
     /// the configured KEK provider (`crypto::build_envelope_cipher`) — local
-    /// master key in dev, GCP Cloud KMS in production.
-    pub fn new(pool: DbPool, cipher: EnvelopeCipher) -> Self {
-        Self { pool, cipher }
+    /// master key in dev, GCP Cloud KMS in production. `keychain` is the
+    /// execution-scoped cache for provider-resolved secrets (Phase 3c).
+    pub fn new(pool: DbPool, cipher: EnvelopeCipher, keychain: KeychainService) -> Self {
+        Self {
+            pool,
+            cipher,
+            keychain,
+        }
     }
 
     /// Create or update a credential.
@@ -161,6 +177,27 @@ impl CredentialService {
             return Ok(None);
         };
 
+        // Cache read (Phase 3c): an earlier step in this execution may have
+        // already resolved + cached this alias — skip the provider fetch.
+        // Best-effort: a cache error degrades to a fresh resolution, it must
+        // never fail the credential lookup.
+        match self
+            .keychain
+            .get(catalog_id, alias, Some(execution_id), KEYCHAIN_CACHE_SCOPE)
+            .await
+        {
+            Ok(c) if c.status == "found" => {
+                if let Some(data) = c.data {
+                    tracing::debug!(execution_id, alias, "keychain.cache_hit");
+                    return Ok(Some(data));
+                }
+            }
+            Ok(_) => {} // not_found / expired → resolve fresh
+            Err(e) => {
+                tracing::warn!(execution_id, alias, error = %e, "keychain.cache_read failed; resolving fresh")
+            }
+        }
+
         // catalog_id → playbook YAML → parse.
         let Some(entry) = catalog_queries::get_catalog_by_id(&self.pool, catalog_id).await? else {
             return Ok(None);
@@ -195,6 +232,22 @@ impl CredentialService {
             "keychain.resolve"
         );
         let data = resolve_keychain_entry(kc, &workload_map, &*provider).await?;
+
+        // Cache write (Phase 3c): envelope-encrypted, execution-scoped, TTL —
+        // best-effort, a cache failure must not fail the resolution.
+        let set_req = KeychainSetRequest {
+            data: data.clone(),
+            scope_type: KEYCHAIN_CACHE_SCOPE.to_string(),
+            execution_id: Some(execution_id),
+            expires_at: None,
+            expires_in: Some(KEYCHAIN_CACHE_TTL_SECS),
+            auto_renew: false,
+            renew_config: None,
+        };
+        if let Err(e) = self.keychain.set(catalog_id, alias, set_req).await {
+            tracing::warn!(execution_id, alias, error = %e, "keychain.cache_write failed");
+        }
+
         Ok(Some(data))
     }
 

--- a/src/services/keychain.rs
+++ b/src/services/keychain.rs
@@ -14,7 +14,7 @@ use crate::db::models::{
 };
 use crate::db::queries::keychain as queries;
 use crate::db::DbPool;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 
 /// Service for keychain operations.
 #[derive(Clone)]
@@ -69,13 +69,12 @@ impl KeychainService {
             }
         }
 
-        // Increment access count
-        queries::increment_access_count(&self.pool, entry.id).await?;
+        // Increment access count (keyed by cache_key — the table PK).
+        queries::increment_access_count(&self.pool, &entry.cache_key).await?;
 
-        // Decrypt data: `entry.data` (BYTEA) holds the UTF-8 envelope JSON.
-        let stored = std::str::from_utf8(&entry.data)
-            .map_err(|e| AppError::Encryption(format!("keychain data not UTF-8: {e}")))?;
-        let data = self.cipher.open_storage_json(stored).await?;
+        // Decrypt data: `data_encrypted` (TEXT) holds the self-describing
+        // envelope JSON string (same storage form as `noetl.credential`).
+        let data = self.cipher.open_storage_json(&entry.data_encrypted).await?;
 
         Ok(KeychainGetResponse {
             status: "found".to_string(),
@@ -107,13 +106,9 @@ impl KeychainService {
                 .map(|seconds| Utc::now() + Duration::seconds(seconds))
         });
 
-        // Envelope-seal data into the self-describing JSON, stored as UTF-8
-        // bytes in the BYTEA `data` column.
-        let encrypted_data = self
-            .cipher
-            .seal_json_to_storage(&request.data)
-            .await?
-            .into_bytes();
+        // Envelope-seal data into the self-describing JSON string, stored in
+        // the `data_encrypted` TEXT column (same form as `noetl.credential`).
+        let encrypted_data = self.cipher.seal_json_to_storage(&request.data).await?;
 
         // Upsert entry
         queries::upsert_keychain_entry(


### PR DESCRIPTION
## What

Secrets Wallet **Phase 3c** (noetl/ai-meta#61) — a write-through cache so a `provider:`-backed keychain alias isn't re-fetched from its secret manager on every credential lookup within an execution.

- **Cache** — `CredentialService` composes `KeychainService` (Phase 1 envelope-encrypted, execution-scoped, TTL'd). `try_resolve_keychain` does a **read** before the provider fetch (best-effort — a cache error degrades to a fresh resolution, never fails the lookup) and a **write** after (envelope-encrypted, 600s TTL, execution-scoped `local` key → cleaned up on execution end).
- **Keychain storage fix** (surfaced by the cache being the first hot-path caller) — the `KeychainService` queries never matched `noetl.keychain`: they used `id`/`data`/`updated_at` but the table has `cache_key` (PK, no `id`), `data_encrypted` (TEXT), no `updated_at`, and NOT-NULL `credential_type`/`cache_type` (CHECK `secret|token`). Aligned model + queries + service to store the envelope JSON string in `data_encrypted` (same form as `noetl.credential`). **Also fixes the `/api/keychain` endpoints, broken since inception.**

## Kind validation (end-to-end)

```
keychain SET  → 200 success (envelope-encrypted into data_encrypted)
keychain GET  → {"status":"found","data":{"api_key":"cached-test-value"}}   (round-trips)
credential GET → {"name":"gcp_probe_token","data":{"api_key":"cached-test-value"}}   ← CACHED, no GCP call
control (different execution_id) → does NOT hit the cache   (execution-scoped)
```

Plus the **regression check**: with the cache empty, the `provider: gcp` alias still resolves (best-effort cache read degrades, R3b path intact). Build warning-free; rustfmt + clippy clean (the one failing test, `playbook::parser::tests::test_parse_invalid_next_reference`, is pre-existing on main).

Closes noetl/server#90
Refs noetl/ai-meta#61