### PR TITLE
feat(secrets): dynamic-secret primitives + cache honors issuer TTL (Phase 6d)

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -399,6 +399,74 @@ pub fn record_secret_residency_check(policy: &str, decision: &str) {
         .inc();
 }
 
+/// Secrets-Wallet Phase 6d: histogram of issuer-reported dynamic-secret
+/// time-to-expiry at resolution time.
+///
+/// Buckets span the common cloud-token TTLs:
+/// `[60, 300, 900, 3600, 14400, 43200]` seconds = 1 min / 5 min / 15 min /
+/// 1 h / 4 h / 12 h.  An operator watching this dashboard sees whether
+/// their fleet is hot-pathing through short-lived creds (most calls
+/// landing in the 1 min – 15 min buckets) or running off long-lived ones
+/// (12 h+).
+///
+/// No labels: the metric tells a fleet-wide story; per-credential
+/// inspection lives on the matching `secret.resolve` tracing span.
+pub fn secret_dynamic_ttl_seconds() -> &'static prometheus::Histogram {
+    static M: OnceLock<prometheus::Histogram> = OnceLock::new();
+    M.get_or_init(|| {
+        let h = prometheus::Histogram::with_opts(
+            HistogramOpts::new(
+                "noetl_secret_dynamic_ttl_seconds",
+                "Issuer-reported time-to-expiry of resolved dynamic secrets (Phase 6d).",
+            )
+            .buckets(vec![60.0, 300.0, 900.0, 3600.0, 14400.0, 43200.0]),
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(h.clone()))
+            .expect("histogram registration must succeed");
+        h
+    })
+}
+
+/// Observe one issuer-reported TTL (seconds).  Caller filters to the
+/// dynamic-secret case (i.e. only when `SecretValue.expires_at` was set).
+pub fn record_secret_dynamic_ttl(seconds: f64) {
+    secret_dynamic_ttl_seconds().observe(seconds);
+}
+
+/// Secrets-Wallet Phase 6d: counter for keychain-cache writes the
+/// resolver skipped.
+///
+/// `reason` is a bounded enum:
+/// - `already_expired` — issuer's `expires_at` already in the past or
+///   within the safety margin.  Caching would store something already
+///   dead.
+///
+/// Future 6d-follow-up reasons may include `unsupported_scope`, etc.
+pub fn secret_cache_skip_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_secret_cache_skip_total",
+                "Keychain-cache writes skipped by reason (Phase 6d).",
+            ),
+            &["reason"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Increment [`secret_cache_skip_total`] by 1.
+pub fn record_secret_cache_skip(reason: &str) {
+    secret_cache_skip_total().with_label_values(&[reason]).inc();
+}
+
 /// Render the global registry as Prometheus text-exposition
 /// format.  Used by the `GET /metrics` handler.
 pub fn gather_text() -> Result<String, prometheus::Error> {

--- a/src/secrets/aws.rs
+++ b/src/secrets/aws.rs
@@ -268,6 +268,7 @@ impl SecretProvider for AwsSmSecretProvider {
         Ok(SecretValue {
             value,
             version: body.version_id,
+            expires_at: None,
         })
     }
 }

--- a/src/secrets/azure.rs
+++ b/src/secrets/azure.rs
@@ -272,6 +272,7 @@ impl SecretProvider for AzureKeyVaultProvider {
         Ok(SecretValue {
             value: body.value,
             version: resolved_version,
+            expires_at: None,
         })
     }
 }

--- a/src/secrets/dynamic.rs
+++ b/src/secrets/dynamic.rs
@@ -1,0 +1,230 @@
+//! Dynamic / short-lived secret support (Secrets Wallet Phase 6d,
+//! [`noetl/ai-meta#61`](https://github.com/noetl/ai-meta/issues/61)).
+//!
+//! Some providers return secrets that the issuer expires on a clock —
+//! AWS STS bearer tokens (15 min – 12 h), AAD access tokens (1 h
+//! default), GCP `iamcredentials.generateAccessToken` (1 h default, 12 h
+//! max), OAuth2 access tokens (issuer-controlled `expires_in`).  The
+//! Phase-3c keychain cache used a fixed 600 s TTL.  Caching a token
+//! past its `expires_at` means the next worker fetch gets a 401 and the
+//! playbook step fails.
+//!
+//! This module computes the **effective cache TTL** — the smaller of the
+//! wallet's default TTL and `expires_at - now - safety_margin` — and
+//! signals back when the issuer-supplied expiry is already past (the
+//! resolver should skip the cache write entirely rather than store
+//! something that's already dead).
+//!
+//! The actual cloud-specific provider implementations (STS / AAD /
+//! iamcredentials) ride follow-up rounds (6d.1 / 6d.2 / 6d.3); this
+//! round establishes the primitives + the cache plumbing so those land
+//! cleanly.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+/// Default safety margin (seconds) when the env override is unset.
+/// 60 s buffers against clock skew + the wall-clock between cache write
+/// and the next worker fetch.
+const DEFAULT_SAFETY_MARGIN_SECS: u64 = 60;
+
+/// Floor for the effective TTL — never cache for less than this even
+/// when `expires_at - now - safety_margin` would compute to something
+/// smaller.  Below this floor we'd be paying the cache cost (round-trip
+/// to the keychain table + envelope encryption) for negligible reuse.
+/// Caller can still opt out via [`effective_cache_ttl_decision`]'s
+/// `SkipCache` arm when `expires_at` is already past.
+const MIN_EFFECTIVE_TTL_SECS: u64 = 5;
+
+/// Read the safety margin from `KEYCHAIN_CACHE_DYNAMIC_SAFETY_MARGIN_SECS`
+/// (defaults to [`DEFAULT_SAFETY_MARGIN_SECS`]).  Process-global, read
+/// once at startup.
+pub fn safety_margin_secs() -> u64 {
+    use std::sync::OnceLock;
+    static M: OnceLock<u64> = OnceLock::new();
+    *M.get_or_init(|| {
+        std::env::var("KEYCHAIN_CACHE_DYNAMIC_SAFETY_MARGIN_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_SAFETY_MARGIN_SECS)
+    })
+}
+
+/// What the cache layer should do with a freshly-resolved secret.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheDecision {
+    /// Cache for this many seconds.
+    CacheFor(u64),
+    /// `expires_at` is in the past (or within the safety margin past
+    /// `now`) — skip the cache write.  The next worker fetch will
+    /// re-resolve from the provider, which is the correct outcome.
+    SkipCacheAlreadyExpired,
+}
+
+/// Decide how to cache a freshly-resolved secret based on the issuer's
+/// reported `expires_at`, the wallet's `default_ttl`, the operator's
+/// `safety_margin`, and the current wall-clock `now`.
+///
+/// Rules, in order:
+/// 1. `expires_at = None` ⇒ caller is a long-lived secret; cache for
+///    `default_ttl` (back-compat with pre-6d behaviour).
+/// 2. `expires_at <= now + safety_margin` ⇒ token is already (or about
+///    to be) dead.  Return [`CacheDecision::SkipCacheAlreadyExpired`].
+/// 3. Otherwise ⇒ cache for `min(default_ttl, expires_at - now -
+///    safety_margin)`, floored at [`MIN_EFFECTIVE_TTL_SECS`].
+pub fn cache_decision(
+    expires_at: Option<DateTime<Utc>>,
+    default_ttl: Duration,
+    safety_margin: Duration,
+    now: DateTime<Utc>,
+) -> CacheDecision {
+    let Some(expires_at) = expires_at else {
+        return CacheDecision::CacheFor(default_ttl.as_secs());
+    };
+
+    let safety =
+        chrono::Duration::from_std(safety_margin).unwrap_or_else(|_| chrono::Duration::seconds(0));
+    let effective_deadline = expires_at - safety;
+    if effective_deadline <= now {
+        return CacheDecision::SkipCacheAlreadyExpired;
+    }
+
+    let remaining = (effective_deadline - now).num_seconds().max(0) as u64;
+    let capped = remaining
+        .min(default_ttl.as_secs())
+        .max(MIN_EFFECTIVE_TTL_SECS);
+    CacheDecision::CacheFor(capped)
+}
+
+/// Convenience entry point that reads the safety margin from env.
+pub fn effective_cache_ttl(
+    expires_at: Option<DateTime<Utc>>,
+    default_ttl: Duration,
+    now: DateTime<Utc>,
+) -> CacheDecision {
+    cache_decision(
+        expires_at,
+        default_ttl,
+        Duration::from_secs(safety_margin_secs()),
+        now,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(secs, 0).unwrap()
+    }
+
+    #[test]
+    fn no_expires_at_uses_default_ttl() {
+        let d = cache_decision(
+            None,
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            at(1000),
+        );
+        assert_eq!(d, CacheDecision::CacheFor(600));
+    }
+
+    #[test]
+    fn expires_at_far_future_is_capped_at_default_ttl() {
+        // expires_at way past default_ttl; the wallet's own TTL still
+        // bounds reuse so the cache doesn't outlive the operator's
+        // refresh policy.
+        let now = at(1000);
+        let expires_at = at(10_000);
+        let d = cache_decision(
+            Some(expires_at),
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            now,
+        );
+        assert_eq!(d, CacheDecision::CacheFor(600));
+    }
+
+    #[test]
+    fn expires_at_near_future_uses_expires_minus_margin() {
+        // expires_at = now + 300 s; safety_margin = 60 s; default_ttl = 600 s
+        // ⇒ effective = 300 - 60 = 240 s.
+        let now = at(1000);
+        let expires_at = at(1000 + 300);
+        let d = cache_decision(
+            Some(expires_at),
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            now,
+        );
+        assert_eq!(d, CacheDecision::CacheFor(240));
+    }
+
+    #[test]
+    fn expires_at_already_past_skips_cache() {
+        let now = at(1000);
+        let expires_at = at(900);
+        let d = cache_decision(
+            Some(expires_at),
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            now,
+        );
+        assert_eq!(d, CacheDecision::SkipCacheAlreadyExpired);
+    }
+
+    #[test]
+    fn expires_at_inside_safety_margin_skips_cache() {
+        // expires_at = now + 30 s; safety_margin = 60 s ⇒ deadline = now - 30.
+        // Treated as already-expired (caching for less time than the
+        // operator's safety buffer is worse than not caching).
+        let now = at(1000);
+        let expires_at = at(1000 + 30);
+        let d = cache_decision(
+            Some(expires_at),
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            now,
+        );
+        assert_eq!(d, CacheDecision::SkipCacheAlreadyExpired);
+    }
+
+    #[test]
+    fn very_small_remaining_clamped_to_min_ttl() {
+        // expires_at = now + 70 s; safety_margin = 60 s ⇒ remaining = 10 s.
+        // Above MIN_EFFECTIVE_TTL_SECS = 5; caches for 10 s.
+        let now = at(1000);
+        let expires_at = at(1000 + 70);
+        let d = cache_decision(
+            Some(expires_at),
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            now,
+        );
+        assert_eq!(d, CacheDecision::CacheFor(10));
+
+        // expires_at = now + 62 s; remaining = 2 s; clamps up to MIN = 5.
+        let expires_at = at(1000 + 62);
+        let d = cache_decision(
+            Some(expires_at),
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            now,
+        );
+        assert_eq!(d, CacheDecision::CacheFor(5));
+    }
+
+    #[test]
+    fn zero_safety_margin_treats_expires_at_as_hard_deadline() {
+        // expires_at exactly equal to now + safety_margin (0) should skip.
+        let now = at(1000);
+        let d = cache_decision(
+            Some(now),
+            Duration::from_secs(600),
+            Duration::from_secs(0),
+            now,
+        );
+        assert_eq!(d, CacheDecision::SkipCacheAlreadyExpired);
+    }
+}

--- a/src/secrets/gcp.rs
+++ b/src/secrets/gcp.rs
@@ -221,7 +221,11 @@ pub fn parse_access_response(body: &str) -> AppResult<SecretValue> {
         .as_deref()
         .and_then(|n| n.split("/versions/").nth(1))
         .map(|s| s.to_string());
-    Ok(SecretValue { value, version })
+    Ok(SecretValue {
+        value,
+        version,
+        expires_at: None,
+    })
 }
 
 #[cfg(test)]

--- a/src/secrets/k8s.rs
+++ b/src/secrets/k8s.rs
@@ -299,6 +299,7 @@ pub fn extract_secret_value(
     Ok(SecretValue {
         value,
         version: obj.metadata.resource_version,
+        expires_at: None,
     })
 }
 

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -15,6 +15,7 @@
 
 mod aws;
 mod azure;
+pub mod dynamic;
 mod gcp;
 mod k8s;
 mod registry;
@@ -27,7 +28,7 @@ pub use azure::AzureKeyVaultProvider;
 pub use gcp::GcpSecretManager;
 pub use k8s::K8sSecretProvider;
 pub use registry::get_provider;
-pub use resolver::resolve_keychain_entry;
+pub use resolver::{resolve_keychain_entry, resolve_keychain_entry_with_meta};
 pub use vault::VaultSecretProvider;
 
 use std::sync::{Arc, OnceLock};
@@ -40,11 +41,16 @@ use crate::error::{AppError, AppResult};
 ///
 /// `value` is the secret material as a UTF-8 string; `version` is the
 /// provider's resolved version identifier when the backend reports one
-/// (e.g. the concrete version number behind a `latest` alias).
-#[derive(Debug, Clone)]
+/// (e.g. the concrete version number behind a `latest` alias);
+/// `expires_at` is Secrets-Wallet Phase 6d — the issuer's reported expiry
+/// for short-lived dynamic secrets (AWS STS / AAD bearer / GCP access
+/// tokens / OAuth2 access tokens with `expires_in`).  `None` for
+/// long-lived API keys whose lifetime is operator-controlled.
+#[derive(Debug, Clone, Default)]
 pub struct SecretValue {
     pub value: String,
     pub version: Option<String>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// A request to fetch one secret from a provider.

--- a/src/secrets/resolver.rs
+++ b/src/secrets/resolver.rs
@@ -39,6 +39,30 @@ pub async fn resolve_keychain_entry(
     workload: &HashMap<String, serde_json::Value>,
     provider: &dyn SecretProvider,
 ) -> AppResult<serde_json::Value> {
+    resolve_keychain_entry_with_meta(kc, workload, provider)
+        .await
+        .map(|(v, _)| v)
+}
+
+/// Phase 6d — same as [`resolve_keychain_entry`] but also returns the
+/// issuer-reported `expires_at` for the resolved credential.
+///
+/// For a `map`-shaped entry that bundles several secrets, the returned
+/// `expires_at` is the **earliest** of any contributing secret's
+/// `expires_at` — caching the bundle past the soonest expiry means the
+/// next worker fetch gets a 401 from whichever member already expired.
+///
+/// The standard Phase-3c keychain-cache write site
+/// (`crate::services::credential`) consumes this `expires_at` and asks
+/// [`crate::secrets::dynamic::effective_cache_ttl`] for the cache TTL —
+/// honouring `min(default_ttl, expires_at - now - safety_margin)`,
+/// skipping the write entirely when the issuer's expiry is already in
+/// the past (defensive: never cache something already dead).
+pub async fn resolve_keychain_entry_with_meta(
+    kc: &KeychainDef,
+    workload: &HashMap<String, serde_json::Value>,
+    provider: &dyn SecretProvider,
+) -> AppResult<(serde_json::Value, Option<chrono::DateTime<chrono::Utc>>)> {
     let renderer = TemplateRenderer::new();
     let region = effective_region(kc);
     let provider_id = provider.provider();
@@ -55,6 +79,9 @@ pub async fn resolve_keychain_entry(
     let result = match &kc.map {
         Some(map) => {
             let mut out = serde_json::Map::with_capacity(map.len());
+            // Phase 6d — the bundle's expires_at is the earliest of any
+            // contributing secret's expires_at (None contributes nothing).
+            let mut earliest_expires_at: Option<chrono::DateTime<chrono::Utc>> = None;
             for (key, path_template) in map {
                 let path = match renderer.render(path_template, workload) {
                     Ok(p) => p,
@@ -77,9 +104,13 @@ pub async fn resolve_keychain_entry(
                         return Err(e);
                     }
                 };
+                if let Some(exp) = secret.expires_at {
+                    earliest_expires_at =
+                        Some(earliest_expires_at.map(|prev| prev.min(exp)).unwrap_or(exp));
+                }
                 out.insert(key.clone(), serde_json::Value::String(secret.value));
             }
-            Ok(serde_json::Value::Object(out))
+            Ok((serde_json::Value::Object(out), earliest_expires_at))
         }
         None => {
             let secret = match provider
@@ -96,7 +127,7 @@ pub async fn resolve_keychain_entry(
                     return Err(e);
                 }
             };
-            Ok(serde_json::Value::String(secret.value))
+            Ok((serde_json::Value::String(secret.value), secret.expires_at))
         }
     };
     if result.is_ok() {
@@ -169,6 +200,7 @@ mod tests {
                 .map(|v| SecretValue {
                     value: v.clone(),
                     version: None,
+                    expires_at: None,
                 })
                 .ok_or_else(|| {
                     AppError::NotFound(format!("fake secret '{}' not found", secret.name))

--- a/src/secrets/vault.rs
+++ b/src/secrets/vault.rs
@@ -287,6 +287,7 @@ pub fn extract_kv_value(
     Ok(SecretValue {
         value,
         version: resp.data.metadata.version.map(|v| v.to_string()),
+        expires_at: None,
     })
 }
 

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -11,16 +11,16 @@ use std::collections::HashMap;
 use chrono::Utc;
 
 use crate::crypto::EnvelopeCipher;
+use crate::db::DbPool;
 use crate::db::models::{
     CredentialCreateRequest, CredentialEntry, CredentialFilter, CredentialListResponse,
     CredentialResponse, KeychainSetRequest,
 };
 use crate::db::queries::catalog as catalog_queries;
 use crate::db::queries::credential as queries;
-use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::playbook::types::Playbook;
-use crate::secrets::{build_secret_provider, resolve_keychain_entry};
+use crate::secrets::{build_secret_provider, dynamic, resolve_keychain_entry_with_meta};
 use crate::services::keychain::KeychainService;
 
 /// TTL (seconds) for a keychain-resolved secret cached after a provider fetch.
@@ -231,21 +231,50 @@ impl CredentialService {
             provider = provider_id,
             "keychain.resolve"
         );
-        let data = resolve_keychain_entry(kc, &workload_map, &*provider).await?;
+        let (data, expires_at) =
+            resolve_keychain_entry_with_meta(kc, &workload_map, &*provider).await?;
 
-        // Cache write (Phase 3c): envelope-encrypted, execution-scoped, TTL —
-        // best-effort, a cache failure must not fail the resolution.
-        let set_req = KeychainSetRequest {
-            data: data.clone(),
-            scope_type: KEYCHAIN_CACHE_SCOPE.to_string(),
-            execution_id: Some(execution_id),
-            expires_at: None,
-            expires_in: Some(KEYCHAIN_CACHE_TTL_SECS),
-            auto_renew: false,
-            renew_config: None,
-        };
-        if let Err(e) = self.keychain.set(catalog_id, alias, set_req).await {
-            tracing::warn!(execution_id, alias, error = %e, "keychain.cache_write failed");
+        // Phase 6d — honour the issuer-reported expiry when one was
+        // supplied.  The decision helper returns CacheFor(secs) for
+        // normal-case secrets, and SkipCacheAlreadyExpired for tokens
+        // whose deadline already passed (or sits inside the operator's
+        // safety margin) — caching something already dead would force
+        // the next worker fetch into a 401.  The Phase-3c cache write
+        // is best-effort, so the skip path just logs and proceeds with
+        // the live response.
+        let now = Utc::now();
+        let cache_decision = dynamic::effective_cache_ttl(
+            expires_at,
+            std::time::Duration::from_secs(KEYCHAIN_CACHE_TTL_SECS as u64),
+            now,
+        );
+        if let Some(exp) = expires_at {
+            let remaining = (exp - now).num_seconds().max(0) as f64;
+            crate::metrics::record_secret_dynamic_ttl(remaining);
+        }
+        match cache_decision {
+            dynamic::CacheDecision::CacheFor(ttl_secs) => {
+                let set_req = KeychainSetRequest {
+                    data: data.clone(),
+                    scope_type: KEYCHAIN_CACHE_SCOPE.to_string(),
+                    execution_id: Some(execution_id),
+                    expires_at,
+                    expires_in: Some(ttl_secs as i64),
+                    auto_renew: false,
+                    renew_config: None,
+                };
+                if let Err(e) = self.keychain.set(catalog_id, alias, set_req).await {
+                    tracing::warn!(execution_id, alias, error = %e, "keychain.cache_write failed");
+                }
+            }
+            dynamic::CacheDecision::SkipCacheAlreadyExpired => {
+                tracing::warn!(
+                    execution_id,
+                    alias,
+                    "keychain.cache_skip: issuer expires_at already in the past or within safety margin"
+                );
+                crate::metrics::record_secret_cache_skip("already_expired");
+            }
         }
 
         Ok(Some(data))


### PR DESCRIPTION
## Summary

Phase 6 round 4 of the Secrets Wallet ([noetl/ai-meta#61](https://github.com/noetl/ai-meta/issues/61)).  Some providers return secrets the issuer expires on a clock — AWS STS bearer tokens (15 min – 12 h), AAD access tokens (1 h), GCP `iamcredentials.generateAccessToken` (1 h default), OAuth2 access tokens with `expires_in`.  The Phase-3c keychain cache previously used a fixed 600 s TTL; caching a token past its `expires_at` means the next worker fetch gets a 401 and the playbook step fails.

This round adds the **primitives + cache plumbing** so the concrete cloud-specific dynamic providers can land as separate clean rounds (6d.1 / 6d.2 / 6d.3).

## What lands

- **`SecretValue.expires_at: Option<DateTime<Utc>>`** — issuer-reported expiry.  Existing providers (GCP SM / AWS SM / Azure KV / Vault / K8s) pass `None` since they return long-lived secrets.
- **`src/secrets/dynamic.rs`** — `cache_decision(expires_at, default_ttl, safety_margin, now)` returns `CacheFor(secs)` or `SkipCacheAlreadyExpired`.  Rules:
  1. `expires_at = None` ⇒ cache for `default_ttl`.
  2. `expires_at <= now + safety_margin` ⇒ skip the cache write (defensive: never store something already dead).
  3. Otherwise ⇒ cache for `min(default_ttl, expires_at - now - safety_margin)`, floored at `MIN_EFFECTIVE_TTL_SECS = 5`.
- **`KEYCHAIN_CACHE_DYNAMIC_SAFETY_MARGIN_SECS`** env (default 60 s).
- **`resolve_keychain_entry_with_meta`** — same as `resolve_keychain_entry` but also returns the bundle's `expires_at`.  For a `map`-shaped entry the bundle TTL is the **earliest** of any contributing secret's `expires_at` (caching past the soonest expiry means the next worker fetch gets a 401 from whichever member already expired).
- **`CredentialService::resolve_via_provider`** consumes the helper — the cache-write site now honours the issuer-reported TTL.  `SkipCacheAlreadyExpired` ⇒ log WARN, bump the skip counter, return the freshly-resolved value without writing the cache.
- **`noetl_secret_dynamic_ttl_seconds`** histogram (buckets `[60, 300, 900, 3600, 14400, 43200]`) — tells operators whether the fleet is hot-pathing through short-lived creds.
- **`noetl_secret_cache_skip_total{reason="already_expired"}`** counter — alert-worthy at sustained rate.

## Tests

Seven new in `secrets::dynamic::tests`:
- `no_expires_at_uses_default_ttl` — providers returning `None` get back-compat behavior.
- `expires_at_far_future_is_capped_at_default_ttl` — wallet's own TTL still bounds reuse.
- `expires_at_near_future_uses_expires_minus_margin` — `expires_at = now + 300; margin = 60` → cache for 240 s.
- `expires_at_already_past_skips_cache` — defensive.
- `expires_at_inside_safety_margin_skips_cache` — treats sub-margin lifetimes as already-expired (caching < safety buffer is worse than not caching).
- `very_small_remaining_clamped_to_min_ttl` — 10 s remaining stays 10 s; 2 s clamps up to 5 s floor.
- `zero_safety_margin_treats_expires_at_as_hard_deadline`.

Lib **398 / 0** passing.

## Backward compatibility

The public `resolve_keychain_entry` signature is unchanged.  Existing providers pass `expires_at: None` so their cache behavior is identical (CacheFor(600 s)).  Workers that don't opt into dynamic-secret backends keep the long-lived path; the new metrics record zero traffic until 6d.1+ ships a dynamic provider.

## Follow-up rounds (separate sub-issues under #61)

- **6d.1**: AWS STS `AssumeRoleWithWebIdentity` provider — `provider: aws_sts`.  Replaces the static IRSA env triple with the actual token-file exchange.
- **6d.2**: GCP `iamcredentials.generateAccessToken` provider — `provider: gcp_iam`.  Workload-Identity impersonation.
- **6d.3**: Azure AAD client-credentials provider — `provider: azure_oauth`.  Beyond IMDS (off-cluster deployments).

## Out of scope

- **6e**: Cross-region broker — natural follow-up to a `strict`-blocked resolution.

## Wiki

Server wiki [`deployment-specification`](https://github.com/noetl/server/wiki/deployment-specification) gets a new "Dynamic short-lived secrets (Phase 6d primitives)" subsection under Secret providers + the new env + both metrics (server.wiki@0d545ac).

## Test plan

- [x] `cargo build --lib` — clean.
- [x] `cargo test --lib` — 398 / 0.
- [ ] Kind-val deferred — pure plumbing change with no new wire endpoint; behavior covered by unit tests.  6d.1+ will warrant a kind e2e with an actual short-lived token.

Closes #116
Refs noetl/ai-meta#61

🤖 Generated with [Claude Code](https://claude.com/claude-code)