### PR TITLE
feat(crypto): wallet KEK rotation primitives (Phase 7a)

### DIFF
--- a/src/crypto/envelope.rs
+++ b/src/crypto/envelope.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
@@ -178,6 +178,64 @@ impl EnvelopeCipher {
         let record = EnvelopeRecord::from_storage_str(raw)?;
         self.open_json(&record).await
     }
+
+    /// Secrets Wallet Phase 7a — re-wrap one stored envelope under the
+    /// current KEK version.
+    ///
+    /// Parses `raw` as a stored envelope.  If `wrapped.key_version` already
+    /// equals the [`KeyManager::current_key_version`], returns
+    /// [`RewrapOutcome::Skipped`] (the row is already on the current key).
+    /// Otherwise unwraps the DEK under whichever historical version
+    /// produced it, then re-wraps under the current version, and returns
+    /// the new storage string in [`RewrapOutcome::Rewrapped`].
+    ///
+    /// The plaintext payload is **never reconstructed** — this is a
+    /// pure DEK re-wrap.  AES-GCM ciphertext bytes stay byte-identical;
+    /// only the `dek` field of the stored envelope changes.  Phase 7a's
+    /// rotation job iterates this primitive across the
+    /// `noetl.credential` + `noetl.keychain` tables under a per-batch
+    /// transaction; 7a.2 will land the actual scan + endpoint plumbing.
+    pub async fn rewrap_storage_string(&self, raw: &str) -> AppResult<RewrapOutcome> {
+        let record = EnvelopeRecord::from_storage_str(raw)?;
+        let current = self.km.current_key_version();
+        // Skip the no-op case — the row is already on the active version.
+        // This is the common path during a routine rotation sweep, so
+        // bailing out without touching the KEK matters.
+        if record.wrapped.key_version == current {
+            return Ok(RewrapOutcome::Skipped {
+                key_version: current.to_string(),
+            });
+        }
+        let dek = self.km.unwrap_dek(&record.wrapped).await?;
+        let new_wrapped = self.km.wrap_dek(&dek).await?;
+        let new_record = EnvelopeRecord {
+            ciphertext: record.ciphertext,
+            wrapped: new_wrapped,
+            enc_alg: record.enc_alg,
+            enc_version: record.enc_version,
+        };
+        Ok(RewrapOutcome::Rewrapped {
+            old_key_version: record.wrapped.key_version,
+            new_key_version: current.to_string(),
+            new_storage_string: new_record.to_storage_string(),
+        })
+    }
+}
+
+/// Outcome of a Phase-7a rotation pass over one stored envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RewrapOutcome {
+    /// The record was already wrapped under the current KEK version; no
+    /// KMS call happened.
+    Skipped { key_version: String },
+    /// The record was unwrapped under the old KEK version and re-wrapped
+    /// under the current one.  `new_storage_string` is the value to
+    /// persist back into the `data_encrypted` column.
+    Rewrapped {
+        old_key_version: String,
+        new_key_version: String,
+        new_storage_string: String,
+    },
 }
 
 #[cfg(test)]
@@ -249,5 +307,84 @@ mod tests {
         let c = cipher();
         // A legacy/garbage value is not a wallet envelope → error (forward-only).
         assert!(c.open_storage_json("AAAAlegacy-base64==").await.is_err());
+    }
+
+    // -------- Phase 7a: KEK rotation primitives --------
+
+    #[tokio::test]
+    async fn rewrap_skips_records_already_on_current_version() {
+        let c = cipher();
+        let v = serde_json::json!({"db_password": "p@ss"});
+        let stored = c.seal_json_to_storage(&v).await.unwrap();
+        // Same cipher → same KEK version → skip.
+        match c.rewrap_storage_string(&stored).await.unwrap() {
+            RewrapOutcome::Skipped { key_version } => {
+                assert_eq!(key_version, "v1");
+            }
+            other => panic!("expected Skipped, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rewrap_emits_new_envelope_under_current_version_when_older() {
+        // Build a record under "v1" then move the manager to "v2" — same
+        // master key (LocalDevKms uses one Encryptor for all versions, so
+        // unwrap works across versions in this test); the rewrap primitive
+        // should produce a fresh storage string tagged "v2".
+        let key = Encryptor::generate_key_base64();
+        let km_v1 = LocalDevKms::from_master_key_base64(&key).unwrap();
+        let c_v1 = EnvelopeCipher::new(Arc::new(km_v1));
+        let stored_v1 = c_v1
+            .seal_json_to_storage(&serde_json::json!({"a": 1}))
+            .await
+            .unwrap();
+
+        // Build a "v2" manager via the test-only constructor.  The KEK
+        // bytes are identical (same master_key_base64), so unwrap still
+        // succeeds even though the version label differs — this models
+        // a KMS key-version bump where the previous version is still
+        // available for unwrap.
+        let km_v2 = LocalDevKms::from_master_key_base64_with_version(&key, "v2").unwrap();
+        let c_v2 = EnvelopeCipher::new(Arc::new(km_v2));
+
+        match c_v2.rewrap_storage_string(&stored_v1).await.unwrap() {
+            RewrapOutcome::Rewrapped {
+                old_key_version,
+                new_key_version,
+                new_storage_string,
+            } => {
+                assert_eq!(old_key_version, "v1");
+                assert_eq!(new_key_version, "v2");
+                // The new envelope decrypts to the same plaintext.
+                let opened = c_v2.open_storage_json(&new_storage_string).await.unwrap();
+                assert_eq!(opened, serde_json::json!({"a": 1}));
+                // The new storage string carries the new version tag.
+                assert!(new_storage_string.contains("\"kv\":\"v2\""));
+            }
+            other => panic!("expected Rewrapped, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rewrap_rejects_non_envelope_storage_value() {
+        let c = cipher();
+        // Same forward-only contract as `open_storage_json` — bad input
+        // bubbles up as an Encryption error rather than silently being
+        // treated as up-to-date.
+        let err = c
+            .rewrap_storage_string("not-a-wallet-envelope")
+            .await
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("not a wallet envelope"));
+    }
+
+    #[test]
+    fn local_kms_reports_its_key_version() {
+        let key = Encryptor::generate_key_base64();
+        let km = LocalDevKms::from_master_key_base64(&key).unwrap();
+        // Locked against accidental drift — Phase 7a's rotation primitive
+        // depends on this being the same string the manager tags
+        // `wrap_dek` outputs with.
+        assert_eq!(km.current_key_version(), "v1");
     }
 }

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -47,6 +47,19 @@ pub trait KeyManager: Send + Sync {
 
     /// Provider id stored alongside records (`local`, `gcp-kms`, …).
     fn provider(&self) -> &str;
+
+    /// Secrets Wallet Phase 7a — current KEK version the next `wrap_dek` call
+    /// will tag.  Wallet-level rotation primitives use this to decide whether
+    /// a stored record's `wrapped.key_version` is the same as the active
+    /// version (skip) or older (re-wrap).
+    ///
+    /// Default implementation reports `"unknown"` so the rotation primitive
+    /// treats every record as "different version, rewrap" — safe but
+    /// inefficient.  Real `KeyManager` implementations override this with
+    /// the version they actually use at `wrap_dek` time.
+    fn current_key_version(&self) -> &str {
+        "unknown"
+    }
 }
 
 /// In-process key manager that wraps DEKs with the server's AES-256-GCM master
@@ -71,6 +84,24 @@ impl LocalDevKms {
             kek,
             key_id: "env:NOETL_ENCRYPTION_KEY".to_string(),
             key_version: "v1".to_string(),
+        })
+    }
+
+    /// Build a `LocalDevKms` with an explicit `key_version` label.  Used
+    /// by Phase-7a rotation tests to simulate the "operator bumped the
+    /// version" path; production paths never need this (the version
+    /// comes from `from_master_key_base64`'s `"v1"` default until a
+    /// real KMS reports a different one).
+    #[cfg(test)]
+    pub fn from_master_key_base64_with_version(
+        master_key_base64: &str,
+        key_version: &str,
+    ) -> AppResult<Self> {
+        let kek = Encryptor::from_base64(master_key_base64)?;
+        Ok(Self {
+            kek,
+            key_id: "env:NOETL_ENCRYPTION_KEY".to_string(),
+            key_version: key_version.to_string(),
         })
     }
 }
@@ -100,6 +131,10 @@ impl KeyManager for LocalDevKms {
 
     fn provider(&self) -> &str {
         "local"
+    }
+
+    fn current_key_version(&self) -> &str {
+        &self.key_version
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -550,6 +550,46 @@ pub fn record_cross_region_broker_call_duration(broker_region: &str, seconds: f6
         .observe(seconds);
 }
 
+/// Secrets-Wallet Phase 7a: wallet KEK-rotation pass outcomes.
+///
+/// `table` is `credential` or `keychain` (the two `noetl.*` tables that
+/// hold envelope-encrypted blobs).  `status` is a bounded enum:
+/// - `skipped` — record already wrapped under the current KEK version.
+/// - `rewrapped` — DEK was unwrapped under the old version and re-wrapped
+///   under the current.
+/// - `failed_unwrap` — provider can't produce the old KEK version (key
+///   compromise + delete-all rotation; operator must reseed).
+/// - `failed_wrap` — provider can't issue a fresh wrap (KMS reachability).
+/// - `parse_error` — stored value isn't a valid envelope (forward-only
+///   contract — re-register the record).
+///
+/// `failed_unwrap` is the alert-worthy combination — it means the
+/// rotation can't complete without operator intervention.
+pub fn wallet_rotate_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_wallet_rotate_total",
+                "Wallet KEK-rotation pass outcomes per table (Phase 7a).",
+            ),
+            &["table", "status"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Increment [`wallet_rotate_total`] by 1.
+pub fn record_wallet_rotate(table: &str, status: &str) {
+    wallet_rotate_total()
+        .with_label_values(&[table, status])
+        .inc();
+}
+
 /// Render the global registry as Prometheus text-exposition
 /// format.  Used by the `GET /metrics` handler.
 pub fn gather_text() -> Result<String, prometheus::Error> {


### PR DESCRIPTION
## Summary

Starts **Phase 7** of the Secrets Wallet ([noetl/ai-meta#61](https://github.com/noetl/ai-meta/issues/61)) — rotation, audit, and auto-renewal.  Phase 6 closed with full residency coverage; Phase 7 hardens the wallet for the operational lifecycle.

Phase 7a ships the **rotation primitives** (same scope shape as 6d): per-record KEK version tracking is already in the Phase-1 storage format via `WrappedDek.key_version`; this round adds the `KeyManager` accessor + the in-process re-wrap primitive that the rotation job will iterate.  The actual rotation endpoint + table scans land as 7a.2.

## What lands

- **`KeyManager::current_key_version() -> &str`** — what the next `wrap_dek` call will tag.  Safe default `"unknown"` (the rotation primitive treats every record as "different version, rewrap" — inefficient but correct).  `LocalDevKms` reports its own version string (defaults `"v1"`).
- **`LocalDevKms::from_master_key_base64_with_version`** — `#[cfg(test)]` constructor accepting an explicit version label.  Lets the rotation tests simulate "operator bumped the version" without re-keying.
- **`EnvelopeCipher::rewrap_storage_string(raw: &str) -> AppResult<RewrapOutcome>`**:
  - Parses `raw` as a stored envelope.
  - If `wrapped.key_version == current_key_version()` → `RewrapOutcome::Skipped { key_version }` — no KMS call.
  - Else: unwraps DEK under historical KEK version → re-wraps under current → `RewrapOutcome::Rewrapped { old_key_version, new_key_version, new_storage_string }`.
  - **Plaintext payload is never reconstructed.**  Pure DEK re-wrap — AES-GCM ciphertext bytes stay byte-identical; only the `dek` field of the stored envelope changes.
- **`noetl_wallet_rotate_total{table, status}`** counter per `agents/rules/observability.md` Principle 1.  `table ∈ {credential, keychain}`; `status ∈ {skipped, rewrapped, failed_unwrap, failed_wrap, parse_error}`.  `failed_unwrap` is the alert-worthy combination — it means the rotation can't complete without operator intervention (KMS deleted the historical key version).

## Why scoped to primitives

Phase 7a.2 will ship:
- `POST /api/internal/wallet/rotate-kek` — async batched re-encrypt job (default 100 rows/iter, per-batch commit).
- `GET /api/internal/wallet/key-status` — per-version row counts for both tables.
- DB scan iterators over `noetl.credential` + `noetl.keychain`.
- Kind-validation with a real DB.

Splitting this out keeps each PR bounded, the primitives reviewable in isolation, and 7a.2 focused purely on the endpoint + DB plumbing.

## Tests

Four new in `crypto::envelope::tests`:
- `rewrap_skips_records_already_on_current_version` — same cipher, no KMS call.
- `rewrap_emits_new_envelope_under_current_version_when_older` — rewrap under v2 manager produces a v2-tagged storage string that decrypts to the original plaintext.
- `rewrap_rejects_non_envelope_storage_value` — forward-only contract preserved.
- `local_kms_reports_its_key_version` — drift guard against the manager's version string changing accidentally.

Lib **414 / 0** passing.

## Backward compatibility

- Existing `KeyManager` implementations get the default `"unknown"` accessor — rotation primitive is safe but inefficient until each provider overrides.
- The public `EnvelopeRecord` shape is unchanged.
- No schema migration.  No DB scans yet.

## Out of scope (later rounds)

- **7a.2**: Rotation endpoint + DB scans + diagnostic `key-status` endpoint.
- **7b**: `secret_audit` append-only table.
- **7c**: Token auto-renewal (Phase-3c cache refreshes OAuth2/JWT before `expires_at`).

## Wiki

Server wiki [`deployment-specification`](https://github.com/noetl/server/wiki/deployment-specification) gets a new "Wallet KEK rotation primitives (Phase 7a)" subsection under Secret providers + the planned 7a.2 operator workflow (server.wiki@36f3cfa).

## Test plan

- [x] `cargo build --lib` — clean.
- [x] `cargo test --lib` — 414 / 0.
- [ ] Kind-val deferred — primitives-only round; 7a.2 will warrant a kind e2e of a full rotation pass.

Closes #120
Refs noetl/ai-meta#61

🤖 Generated with [Claude Code](https://claude.com/claude-code)