### PR TITLE
feat(replay): Phase D R5 R7 — cross-server parity harness (#148)

### DIFF
--- a/tests/parity_harness.rs
+++ b/tests/parity_harness.rs
@@ -1,0 +1,362 @@
+//! Cross-server parity harness — Phase D R5 R7
+//! (noetl/ai-meta#49 / noetl/server#148).
+//!
+//! Loads `tests/parity_harness/events.json` (a synthetic event log
+//! exercising all six replay projections + payload refs), folds it
+//! through both the Rust [`fold_replay_state`] and a pre-recorded
+//! Python snapshot (`tests/parity_harness/expected.json` generated
+//! by `tests/parity_harness/regenerate_expected.py`), and asserts
+//! structural parity field-by-field.
+//!
+//! ## What "parity" means here
+//!
+//! - **Structural** — same projection keys, same per-key field
+//!   values (status, counters, summaries, etc.).  This is the
+//!   load-bearing contract: the Rust port produces the same
+//!   logical view as the Python source-of-truth.
+//! - **NOT byte-for-byte hex** — Python and Rust hash different
+//!   digest inputs (Python feeds the `normalize_replayed_*_projection`
+//!   flat-row layer; Rust hashes the typed state directly).  The
+//!   `checksum` + `projection_checksums` hex values are explicitly
+//!   OUT of scope for the parity harness; they're a Rust-side
+//!   determinism contract verified by the R4 unit tests.
+//!
+//! ## How to regenerate `expected.json`
+//!
+//! ```bash
+//! cd tests/parity_harness
+//! python3 regenerate_expected.py
+//! ```
+//!
+//! The Python script is a self-contained standalone extract of
+//! `noetl/server/api/replay/service.py::fold_replay_state` —
+//! re-sync that extract whenever the Python implementation
+//! changes (it's the load-bearing parity contract).
+
+use std::fs;
+
+use chrono::Utc;
+use noetl_server::services::replay::{
+    fold_replay_state, ReplayEventRow, ReplayProjection, ReplayState,
+};
+use serde_json::Value;
+
+const EVENTS_PATH: &str = "tests/parity_harness/events.json";
+const EXPECTED_PATH: &str = "tests/parity_harness/expected.json";
+
+/// Load the events.json fixture and convert each entry to a
+/// [`ReplayEventRow`].  Mirrors what the sqlx FromRow decode
+/// would produce in production, just sourced from JSON instead
+/// of a Postgres rowset.
+fn load_events_fixture() -> Vec<ReplayEventRow> {
+    let raw = fs::read_to_string(EVENTS_PATH)
+        .unwrap_or_else(|e| panic!("read {EVENTS_PATH}: {e}"));
+    let parsed: Vec<Value> = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("parse {EVENTS_PATH}: {e}"));
+    parsed
+        .into_iter()
+        .map(|v| ReplayEventRow {
+            event_id: v["event_id"].as_i64().expect("event_id i64"),
+            event_type: v["event_type"]
+                .as_str()
+                .expect("event_type str")
+                .to_string(),
+            node_name: v.get("node_name").and_then(|x| x.as_str()).map(String::from),
+            status: v
+                .get("status")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string(),
+            created_at: Utc::now(),
+            stage_id: v.get("stage_id").and_then(|x| x.as_str()).map(String::from),
+            frame_id: v.get("frame_id").and_then(|x| x.as_str()).map(String::from),
+            command_id: v.get("command_id").and_then(|x| x.as_i64()),
+            worker_id: v.get("worker_id").and_then(|x| x.as_str()).map(String::from),
+            aggregate_type: v
+                .get("aggregate_type")
+                .and_then(|x| x.as_str())
+                .map(String::from),
+            aggregate_id: v
+                .get("aggregate_id")
+                .and_then(|x| x.as_str())
+                .map(String::from),
+            meta: v
+                .get("meta")
+                .filter(|m| !m.is_null())
+                .cloned(),
+            result: v
+                .get("result")
+                .filter(|m| !m.is_null())
+                .cloned(),
+        })
+        .collect()
+}
+
+fn load_expected() -> Value {
+    let raw = fs::read_to_string(EXPECTED_PATH)
+        .unwrap_or_else(|e| panic!("read {EXPECTED_PATH}: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {EXPECTED_PATH}: {e}"))
+}
+
+fn rust_fold() -> ReplayState {
+    let events = load_events_fixture();
+    fold_replay_state(&events, "default", "default", 999, ReplayProjection::All)
+}
+
+#[test]
+fn parity_top_level_counts_match() {
+    let state = rust_fold();
+    let expected = load_expected();
+    assert_eq!(state.event_count, expected["event_count"].as_u64().unwrap());
+    assert_eq!(
+        state.last_event_id,
+        expected["last_event_id"].as_i64(),
+    );
+    assert_eq!(
+        state.last_event_type.as_deref(),
+        expected["last_event_type"].as_str(),
+    );
+}
+
+#[test]
+fn parity_execution_status_and_last_node_name() {
+    let state = rust_fold();
+    let expected = load_expected();
+    assert_eq!(
+        state.execution.status,
+        expected["execution"]["status"].as_str().unwrap(),
+    );
+    assert_eq!(
+        state.execution.last_node_name.as_deref(),
+        expected["execution"]["last_node_name"].as_str(),
+    );
+}
+
+#[test]
+fn parity_execution_payload_refs() {
+    let state = rust_fold();
+    let expected = load_expected();
+    let expected_refs = expected["execution"]["payload_refs"]
+        .as_array()
+        .expect("payload_refs is array");
+    assert_eq!(
+        state.execution.payload_refs.len(),
+        expected_refs.len(),
+        "payload_refs count differs",
+    );
+    for (rust, py) in state.execution.payload_refs.iter().zip(expected_refs) {
+        assert_eq!(rust.event_id, py["event_id"].as_i64().unwrap());
+        // Python's execution.payload_refs entries don't carry a
+        // pre-computed summary (they only have {event_id, reference}).
+        // The Rust port pre-computes one for consistency — the
+        // parity test compares only the fields Python emits.
+        assert_eq!(&rust.reference, &py["reference"]);
+    }
+}
+
+#[test]
+fn parity_stage_projection() {
+    let state = rust_fold();
+    let expected = load_expected();
+    let expected_stages = expected["stages"].as_object().expect("stages map");
+    assert_eq!(
+        state.stages.len(),
+        expected_stages.len(),
+        "stages count differs",
+    );
+    for (key, expected_stage) in expected_stages {
+        let rust_stage = state
+            .stages
+            .get(key)
+            .unwrap_or_else(|| panic!("stage `{key}` missing in Rust fold"));
+        assert_eq!(rust_stage.stage_id, key.as_str());
+        assert_eq!(
+            rust_stage.status,
+            expected_stage["status"].as_str().unwrap(),
+            "stage `{key}` status mismatch",
+        );
+        assert_eq!(
+            rust_stage.opened_event_id,
+            expected_stage.get("opened_event_id").and_then(|v| v.as_i64()),
+            "stage `{key}` opened_event_id mismatch",
+        );
+        assert_eq!(
+            rust_stage.closed_event_id,
+            expected_stage.get("closed_event_id").and_then(|v| v.as_i64()),
+            "stage `{key}` closed_event_id mismatch",
+        );
+    }
+}
+
+#[test]
+fn parity_frame_projection() {
+    let state = rust_fold();
+    let expected = load_expected();
+    let expected_frames = expected["frames"].as_object().expect("frames map");
+    assert_eq!(state.frames.len(), expected_frames.len());
+    for (key, expected_frame) in expected_frames {
+        let rust_frame = state
+            .frames
+            .get(key)
+            .unwrap_or_else(|| panic!("frame `{key}` missing in Rust fold"));
+        assert_eq!(rust_frame.frame_id, key.as_str());
+        assert_eq!(
+            rust_frame.status,
+            expected_frame["status"].as_str().unwrap(),
+            "frame `{key}` status mismatch",
+        );
+        assert_eq!(
+            rust_frame.row_count,
+            expected_frame["row_count"].as_i64().unwrap_or(0),
+            "frame `{key}` row_count mismatch",
+        );
+        assert_eq!(
+            rust_frame.events_emitted,
+            expected_frame["events_emitted"].as_i64().unwrap_or(0),
+            "frame `{key}` events_emitted mismatch",
+        );
+        // R6 payload-resolver fields.
+        match expected_frame.get("output_ref") {
+            Some(Value::Null) | None => {
+                assert!(
+                    rust_frame.output_ref.is_none(),
+                    "frame `{key}` Rust set output_ref but Python did not",
+                );
+            }
+            Some(py_ref) => {
+                assert_eq!(
+                    rust_frame.output_ref.as_ref().unwrap(),
+                    py_ref,
+                    "frame `{key}` output_ref mismatch",
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn parity_command_projection() {
+    let state = rust_fold();
+    let expected = load_expected();
+    let expected_cmds = expected["commands"].as_object().expect("commands map");
+    assert_eq!(state.commands.len(), expected_cmds.len());
+    for (key, expected_cmd) in expected_cmds {
+        let rust_cmd = state
+            .commands
+            .get(key)
+            .unwrap_or_else(|| panic!("command `{key}` missing in Rust fold"));
+        assert_eq!(rust_cmd.command_id, key.as_str());
+        assert_eq!(
+            rust_cmd.status,
+            expected_cmd["status"].as_str().unwrap(),
+            "command `{key}` status mismatch",
+        );
+        assert_eq!(
+            rust_cmd.issued_event_id,
+            expected_cmd.get("issued_event_id").and_then(|v| v.as_i64()),
+        );
+        assert_eq!(
+            rust_cmd.terminal_event_id,
+            expected_cmd.get("terminal_event_id").and_then(|v| v.as_i64()),
+        );
+    }
+}
+
+#[test]
+fn parity_business_object_projection() {
+    let state = rust_fold();
+    let expected = load_expected();
+    let expected_bos = expected["business_objects"]
+        .as_object()
+        .expect("business_objects map");
+    assert_eq!(state.business_objects.len(), expected_bos.len());
+    for (key, expected_bo) in expected_bos {
+        let rust_bo = state
+            .business_objects
+            .get(key)
+            .unwrap_or_else(|| panic!("BO `{key}` missing in Rust fold"));
+        assert_eq!(rust_bo.object_key, key.as_str());
+        assert_eq!(rust_bo.object_type, expected_bo["object_type"].as_str().unwrap());
+        assert_eq!(rust_bo.object_id, expected_bo["object_id"].as_str().unwrap());
+        assert_eq!(
+            rust_bo.status,
+            expected_bo["status"].as_str().unwrap(),
+            "BO `{key}` status mismatch",
+        );
+        assert_eq!(
+            rust_bo.version,
+            expected_bo["version"].as_i64().unwrap(),
+            "BO `{key}` version mismatch",
+        );
+        assert_eq!(
+            rust_bo.event_count,
+            expected_bo["event_count"].as_i64().unwrap(),
+            "BO `{key}` event_count mismatch",
+        );
+        // Attributes match.
+        let rust_attrs: Value = serde_json::to_value(&rust_bo.attributes).unwrap();
+        assert_eq!(
+            &rust_attrs,
+            &expected_bo["attributes"],
+            "BO `{key}` attributes mismatch",
+        );
+        // payload_refs count + per-entry reference equality.
+        let expected_refs = expected_bo["payload_refs"].as_array().unwrap();
+        assert_eq!(
+            rust_bo.payload_refs.len(),
+            expected_refs.len(),
+            "BO `{key}` payload_refs count mismatch",
+        );
+        for (rust_pr, py_pr) in rust_bo.payload_refs.iter().zip(expected_refs) {
+            assert_eq!(rust_pr.event_id, py_pr["event_id"].as_i64().unwrap());
+            assert_eq!(&rust_pr.reference, &py_pr["reference"]);
+            // Per-payload summary parity — sha256 + ref are the
+            // load-bearing fields the parity test compares; other
+            // fields fall through to None on both sides when the
+            // reference doesn't carry them.
+            assert_eq!(
+                rust_pr.summary.sha256.as_deref(),
+                py_pr["summary"]["sha256"].as_str(),
+            );
+            assert_eq!(
+                rust_pr.summary.reference_uri.as_deref(),
+                py_pr["summary"]["ref"].as_str(),
+            );
+        }
+    }
+}
+
+#[test]
+fn parity_loop_projection() {
+    let state = rust_fold();
+    let expected = load_expected();
+    let expected_loops = expected["loops"].as_object().expect("loops map");
+    assert_eq!(state.loops.len(), expected_loops.len());
+    for (key, expected_loop) in expected_loops {
+        let rust_loop = state
+            .loops
+            .get(key)
+            .unwrap_or_else(|| panic!("loop `{key}` missing in Rust fold"));
+        assert_eq!(rust_loop.loop_id, key.as_str());
+        assert_eq!(
+            rust_loop.done,
+            expected_loop["done"].as_i64().unwrap(),
+            "loop `{key}` done mismatch",
+        );
+        assert_eq!(
+            rust_loop.failed,
+            expected_loop["failed"].as_i64().unwrap(),
+            "loop `{key}` failed mismatch",
+        );
+        assert_eq!(
+            rust_loop.completed,
+            expected_loop["completed"].as_bool().unwrap(),
+            "loop `{key}` completed mismatch",
+        );
+        assert_eq!(
+            rust_loop.total,
+            expected_loop.get("total").and_then(|v| v.as_i64()),
+            "loop `{key}` total mismatch",
+        );
+    }
+}

--- a/tests/parity_harness/README.md
+++ b/tests/parity_harness/README.md
@@ -1,0 +1,85 @@
+# Replay Parity Harness — Phase D R5 R7
+
+Cross-server parity test for the Rust `fold_replay_state` port
+(noetl/ai-meta#49 → noetl/server#148).  Feeds a synthetic event
+log through both folds and asserts structural equality.
+
+## Files
+
+| File | Owner | Purpose |
+| :-- | :-- | :-- |
+| `events.json` | hand-authored | Synthetic event log exercising all six replay projections (`execution` / `stage` / `frame` / `command` / `business_object` / `loop`) plus payload refs. |
+| `expected.json` | generated | Python's structured fold output for `events.json`, computed by `regenerate_expected.py`.  Committed alongside so the parity test is hermetic. |
+| `regenerate_expected.py` | hand-authored | Standalone Python script — verbatim extract of `noetl/server/api/replay/service.py::fold_replay_state` + helpers.  Reads `events.json`, folds, emits `expected.json`.  No `noetl`-package imports (avoids the transitive-dep chain). |
+| `../parity_harness.rs` | hand-authored | Rust integration test.  Loads both files; folds events through the Rust port; compares structurally. |
+
+## Parity contract
+
+The harness asserts **structural** parity — same projection keys,
+same per-key field values (status, counters, summaries,
+references).  This is the load-bearing contract: the Rust port
+produces the same logical view as the Python source-of-truth.
+
+The harness explicitly does **NOT** assert byte-for-byte hex
+parity on `checksum.value` / `projection_checksums[*].value`.
+Python and Rust hash different digest inputs:
+- Python feeds the `normalize_replayed_*_projection` flat-row
+  layer into SHA-256.
+- Rust hashes the typed state directly (per R4's design
+  decision — see [server#148
+  comment](https://github.com/noetl/server/issues/148#issuecomment-4643219314)).
+
+Both approaches deliver determinism + replay validation; they
+just produce different hex output.  The typed `Checksum { type,
+value }` shape (R4) keeps the wire shape stable across future
+algorithm additions.
+
+## Regenerating the snapshot
+
+When the Python fold logic changes (or when you extend
+`events.json`):
+
+```bash
+cd tests/parity_harness
+python3 regenerate_expected.py
+```
+
+The script is standalone Python 3.10+; no `noetl`-package
+imports.  Re-sync the verbatim-extracted helpers at the top of
+the script whenever `noetl/server/api/replay/service.py`
+changes — that's the load-bearing parity contract.
+
+## Running the parity test
+
+```bash
+cd repos/server
+cargo test --test parity_harness
+```
+
+Eight tests should pass:
+
+- `parity_top_level_counts_match`
+- `parity_execution_status_and_last_node_name`
+- `parity_execution_payload_refs`
+- `parity_stage_projection`
+- `parity_frame_projection`
+- `parity_command_projection`
+- `parity_business_object_projection`
+- `parity_loop_projection`
+
+Each test runs the Rust fold over the same event log and
+compares against the matching slice of `expected.json` —
+field-by-field, with helpful failure messages identifying the
+diverging key + field.
+
+## What's out of scope
+
+- **Live cross-server execution.**  The harness uses a fixture +
+  pre-recorded Python output, not a live Python service.  The
+  benefit: reproducible, hermetic, fast, no Python runtime
+  required at test time.  The cost: the parity guarantee is only
+  as strong as the Python snapshot's accuracy + freshness.
+- **Snapshot-seed / base_state path.**  R5 R5 surfaces are
+  covered by the Rust unit-test layer, not exercised here.
+- **The `checksum` field's hex value** — see "Parity contract"
+  above.

--- a/tests/parity_harness/events.json
+++ b/tests/parity_harness/events.json
@@ -1,0 +1,210 @@
+[
+  {
+    "event_id": 100,
+    "event_type": "playbook_started",
+    "node_name": null,
+    "status": "RUNNING",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": null,
+    "result": null
+  },
+  {
+    "event_id": 101,
+    "event_type": "step.enter",
+    "node_name": "start",
+    "status": "ENTERED",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": null,
+    "result": null
+  },
+  {
+    "event_id": 102,
+    "event_type": "stage.opened",
+    "node_name": "fanout",
+    "status": "OPEN",
+    "stage_id": "s-1",
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {"kind": "fanout", "step_name": "fanout"},
+    "result": null
+  },
+  {
+    "event_id": 103,
+    "event_type": "frame.dispatched",
+    "node_name": "fanout",
+    "status": "CLAIMED",
+    "stage_id": "s-1",
+    "frame_id": "f-1",
+    "command_id": 9001,
+    "worker_id": "worker-a",
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {"attempt": 1},
+    "result": null
+  },
+  {
+    "event_id": 104,
+    "event_type": "command.issued",
+    "node_name": "fanout",
+    "status": "ISSUED",
+    "stage_id": "s-1",
+    "frame_id": "f-1",
+    "command_id": 9001,
+    "worker_id": "worker-a",
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": null,
+    "result": null
+  },
+  {
+    "event_id": 105,
+    "event_type": "frame.committed",
+    "node_name": "fanout",
+    "status": "COMPLETED",
+    "stage_id": "s-1",
+    "frame_id": "f-1",
+    "command_id": 9001,
+    "worker_id": "worker-a",
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {"row_count": 42, "events_emitted": 3},
+    "result": {
+      "status": "ok",
+      "reference": {
+        "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+        "row_count": 42,
+        "media_type": "application/json",
+        "ref": "gs://bucket/output-1"
+      }
+    }
+  },
+  {
+    "event_id": 106,
+    "event_type": "command.completed",
+    "node_name": "fanout",
+    "status": "success",
+    "stage_id": "s-1",
+    "frame_id": "f-1",
+    "command_id": 9001,
+    "worker_id": "worker-a",
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": null,
+    "result": null
+  },
+  {
+    "event_id": 107,
+    "event_type": "loop.shard.done",
+    "node_name": "iterate",
+    "status": "",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {"loop_id": "L-1", "collection_size": 2},
+    "result": null
+  },
+  {
+    "event_id": 108,
+    "event_type": "loop.done",
+    "node_name": "iterate",
+    "status": "",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {"loop_id": "L-1"},
+    "result": null
+  },
+  {
+    "event_id": 109,
+    "event_type": "customer.created",
+    "node_name": "ingest_customer",
+    "status": "",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {
+      "business_object": {
+        "object_type": "customer",
+        "object_id": "c-99",
+        "state": {"name": "Alice"}
+      }
+    },
+    "result": {
+      "status": "ok",
+      "reference": {
+        "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+        "ref": "gs://bucket/customer-v1"
+      }
+    }
+  },
+  {
+    "event_id": 110,
+    "event_type": "customer.updated",
+    "node_name": "ingest_customer",
+    "status": "",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": {
+      "business_object": {
+        "object_type": "customer",
+        "object_id": "c-99",
+        "patch": {"name": "Alice S."}
+      }
+    },
+    "result": null
+  },
+  {
+    "event_id": 111,
+    "event_type": "stage.closed",
+    "node_name": "fanout",
+    "status": "CLOSED",
+    "stage_id": "s-1",
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": null,
+    "result": null
+  },
+  {
+    "event_id": 112,
+    "event_type": "playbook.completed",
+    "node_name": null,
+    "status": "COMPLETED",
+    "stage_id": null,
+    "frame_id": null,
+    "command_id": null,
+    "worker_id": null,
+    "aggregate_type": null,
+    "aggregate_id": null,
+    "meta": null,
+    "result": null
+  }
+]

--- a/tests/parity_harness/expected.json
+++ b/tests/parity_harness/expected.json
@@ -1,0 +1,139 @@
+{
+  "business_objects": {
+    "customer/c-99": {
+      "attributes": {
+        "name": "Alice S."
+      },
+      "deleted_event_id": null,
+      "event_count": 2,
+      "first_event_id": 109,
+      "last_event_id": 110,
+      "last_event_type": "customer.updated",
+      "last_payload_ref": {
+        "event_id": 109,
+        "reference": {
+          "ref": "gs://bucket/customer-v1",
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+        },
+        "summary": {
+          "media_type": null,
+          "ref": "gs://bucket/customer-v1",
+          "row_count": null,
+          "schema_digest": null,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+        }
+      },
+      "object_id": "c-99",
+      "object_key": "customer/c-99",
+      "object_type": "customer",
+      "payload_refs": [
+        {
+          "event_id": 109,
+          "reference": {
+            "ref": "gs://bucket/customer-v1",
+            "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+          },
+          "summary": {
+            "media_type": null,
+            "ref": "gs://bucket/customer-v1",
+            "row_count": null,
+            "schema_digest": null,
+            "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+          }
+        }
+      ],
+      "status": "ACTIVE",
+      "version": 2
+    }
+  },
+  "commands": {
+    "9001": {
+      "command_id": "9001",
+      "frame_id": "f-1",
+      "issued_event_id": 104,
+      "last_event_id": 106,
+      "stage_id": "s-1",
+      "status": "success",
+      "terminal_event_id": 106,
+      "worker_id": "worker-a"
+    }
+  },
+  "event_count": 13,
+  "execution": {
+    "last_node_name": "fanout",
+    "payload_refs": [
+      {
+        "event_id": 105,
+        "reference": {
+          "media_type": "application/json",
+          "ref": "gs://bucket/output-1",
+          "row_count": 42,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      },
+      {
+        "event_id": 109,
+        "reference": {
+          "ref": "gs://bucket/customer-v1",
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+        }
+      }
+    ],
+    "status": "COMPLETED"
+  },
+  "frames": {
+    "f-1": {
+      "attempts": 1,
+      "claimed_event_id": 103,
+      "command_id": "9001",
+      "events_emitted": 3,
+      "frame_id": "f-1",
+      "last_event_id": 106,
+      "output_ref": {
+        "media_type": "application/json",
+        "ref": "gs://bucket/output-1",
+        "row_count": 42,
+        "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "output_ref_summary": {
+        "media_type": "application/json",
+        "ref": "gs://bucket/output-1",
+        "row_count": 42,
+        "schema_digest": null,
+        "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "row_count": 42,
+      "stage_id": "s-1",
+      "status": "success",
+      "terminal_event_id": 105
+    }
+  },
+  "last_event_id": 112,
+  "last_event_type": "playbook.completed",
+  "loops": {
+    "L-1": {
+      "completed": true,
+      "done": 1,
+      "failed": 0,
+      "last_event_id": 108,
+      "loop_id": "L-1",
+      "step_name": "iterate",
+      "total": 2
+    }
+  },
+  "stages": {
+    "s-1": {
+      "closed_event_id": 111,
+      "events_emitted": 0,
+      "failed_count": 0,
+      "frame_count": 0,
+      "kind": "fanout",
+      "last_event_id": 111,
+      "opened_event_id": 102,
+      "row_count": 0,
+      "stage_id": "s-1",
+      "status": "CLOSED",
+      "step_name": "fanout"
+    }
+  }
+}

--- a/tests/parity_harness/regenerate_expected.py
+++ b/tests/parity_harness/regenerate_expected.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Regenerate expected.json from events.json by running Python's
+fold_replay_state logic (extracted standalone to avoid the noetl
+package's transitive-dep chain) and emitting the projection state
+subset the Rust parity test structurally compares.
+
+The fold logic below is a VERBATIM EXTRACT of
+`noetl/server/api/replay/service.py::fold_replay_state` and its
+helpers (`_event_id`, `_meta`, `_payload_ref`, `_payload_summary`,
+`_stage_id`, `_frame_id`, `_loop_id`, `_command_id`,
+`_business_object_identity`, `_business_object_status`).  Re-sync
+this file whenever the Python implementation changes — that's
+the load-bearing parity contract.
+
+This script is the **source of truth** for what Python's fold
+produces for the parity-harness fixture.  Re-run it whenever:
+- events.json changes
+- Python's fold logic changes (re-extract the helpers below)
+- the structural-parity contract changes
+
+Usage:
+    cd repos/server/tests/parity_harness
+    python3 regenerate_expected.py
+
+Output: writes expected.json next to this script.
+
+No noetl-package imports.  Standalone Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------
+# Verbatim extract from noetl/server/api/replay/service.py
+# (helpers + fold_replay_state).  No noetl-package imports —
+# this file stands alone.
+# ---------------------------------------------------------------
+
+
+def _event_id(event: Mapping[str, Any]) -> Optional[int]:
+    value = event.get("event_id")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _meta(event: Mapping[str, Any]) -> dict[str, Any]:
+    meta = event.get("meta")
+    return meta if isinstance(meta, dict) else {}
+
+
+def _payload_ref(event: Mapping[str, Any]) -> Any:
+    if event.get("payload_ref") is not None:
+        return event.get("payload_ref")
+    result = event.get("result")
+    if isinstance(result, dict):
+        return result.get("reference")
+    return None
+
+
+def _payload_summary(reference: Any) -> dict[str, Any]:
+    if not isinstance(reference, Mapping):
+        return {
+            "sha256": None,
+            "schema_digest": None,
+            "row_count": None,
+            "media_type": None,
+            "ref": None,
+        }
+    rows_ref = reference.get("rows_ref")
+    rows_ref = rows_ref if isinstance(rows_ref, Mapping) else {}
+    rows_meta = rows_ref.get("meta")
+    rows_meta = rows_meta if isinstance(rows_meta, Mapping) else {}
+    rows_ipc = rows_ref.get("ipc")
+    rows_ipc = rows_ipc if isinstance(rows_ipc, Mapping) else {}
+    return {
+        "sha256": (
+            reference.get("sha256")
+            or rows_meta.get("sha256")
+            or rows_ipc.get("sha256")
+            or reference.get("digest")
+        ),
+        "schema_digest": (
+            reference.get("schema_digest")
+            or rows_meta.get("schema_digest")
+            or rows_ipc.get("schema_digest")
+        ),
+        "row_count": (
+            reference.get("row_count")
+            or rows_meta.get("row_count")
+            or rows_ipc.get("row_count")
+        ),
+        "media_type": (
+            reference.get("media_type")
+            or rows_meta.get("media_type")
+            or rows_ipc.get("media_type")
+        ),
+        "ref": reference.get("ref") or rows_ref.get("ref") or reference.get("uri"),
+    }
+
+
+def _stage_id(event: Mapping[str, Any]) -> Optional[str]:
+    column_value = event.get("stage_id")
+    if column_value is not None:
+        return str(column_value)
+    aggregate_type = event.get("aggregate_type")
+    aggregate_id = event.get("aggregate_id")
+    if aggregate_type == "stage" and aggregate_id:
+        return str(aggregate_id).removeprefix("stage/")
+    meta = _meta(event)
+    value = meta.get("stage_id")
+    return str(value) if value is not None else None
+
+
+def _frame_id(event: Mapping[str, Any]) -> Optional[str]:
+    column_value = event.get("frame_id")
+    if column_value is not None:
+        return str(column_value)
+    aggregate_type = event.get("aggregate_type")
+    aggregate_id = event.get("aggregate_id")
+    if aggregate_type == "frame" and aggregate_id:
+        return str(aggregate_id).removeprefix("frame/")
+    meta = _meta(event)
+    value = meta.get("frame_id")
+    return str(value) if value is not None else None
+
+
+def _loop_id(event: Mapping[str, Any]) -> Optional[str]:
+    meta = _meta(event)
+    for key in ("loop_id", "loop_event_id", "__loop_epoch_id"):
+        value = meta.get(key)
+        if value is not None:
+            return str(value)
+    return None
+
+
+def _command_id(event: Mapping[str, Any]) -> Optional[str]:
+    value = event.get("command_id")
+    if value is not None:
+        return str(value)
+    meta = _meta(event)
+    value = meta.get("command_id")
+    return str(value) if value is not None else None
+
+
+def _business_object_identity(event: Mapping[str, Any]) -> tuple[str, str, str] | None:
+    meta = _meta(event)
+    business = meta.get("business_object")
+    business = business if isinstance(business, Mapping) else {}
+
+    object_type = (
+        business.get("object_type")
+        or business.get("type")
+        or meta.get("business_object_type")
+        or meta.get("object_type")
+    )
+    object_id = (
+        business.get("object_id")
+        or business.get("id")
+        or meta.get("business_object_id")
+        or meta.get("object_id")
+    )
+
+    aggregate_type = str(event.get("aggregate_type") or "")
+    aggregate_id = event.get("aggregate_id")
+    if aggregate_type == "business_object" and aggregate_id is not None:
+        parts = [part for part in str(aggregate_id).split("/") if part]
+        if parts[:1] == ["business_object"]:
+            parts = parts[1:]
+        if len(parts) >= 2:
+            object_type = object_type or parts[0]
+            object_id = object_id or "/".join(parts[1:])
+        else:
+            object_type = object_type or "business_object"
+            object_id = object_id or str(aggregate_id)
+
+    if object_type is None or object_id is None:
+        return None
+    object_type = str(object_type)
+    object_id = str(object_id)
+    return f"{object_type}/{object_id}", object_type, object_id
+
+
+def _business_object_status(event_type: str, status: Any) -> str | None:
+    if status is not None and status != "":
+        return str(status)
+    lowered = event_type.lower()
+    if lowered.endswith(".deleted") or lowered.endswith(".removed"):
+        return "DELETED"
+    if lowered.endswith(".created") or lowered.endswith(".updated") or lowered.endswith(".upserted"):
+        return "ACTIVE"
+    return None
+
+
+def fold_replay_state(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    tenant_id: str = "default",
+    organization_id: str = "default",
+    execution_id: int = 1,
+    projection: str = "all",
+) -> dict[str, Any]:
+    """Fold canonical events into a deterministic lightweight state snapshot.
+
+    Extracted verbatim from
+    `noetl/server/api/replay/service.py::fold_replay_state`
+    minus the snapshot-seed / base_state / upcaster path
+    (R5 R5 surfaces; not used by the parity-harness fixture).
+    """
+    ordered_events = sorted(events, key=lambda event: (_event_id(event) or 0))
+    state: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "organization_id": organization_id,
+        "execution_id": execution_id,
+        "projection": projection,
+        "event_count": 0,
+        "last_event_id": None,
+        "last_event_type": None,
+        "execution": {
+            "status": "UNKNOWN",
+            "last_node_name": None,
+            "payload_refs": [],
+        },
+        "stages": {},
+        "frames": {},
+        "commands": {},
+        "business_objects": {},
+        "loops": {},
+    }
+
+    for event in ordered_events:
+        event_id = _event_id(event)
+        event_type = str(event.get("event_type") or "")
+        status = event.get("status")
+        meta = _meta(event)
+
+        state["event_count"] += 1
+        state["last_event_id"] = event_id
+        state["last_event_type"] = event_type
+
+        # Execution-level status transitions + last_node_name.
+        if event_type in {"playbook.completed", "playbook_completed",
+                          "workflow.completed", "execution.completed"}:
+            state["execution"]["status"] = "COMPLETED"
+        elif event_type in {"playbook.failed", "playbook_failed",
+                            "workflow.failed", "execution.failed"}:
+            state["execution"]["status"] = "FAILED"
+        elif event_type in {"playbook.cancelled", "playbook_cancelled"}:
+            state["execution"]["status"] = "CANCELLED"
+        elif event_type in {"step.enter", "step_enter", "step_started"}:
+            if state["execution"]["status"] == "UNKNOWN":
+                state["execution"]["status"] = "RUNNING"
+            node = event.get("node_name")
+            if node is not None:
+                state["execution"]["last_node_name"] = node
+        elif event_type in {"step.exit", "step_completed", "command.completed"}:
+            node = event.get("node_name")
+            if node is not None:
+                state["execution"]["last_node_name"] = node
+
+        # Execution-level payload_refs.
+        payload_ref = _payload_ref(event)
+        if payload_ref is not None:
+            state["execution"]["payload_refs"].append(
+                {"event_id": event_id, "reference": payload_ref}
+            )
+
+        # Stage projection.
+        stage_id = _stage_id(event)
+        if stage_id:
+            stage = state["stages"].setdefault(
+                stage_id,
+                {
+                    "stage_id": stage_id,
+                    "status": "UNKNOWN",
+                    "kind": meta.get("kind"),
+                    "step_name": meta.get("step_name") or event.get("node_name"),
+                    "frame_count": 0,
+                    "row_count": 0,
+                    "events_emitted": 0,
+                    "failed_count": 0,
+                },
+            )
+            stage["last_event_id"] = event_id
+            if event_type == "stage.opened":
+                stage["status"] = "OPEN"
+                stage["opened_event_id"] = event_id
+            elif event_type == "stage.closed":
+                stage["status"] = "CLOSED" if not status else str(status)
+                stage["closed_event_id"] = event_id
+
+        # Frame projection.
+        frame_id = _frame_id(event)
+        if frame_id:
+            frame = state["frames"].setdefault(
+                frame_id,
+                {
+                    "frame_id": frame_id,
+                    "stage_id": stage_id,
+                    "status": "UNKNOWN",
+                    "row_count": 0,
+                    "attempts": 0,
+                    "events_emitted": 0,
+                },
+            )
+            frame["last_event_id"] = event_id
+            if stage_id:
+                frame["stage_id"] = stage_id
+            cmd_id_now = _command_id(event)
+            if cmd_id_now:
+                frame["command_id"] = cmd_id_now
+
+            if event_type == "frame.dispatched":
+                frame["status"] = "CLAIMED"
+                frame["claimed_event_id"] = event_id
+                attempt = meta.get("attempt") or 1
+                try:
+                    frame["attempts"] = max(int(frame.get("attempts") or 0), int(attempt))
+                except (TypeError, ValueError):
+                    pass
+            elif event_type == "frame.started":
+                frame["status"] = "RUNNING"
+            elif event_type == "frame.committed":
+                frame["status"] = str(status) if status else "COMPLETED"
+                row_count = meta.get("row_count")
+                if row_count is not None:
+                    try:
+                        frame["row_count"] = int(row_count)
+                    except (TypeError, ValueError):
+                        pass
+                emitted = meta.get("events_emitted")
+                if emitted is not None:
+                    try:
+                        frame["events_emitted"] = int(emitted)
+                    except (TypeError, ValueError):
+                        pass
+                frame["terminal_event_id"] = event_id
+                frame["output_ref"] = payload_ref
+                frame["output_ref_summary"] = _payload_summary(payload_ref)
+            elif event_type == "frame.failed":
+                frame["status"] = str(status) if status else "FAILED"
+                emitted = meta.get("events_emitted")
+                if emitted is not None:
+                    try:
+                        frame["events_emitted"] = int(emitted)
+                    except (TypeError, ValueError):
+                        pass
+                frame["terminal_event_id"] = event_id
+                frame["output_ref"] = payload_ref
+                frame["output_ref_summary"] = _payload_summary(payload_ref)
+            elif event_type == "frame.abandoned":
+                frame["status"] = str(status) if status else "ABANDONED"
+            elif status:
+                frame["status"] = str(status)
+
+        # Command projection.
+        command_id = _command_id(event)
+        if command_id:
+            command = state["commands"].setdefault(
+                command_id,
+                {
+                    "command_id": command_id,
+                    "status": "UNKNOWN",
+                },
+            )
+            command["last_event_id"] = event_id
+            if stage_id:
+                command["stage_id"] = stage_id
+            if frame_id:
+                command["frame_id"] = frame_id
+            wid = event.get("worker_id")
+            if wid:
+                command["worker_id"] = str(wid)
+            if event_type == "command.issued":
+                command["status"] = "PENDING"
+                command["issued_event_id"] = event_id
+            elif event_type == "command.claimed":
+                command["status"] = "CLAIMED"
+                command["claimed_event_id"] = event_id
+            elif event_type == "command.started":
+                command["status"] = "RUNNING"
+                command["started_event_id"] = event_id
+            elif event_type == "command.completed":
+                command["status"] = str(status) if status else "COMPLETED"
+                command["terminal_event_id"] = event_id
+            elif event_type == "command.failed":
+                command["status"] = str(status) if status else "FAILED"
+                command["terminal_event_id"] = event_id
+            elif event_type == "command.cancelled":
+                command["status"] = str(status) if status else "CANCELLED"
+                command["terminal_event_id"] = event_id
+            elif event_type.startswith("command.") and status:
+                command["status"] = str(status)
+
+        # Business object projection.
+        business_identity = _business_object_identity(event)
+        if business_identity:
+            object_key, object_type, object_id = business_identity
+            business_meta = meta.get("business_object")
+            business_meta = business_meta if isinstance(business_meta, Mapping) else {}
+            business_object = state["business_objects"].setdefault(
+                object_key,
+                {
+                    "object_key": object_key,
+                    "object_type": object_type,
+                    "object_id": object_id,
+                    "status": "UNKNOWN",
+                    "version": 0,
+                    "event_count": 0,
+                    "first_event_id": event_id,
+                    "last_event_id": None,
+                    "deleted_event_id": None,
+                    "last_event_type": None,
+                    "last_payload_ref": None,
+                    "payload_refs": [],
+                    "attributes": {},
+                },
+            )
+            business_object["last_event_id"] = event_id
+            business_object["last_event_type"] = event_type
+            business_object["event_count"] = int(business_object.get("event_count") or 0) + 1
+            business_object["version"] = int(
+                business_meta.get("version")
+                or meta.get("business_object_version")
+                or business_object["event_count"]
+            )
+
+            object_status = _business_object_status(event_type, status)
+            if object_status:
+                business_object["status"] = object_status
+                if object_status == "DELETED":
+                    business_object["deleted_event_id"] = event_id
+
+            state_value = business_meta.get("state")
+            if isinstance(state_value, Mapping):
+                business_object["attributes"] = dict(state_value)
+            patch_value = business_meta.get("patch") or business_meta.get("attributes")
+            if isinstance(patch_value, Mapping):
+                business_object["attributes"].update(dict(patch_value))
+
+            if payload_ref is not None:
+                payload_entry = {
+                    "event_id": event_id,
+                    "reference": payload_ref,
+                    "summary": _payload_summary(payload_ref),
+                }
+                business_object["payload_refs"].append(payload_entry)
+                business_object["last_payload_ref"] = payload_entry
+
+        # Loop projection.
+        loop_id = _loop_id(event)
+        if loop_id:
+            loop = state["loops"].setdefault(
+                loop_id,
+                {
+                    "loop_id": loop_id,
+                    "step_name": event.get("node_name"),
+                    "total": meta.get("collection_size") or meta.get("total"),
+                    "done": 0,
+                    "failed": 0,
+                    "completed": False,
+                    "last_event_id": None,
+                },
+            )
+            loop["last_event_id"] = event_id
+            if event_type in {"command.completed", "loop.shard.done"}:
+                loop["done"] = int(loop.get("done") or 0) + 1
+            elif event_type in {"command.failed", "loop.shard.failed"}:
+                loop["failed"] = int(loop.get("failed") or 0) + 1
+            elif event_type in {"loop.done", "loop.fanin.completed"}:
+                loop["completed"] = True
+
+    return state
+
+
+# ---------------------------------------------------------------
+# Harness driver: load events.json → fold → emit structural
+# subset to expected.json.
+# ---------------------------------------------------------------
+
+
+def _load_events(events_path: Path) -> list[Mapping[str, Any]]:
+    with events_path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _structural_subset(state: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract the subset the Rust parity test structurally compares.
+
+    Excluded:
+    - `checksum` / `checksum_algorithm` / `projection_checksums` —
+      Python and Rust use different digest inputs (Python flat-row
+      vs. Rust typed state), so byte-for-byte hex parity is NOT a
+      requirement.  The structural fields below ARE.
+    - `replay_snapshot` / `upcaster_registry_digest` — not exercised
+      by this fixture; the typed-shape harness for those lives in
+      the Rust unit tests.
+    - `payload_summary.summary` on execution.payload_refs entries —
+      Python doesn't pre-compute the per-event summary at this level
+      (it only sets it on business_object payload_refs).  The Rust
+      port does pre-compute it for consistency, so the parity test
+      ignores that field at the execution level.
+    """
+    out: dict[str, Any] = {
+        "event_count": state["event_count"],
+        "last_event_id": state.get("last_event_id"),
+        "last_event_type": state.get("last_event_type"),
+        "execution": dict(state.get("execution") or {}),
+        "stages": dict(state.get("stages") or {}),
+        "frames": dict(state.get("frames") or {}),
+        "commands": dict(state.get("commands") or {}),
+        "business_objects": dict(state.get("business_objects") or {}),
+        "loops": dict(state.get("loops") or {}),
+    }
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--events",
+        type=Path,
+        default=Path(__file__).parent / "events.json",
+        help="Path to events.json fixture (default: events.json beside this script).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(__file__).parent / "expected.json",
+        help="Output path (default: expected.json beside this script).",
+    )
+    args = parser.parse_args()
+
+    events = _load_events(args.events)
+    state = fold_replay_state(events)
+    subset = _structural_subset(state)
+
+    with args.out.open("w", encoding="utf-8") as fh:
+        json.dump(subset, fh, indent=2, sort_keys=True, default=str)
+        fh.write("\n")
+
+    print(f"Wrote {args.out} from {args.events} ({len(events)} events).", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

**Closes the Phase D R5 umbrella.**  Final slice — a cross-server
parity harness that feeds a synthetic event log through both
the Rust \`fold_replay_state\` port and a pre-recorded Python
snapshot, asserts structural equality field-by-field across
every projection.

## What ships

### Fixture data + Python regen

- **\`tests/parity_harness/events.json\`** — 13 synthetic events
  exercising all six replay projections (\`execution\` / \`stage\`
  / \`frame\` / \`command\` / \`business_object\` / \`loop\`)
  plus payload refs.
- **\`tests/parity_harness/expected.json\`** — Python fold
  output for that event log, committed alongside (hermetic
  harness — no live Python runtime needed at test time).
- **\`tests/parity_harness/regenerate_expected.py\`** —
  standalone Python 3.10+ script, **verbatim extract** of
  \`noetl/server/api/replay/service.py\` fold + helpers (no
  \`noetl\`-package imports; avoids the transitive-dep chain
  that blocked direct import of the noetl package).

### Rust integration test

**\`tests/parity_harness.rs\`** — 8 tests, all passing:

1. \`parity_top_level_counts_match\` — event_count, last_event_id, last_event_type.
2. \`parity_execution_status_and_last_node_name\`.
3. \`parity_execution_payload_refs\` — per-entry event_id + reference.
4. \`parity_stage_projection\` — keys + status + opened/closed event_ids.
5. \`parity_frame_projection\` — keys + status + row_count + events_emitted + output_ref.
6. \`parity_command_projection\` — keys + status + issued/terminal event_ids.
7. \`parity_business_object_projection\` — keys + status + version + event_count + attributes + payload_refs entries with sha256+ref summary parity.
8. \`parity_loop_projection\` — keys + done + failed + completed + total.

## Parity contract — what we assert (and what we don't)

**Structural parity** — same projection keys, same per-key
field values.  This is the load-bearing contract: the Rust
port produces the same logical view as Python's source-of-truth.

**NOT byte-for-byte hex** on \`checksum.value\` /
\`projection_checksums[*].value\`.  Python and Rust hash
different digest inputs:

- Python feeds \`normalize_replayed_*_projection\` flat-row
  output into SHA-256.
- Rust hashes the typed state directly (per R4's design
  decision documented on [server#148](https://github.com/noetl/server/issues/148#issuecomment-4643219314)).

Both deliver determinism + replay validation; they just
produce different hex.  The typed \`Checksum { type, value }\`
shape (R4) keeps the wire stable for future algorithm
additions.

## Test plan

- [x] \`cargo build --lib\` clean.
- [x] \`cargo build --release --bin noetl-control-plane\` clean.
- [x] \`cargo test --lib -- --test-threads=1\` — **564/0/0**.
- [x] \`cargo test --test parity_harness\` — **8/0/0**.
- [x] \`python3 tests/parity_harness/regenerate_expected.py\` regenerates \`expected.json\` deterministically.

No kind-val needed — the parity harness runs purely against
the test fixture; no live cluster involved.

## Closes Phase D R5

All seven rounds shipped:

| Round | Topic | Status |
| :-- | :-- | :-- |
| R1 | Endpoint scaffold + \`execution\` projection | ✅ v2.51.0 |
| R2 | \`stages\` + \`frames\` + \`commands\` projections | ✅ v2.52.0 |
| R3 | \`loops\` + \`business_objects\` projections | ✅ v2.53.0 |
| R4 | typed \`Checksum\` + \`projection_checksums\` | ✅ v2.54.0 |
| R5 | snapshot seed + \`base_state\` + upcaster digest | ✅ v2.55.0 |
| R6 | payload resolver | ✅ v2.56.0 |
| R7 | cross-server parity harness against Python | ✅ this PR |

After this merges + a release-please tag, the Phase D R5
sub-issue [server#148](https://github.com/noetl/server/issues/148)
closes — and Phase D of [noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49)
is complete.

Refs noetl/ai-meta#49 Phase D R5
Closes noetl/server#148

🤖 Generated with [Claude Code](https://claude.com/claude-code)