### PR TITLE
fix(orchestrator): emit terminal playbook.failed on deterministic evaluate error

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -940,6 +940,81 @@ mod tests {
     }
 
     #[test]
+    fn test_evaluate_errors_on_invalid_template_in_step_body() {
+        // noetl/ai-meta#54 (e2e regression sweep): a step whose tool
+        // `code` body carries an invalid Jinja expression (`{{ ctx.* }}`)
+        // must make `evaluate` return `Err` — deterministically, not
+        // `Ok`-with-no-commands and not a panic.  `handlers::events::
+        // trigger_orchestrator` relies on this contract to emit a
+        // terminal `playbook.failed` event instead of stranding the
+        // execution in RUNNING forever (the original symptom:
+        // `test_vars_template_access` hung after `set_variables`).
+        let orchestrator = WorkflowOrchestrator::new();
+
+        // `start` has completed; evaluate must now build the command for
+        // `bad_step`, which renders its invalid-template code body.
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {}, "path": "test", "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+        ];
+
+        let bad_step = {
+            let mut s = make_step("bad_step", Some("end"));
+            s.tool = ToolDefinition::Single(ToolSpec {
+                kind: ToolKind::Python,
+                eval: None,
+                auth: None,
+                libs: None,
+                args: None,
+                code: Some("# uses {{ ctx.* }} templates\nresult = {}".to_string()),
+                url: None,
+                method: None,
+                query: None,
+                command: None,
+                connection: None,
+                params: None,
+                headers: None,
+                output_select: None,
+                extra: HashMap::new(),
+            });
+            s
+        };
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "bad_template".to_string(),
+                path: Some("test/bad_template".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![
+                make_step("start", Some("bad_step")),
+                bad_step,
+                make_step("end", None),
+            ],
+        };
+
+        let result = orchestrator.evaluate(&events, &playbook, Some("command.completed"));
+        assert!(
+            result.is_err(),
+            "evaluate must return Err for an invalid template in a step body, got Ok"
+        );
+    }
+
+    #[test]
     fn test_handle_failure() {
         let orchestrator = WorkflowOrchestrator::new();
         let state = WorkflowState::new(12345, 67890);

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1390,9 +1390,36 @@ async fn trigger_orchestrator(
         .map(|e| e.event_type.as_str())
         .unwrap_or("command.completed");
     let orchestrator = WorkflowOrchestrator::new();
-    let result = orchestrator
-        .evaluate(&events, &playbook, Some(trigger_event_type))
-        .map_err(|e| AppError::Internal(format!("Orchestrator evaluate failed: {e}")))?;
+    let result = match orchestrator.evaluate(&events, &playbook, Some(trigger_event_type)) {
+        Ok(r) => r,
+        Err(e) => {
+            // A deterministic orchestrator evaluate failure (invalid
+            // template in a step body, unknown step in a `next` arc,
+            // malformed routing) fails identically on every retry.
+            // Emitting only a WARN here strands the execution in RUNNING
+            // forever — the next step is never issued and no terminal
+            // event is written, so `/api/executions/{id}` reports RUNNING
+            // indefinitely.  Instead write a terminal `playbook.failed`
+            // event so the run resolves to FAILED with the error surfaced
+            // to the client.
+            //
+            // noetl/ai-meta#54 (e2e regression sweep): `test_vars_template_access`
+            // hung after `set_variables` because an invalid `{{ ctx.* }}`
+            // template in a downstream step's `code` body tripped minijinja
+            // inside `evaluate`, and the WARN-only path left no terminal
+            // event.  This mirrors the noetl/ai-meta#58 `command.failed`
+            // stall class — a deterministic failure must still produce a
+            // terminal event.
+            let msg = format!("Orchestrator evaluate failed: {e}");
+            warn!(
+                execution_id,
+                error = %msg,
+                "Orchestrator evaluate error is deterministic — terminating execution as FAILED"
+            );
+            emit_playbook_failed(state, execution_id, catalog_id, trigger_event_id, &msg).await?;
+            return Ok(0);
+        }
+    };
 
     info!(
         execution_id,
@@ -1510,6 +1537,53 @@ async fn trigger_orchestrator(
     }
 
     Ok(commands_generated)
+}
+
+/// Emit a terminal `playbook.failed` event for an execution that hit a
+/// deterministic, non-retryable orchestrator error during evaluate.
+///
+/// Without this an evaluate failure (invalid template in a step body,
+/// unknown step in a `next` arc) leaves only a WARN in the server log
+/// and strands the execution in RUNNING forever — no terminal event is
+/// ever written.  The list-status aggregation in `list_executions`
+/// maps `playbook.failed` -> FAILED, so writing this event resolves the
+/// run and surfaces `error` to API readers.  Parented on the trigger
+/// event so the causal chain stays intact.
+async fn emit_playbook_failed(
+    state: &AppState,
+    execution_id: i64,
+    catalog_id: i64,
+    trigger_event_id: i64,
+    error: &str,
+) -> AppResult<()> {
+    let event_id = state.snowflake.generate()?;
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.event (
+            event_id, execution_id, catalog_id, event_type,
+            node_id, node_name, status, result, meta, created_at, parent_event_id
+        ) VALUES ($1, $2, $3, 'playbook.failed', 'playbook', 'playbook', 'FAILED', $4, $5, $6, $7)
+        "#,
+    )
+    .bind(event_id)
+    .bind(execution_id)
+    .bind(catalog_id)
+    .bind(serde_json::json!({"status": "FAILED", "context": {"error": error}}))
+    .bind(serde_json::json!({
+        "emitted_by": "orchestrator",
+        "reason": "evaluate_error",
+        "error": error,
+    }))
+    .bind(chrono::Utc::now())
+    .bind(trigger_event_id)
+    .execute(state.pools.pool_for(execution_id))
+    .await?;
+    info!(
+        execution_id,
+        terminal_event = "playbook.failed",
+        "Orchestrator evaluate error → execution terminated as FAILED"
+    );
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

A deterministic orchestrator evaluate failure — an invalid template in a step
body, an unknown step in a `next` arc, malformed routing — was caught by the
WARN-only arm in `handle_event` and produced **no terminal event**. The
execution stranded in `RUNNING` forever; `/api/executions/{id}` never resolved.

`trigger_orchestrator` now matches on `evaluate(...)`: on `Err` it emits a
terminal `playbook.failed` event (status `FAILED`, error surfaced in
`result.context.error`, parented on the trigger event) and returns `Ok(0)`, so
the run resolves to FAILED. Transient/infra errors *before* evaluate (DB load
of events / catalog) keep `?`-propagating to the existing WARN-only path —
those are retryable and must not kill a recoverable execution.

## Why

Surfaced by the noetl/ai-meta#54 e2e regression sweep on the Rust-only kind
stack. `vars_test/test_vars_template_access` hung in RUNNING after
`set_variables` completed:

```
INFO  Transitioning to step: use_vars_in_template
WARN  Orchestrator error: Internal error: Orchestrator evaluate failed: Template error: Template parse error: syntax error: unexpected `*`, expected identifier or integer (in <string>:1)
```

The trigger was an invalid `{{ ctx.* }}` Jinja expression in a downstream
step's `code` body (rendered by `engine::commands::build_tool_command` during
evaluate). This is the same stall class as noetl/ai-meta#58 (`command.failed`)
— a deterministic failure must still produce a terminal event.

## Test + kind validation

- New unit test `test_evaluate_errors_on_invalid_template_in_step_body` locks
  the precondition: an invalid template in a step body makes `evaluate` return
  `Err` (not `Ok`, not panic). Full lib suite: 307 passed / 0 failed.
- Kind-validated against this image on the local kind cluster:
  - A 3-step playbook with an invalid `{{ ctx.* }}` code body → **FAILED**
    with the error surfaced (was RUNNING-forever).
  - The fixed `test_vars_template_access` fixture → **COMPLETED**.
  - Regression spot-check (`hello_world`, `test_transient`, `loop_test`) →
    all **COMPLETED**.

The companion noetl/e2e fixture fix (removing the invalid `{{ ctx.* }}` from
the comment) ships separately.

Closes #94
Refs noetl/ai-meta#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)