### PR TITLE
engine: apply_event handles step.skipped — closes barrier follow-up (#144)

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -1995,25 +1995,13 @@ mod tests {
         );
     }
 
-    /// TODO(noetl/server#142 follow-up): `state::apply_event`
-    /// currently has no case for `step.skipped`, so an upstream
-    /// that goes through the step.when guard-false path stays in
-    /// `StepState::Pending` rather than `StepState::Skipped`.  The
-    /// orchestrator then RE-dispatches the upstream when its
-    /// parent's command.completed event lands.  The barrier code
-    /// in this PR already does the right thing on the
-    /// reconstructed state side (the `is_step_done(up)` clause at
-    /// line 540 of state.rs treats Skipped as terminal); the
-    /// missing piece is the apply_event mapping.  File a sibling
-    /// sub-issue to add the `step.skipped` arm in apply_event and
-    /// flip this test from `#[ignore]` to active.  Reality today:
-    /// a skipped upstream defers reduce dispatch forever, which is
-    /// arguably worse than the pre-PR behaviour of dispatching on
-    /// first completion — but only triggers when a fan-in target
-    /// has BOTH a real branch AND a when-guarded branch sharing
-    /// the same upstream parent, which is rare in practice.
+    /// Phase D R4 slice 2 (noetl/server#144) flipped this from
+    /// `#[ignore]` to active by adding the `step.skipped` arm to
+    /// `state::apply_event`.  The barrier check already treated
+    /// Skipped as terminal via `is_step_done` (state.rs:540); the
+    /// missing piece was the apply_event mapping that records the
+    /// skipped step into `state.steps` with `StepState::Skipped`.
     #[test]
-    #[ignore]
     fn test_reduce_step_treats_skipped_upstream_as_done() {
         // Same topology but branch_b is SKIPPED (the step.when
         // guard-false path emits `step.skipped`, which apply_event

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -359,6 +359,33 @@ impl WorkflowState {
                     }
                 }
             }
+            "step.skipped" | "step_skipped" => {
+                // Phase D R4 slice 2 (noetl/ai-meta#49 →
+                // noetl/server#144).  The orchestrator emits
+                // `step.skipped` when a step's `when` guard evaluates
+                // false (see `process_in_progress` in orchestrator.rs).
+                // Without this arm `reconstruct` left the step in
+                // `StepState::Pending` and every downstream consumer
+                // (fan-in barrier check, completion-decision quiescent
+                // clause, next-pass dispatch loop) was blind to the
+                // skip.  The barrier check needs `is_step_done` to
+                // see `Skipped` so a fan-in target with a guard-false
+                // upstream + a real upstream eventually dispatches.
+                //
+                // We set `entered_at` to the event's `created_at` —
+                // semantically the step's lifecycle began at the
+                // moment the guard was evaluated; the workflow has
+                // no other anchor for skipped steps.
+                if let Some(name) = &event.node_name {
+                    let step = self
+                        .steps
+                        .entry(name.clone())
+                        .or_insert_with(|| StepInfo::new(name));
+                    step.state = StepState::Skipped;
+                    step.entered_at = Some(event.created_at);
+                    step.completed_at = Some(event.created_at);
+                }
+            }
             "command.issued" => {
                 if let Some(name) = &event.node_name {
                     let step = self
@@ -878,6 +905,53 @@ mod tests {
         assert_eq!(
             state.steps.get("step1").unwrap().state,
             StepState::Completed
+        );
+    }
+
+    /// Phase D R4 slice 2 (noetl/server#144).  `step.skipped`
+    /// events emitted by the orchestrator (`process_in_progress`
+    /// when a step's `when` guard evaluates false) used to be
+    /// silently dropped by `apply_event` — leaving the step in
+    /// `StepState::Pending` and breaking the fan-in barrier's
+    /// terminal-state check for guard-skipped upstreams.  The new
+    /// arm records the step into `state.steps` with
+    /// `StepState::Skipped` and stamps `entered_at` +
+    /// `completed_at` to the event timestamp so the lifecycle is
+    /// recorded even though no actual work ran.
+    #[test]
+    fn step_skipped_event_marks_state_skipped() {
+        let mut state = WorkflowState::new(1, 1);
+
+        // Step doesn't exist yet — apply_event creates it.
+        state.apply_event(&make_event("step.skipped", Some("guarded_step")));
+        let step = state
+            .steps
+            .get("guarded_step")
+            .expect("apply_event should record the skipped step");
+        assert_eq!(step.state, StepState::Skipped);
+        assert!(step.entered_at.is_some());
+        assert!(step.completed_at.is_some());
+
+        // Skipped step is terminal — `is_step_done` returns true
+        // (this is the load-bearing check for the fan-in barrier).
+        assert!(state.is_step_done("guarded_step"));
+        // But it's NOT completed (Completed and Skipped are
+        // distinct terminal states); the dashboard should be able
+        // to tell them apart.
+        assert!(!state.is_step_completed("guarded_step"));
+    }
+
+    /// Underscore alias `step_skipped` works the same as the
+    /// dotted form — both are emitted depending on the producer
+    /// (Python-era code historically used the underscore form;
+    /// the orchestrator and apply_event now accept both).
+    #[test]
+    fn step_skipped_underscore_alias_also_marks_skipped() {
+        let mut state = WorkflowState::new(1, 1);
+        state.apply_event(&make_event("step_skipped", Some("guarded_step")));
+        assert_eq!(
+            state.steps.get("guarded_step").unwrap().state,
+            StepState::Skipped
         );
     }
 


### PR DESCRIPTION
## Summary

- New `"step.skipped" | "step_skipped"` arm in
  `state::WorkflowState::apply_event`.  Records the step into
  `state.steps` with `StepState::Skipped` keyed on
  `event.node_name`; sets `entered_at` + `completed_at` to the
  event timestamp.
- Flipped the previously-ignored
  `test_reduce_step_treats_skipped_upstream_as_done` to active —
  the fan-in barrier (server#143) now clears when one upstream
  is Skipped and the other Completed.
- Two new focused state tests
  (`step_skipped_event_marks_state_skipped` +
  `step_skipped_underscore_alias_also_marks_skipped`).
- Server lib: 493/0/0 ignored (was 490/0/+1 ignored after #143).

## Why

The slice 1 PR (#143) shipped a fan-in / reduce barrier that
deferred dispatch until all upstream steps reached a terminal
state.  `is_step_done` at `state.rs:540` already treated
`StepState::Skipped` as terminal — but `apply_event` had no case
for `step.skipped` events, so a step whose `when` guard
evaluated false stayed in `StepState::Pending` after state
reconstruction.

Result: the barrier kept deferring a multi-upstream reduce step
forever if any upstream was guard-skipped.  Documented in the
slice 1 PR with `#[ignore]` and a TODO.  This PR closes the
follow-up.

## Test plan

- [x] `cargo test --lib engine` clean.
- [x] `cargo test --lib` — 493/0/0 ignored.
- [x] Slice-1 ignored test (`test_reduce_step_treats_skipped_upstream_as_done`)
      now passes when flipped to active.

## Observability artifacts

Per `agents/rules/observability.md` Principle 1: no new spans /
metrics needed — this is a pure-state correctness fix on an
already-instrumented event handler.  The existing `event.ingest`
span carries `execution_id`; the existing
`noetl_orchestrator_*` metric inventory covers the dispatch
path.

Closes noetl/server#144
Refs noetl/ai-meta#49 Phase D R4

🤖 Generated with [Claude Code](https://claude.com/claude-code)