### PR TITLE
feat(crypto): sealed payload primitives (Secrets Wallet Phase 5a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +349,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -469,6 +494,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1363,16 +1389,19 @@ dependencies = [
  "axum",
  "axum-server",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "ctor",
  "dotenvy",
  "envy",
  "hex",
+ "hkdf",
  "hmac",
  "minijinja",
  "noetl-events",
  "prometheus",
  "rand 0.8.6",
+ "rand_core 0.6.4",
  "regex",
  "reqwest",
  "rustls",
@@ -1394,6 +1423,7 @@ dependencies = [
  "tracing-subscriber",
  "twox-hash",
  "uuid",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -1602,6 +1632,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "polyval"
@@ -3722,6 +3763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,6 +3843,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,15 @@ subtle = "2.6"
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
+# Secrets Wallet Phase 5a (noetl/ai-meta#61) — sealed payload primitives
+# (src/crypto/sealed.rs).  X25519 ECDH + HKDF-SHA256 key derivation + ChaCha20-
+# Poly1305 AEAD, no SDK dep tree.  The recipient (worker) holds a long-lived
+# StaticSecret + PublicKey; the server uses an EphemeralSecret per call so the
+# ECDH shared secret is single-use.
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+chacha20poly1305 = "0.10"
+hkdf = "0.12"
+rand_core = "0.6"
 
 # Utilities
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -8,11 +8,13 @@ pub mod encryption;
 pub mod envelope;
 pub mod keymanager;
 pub mod kms_gcp;
+pub mod sealed;
 
 pub use encryption::{decrypt, encrypt, Encryptor};
 pub use envelope::{EnvelopeCipher, EnvelopeRecord, ENC_ALG, ENC_VERSION};
 pub use keymanager::{KeyManager, LocalDevKms, WrappedDek};
 pub use kms_gcp::GcpKms;
+pub use sealed::{open as sealed_open, seal as sealed_seal, SealedEnvelope, SEAL_ALG, SEAL_V};
 
 use std::sync::Arc;
 

--- a/src/crypto/sealed.rs
+++ b/src/crypto/sealed.rs
@@ -1,0 +1,331 @@
+//! Sealed payload primitives (Secrets Wallet Phase 5a, noetl/ai-meta#61).
+//!
+//! Defense in depth on top of the Phase-4 mTLS transport (server v2.30.0 / worker
+//! v5.12.0 / ops 4c+4d).  mTLS encrypts the *wire*; sealing encrypts the *payload*
+//! to a key only the recipient worker holds.  The cleartext never enters the
+//! response body; an operator with kubectl exec on the server pod sees only the
+//! ciphertext (and the briefly-held cleartext during the encrypt call itself).
+//!
+//! ## Construction
+//!
+//! Standard ephemeral-static ECDH "sealed box" shape:
+//!
+//! 1. Recipient (worker) generates a long-lived [`x25519_dalek::StaticSecret`]
+//!    at startup and registers its [`PublicKey`] with the server (Phase 5b).
+//! 2. Sender (server) at seal time generates a fresh
+//!    [`x25519_dalek::EphemeralSecret`], computes `shared = ECDH(eph_sk, recipient_pk)`,
+//!    derives a 32-byte key + 12-byte nonce via **HKDF-SHA256** with a
+//!    domain-separating info string (`alg` + `v`), and AEAD-encrypts with
+//!    **ChaCha20-Poly1305**.  The associated data ("AAD") binds the algorithm
+//!    string + version so a future algorithm change rejects forged-as-old
+//!    envelopes with a clean auth failure.
+//! 3. Wire envelope carries the ephemeral public key + AEAD ciphertext.  The
+//!    recipient runs the same ECDH + HKDF + AEAD-decrypt in reverse.
+//!
+//! The seal is **one-shot**: the ephemeral secret is consumed by the ECDH agree
+//! and dropped; the same `recipient_pk` may be used to seal arbitrarily many
+//! independent payloads without compromise.  No state is persisted on the sender.
+//!
+//! ## Wire format
+//!
+//! [`SealedEnvelope`] serializes as JSON with all binary fields base64-encoded
+//! (standard padded `base64::STANDARD` alphabet — easy to embed in HTTP response
+//! bodies and YAML test fixtures):
+//!
+//! ```json
+//! {
+//!   "alg": "x25519-hkdf-sha256-chacha20-poly1305",
+//!   "v": 1,
+//!   "eph_pub":    "<32 bytes b64>",
+//!   "ciphertext": "<n+16 bytes b64>"
+//! }
+//! ```
+//!
+//! The nonce is **derived** from the ECDH shared secret via HKDF (not a separate
+//! field): one ephemeral key per call gives a unique shared secret + unique
+//! derived nonce, so nonce reuse is structurally impossible.  Including the
+//! nonce on the wire would only invite confusion about whether the recipient
+//! checks it (the AAD already pins `alg` + `v`).
+//!
+//! Phase 5b wires this into the credential-fetch endpoint; Phase 5c is the
+//! worker-side ephemeral keypair + unseal + `zeroize`-after-use.
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use hkdf::Hkdf;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
+
+use crate::error::{AppError, AppResult};
+
+/// Algorithm identifier carried on the wire + bound into the AEAD AAD.
+///
+/// A future revision (different curve / KDF / cipher) MUST mint a new string
+/// here; mismatch on `open` is a clean auth failure rather than a silent
+/// downgrade.
+pub const SEAL_ALG: &str = "x25519-hkdf-sha256-chacha20-poly1305";
+
+/// Format version.  Bumped only when the wire shape changes (the algorithm
+/// constant is the orthogonal control for crypto changes).
+pub const SEAL_V: u8 = 1;
+
+/// HKDF "info" prefix.  Domain-separates this scheme from any other use of
+/// the same shared secret elsewhere in the stack.
+const KDF_INFO: &[u8] = b"noetl-sealed-v1";
+
+/// Sealed envelope as it travels on the wire.
+///
+/// All binary fields are base64-encoded (`base64::STANDARD`, padded).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SealedEnvelope {
+    /// Algorithm id ([`SEAL_ALG`]).  Bound into AAD; tamper rejects.
+    pub alg: String,
+    /// Format version ([`SEAL_V`]).  Bound into AAD; tamper rejects.
+    pub v: u8,
+    /// Ephemeral X25519 public key (32 bytes, base64).
+    pub eph_pub: String,
+    /// AEAD ciphertext (plaintext-len + 16-byte tag, base64).
+    pub ciphertext: String,
+}
+
+/// Seal `plaintext` to `recipient_pk`.
+///
+/// Generates a fresh ephemeral X25519 keypair, computes the ECDH shared secret,
+/// derives a 32-byte encryption key + 12-byte AEAD nonce via HKDF-SHA256, and
+/// encrypts with ChaCha20-Poly1305.  The associated data binds [`SEAL_ALG`] +
+/// [`SEAL_V`].
+pub fn seal(recipient_pk: &PublicKey, plaintext: &[u8]) -> AppResult<SealedEnvelope> {
+    let eph_sk = EphemeralSecret::random_from_rng(rand_core::OsRng);
+    let eph_pk = PublicKey::from(&eph_sk);
+    let shared = eph_sk.diffie_hellman(recipient_pk);
+
+    let (key, nonce) = derive_key_nonce(shared.as_bytes())?;
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key));
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad: associated_data().as_bytes(),
+            },
+        )
+        .map_err(|e| AppError::Internal(format!("sealed encrypt: {e}")))?;
+
+    Ok(SealedEnvelope {
+        alg: SEAL_ALG.to_string(),
+        v: SEAL_V,
+        eph_pub: B64.encode(eph_pk.as_bytes()),
+        ciphertext: B64.encode(&ciphertext),
+    })
+}
+
+/// Open a [`SealedEnvelope`] addressed to `recipient_sk`.
+///
+/// Reverses `seal`: decodes the wire fields, reconstructs the ECDH shared
+/// secret, re-derives the key + nonce, and verifies + decrypts the AEAD.
+/// Returns the plaintext bytes; the caller is responsible for `zeroize`ing
+/// them after use (the worker-side integration in Phase 5c).
+pub fn open(recipient_sk: &StaticSecret, env: &SealedEnvelope) -> AppResult<Vec<u8>> {
+    if env.alg != SEAL_ALG {
+        return Err(AppError::BadRequest(format!(
+            "sealed open: unsupported alg '{}' (expected '{SEAL_ALG}')",
+            env.alg
+        )));
+    }
+    if env.v != SEAL_V {
+        return Err(AppError::BadRequest(format!(
+            "sealed open: unsupported version {} (expected {SEAL_V})",
+            env.v
+        )));
+    }
+    let eph_pub_bytes = B64
+        .decode(&env.eph_pub)
+        .map_err(|e| AppError::BadRequest(format!("sealed open: eph_pub base64: {e}")))?;
+    let eph_pub_array: [u8; 32] = eph_pub_bytes.as_slice().try_into().map_err(|_| {
+        AppError::BadRequest(format!(
+            "sealed open: eph_pub must be 32 bytes, got {}",
+            eph_pub_bytes.len()
+        ))
+    })?;
+    let eph_pk = PublicKey::from(eph_pub_array);
+    let ciphertext = B64
+        .decode(&env.ciphertext)
+        .map_err(|e| AppError::BadRequest(format!("sealed open: ciphertext base64: {e}")))?;
+
+    let shared = recipient_sk.diffie_hellman(&eph_pk);
+    let (key, nonce) = derive_key_nonce(shared.as_bytes())?;
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key));
+    cipher
+        .decrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: &ciphertext,
+                aad: associated_data().as_bytes(),
+            },
+        )
+        .map_err(|e| AppError::BadRequest(format!("sealed open: AEAD verify/decrypt: {e}")))
+}
+
+/// Domain-separated HKDF that produces a 32-byte AEAD key + 12-byte nonce from
+/// the ECDH shared secret.
+fn derive_key_nonce(shared: &[u8; 32]) -> AppResult<([u8; 32], [u8; 12])> {
+    let hkdf = Hkdf::<Sha256>::new(None, shared);
+    let mut okm = [0u8; 32 + 12];
+    hkdf.expand(KDF_INFO, &mut okm)
+        .map_err(|e| AppError::Internal(format!("sealed kdf: {e}")))?;
+    let mut key = [0u8; 32];
+    let mut nonce = [0u8; 12];
+    key.copy_from_slice(&okm[..32]);
+    nonce.copy_from_slice(&okm[32..]);
+    Ok((key, nonce))
+}
+
+/// Associated data bound into the AEAD; rejects forged-as-old envelopes when
+/// the algorithm or version constants change.
+fn associated_data() -> String {
+    format!("{SEAL_ALG}|v={SEAL_V}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: generate a recipient long-lived keypair.
+    fn recipient_keypair() -> (StaticSecret, PublicKey) {
+        let sk = StaticSecret::random_from_rng(rand_core::OsRng);
+        let pk = PublicKey::from(&sk);
+        (sk, pk)
+    }
+
+    #[test]
+    fn round_trip_short_payload() {
+        let (sk, pk) = recipient_keypair();
+        let env = seal(&pk, b"hello-secret").unwrap();
+        let opened = open(&sk, &env).unwrap();
+        assert_eq!(opened, b"hello-secret");
+    }
+
+    #[test]
+    fn round_trip_realistic_credential_payload() {
+        // A multi-field credential JSON — the shape a `get_credential`
+        // response will seal in Phase 5b.
+        let (sk, pk) = recipient_keypair();
+        let plaintext =
+            br#"{"type":"bearer","data":{"token":"sk-test-AbCdEf123","expires_in":3600}}"#;
+        let env = seal(&pk, plaintext).unwrap();
+        let opened = open(&sk, &env).unwrap();
+        assert_eq!(&opened[..], plaintext);
+    }
+
+    #[test]
+    fn envelope_uses_documented_wire_constants() {
+        let (_, pk) = recipient_keypair();
+        let env = seal(&pk, b"x").unwrap();
+        assert_eq!(env.alg, SEAL_ALG);
+        assert_eq!(env.v, SEAL_V);
+        let eph = B64.decode(env.eph_pub).unwrap();
+        assert_eq!(eph.len(), 32, "eph_pub is 32 bytes (X25519)");
+        let ct = B64.decode(env.ciphertext).unwrap();
+        // ChaCha20-Poly1305 tag is 16 bytes; plaintext is 1 byte ⇒ ct = 17.
+        assert_eq!(ct.len(), 1 + 16);
+    }
+
+    #[test]
+    fn two_seals_to_same_recipient_use_distinct_eph_keys() {
+        // Each call generates a fresh ephemeral key, so the wire envelopes
+        // differ even when sealing the same plaintext to the same recipient.
+        // Critically this means the derived nonce + key differ too, so AEAD
+        // nonce reuse is structurally impossible across calls.
+        let (_, pk) = recipient_keypair();
+        let a = seal(&pk, b"same-input").unwrap();
+        let b = seal(&pk, b"same-input").unwrap();
+        assert_ne!(a.eph_pub, b.eph_pub);
+        assert_ne!(a.ciphertext, b.ciphertext);
+    }
+
+    #[test]
+    fn open_rejects_tampered_ciphertext() {
+        let (sk, pk) = recipient_keypair();
+        let mut env = seal(&pk, b"important").unwrap();
+        // Flip a byte in the ciphertext.
+        let mut ct = B64.decode(&env.ciphertext).unwrap();
+        ct[0] ^= 0x01;
+        env.ciphertext = B64.encode(&ct);
+        let err = open(&sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("AEAD verify/decrypt"));
+    }
+
+    #[test]
+    fn open_rejects_tampered_eph_pub() {
+        let (sk, pk) = recipient_keypair();
+        let mut env = seal(&pk, b"important").unwrap();
+        // Substitute a different (valid) ephemeral pub — derived key + nonce
+        // shift, decrypt fails.
+        let (_, other_pk) = recipient_keypair();
+        env.eph_pub = B64.encode(other_pk.as_bytes());
+        let err = open(&sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("AEAD verify/decrypt"));
+    }
+
+    #[test]
+    fn open_rejects_wrong_recipient() {
+        // Wrong recipient → wrong shared secret → wrong key/nonce → AEAD
+        // verify fails.
+        let (_alice_sk, alice_pk) = recipient_keypair();
+        let (bob_sk, _bob_pk) = recipient_keypair();
+        let env = seal(&alice_pk, b"for-alice").unwrap();
+        let err = open(&bob_sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("AEAD verify/decrypt"));
+    }
+
+    #[test]
+    fn open_rejects_unknown_alg() {
+        let (sk, pk) = recipient_keypair();
+        let mut env = seal(&pk, b"x").unwrap();
+        env.alg = "x25519-hkdf-sha256-aes-gcm-v2".to_string();
+        let err = open(&sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("unsupported alg"));
+    }
+
+    #[test]
+    fn open_rejects_wrong_version() {
+        let (sk, pk) = recipient_keypair();
+        let mut env = seal(&pk, b"x").unwrap();
+        env.v = SEAL_V + 7;
+        let err = open(&sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("unsupported version"));
+    }
+
+    #[test]
+    fn open_rejects_short_eph_pub() {
+        let (sk, pk) = recipient_keypair();
+        let mut env = seal(&pk, b"x").unwrap();
+        env.eph_pub = B64.encode([0u8; 16]); // wrong length
+        let err = open(&sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("eph_pub must be 32 bytes"));
+    }
+
+    #[test]
+    fn open_rejects_invalid_base64() {
+        let (sk, pk) = recipient_keypair();
+        let mut env = seal(&pk, b"x").unwrap();
+        env.ciphertext = "%not base64%".to_string();
+        let err = open(&sk, &env).unwrap_err();
+        assert!(format!("{err:?}").contains("ciphertext base64"));
+    }
+
+    #[test]
+    fn envelope_round_trips_through_json() {
+        // Wire stability: serializing + parsing a SealedEnvelope must not
+        // change the bytes the recipient sees.
+        let (sk, pk) = recipient_keypair();
+        let env = seal(&pk, b"json-stable").unwrap();
+        let json = serde_json::to_string(&env).unwrap();
+        let parsed: SealedEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(env, parsed);
+        let opened = open(&sk, &parsed).unwrap();
+        assert_eq!(opened, b"json-stable");
+    }
+}


### PR DESCRIPTION
## Summary

Secrets Wallet **Phase 5a** (`Refs noetl/ai-meta#61`) — defense-in-depth crypto
on top of the Phase-4 mTLS transport. mTLS encrypts the *wire*; sealing
encrypts the *credential payload* to a key only the recipient worker holds.
Cleartext never enters the response body; an operator with `kubectl exec` on
the server pod sees only ciphertext.

This round is **lib-only** — primitives + tests. Phase 5b adds the
runtime-registry worker pubkey + the sealing endpoint; Phase 5c integrates the
worker side (ephemeral keypair + unseal + `zeroize`-after-use).

## `src/crypto/sealed.rs`

Standard ephemeral-static **sealed box** shape:

- `seal(recipient_pk, plaintext) -> SealedEnvelope` — fresh ephemeral X25519
  keypair per call → ECDH shared secret → HKDF-SHA256 derives a 32-byte AEAD
  key + 12-byte nonce → **ChaCha20-Poly1305** encrypts with AAD =
  `<alg>|v=<v>` so a future algorithm change rejects forged-as-old envelopes
  with a clean auth failure.
- `open(recipient_sk, env) -> Vec<u8>` — reverses the construction; AEAD auth
  tag rejects on any tamper.

Wire shape (`SealedEnvelope`): `{ alg, v, eph_pub (b64), ciphertext (b64) }`.
**Nonce is derived, not transmitted** — one ephemeral key per call gives a
fresh shared secret + derived nonce, so AEAD nonce reuse is structurally
impossible across calls. `SEAL_ALG = "x25519-hkdf-sha256-chacha20-poly1305"`,
`SEAL_V = 1`.

## Tests

12 unit tests: round-trip (short + realistic credential JSON); wire constants
+ ciphertext length math; distinct eph keys across calls (nonce-reuse guard);
tamper rejection on ciphertext / eph_pub / wrong recipient; alg-mismatch +
version-mismatch + short-eph-pub + invalid-base64 rejection; JSON wire
round-trip. **Lib 369/0**; clippy lib-clean.

## Dep footprint

`x25519-dalek` 2 (`static_secrets` feature), `chacha20poly1305` 0.10, `hkdf`
0.12, `rand_core` 0.6 — all small RustCrypto crates, no SDK trees.

## Scope

Lib-only — no schema or API change. Phase 5b (runtime-registry pubkey +
sealing endpoint) and 5c (worker integration) follow as bounded rounds.

Closes #106
Refs noetl/ai-meta#61