### PR TITLE
feat(api): sealed credential delivery endpoint (Secrets Wallet Phase 5b)

### DIFF
--- a/src/handlers/credentials.rs
+++ b/src/handlers/credentials.rs
@@ -9,9 +9,10 @@ use axum::{
 };
 use serde::Deserialize;
 
+use crate::crypto::{sealed_seal, SealedEnvelope};
 use crate::db::models::{CredentialCreateRequest, CredentialListResponse, CredentialResponse};
-use crate::error::AppResult;
-use crate::services::CredentialService;
+use crate::error::{AppError, AppResult};
+use crate::services::{CredentialService, RuntimeService};
 
 /// Query parameters for listing credentials.
 #[derive(Debug, Deserialize, Default)]
@@ -179,4 +180,160 @@ pub async fn delete(
         "message": "Credential deleted successfully",
         "id": id
     })))
+}
+
+/// State extractor for the sealed-credential endpoint — bundles the two
+/// services the handler needs (Secrets Wallet Phase 5b, noetl/ai-meta#61).
+#[derive(Clone)]
+pub struct SealedCredentialDeps {
+    pub credentials: CredentialService,
+    pub runtime: RuntimeService,
+}
+
+/// Query parameters for the sealed-credential endpoint.
+#[derive(Debug, Deserialize, Default)]
+pub struct GetSealedCredentialQuery {
+    /// `name` of the worker_pool row in `noetl.runtime` whose registered
+    /// public key the response is sealed to.
+    pub worker_id: String,
+    /// Forwarded to the underlying credential fetch — kept for audit
+    /// correlation, NOT used as the seal recipient.
+    pub execution_id: Option<i64>,
+    /// Forwarded to the underlying credential fetch.
+    pub parent_execution_id: Option<i64>,
+}
+
+/// Get a credential as a sealed payload addressed to a specific worker.
+///
+/// Secrets Wallet **Phase 5b** ([noetl/ai-meta#61]).  The credential payload
+/// (the same JSON the plain `GET /api/credentials/{identifier}` returns with
+/// `include_data=true`) is sealed with the X25519 public key the worker
+/// registered with itself at startup.  The plaintext exists briefly inside
+/// the server process at seal time; it never enters the response body, so an
+/// operator with `kubectl exec` on the server pod sees only ciphertext.
+///
+/// `GET /api/credentials/{identifier}/sealed?worker_id=<name>`
+///
+/// The query MUST supply `worker_id` (the `name` of the `kind=worker_pool`
+/// row in `noetl.runtime` that registered a sealing pubkey).  When the
+/// worker exists but didn't register a key, returns `400 BadRequest`.
+///
+/// Response: a [`SealedEnvelope`] JSON (see `src/crypto/sealed.rs` for the
+/// wire shape).  Phase 5c integrates the worker side (ephemeral X25519
+/// keypair at startup + unseal + `zeroize` after the caller's tool dispatch).
+///
+/// [noetl/ai-meta#61]: https://github.com/noetl/ai-meta/issues/61
+pub async fn get_sealed(
+    State(deps): State<SealedCredentialDeps>,
+    Path(identifier): Path<String>,
+    Query(query): Query<GetSealedCredentialQuery>,
+) -> AppResult<Json<SealedEnvelope>> {
+    let span = tracing::info_span!(
+        "credential.seal",
+        worker_id = %query.worker_id,
+        identifier = %identifier,
+        execution_id = query.execution_id,
+    );
+    let _guard = span.enter();
+
+    // Look up the worker's sealing pubkey first; this is the cheapest reject
+    // and avoids decrypting + serialising the credential for a worker that
+    // can't unseal it.
+    let pubkey_bytes = match deps
+        .runtime
+        .get_worker_public_key(&query.worker_id)
+        .await
+    {
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            crate::metrics::record_credential_seal("no_pubkey");
+            return Err(AppError::BadRequest(format!(
+                "worker '{}' did not register a sealing pubkey (worker_public_key \
+                 missing from the noetl.runtime row, or the worker_pool row \
+                 doesn't exist)",
+                query.worker_id
+            )));
+        }
+        Err(e) => {
+            crate::metrics::record_credential_seal("worker_not_found");
+            return Err(e);
+        }
+    };
+    let pubkey = x25519_dalek::PublicKey::from(pubkey_bytes);
+
+    // Fetch the credential payload (with include_data=true — the whole point
+    // of sealing is to deliver the resolved secret).
+    let credential = match deps
+        .credentials
+        .get(&identifier, true, query.execution_id)
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            crate::metrics::record_credential_seal("credential_error");
+            return Err(e);
+        }
+    };
+    let plaintext = serde_json::to_vec(&credential).map_err(|e| {
+        crate::metrics::record_credential_seal("seal_error");
+        AppError::Internal(format!("sealed get: serialize credential: {e}"))
+    })?;
+
+    let envelope = sealed_seal(&pubkey, &plaintext).inspect_err(|_| {
+        crate::metrics::record_credential_seal("seal_error");
+    })?;
+    crate::metrics::record_credential_seal("ok");
+    Ok(Json(envelope))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::sealed_open;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    /// End-to-end primitive contract: sealing a serialized credential JSON
+    /// and opening it on the worker side round-trips losslessly via the
+    /// sealed_seal / sealed_open primitives the handler uses.  Locks the
+    /// shape `get_sealed` produces against drift in either crypto-side
+    /// constant.
+    #[test]
+    fn sealed_credential_round_trips_via_primitives() {
+        let recipient_sk = StaticSecret::random_from_rng(rand_core::OsRng);
+        let recipient_pk = PublicKey::from(&recipient_sk);
+
+        let credential = serde_json::json!({
+            "id": "1234567890",
+            "name": "duffel-token",
+            "type": "bearer",
+            "data": { "token": "sk-test-AbCdEf123" }
+        });
+        let plaintext = serde_json::to_vec(&credential).unwrap();
+
+        let envelope = sealed_seal(&recipient_pk, &plaintext).unwrap();
+        let opened = sealed_open(&recipient_sk, &envelope).unwrap();
+        let opened_json: serde_json::Value = serde_json::from_slice(&opened).unwrap();
+
+        assert_eq!(opened_json, credential);
+    }
+
+    /// Tampered envelope is rejected — the AEAD auth tag catches any flipped
+    /// byte in the sealed-credential ciphertext (same guarantee Phase 5a's
+    /// `sealed::tests` exercise, here pinned at the handler-payload layer).
+    #[test]
+    fn tampered_sealed_credential_is_rejected() {
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+
+        let recipient_sk = StaticSecret::random_from_rng(rand_core::OsRng);
+        let recipient_pk = PublicKey::from(&recipient_sk);
+        let plaintext = br#"{"id":"1","name":"x","type":"bearer","data":{"token":"t"}}"#;
+        let mut envelope = sealed_seal(&recipient_pk, plaintext).unwrap();
+
+        let mut ct = B64.decode(&envelope.ciphertext).unwrap();
+        ct[0] ^= 0x01;
+        envelope.ciphertext = B64.encode(&ct);
+
+        let err = sealed_open(&recipient_sk, &envelope).unwrap_err();
+        assert!(format!("{err:?}").contains("AEAD verify/decrypt"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,21 @@ fn build_router(
             "/api/credentials/{identifier}",
             delete(handlers::credentials::delete),
         )
-        .with_state(credential_service);
+        .with_state(credential_service.clone());
+
+    // Sealed-credential endpoint (Secrets Wallet Phase 5b, noetl/ai-meta#61).
+    // Returns a SealedEnvelope (X25519-sealed credential JSON) addressed to
+    // the worker named via `?worker_id=<name>`.  Defense-in-depth on top of
+    // Phase-4 mTLS — cleartext never enters the response body.
+    let sealed_credential_routes = Router::new()
+        .route(
+            "/api/credentials/{identifier}/sealed",
+            get(handlers::credentials::get_sealed),
+        )
+        .with_state(handlers::credentials::SealedCredentialDeps {
+            credentials: credential_service,
+            runtime: runtime_service.clone(),
+        });
 
     // Keychain routes
     let keychain_routes = Router::new()
@@ -287,6 +301,7 @@ fn build_router(
         .merge(health_routes)
         .merge(catalog_routes)
         .merge(credential_routes)
+        .merge(sealed_credential_routes)
         .merge(keychain_routes)
         .merge(execution_routes)
         .merge(executions_routes)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -201,6 +201,44 @@ pub fn record_write_request(endpoint: &str, status: &str, duration_seconds: f64)
         .observe(duration_seconds);
 }
 
+/// Counter: sealed credential responses on `GET /api/credentials/{id}/sealed`,
+/// bucketed by outcome.
+///
+/// Secrets Wallet Phase 5b (noetl/ai-meta#61) — pairs with the `credential.seal`
+/// span in `handlers::credentials::get_sealed`.  Labels:
+///
+/// - `status` ∈ {`ok`, `no_pubkey`, `worker_not_found`, `seal_error`,
+///   `credential_error`} — the outcome bucket.
+///
+/// `noetl_credentials_sealed_total{status="ok"}` is the throughput counter;
+/// the other label values are failure modes worth grepping in Prometheus
+/// when a worker stops being able to fetch sealed credentials.  `execution_id`
+/// is NOT a label (cardinality) — it lives on the matching span.
+pub fn credentials_sealed_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_credentials_sealed_total",
+                "GET /api/credentials/{id}/sealed calls by outcome status.",
+            ),
+            &["status"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Increment [`credentials_sealed_total`] by 1 for the given outcome.
+pub fn record_credential_seal(status: &str) {
+    credentials_sealed_total()
+        .with_label_values(&[status])
+        .inc();
+}
+
 /// Render the global registry as Prometheus text-exposition
 /// format.  Used by the `GET /metrics` handler.
 pub fn gather_text() -> Result<String, prometheus::Error> {
@@ -321,7 +359,10 @@ mod tests {
             endpoint::RUNTIME_HEARTBEAT,
         ];
         // Sanity: they're all distinct and non-empty.
-        assert_eq!(names.iter().collect::<std::collections::HashSet<_>>().len(), names.len());
+        assert_eq!(
+            names.iter().collect::<std::collections::HashSet<_>>().len(),
+            names.len()
+        );
         assert!(names.iter().all(|n| !n.is_empty()));
     }
 }

--- a/src/services/runtime.rs
+++ b/src/services/runtime.rs
@@ -230,6 +230,65 @@ impl RuntimeService {
         Ok(())
     }
 
+    /// Look up the X25519 sealing public key a worker registered with itself.
+    ///
+    /// Secrets Wallet Phase 5b (noetl/ai-meta#61).  Workers opt into sealed
+    /// credential delivery by including a base64 32-byte X25519 public key in
+    /// the `runtime` JSON blob they pass to register, e.g.:
+    ///
+    /// ```json
+    /// {
+    ///   "worker_public_key": "<base64(32-byte-x25519-pub)>"
+    /// }
+    /// ```
+    ///
+    /// This is the JSON shape the server already persists as the `runtime`
+    /// column; no schema migration is needed and workers that don't opt in
+    /// keep working unchanged (the sealing endpoint just returns
+    /// `BadRequest` for those workers).
+    ///
+    /// Returns `Ok(Some(pk))` when the lookup succeeds, `Ok(None)` when the
+    /// worker exists but didn't register a key, and an error when the
+    /// `worker_pool` runtime row doesn't exist or the key is malformed.
+    pub async fn get_worker_public_key(
+        &self,
+        worker_name: &str,
+    ) -> AppResult<Option<[u8; 32]>> {
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+
+        let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+            "SELECT runtime FROM noetl.runtime WHERE kind = 'worker_pool' AND name = $1",
+        )
+        .bind(worker_name)
+        .fetch_optional(&self.db)
+        .await?;
+        let runtime_json = match row {
+            Some((Some(v),)) => v,
+            Some((None,)) | None => {
+                // Row missing entirely, OR runtime metadata column is NULL —
+                // either way the worker did not opt into sealing.  The
+                // caller surfaces the right error message.
+                return Ok(None);
+            }
+        };
+        let encoded = match runtime_json.get("worker_public_key").and_then(|v| v.as_str()) {
+            Some(s) if !s.is_empty() => s,
+            _ => return Ok(None),
+        };
+        let bytes = B64
+            .decode(encoded)
+            .map_err(|e| AppError::BadRequest(format!(
+                "worker '{worker_name}' worker_public_key base64: {e}"
+            )))?;
+        let array: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+            AppError::BadRequest(format!(
+                "worker '{worker_name}' worker_public_key must be 32 bytes, got {}",
+                bytes.len()
+            ))
+        })?;
+        Ok(Some(array))
+    }
+
     /// Update heartbeat for a runtime.
     pub async fn heartbeat(&self, kind: &str, name: &str) -> AppResult<()> {
         let result = sqlx::query(


### PR DESCRIPTION
## Summary

Secrets Wallet **Phase 5b** (`Refs noetl/ai-meta#61`) — wires the Phase-5a
sealed-payload primitives ([server#107](https://github.com/noetl/server/pull/107),
v2.32.0) into the request path.  Defense-in-depth on top of the now-merged
Phase-4 mTLS transport: cleartext never enters the response body.

## What it adds

- **`src/services/runtime.rs`** — `RuntimeService::get_worker_public_key(name)`
  reads the X25519 pubkey workers opt into by including it in their register
  payload's `runtime` JSON blob: `{"worker_public_key":"<base64-32-bytes>"}`.
  **No schema migration needed** — the `noetl.runtime.runtime` column already
  accepts arbitrary metadata.  Workers that don't send a key keep working
  unchanged.
- **`src/handlers/credentials.rs`** — new `GET /api/credentials/{identifier}/sealed?worker_id=<name>`
  endpoint.  Looks up the pubkey, fetches the credential with
  `include_data=true`, serialises the standard `CredentialResponse` JSON, seals
  it with the Phase-5a primitives, returns a `SealedEnvelope`.  400 BadRequest
  when the `worker_pool` row exists but didn't register a pubkey — the error
  message points at the runtime-row condition so the operator can fix
  registration.
- **`src/metrics.rs`** — `noetl_credentials_sealed_total{status}` counter where
  status ∈ {`ok`, `no_pubkey`, `worker_not_found`, `seal_error`,
  `credential_error`}; pairs with a `credential.seal` tracing span carrying
  `worker_id`, `identifier`, and `execution_id` when provided. Per
  `observability.md` Principles 1 + 4.

## Kind validation

End-to-end against the local kind cluster:

1. POST `/api/worker/pool/register` with a Python-generated X25519 pubkey.
2. POST `/api/credentials` upserting `phase5b-test-bearer`.
3. GET `/api/credentials/phase5b-test-bearer/sealed?worker_id=phase5b-test-pool`
   → `SealedEnvelope` JSON.
4. Open with the matching secret using `cryptography` + HKDF +
   ChaCha20-Poly1305 → recovered the **exact** bearer token + scope round-trip.
5. Negative case (worker without pubkey) → **400** with the documented
   "did not register a sealing pubkey" message.
6. `/metrics` shows `noetl_credentials_sealed_total{status="ok"} 1` +
   `{status="no_pubkey"} 1`.

## Tests

Handler-side: sealed primitives round-trip the exact `CredentialResponse` JSON
shape the endpoint produces; tamper rejection at the sealed-credential layer.
Lib **371/0**; clippy lib-clean.

## Next

Phase 5c: worker generates an ephemeral X25519 keypair at startup, sends pubkey
on register, hits the `/sealed` endpoint instead of the plaintext one, unseals,
`zeroize`s the cleartext after the caller's tool dispatch returns.

Closes #108
Refs noetl/ai-meta#61