### PR TITLE
feat(secrets): token auto-renewal primitives — final named round of Phase 7 (Phase 7c)

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -629,6 +629,72 @@ pub fn record_secret_audit_write(operation: &str, outcome: &str, status: &str) {
         .inc();
 }
 
+/// Secrets-Wallet Phase 7c: token auto-renewal outcomes.
+///
+/// `outcome` is a bounded enum:
+/// - `triggered` — refresh decision made (will spawn or collapse).
+/// - `succeeded` — refresh ran and the new value landed in the cache.
+/// - `failed` — refresh ran but the provider errored.  The cached
+///   row is **preserved** (we don't poison the cache on a transient
+///   outage; the next natural cache miss after `expires_at` re-resolves).
+/// - `stampede_collapsed` — concurrent request found a refresh already
+///   in flight; piggy-backed on it.
+///
+/// `failed` at sustained rate is alert-worthy — it means a provider
+/// is unreachable AND a cached token is about to expire.
+pub fn secret_refresh_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_secret_refresh_total",
+                "Token auto-renewal outcomes (Phase 7c).  Aliases are NOT \
+                 labeled (cardinality); per-alias detail lives on the \
+                 secret.refresh tracing span.",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Increment [`secret_refresh_total`] by 1.
+pub fn record_secret_refresh(outcome: &str) {
+    secret_refresh_total().with_label_values(&[outcome]).inc();
+}
+
+/// Secrets-Wallet Phase 7c: histogram of token auto-renewal wall-clock
+/// latency.  Buckets `[0.05, 0.1, 0.25, 0.5, 1, 2, 5]` — span the range
+/// where auth round-trips actually live.  Observed regardless of
+/// outcome so a dashboard surfaces "refresh is slow" + "refresh is
+/// failing" independently.
+pub fn secret_refresh_duration_seconds() -> &'static prometheus::Histogram {
+    static M: OnceLock<prometheus::Histogram> = OnceLock::new();
+    M.get_or_init(|| {
+        let h = prometheus::Histogram::with_opts(
+            HistogramOpts::new(
+                "noetl_secret_refresh_duration_seconds",
+                "Wall-clock seconds spent in one token auto-renewal (Phase 7c).",
+            )
+            .buckets(vec![0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0]),
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(h.clone()))
+            .expect("histogram registration must succeed");
+        h
+    })
+}
+
+/// Observe one refresh duration.
+pub fn record_secret_refresh_duration(seconds: f64) {
+    secret_refresh_duration_seconds().observe(seconds);
+}
+
 /// Render the global registry as Prometheus text-exposition
 /// format.  Used by the `GET /metrics` handler.
 pub fn gather_text() -> Result<String, prometheus::Error> {

--- a/src/secrets/dynamic.rs
+++ b/src/secrets/dynamic.rs
@@ -29,6 +29,13 @@ use chrono::{DateTime, Utc};
 /// and the next worker fetch.
 const DEFAULT_SAFETY_MARGIN_SECS: u64 = 60;
 
+/// Default refresh window (seconds) when the env override is unset.
+/// Secrets Wallet Phase 7c: a cached short-lived token gets a
+/// background refresh once its remaining lifetime drops below this
+/// threshold.  60 s covers a typical OAuth2 refresh round-trip (~200ms)
+/// plus headroom.
+const DEFAULT_REFRESH_WINDOW_SECS: u64 = 60;
+
 /// Floor for the effective TTL — never cache for less than this even
 /// when `expires_at - now - safety_margin` would compute to something
 /// smaller.  Below this floor we'd be paying the cache cost (round-trip
@@ -48,6 +55,21 @@ pub fn safety_margin_secs() -> u64 {
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(DEFAULT_SAFETY_MARGIN_SECS)
+    })
+}
+
+/// Secrets Wallet Phase 7c: how long before `expires_at` to mark a
+/// cached row "renewable."  Read once at startup from
+/// `KEYCHAIN_CACHE_REFRESH_WINDOW_SECS` (defaults to
+/// [`DEFAULT_REFRESH_WINDOW_SECS`]).
+pub fn refresh_window_secs() -> u64 {
+    use std::sync::OnceLock;
+    static M: OnceLock<u64> = OnceLock::new();
+    *M.get_or_init(|| {
+        std::env::var("KEYCHAIN_CACHE_REFRESH_WINDOW_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_REFRESH_WINDOW_SECS)
     })
 }
 
@@ -107,6 +129,53 @@ pub fn effective_cache_ttl(
         expires_at,
         default_ttl,
         Duration::from_secs(safety_margin_secs()),
+        now,
+    )
+}
+
+/// Secrets Wallet Phase 7c — should the cached row be refreshed *now*
+/// in the background?
+///
+/// Returns `true` iff:
+/// - `expires_at` is set (long-lived secrets without an issuer expiry
+///   stay on the periodic-eviction path and never get a refresh
+///   triggered);
+/// - the token is STILL VALID (`expires_at > now`) — we don't trigger
+///   a refresh for something already dead; that's
+///   [`CacheDecision::SkipCacheAlreadyExpired`]'s job at the next
+///   resolve;
+/// - the remaining lifetime is within the refresh window
+///   (`now + refresh_window >= expires_at`).
+///
+/// The caller (resolver / cache layer) treats `true` as "return the
+/// still-valid cached value AND spawn a background refresh."
+/// Stampede collapse + the actual refresh path live in
+/// `services::credential`; this is the pure decision primitive.
+pub fn should_refresh(
+    expires_at: Option<DateTime<Utc>>,
+    refresh_window: Duration,
+    now: DateTime<Utc>,
+) -> bool {
+    let Some(expires_at) = expires_at else {
+        return false;
+    };
+    if expires_at <= now {
+        // Already past the deadline — eviction path, not refresh path.
+        return false;
+    }
+    let window = chrono::Duration::from_std(refresh_window)
+        .unwrap_or_else(|_| chrono::Duration::seconds(0));
+    expires_at - window <= now
+}
+
+/// Convenience entry point that reads the refresh window from env.
+pub fn should_refresh_default(
+    expires_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> bool {
+    should_refresh(
+        expires_at,
+        Duration::from_secs(refresh_window_secs()),
         now,
     )
 }
@@ -226,5 +295,66 @@ mod tests {
             now,
         );
         assert_eq!(d, CacheDecision::SkipCacheAlreadyExpired);
+    }
+
+    // -------- Phase 7c: refresh-before-expiry --------
+
+    #[test]
+    fn should_refresh_returns_false_when_no_expires_at() {
+        // Long-lived secrets without an issuer expiry stay on the
+        // periodic-eviction path; never trigger a refresh.
+        assert!(!should_refresh(None, Duration::from_secs(60), at(1000)));
+    }
+
+    #[test]
+    fn should_refresh_returns_false_when_already_expired() {
+        // expires_at past now — defensive.  Already-expired tokens go
+        // through the cache eviction path (SkipCacheAlreadyExpired),
+        // not the refresh path.
+        let now = at(1000);
+        let expires_at = at(990); // 10 s past
+        assert!(!should_refresh(
+            Some(expires_at),
+            Duration::from_secs(60),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_refresh_returns_false_when_outside_window() {
+        // expires_at far in the future — no refresh needed.
+        let now = at(1000);
+        let expires_at = at(2000); // 1000 s away
+        assert!(!should_refresh(
+            Some(expires_at),
+            Duration::from_secs(60),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_refresh_returns_true_inside_window() {
+        // expires_at = now + 30 s; window = 60 s → inside the window,
+        // still valid → refresh.
+        let now = at(1000);
+        let expires_at = at(1030);
+        assert!(should_refresh(
+            Some(expires_at),
+            Duration::from_secs(60),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_refresh_at_exact_window_boundary() {
+        // Boundary case: expires_at = now + window.  The condition
+        // `expires_at - window <= now` is `now <= now` → true.  Refresh.
+        let now = at(1000);
+        let expires_at = at(1060);
+        assert!(should_refresh(
+            Some(expires_at),
+            Duration::from_secs(60),
+            now
+        ));
     }
 }


### PR DESCRIPTION
## Summary

**Final named round of Phase 7** of the Secrets Wallet ([noetl/ai-meta#61](https://github.com/noetl/ai-meta/issues/61)).  7a + 7b shipped the rotation + audit primitives.  7c hardens the cache against the dominant short-lived-credential failure mode.

OAuth2 / JWT access tokens (Auth0, Okta, Duffel) with `expires_in` are the most common short-lived-credential shape in production.  Phase 6d added `SecretValue.expires_at` + cache-TTL plumbing so the Phase-3c cache doesn't store something already dead.  But the current cache is **reactive**: when `expires_at` is past, the row is evicted; on the next worker fetch, the resolver re-runs the auth playbook (slow path — 200ms – 2s of round-trips).

7c adds **proactive refresh-before-expiry** so the cache renews when the remaining lifetime drops below a configurable threshold.  Worker fetches stay on the cached-fresh-token fast path; the auth playbook runs at most once per natural token lifetime instead of once per worker burst.

## What lands

- **`secrets::dynamic::should_refresh(expires_at, refresh_window, now) -> bool`** decision primitive:
  - Returns `false` when `expires_at` is `None` (long-lived secret; eviction-only path).
  - Returns `false` when `expires_at <= now` (already past; eviction, not refresh).
  - Returns `true` when `expires_at - refresh_window <= now` (inside the window, still valid).
  - Pure function; no side effects.
- **`secrets::dynamic::should_refresh_default(expires_at, now)`** — convenience wrapper reading the window from env.
- **`KEYCHAIN_CACHE_REFRESH_WINDOW_SECS`** env (default 60 s).
- **`noetl_secret_refresh_total{outcome}`** counter per `agents/rules/observability.md` Principle 1.  `outcome ∈ {triggered, succeeded, failed, stampede_collapsed}`.  `failed` at sustained rate is alert-worthy.  Aliases are NOT a label — cardinality lives on the `secret.refresh` tracing span per Principle 4.
- **`noetl_secret_refresh_duration_seconds`** histogram (buckets `[0.05, 0.1, 0.25, 0.5, 1, 2, 5]` — auth round-trips dominate).  Observed regardless of outcome so a dashboard shows "refresh is slow" + "refresh is failing" independently.

## Why before-not-after

A reactive cache pays the full auth round-trip on the first request AFTER expiry.  Under a steady stream of worker requests for one alias, that's one slow request per natural token lifetime — typically 1/hour for OAuth2.  Not catastrophic, but visible in tail latency.

The proactive shape moves the round-trip OFF the request path entirely: the refresh happens in a background task triggered by an earlier request whose token is still valid.  The worker that triggered the refresh returns the fresh-enough cached value immediately; subsequent workers hit the freshly-refreshed value.  Tail latency stays flat across rotations.

## Tests

Five new in `secrets::dynamic::tests`:
- `should_refresh_returns_false_when_no_expires_at` — long-lived secrets stay on the eviction path.
- `should_refresh_returns_false_when_already_expired` — defensive; already-expired tokens are eviction, not refresh.
- `should_refresh_returns_false_when_outside_window` — plenty of life left.
- `should_refresh_returns_true_inside_window` — token has < refresh_window remaining.
- `should_refresh_at_exact_window_boundary` — `expires_at = now + window` triggers refresh.

Lib **427 / 0** passing.

## Phase 7c.2 follow-up (separate sub-issue)

- `KeychainService::should_refresh(row, now)` method on the cache layer.
- Resolver: on cache hit + should_refresh → spawn background refresh; return cached value immediately.
- Stampede protection: per-`(catalog_id, alias)` `tokio::sync::Mutex` so concurrent refresh attempts collapse to one provider call.
- Refresh path records its own Phase-7b `AuditEvent` (the refresh produced a fresh credential just like a normal resolution).
- Kind-val with a real short-lived token (Auth0 client_credentials, etc.).

## After Phase 7c

The named-round queue for the Secrets Wallet umbrella closes.  Remaining work all lives in discrete follow-up sub-issues:

- **6d.1 / 6d.2 / 6d.3** — AWS STS / GCP iamcredentials / Azure AAD dynamic-secret providers.
- **7a.2** — Wallet KEK rotation endpoint + DB scans + diagnostic `key-status` endpoint.
- **7b.2** — `noetl.secret_audit` table + `DbAuditSink` + `GET /api/internal/secret-audit` query endpoint + wire-up to the four credential surfaces.
- **7c.2** — Cache + resolver wire-up + stampede mutex + handler integration.

## Wiki

Server wiki [`deployment-specification`](https://github.com/noetl/server/wiki/deployment-specification) gets a new "Token auto-renewal (Phase 7c primitives)" subsection under Secret providers + the new env + both metrics (server.wiki@0ad86de).

## Test plan

- [x] `cargo build --lib` — clean.
- [x] `cargo test --lib` — 427 / 0.
- [ ] Kind-val deferred — primitives-only round; 7c.2 will warrant a kind e2e with a real OAuth2 client_credentials flow.

Closes #124
Refs noetl/ai-meta#61

🤖 Generated with [Claude Code](https://claude.com/claude-code)