### PR TITLE
feat(keychain): background refresh + stampede collapse (Phase 7c.3)

### DIFF
--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -22,6 +22,7 @@ use crate::error::{AppError, AppResult};
 use crate::playbook::types::Playbook;
 use crate::secrets::{build_secret_provider, dynamic, resolve_keychain_entry_with_meta};
 use crate::services::keychain::KeychainService;
+use crate::services::keychain_refresh::RefreshInflight;
 
 /// TTL (seconds) for a keychain-resolved secret cached after a provider fetch.
 /// Execution-scoped, so it's also cleaned up when the execution ends; the TTL
@@ -38,6 +39,11 @@ pub struct CredentialService {
     pool: DbPool,
     cipher: EnvelopeCipher,
     keychain: KeychainService,
+    /// Per-`(catalog_id, alias)` stampede collapse for the Phase 7c.3
+    /// background refresh path.  `Clone` shares the inner `Arc` so every
+    /// `CredentialService` instance derived from the same root sees the
+    /// same inflight set.
+    refresh_inflight: RefreshInflight,
 }
 
 impl CredentialService {
@@ -52,6 +58,7 @@ impl CredentialService {
             pool,
             cipher,
             keychain,
+            refresh_inflight: RefreshInflight::new(),
         }
     }
 
@@ -189,6 +196,22 @@ impl CredentialService {
             Ok(c) if c.status == "found" => {
                 if let Some(data) = c.data {
                     tracing::debug!(execution_id, alias, "keychain.cache_hit");
+                    // Phase 7c.3 — proactive refresh-before-expiry.  If the
+                    // cached row is still valid but inside the refresh
+                    // window, spawn a background task to re-resolve via the
+                    // provider and update the cache.  The cached value
+                    // returns to this caller IMMEDIATELY — worker fetches
+                    // stay on the fast path.  Stampedes (multiple workers
+                    // crossing the refresh threshold simultaneously)
+                    // collapse to one provider call: the inflight tracker
+                    // is shared across all `CredentialService` clones.
+                    self.maybe_spawn_refresh(
+                        catalog_id,
+                        alias.to_string(),
+                        execution_id,
+                        workload.clone(),
+                    )
+                    .await;
                     return Ok(Some(data));
                 }
             }
@@ -198,6 +221,29 @@ impl CredentialService {
             }
         }
 
+        // Cache miss — resolve via the provider chain.
+        self.resolve_via_provider(catalog_id, alias, execution_id, workload)
+            .await
+    }
+
+    /// Resolve `alias` via the provider chain and write the result into the
+    /// keychain cache.  Returns `Ok(Some(data))` on a successful provider
+    /// fetch, `Ok(None)` when `alias` is not a `provider:`-backed entry
+    /// (caller treats as not-found), and `Err(_)` when the entry exists but
+    /// the provider call failed.
+    ///
+    /// Shared by:
+    ///
+    /// - The cache-miss inline path in [`Self::try_resolve_keychain`].
+    /// - The Phase-7c.3 background refresh task spawned from
+    ///   [`Self::maybe_spawn_refresh`].
+    async fn resolve_via_provider(
+        &self,
+        catalog_id: i64,
+        alias: &str,
+        execution_id: i64,
+        workload: Option<serde_json::Value>,
+    ) -> AppResult<Option<serde_json::Value>> {
         // catalog_id → playbook YAML → parse.
         let Some(entry) = catalog_queries::get_catalog_by_id(&self.pool, catalog_id).await? else {
             return Ok(None);
@@ -278,6 +324,103 @@ impl CredentialService {
         }
 
         Ok(Some(data))
+    }
+
+    /// Phase 7c.3 — background-refresh trigger.  Called from the cache-hit
+    /// branch after a fresh-but-aging row is returned to the caller.
+    ///
+    /// 1. Ask the cache-side primitive whether the row needs refreshing.
+    ///    A `false` (or any error reading the row) short-circuits silently
+    ///    — the cached value already went out, no further work to do.
+    /// 2. Try to claim the per-`(catalog_id, alias)` inflight slot.
+    ///    - **Claim won.**  Spawn a `tokio::spawn` task that calls
+    ///      [`Self::resolve_via_provider`] using cloned state, records the
+    ///      outcome on `noetl_secret_refresh_total`, then releases the
+    ///      slot — even on the error path.
+    ///    - **Claim lost.**  A concurrent refresh for the same key is in
+    ///      flight; bump `outcome="stampede_collapsed"` and return.  The
+    ///      next worker to find the cache row inside the refresh window
+    ///      after the in-flight refresh completes will re-evaluate.
+    ///
+    /// This method NEVER blocks the caller on the provider call.  The
+    /// `should_refresh` lookup IS awaited (a single indexed cache read),
+    /// but the heavy work — provider fetch + cache write — runs on the
+    /// background task.
+    async fn maybe_spawn_refresh(
+        &self,
+        catalog_id: i64,
+        alias: String,
+        execution_id: i64,
+        workload: Option<serde_json::Value>,
+    ) {
+        let needs_refresh = match self
+            .keychain
+            .should_refresh(
+                catalog_id,
+                &alias,
+                Some(execution_id),
+                KEYCHAIN_CACHE_SCOPE,
+                Utc::now(),
+            )
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                // Don't fail the credential lookup on a refresh-decision
+                // read error — log + skip; the cached value already
+                // returned to the caller.
+                tracing::warn!(
+                    execution_id,
+                    alias = %alias,
+                    error = %e,
+                    "keychain.refresh_decision_failed; skipping background refresh"
+                );
+                return;
+            }
+        };
+        if !needs_refresh {
+            return;
+        }
+
+        let key = (catalog_id, alias.clone());
+        if !self.refresh_inflight.try_claim(key.clone()).await {
+            // Stampede collapse — another refresh for the same key is in
+            // flight; piggy-back via the metric and return.
+            tracing::debug!(
+                execution_id,
+                alias = %alias,
+                catalog_id,
+                "keychain.refresh_stampede_collapsed"
+            );
+            crate::metrics::record_secret_refresh("stampede_collapsed");
+            return;
+        }
+
+        // Slot claimed; spawn the actual provider re-resolution.  Clone
+        // shares `Arc`-backed state — the new task is `'static`.
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let started = std::time::Instant::now();
+            let outcome = match svc
+                .resolve_via_provider(catalog_id, &alias, execution_id, workload)
+                .await
+            {
+                Ok(_) => "succeeded",
+                Err(e) => {
+                    tracing::warn!(
+                        execution_id,
+                        alias = %alias,
+                        catalog_id,
+                        error = %e,
+                        "keychain.refresh_failed"
+                    );
+                    "failed"
+                }
+            };
+            crate::metrics::record_secret_refresh(outcome);
+            crate::metrics::record_secret_refresh_duration(started.elapsed().as_secs_f64());
+            svc.refresh_inflight.release(&key).await;
+        });
     }
 
     /// Build a response for a credential resolved from a keychain provider

--- a/src/services/keychain_refresh.rs
+++ b/src/services/keychain_refresh.rs
@@ -1,0 +1,146 @@
+//! Background-refresh inflight tracker for Phase 7c.3.
+//!
+//! When the resolver's cache-hit path finds a row inside the refresh window
+//! (Phase 7c.2 `KeychainService::should_refresh` → true), it spawns a
+//! background task to re-resolve via the provider and update the cache.
+//! This tracker collapses stampedes: if N workers find the same row in
+//! the refresh window at the same time, only the first claim wins the
+//! refresh slot — the rest piggy-back via
+//! `noetl_secret_refresh_total{outcome="stampede_collapsed"}`.
+//!
+//! Lifecycle:
+//!
+//! 1. `try_claim(key)` returns `true` only if the key was NOT in the set
+//!    (and inserts it).  The caller MUST `release(key)` exactly once when
+//!    the spawned refresh finishes (success or failure) — otherwise the
+//!    key is permanently locked out from future refreshes until process
+//!    restart.
+//! 2. The companion span / metric instrumentation lives in the resolver
+//!    (`src/services/credential.rs`), not here.  This module is purely
+//!    the synchronisation primitive.
+//!
+//! The set is keyed by `(catalog_id, alias)` — distinct executions
+//! refreshing the same `(catalog_id, alias)` collapse to one provider
+//! call, exactly as Phase 7c.3 specifies.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+/// Refresh-inflight tracker.  Clone is cheap (Arc clone) and shares the
+/// underlying set across all clones — that's the point.
+#[derive(Clone, Debug, Default)]
+pub struct RefreshInflight {
+    inner: Arc<Mutex<HashSet<(i64, String)>>>,
+}
+
+impl RefreshInflight {
+    /// Build a fresh tracker.  In production one per process; clone into
+    /// every `CredentialService` instance.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// Atomically reserve the refresh slot for `key`.  Returns `true` if
+    /// the slot was free (and is now held by the caller); `false` if a
+    /// concurrent refresh is already in flight for the same key.
+    ///
+    /// The caller MUST call [`Self::release`] on the same key when the
+    /// refresh task finishes — even on the error path.
+    pub async fn try_claim(&self, key: (i64, String)) -> bool {
+        let mut set = self.inner.lock().await;
+        set.insert(key)
+    }
+
+    /// Release the refresh slot for `key`.  Idempotent — calling this for
+    /// a key that wasn't held is a no-op.
+    pub async fn release(&self, key: &(i64, String)) {
+        let mut set = self.inner.lock().await;
+        set.remove(key);
+    }
+
+    /// Inspect whether a key currently has a refresh in flight.  Mostly
+    /// useful for tests; production code uses [`Self::try_claim`].
+    #[cfg(test)]
+    pub async fn contains(&self, key: &(i64, String)) -> bool {
+        let set = self.inner.lock().await;
+        set.contains(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn try_claim_succeeds_for_free_slot() {
+        let inflight = RefreshInflight::new();
+        let key = (42, "duffel_token".to_string());
+        assert!(inflight.try_claim(key.clone()).await);
+        assert!(inflight.contains(&key).await);
+    }
+
+    #[tokio::test]
+    async fn try_claim_fails_for_held_slot() {
+        let inflight = RefreshInflight::new();
+        let key = (42, "duffel_token".to_string());
+        assert!(inflight.try_claim(key.clone()).await);
+        // Second claim for the same key collapses — the stampede signal.
+        assert!(!inflight.try_claim(key.clone()).await);
+    }
+
+    #[tokio::test]
+    async fn release_allows_reclaim() {
+        let inflight = RefreshInflight::new();
+        let key = (42, "duffel_token".to_string());
+        assert!(inflight.try_claim(key.clone()).await);
+        inflight.release(&key).await;
+        assert!(!inflight.contains(&key).await);
+        // After release the slot can be claimed again — next refresh round.
+        assert!(inflight.try_claim(key.clone()).await);
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_dont_collide() {
+        let inflight = RefreshInflight::new();
+        let key_a = (42, "duffel_token".to_string());
+        let key_b = (42, "openai_key".to_string());
+        let key_c = (43, "duffel_token".to_string());
+        assert!(inflight.try_claim(key_a.clone()).await);
+        assert!(inflight.try_claim(key_b.clone()).await);
+        assert!(inflight.try_claim(key_c.clone()).await);
+        // Each distinct key gets its own slot — alias-level and catalog-level
+        // independence.
+        assert!(inflight.contains(&key_a).await);
+        assert!(inflight.contains(&key_b).await);
+        assert!(inflight.contains(&key_c).await);
+    }
+
+    #[tokio::test]
+    async fn release_is_idempotent() {
+        let inflight = RefreshInflight::new();
+        let key = (42, "missing".to_string());
+        // Releasing a never-claimed slot is a no-op (mirror set.remove on absent key).
+        inflight.release(&key).await;
+        assert!(!inflight.contains(&key).await);
+    }
+
+    #[tokio::test]
+    async fn clone_shares_inner_state() {
+        // Critical invariant: cloned trackers share the same underlying set
+        // so the resolver's stampede collapse works across CredentialService
+        // clones (which clone the field).
+        let inflight = RefreshInflight::new();
+        let clone = inflight.clone();
+        let key = (42, "duffel_token".to_string());
+        assert!(inflight.try_claim(key.clone()).await);
+        // The clone sees the same slot — second claim collapses.
+        assert!(!clone.try_claim(key.clone()).await);
+        clone.release(&key).await;
+        // And release through the clone frees the slot for the original.
+        assert!(inflight.try_claim(key.clone()).await);
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -9,6 +9,7 @@ pub mod event;
 pub mod execution;
 pub mod internal;
 pub mod keychain;
+pub mod keychain_refresh;
 pub mod runtime;
 pub mod secret_audit;
 pub mod ui_schema;


### PR DESCRIPTION
## Summary

- Wire the Phase-7c `secrets::dynamic::should_refresh` decision primitive (server#125) + the Phase-7c.2 cache-side `KeychainService::should_refresh` (server#131) into the resolver's cache-hit path.
- When `CredentialService::try_resolve_keychain` hits a fresh-but-aging row, the cached value returns IMMEDIATELY and a background `tokio::spawn` re-resolves via the Phase-3b SecretProvider + updates the cache via `KeychainService::set`.
- **Stampede collapse** — new `RefreshInflight` (`src/services/keychain_refresh.rs`) wraps `Arc<tokio::sync::Mutex<HashSet<(i64, String)>>>`.  N workers crossing the refresh threshold for the same `(catalog_id, alias)` collapse to one provider call: first claim wins; concurrent callers piggy-back via `noetl_secret_refresh_total{outcome="stampede_collapsed"}`.
- Refactor: extracted the cache-miss provider resolution into a separate `resolve_via_provider` method.  Both cache-miss inline AND background-refresh call it — identical code path, no behavior drift.

## Failure modes handled

- `should_refresh` read errors → log + skip (do NOT fail the credential lookup; cached value already went out).
- Concurrent refresh in flight → `stampede_collapsed` metric; next worker re-evaluates after slot frees.
- Provider call fails in background task → log + bump `outcome="failed"` + release slot.  Cached row stays; next worker retries.

## Tests

Six new unit tests in `services::keychain_refresh::tests`:

- single-claim succeeds
- second-claim for same key returns false (stampede signal)
- release allows re-claim
- distinct keys don't collide (alias-level + catalog-level independence)
- release is idempotent
- clone shares inner state (critical: verifies the stampede-collapse invariant works across `CredentialService` clones)

Lib **441/0** passing (435 → 441; +6 from this round).

## Backward compatibility

The refresh-decision lookup short-circuits to `false` when the row has no `expires_at` (long-lived secret), is already expired, or is outside the refresh window.  Existing deployments without dynamic-secret providers see no change — the refresh path simply never triggers.

## Test plan

- [x] `cargo build --lib` clean
- [x] `cargo test --lib` — 441/0
- [x] `cargo clippy --lib` — no new warnings from this round (12 pre-existing doc-style warnings unrelated)
- [ ] Kind validation (Phase 7c.4 — dynamic-secret provider is needed for a meaningful end-to-end test; deferred until 6d.1/6d.2/6d.3 lands a provider that returns a real `expires_at`)

Closes #135.  Refs noetl/ai-meta#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)