### PR TITLE
feat(audit): noetl.secret_audit table + DbAuditSink + query endpoint (Phase 7b.2)

### DIFF
--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -6,3 +6,4 @@ pub mod catalog;
 pub mod credential;
 pub mod event;
 pub mod keychain;
+pub mod secret_audit;

--- a/src/db/queries/secret_audit.rs
+++ b/src/db/queries/secret_audit.rs
@@ -1,0 +1,156 @@
+//! `noetl.secret_audit` queries (Secrets Wallet Phase 7b.2,
+//! [`noetl/ai-meta#61`](https://github.com/noetl/ai-meta/issues/61)).
+//!
+//! The table is created idempotently at server startup via
+//! [`ensure_table`].  Insert is one row per credential resolution
+//! outcome; query is bounded by `credential` / `from` / `to` /
+//! `execution_id` filters with a hard `LIMIT` cap so an operator can't
+//! accidentally pull millions of rows.
+
+use chrono::{DateTime, Utc};
+use sqlx::Row;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::services::secret_audit::AuditEvent;
+
+/// Hard cap on rows returned by the audit query endpoint — even if the
+/// caller asks for more, only this many come back.  Operators pulling
+/// for compliance reports paginate by adjusting `to` / `from`.
+pub const QUERY_HARD_CAP: i64 = 10_000;
+
+/// Idempotent table creation.  Runs once at startup so the schema
+/// lands on first boot without operators needing to run a migration
+/// out of band.  The table is `noetl/server`-owned end-to-end (no
+/// other component writes to it) so a CREATE-on-startup is the right
+/// shape.
+pub async fn ensure_table(pool: &DbPool) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS noetl.secret_audit (
+            audit_id            BIGINT PRIMARY KEY,
+            occurred_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+            credential          TEXT NOT NULL,
+            operation           TEXT NOT NULL,
+            outcome             TEXT NOT NULL,
+            worker_id           TEXT,
+            execution_id        BIGINT,
+            parent_execution_id BIGINT,
+            server_region       TEXT,
+            broker_region       TEXT,
+            kek_version         TEXT,
+            notes               TEXT
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    // Two indexes that the compliance-query shape needs.  Idempotent
+    // (CREATE INDEX IF NOT EXISTS); cheap on an empty / lightly-used
+    // table.
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS secret_audit_credential_time
+        ON noetl.secret_audit (credential, occurred_at DESC)
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS secret_audit_execution
+        ON noetl.secret_audit (execution_id)
+        WHERE execution_id IS NOT NULL
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Insert one audit row.  Caller is the DB-backed `AuditSink`; this
+/// function never logs the secret value (the `AuditEvent` itself never
+/// carries one).
+pub async fn insert(pool: &DbPool, event: &AuditEvent) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.secret_audit (
+            audit_id, occurred_at, credential, operation, outcome,
+            worker_id, execution_id, parent_execution_id,
+            server_region, broker_region, kek_version, notes
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        ON CONFLICT (audit_id) DO NOTHING
+        "#,
+    )
+    .bind(event.audit_id)
+    .bind(event.occurred_at)
+    .bind(&event.credential)
+    .bind(&event.operation)
+    .bind(&event.outcome)
+    .bind(event.worker_id.as_deref())
+    .bind(event.execution_id)
+    .bind(event.parent_execution_id)
+    .bind(event.server_region.as_deref())
+    .bind(event.broker_region.as_deref())
+    .bind(event.kek_version.as_deref())
+    .bind(event.notes.as_deref())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Filter shape for the query endpoint.
+#[derive(Debug, Clone, Default)]
+pub struct AuditQuery {
+    pub credential: Option<String>,
+    pub execution_id: Option<i64>,
+    pub from: Option<DateTime<Utc>>,
+    pub to: Option<DateTime<Utc>>,
+    pub limit: Option<i64>,
+}
+
+/// Run the bounded query.  `limit` is capped at [`QUERY_HARD_CAP`].
+/// Results are ordered by `occurred_at DESC` (newest first).
+pub async fn query(pool: &DbPool, q: AuditQuery) -> AppResult<Vec<AuditEvent>> {
+    let limit = q.limit.unwrap_or(100).clamp(1, QUERY_HARD_CAP);
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            audit_id, occurred_at, credential, operation, outcome,
+            worker_id, execution_id, parent_execution_id,
+            server_region, broker_region, kek_version, notes
+        FROM noetl.secret_audit
+        WHERE ($1::text       IS NULL OR credential = $1)
+          AND ($2::bigint     IS NULL OR execution_id = $2)
+          AND ($3::timestamptz IS NULL OR occurred_at >= $3)
+          AND ($4::timestamptz IS NULL OR occurred_at < $4)
+        ORDER BY occurred_at DESC
+        LIMIT $5
+        "#,
+    )
+    .bind(q.credential)
+    .bind(q.execution_id)
+    .bind(q.from)
+    .bind(q.to)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| AuditEvent {
+            audit_id: r.get::<i64, _>("audit_id"),
+            occurred_at: r.get::<DateTime<Utc>, _>("occurred_at"),
+            credential: r.get::<String, _>("credential"),
+            operation: r.get::<String, _>("operation"),
+            outcome: r.get::<String, _>("outcome"),
+            worker_id: r.get::<Option<String>, _>("worker_id"),
+            execution_id: r.get::<Option<i64>, _>("execution_id"),
+            parent_execution_id: r.get::<Option<i64>, _>("parent_execution_id"),
+            server_region: r.get::<Option<String>, _>("server_region"),
+            broker_region: r.get::<Option<String>, _>("broker_region"),
+            kek_version: r.get::<Option<String>, _>("kek_version"),
+            notes: r.get::<Option<String>, _>("notes"),
+        })
+        .collect())
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod health;
 pub mod internal;
 pub mod keychain;
 pub mod runtime;
+pub mod secret_audit;
 pub mod sharding;
 pub mod system;
 pub mod variables;

--- a/src/handlers/secret_audit.rs
+++ b/src/handlers/secret_audit.rs
@@ -1,0 +1,97 @@
+//! Secret-audit query endpoint (Secrets Wallet Phase 7b.2,
+//! [`noetl/ai-meta#61`](https://github.com/noetl/ai-meta/issues/61)).
+//!
+//! `GET /api/internal/secret-audit?credential=...&execution_id=...&from=...&to=...&limit=...`.
+//! Internal-only — same `/api/internal/*` gating as the other
+//! peer-only endpoints.  Returns up to
+//! [`crate::db::queries::secret_audit::QUERY_HARD_CAP`] rows
+//! regardless of what the caller asks for, ordered newest-first.
+
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::db::queries::secret_audit::{self as queries, AuditQuery};
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::services::secret_audit::AuditEvent;
+
+/// State for the audit-query endpoint — pool only; the query layer is
+/// stateless.
+#[derive(Clone)]
+pub struct SecretAuditDeps {
+    pub pool: DbPool,
+}
+
+/// Querystring shape.  All fields optional; the query SQL applies the
+/// supplied filters.
+#[derive(Debug, Deserialize, Default)]
+pub struct AuditQueryParams {
+    pub credential: Option<String>,
+    pub execution_id: Option<i64>,
+    pub from: Option<DateTime<Utc>>,
+    pub to: Option<DateTime<Utc>>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuditQueryResponse {
+    pub rows: Vec<AuditEvent>,
+}
+
+/// `GET /api/internal/secret-audit`.
+pub async fn query(
+    State(deps): State<SecretAuditDeps>,
+    Query(params): Query<AuditQueryParams>,
+) -> AppResult<Json<AuditQueryResponse>> {
+    let span = tracing::info_span!(
+        "secret_audit.query",
+        credential = params.credential.as_deref(),
+        execution_id = params.execution_id,
+        limit = params.limit,
+    );
+    let _g = span.enter();
+    let rows = queries::query(
+        &deps.pool,
+        AuditQuery {
+            credential: params.credential,
+            execution_id: params.execution_id,
+            from: params.from,
+            to: params.to,
+            limit: params.limit,
+        },
+    )
+    .await?;
+    Ok(Json(AuditQueryResponse { rows }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_params_round_trip_via_json() {
+        // Lock against drift in the public field names — `axum`'s
+        // querystring decoder uses the same serde derive surface.
+        let v: AuditQueryParams = serde_json::from_str(
+            r#"{"credential":"duffel_token","execution_id":42,"limit":50}"#,
+        )
+        .unwrap();
+        assert_eq!(v.credential.as_deref(), Some("duffel_token"));
+        assert_eq!(v.execution_id, Some(42));
+        assert_eq!(v.limit, Some(50));
+    }
+
+    #[test]
+    fn empty_object_decodes_to_all_none() {
+        let v: AuditQueryParams = serde_json::from_str("{}").unwrap();
+        assert!(v.credential.is_none());
+        assert!(v.execution_id.is_none());
+        assert!(v.from.is_none());
+        assert!(v.to.is_none());
+        assert!(v.limit.is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,19 @@ fn build_router(
             credentials: credential_service,
         });
 
+    // Secret-audit query endpoint (Secrets Wallet Phase 7b.2,
+    // noetl/ai-meta#61).  GET /api/internal/secret-audit returns
+    // bounded rows from `noetl.secret_audit` (table created at
+    // startup via `db::queries::secret_audit::ensure_table`).
+    let secret_audit_routes = Router::new()
+        .route(
+            "/api/internal/secret-audit",
+            get(handlers::secret_audit::query),
+        )
+        .with_state(handlers::secret_audit::SecretAuditDeps {
+            pool: db_pool.clone(),
+        });
+
     // Keychain routes
     let keychain_routes = Router::new()
         .route(
@@ -319,6 +332,7 @@ fn build_router(
         .merge(credential_routes)
         .merge(sealed_credential_routes)
         .merge(cross_region_routes)
+        .merge(secret_audit_routes)
         .merge(keychain_routes)
         .merge(execution_routes)
         .merge(executions_routes)
@@ -537,6 +551,12 @@ async fn main() -> anyhow::Result<()> {
     // the credential and keychain services.
     let catalog_service = CatalogService::new(db_pool.clone());
     let wallet_cipher = noetl_server::crypto::build_envelope_cipher(&encryption_key)?;
+
+    // Secrets Wallet Phase 7b.2 — `noetl.secret_audit` table is owned
+    // entirely by noetl/server (no other component writes to it), so a
+    // CREATE TABLE IF NOT EXISTS at startup is the right shape — no
+    // out-of-band migration step required for first-boot deployments.
+    noetl_server::db::queries::secret_audit::ensure_table(&db_pool).await?;
     // Keychain is the execution-scoped cache for credential resolution
     // (Secrets Wallet Phase 3c), so it is built first + shared into the
     // credential service.

--- a/src/services/secret_audit.rs
+++ b/src/services/secret_audit.rs
@@ -171,6 +171,31 @@ impl AuditSink for NoopAuditSink {
     }
 }
 
+/// Production sink — writes one row to `noetl.secret_audit` per event.
+/// Phase 7b.2 ships this alongside the table-creation helper
+/// (`db::queries::secret_audit::ensure_table`) that `main.rs` invokes
+/// at startup.
+#[derive(Debug, Clone)]
+pub struct DbAuditSink {
+    pool: crate::db::DbPool,
+}
+
+impl DbAuditSink {
+    pub fn new(pool: crate::db::DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl AuditSink for DbAuditSink {
+    async fn write(&self, event: &AuditEvent) -> AppResult<()> {
+        crate::db::queries::secret_audit::insert(&self.pool, event).await
+    }
+    fn sink_id(&self) -> &str {
+        "db"
+    }
+}
+
 /// Service wrapper a handler uses to record events.  Decouples the
 /// "build an event" code path from the "write to DB or drop" path so
 /// the handler integration is one line.


### PR DESCRIPTION
Wires Phase 7b's AuditEvent + AuditSink primitives into a durable backing store + a bounded query endpoint.  Table is server-owned, so a CREATE TABLE IF NOT EXISTS at startup handles first-boot without an out-of-band migration step.  Indexes: (credential, occurred_at DESC) for the canonical query shape, (execution_id) WHERE NOT NULL for execution-scoped pulls.  Hard cap of 10k rows on the query response.

Closes #128.  Refs noetl/ai-meta#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)