### PR TITLE
feat(tls): opt-in TLS/mTLS listener for the control-plane API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +206,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -630,6 +661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +817,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +955,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1300,6 +1361,7 @@ dependencies = [
  "async-nats",
  "async-trait",
  "axum",
+ "axum-server",
  "base64",
  "chrono",
  "ctor",
@@ -1311,6 +1373,8 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1913,6 +1977,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "tim
 
 # Web framework
 axum = { version = "0.8", features = ["macros"] }
+# Phase 4a (noetl/ai-meta#61): opt-in TLS/mTLS listener.  `-no-provider`
+# variant so axum-server doesn't pull aws-lc-rs — we build the rustls
+# ServerConfig with the `ring` provider the rest of the stack already uses.
+axum-server = { version = "0.7", default-features = false, features = ["tls-rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-pemfile = "2"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod sanitize;
 pub mod secrets;
 pub mod services;
 pub mod sharding;
+pub mod tls;
 pub mod snowflake;
 pub mod state;
 pub mod template;

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,14 +531,38 @@ async fn main() -> anyhow::Result<()> {
 
     // Bind to address
     let addr: SocketAddr = app_config.bind_address().parse()?;
-    let listener = TcpListener::bind(addr).await?;
 
-    tracing::info!(address = %addr, "Server listening");
-
-    // Run the server with graceful shutdown
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // Phase 4a (noetl/ai-meta#61): opt-in TLS / mTLS listener.  Plain HTTP
+    // (unchanged default) unless NOETL_TLS_CERT + NOETL_TLS_KEY are set;
+    // NOETL_TLS_CLIENT_CA additionally requires + verifies client certs (mTLS),
+    // so the worker↔server credential channel is authenticated + encrypted.
+    match noetl_server::tls::tls_params_from_env()? {
+        Some(params) => {
+            let mtls = params.mtls();
+            let server_config = noetl_server::tls::build_server_config(&params)?;
+            let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(
+                std::sync::Arc::new(server_config),
+            );
+            tracing::info!(address = %addr, tls = true, mtls, "Server listening (TLS)");
+            let handle = axum_server::Handle::new();
+            let shutdown_handle = handle.clone();
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(10)));
+            });
+            axum_server::bind_rustls(addr, rustls_config)
+                .handle(handle)
+                .serve(app.into_make_service())
+                .await?;
+        }
+        None => {
+            let listener = TcpListener::bind(addr).await?;
+            tracing::info!(address = %addr, "Server listening");
+            axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown_signal())
+                .await?;
+        }
+    }
 
     tracing::info!("Server shutdown complete");
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,177 @@
+//! Opt-in TLS / mTLS for the control-plane HTTP listener
+//! (Secrets Wallet Phase 4a, noetl/ai-meta#61).
+//!
+//! Plain HTTP by default (unchanged).  When `NOETL_TLS_CERT` + `NOETL_TLS_KEY`
+//! are set the server serves HTTPS; adding `NOETL_TLS_CLIENT_CA` requires +
+//! verifies client certificates (**mTLS**).  This is the transport half of the
+//! sealed-delivery work: with mTLS the worker↔server credential channel is
+//! authenticated + encrypted, so the resolved secret no longer travels
+//! plaintext over the wire (today `GET /api/credentials/<alias>` is plain
+//! HTTP).  Payload sealing (encrypting the value to the worker's key) is the
+//! companion Phase 5.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::Arc;
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::WebPkiClientVerifier;
+use rustls::{RootCertStore, ServerConfig};
+
+use crate::error::{AppError, AppResult};
+
+/// TLS file paths resolved from the environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsParams {
+    pub cert_path: String,
+    pub key_path: String,
+    /// When set, client certs are required + verified against this CA (mTLS).
+    pub client_ca_path: Option<String>,
+}
+
+impl TlsParams {
+    /// Whether mutual TLS (client-cert verification) is enabled.
+    pub fn mtls(&self) -> bool {
+        self.client_ca_path.is_some()
+    }
+}
+
+/// Resolve the TLS mode from the environment.
+///
+/// `None` ⇒ plain HTTP (the default).  Both `NOETL_TLS_CERT` and
+/// `NOETL_TLS_KEY` enable HTTPS; `NOETL_TLS_CLIENT_CA` additionally enables
+/// mTLS.  Setting exactly one of cert/key is a misconfiguration (fail fast).
+pub fn tls_params_from_env() -> AppResult<Option<TlsParams>> {
+    let env = |k: &str| std::env::var(k).ok().filter(|s| !s.is_empty());
+    resolve_tls_params(
+        env("NOETL_TLS_CERT"),
+        env("NOETL_TLS_KEY"),
+        env("NOETL_TLS_CLIENT_CA"),
+    )
+}
+
+/// Pure resolver (testable without touching the process environment).
+pub fn resolve_tls_params(
+    cert: Option<String>,
+    key: Option<String>,
+    client_ca: Option<String>,
+) -> AppResult<Option<TlsParams>> {
+    match (cert, key) {
+        (Some(cert_path), Some(key_path)) => Ok(Some(TlsParams {
+            cert_path,
+            key_path,
+            client_ca_path: client_ca,
+        })),
+        (None, None) => Ok(None),
+        _ => Err(AppError::Config(
+            "TLS misconfigured: set both NOETL_TLS_CERT and NOETL_TLS_KEY (or neither)".to_string(),
+        )),
+    }
+}
+
+/// Build a rustls [`ServerConfig`] for the listener.
+///
+/// Installs the `ring` crypto provider (matching the rest of the stack;
+/// idempotent).  mTLS — a [`WebPkiClientVerifier`] — is wired when
+/// `client_ca_path` is set.
+pub fn build_server_config(params: &TlsParams) -> AppResult<ServerConfig> {
+    // Idempotent: ignore "a provider is already installed".
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let certs = load_certs(&params.cert_path)?;
+    let key = load_key(&params.key_path)?;
+
+    let builder = ServerConfig::builder();
+    let config = match &params.client_ca_path {
+        Some(ca) => {
+            let mut roots = RootCertStore::empty();
+            for cert in load_certs(ca)? {
+                roots.add(cert).map_err(|e| {
+                    AppError::Config(format!("TLS: client CA '{ca}' not a valid cert: {e}"))
+                })?;
+            }
+            let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+                .build()
+                .map_err(|e| AppError::Config(format!("TLS: client-cert verifier: {e}")))?;
+            builder.with_client_cert_verifier(verifier)
+        }
+        None => builder.with_no_client_auth(),
+    };
+    config
+        .with_single_cert(certs, key)
+        .map_err(|e| AppError::Config(format!("TLS: server cert/key: {e}")))
+}
+
+fn load_certs(path: &str) -> AppResult<Vec<CertificateDer<'static>>> {
+    let file =
+        File::open(path).map_err(|e| AppError::Config(format!("TLS: open '{path}': {e}")))?;
+    let mut reader = BufReader::new(file);
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AppError::Config(format!("TLS: reading certs '{path}': {e}")))?;
+    if certs.is_empty() {
+        return Err(AppError::Config(format!(
+            "TLS: no certificates in '{path}'"
+        )));
+    }
+    Ok(certs)
+}
+
+fn load_key(path: &str) -> AppResult<PrivateKeyDer<'static>> {
+    let file =
+        File::open(path).map_err(|e| AppError::Config(format!("TLS: open '{path}': {e}")))?;
+    let mut reader = BufReader::new(file);
+    rustls_pemfile::private_key(&mut reader)
+        .map_err(|e| AppError::Config(format!("TLS: reading key '{path}': {e}")))?
+        .ok_or_else(|| AppError::Config(format!("TLS: no private key in '{path}'")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_none_when_unset() {
+        assert!(resolve_tls_params(None, None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn resolve_https_without_mtls() {
+        let p = resolve_tls_params(Some("c.pem".into()), Some("k.pem".into()), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(p.cert_path, "c.pem");
+        assert_eq!(p.key_path, "k.pem");
+        assert!(!p.mtls());
+    }
+
+    #[test]
+    fn resolve_mtls_when_client_ca_set() {
+        let p = resolve_tls_params(
+            Some("c.pem".into()),
+            Some("k.pem".into()),
+            Some("ca.pem".into()),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(p.mtls());
+        assert_eq!(p.client_ca_path.as_deref(), Some("ca.pem"));
+    }
+
+    #[test]
+    fn resolve_rejects_partial_cert_key() {
+        assert!(resolve_tls_params(Some("c.pem".into()), None, None).is_err());
+        assert!(resolve_tls_params(None, Some("k.pem".into()), None).is_err());
+    }
+
+    #[test]
+    fn build_config_errors_on_missing_cert_file() {
+        let params = TlsParams {
+            cert_path: "/nonexistent/cert.pem".into(),
+            key_path: "/nonexistent/key.pem".into(),
+            client_ca_path: None,
+        };
+        let err = build_server_config(&params).unwrap_err();
+        assert!(format!("{err:?}").contains("open"), "got: {err:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Secrets Wallet **Phase 4a** (`Refs noetl/ai-meta#61`) — the transport half of
sealed secret delivery. The worker↔server credential channel
(`GET /api/credentials/<alias>`) was **plain HTTP**: the resolved secret
travelled plaintext on the wire. This adds an **opt-in** TLS listener.

- Plain HTTP unchanged (default). `NOETL_TLS_CERT` + `NOETL_TLS_KEY` ⇒ HTTPS;
  adding `NOETL_TLS_CLIENT_CA` requires + verifies client certs (**mTLS**).
- New `src/tls.rs`: env→mode resolver + a rustls `ServerConfig` builder on the
  **`ring`** provider the rest of the stack already uses (no aws-lc-rs clash),
  `WebPkiClientVerifier` for mTLS. `main.rs` serves via `axum-server`
  `bind_rustls` (+ graceful-shutdown `Handle`) on that path, else the existing
  `axum::serve`.
- Setting exactly one of cert/key is a fail-fast misconfiguration.

## Tests

5 unit tests (resolver: none / https / mTLS / partial-misconfig; builder
missing-file error). Lib suite **335/0**; clippy + rustfmt clean.

## Kind validation

CA + server cert (SAN `localhost`, `noetl-server-rust.noetl.svc[.cluster.local]`,
`127.0.0.1`) + a `clientAuth` cert, mounted via a Secret with
`NOETL_TLS_{CERT,KEY,CLIENT_CA}`:

- log: `Server listening (TLS) tls=true mtls=true`
- `curl --cacert ca.crt --cert client.crt --key client.key https://…/api/health` → **200 `{status:ok}`**
- same without a client cert → **TLS rejected** (`http=000`)
- plain `http://…/api/health` → **refused** (`HTTP/0.9 not allowed`)

**Operational finding:** mTLS breaks HTTP(S) K8s health probes (they can't
present a client cert) — the validation switched the deployment probes to
`tcpSocket`. Documented on the server deployment-specification wiki (TCP probe
or a separate non-mTLS health port).

## Follow-ups

Phase 4b wires the worker `ControlPlaneClient` mTLS client; Phase 5 seals the
payload (encrypt-to-worker-key).

Closes #102
Refs noetl/ai-meta#61