### PR TITLE
feat(keychain): should_refresh primitive (Phase 7c.2)

### DIFF
--- a/src/services/keychain.rs
+++ b/src/services/keychain.rs
@@ -85,6 +85,45 @@ impl KeychainService {
         })
     }
 
+    /// Secrets Wallet Phase 7c.2 — should the cached row for
+    /// `(catalog_id, keychain_name, execution_id, scope_type)` be
+    /// refreshed in the background right now?
+    ///
+    /// Reads the row's `expires_at`, hands it to
+    /// [`crate::secrets::dynamic::should_refresh_default`] (which
+    /// honours `KEYCHAIN_CACHE_REFRESH_WINDOW_SECS`), and returns the
+    /// pure-function answer.
+    ///
+    /// Returns `false` when the row doesn't exist, the row has no
+    /// issuer-reported `expires_at`, the row is already expired
+    /// (eviction path), or the row's remaining lifetime is outside the
+    /// refresh window.  Returns `true` only when the cached row is
+    /// still valid AND inside the window.
+    ///
+    /// Bumps `noetl_secret_refresh_total{outcome="triggered"}` when
+    /// returning `true`.  The actual background spawn + per-(catalog_id,
+    /// alias) `tokio::sync::Mutex` stampede collapse + provider re-
+    /// resolution lives in Phase 7c.3.
+    pub async fn should_refresh(
+        &self,
+        catalog_id: i64,
+        keychain_name: &str,
+        execution_id: Option<i64>,
+        scope_type: &str,
+        now: chrono::DateTime<Utc>,
+    ) -> AppResult<bool> {
+        let cache_key =
+            queries::build_cache_key(keychain_name, catalog_id, scope_type, execution_id);
+        let Some(entry) = queries::get_keychain_by_cache_key(&self.pool, &cache_key).await? else {
+            return Ok(false);
+        };
+        let triggered = crate::secrets::dynamic::should_refresh_default(entry.expires_at, now);
+        if triggered {
+            crate::metrics::record_secret_refresh("triggered");
+        }
+        Ok(triggered)
+    }
+
     /// Set a keychain entry.
     pub async fn set(
         &self,


### PR DESCRIPTION
Phase 7c (server#125) shipped the pure decision primitive secrets::dynamic::should_refresh.  This round adds the cache-layer-side primitive KeychainService::should_refresh that reads the row's expires_at, asks the Phase 7c primitive whether it's inside the refresh window, and bumps noetl_secret_refresh_total{outcome="triggered"} on a true return.

The actual resolver-side wire-up (spawning the background refresh task, per-(catalog_id, alias) tokio::sync::Mutex stampede collapse, calling provider re-resolution + KeychainService::set) lands in 7c.3 — that integration site needs careful interaction with the existing CredentialService::resolve_via_provider call chain.

Closes #130.  Refs noetl/ai-meta#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)