### PR TITLE
fix(orchestrator): emit step.skipped for untaken exclusive-routing siblings

### DIFF
--- a/src/engine/evaluator.rs
+++ b/src/engine/evaluator.rs
@@ -53,6 +53,22 @@ impl EvaluationResult {
         }
     }
 
+    /// Create a non-matched result that carries the target step name.
+    /// Used by `evaluate_next_transitions` to surface arc targets
+    /// that didn't fire (because exclusive mode already chose a
+    /// sibling, or the arc's `when` evaluated false).  The
+    /// orchestrator emits `step.skipped` for these so the R4 fan-in
+    /// barrier correctly treats them as terminal.  See
+    /// noetl/ai-meta#67.
+    pub fn not_matched_with_target(target: &str) -> Self {
+        Self {
+            matched: false,
+            next_step: Some(target.to_string()),
+            with_params: None,
+            error: None,
+        }
+    }
+
     /// Create an error result.
     pub fn error(message: &str) -> Self {
         Self {
@@ -170,7 +186,28 @@ impl ConditionEvaluator {
                     .map(|m| NextMode::from_str(m))
                     .unwrap_or(next_mode);
 
+                // #67 fix: emit `EvaluationResult { matched: false,
+                // next_step: Some(...) }` for arcs that don't fire
+                // (either because exclusive mode already picked an
+                // earlier match, or because the arc's `when`
+                // evaluated false).  process_in_progress uses these
+                // to emit `step.skipped` for those targets so the
+                // R4 fan-in barrier correctly treats them as
+                // terminal.  Without this, a sibling arc target
+                // (e.g. process_low under exclusive routing) stays
+                // Pending forever and a fan-in target downstream
+                // (e.g. summarize) deadlocks.
+                let mut exclusive_matched = false;
                 for arc in &router.arcs {
+                    // In exclusive mode, once we've matched once,
+                    // emit the rest as not-matched-with-target so
+                    // the caller can skip them.  We do NOT evaluate
+                    // their when (irrelevant — they won't fire).
+                    if exclusive_matched {
+                        results.push(EvaluationResult::not_matched_with_target(&arc.step));
+                        continue;
+                    }
+
                     // Evaluate when condition if present
                     let should_transition = match &arc.when {
                         Some(when_expr) => self.evaluate_condition(when_expr, context)?,
@@ -183,16 +220,33 @@ impl ConditionEvaluator {
                         });
                         results.push(EvaluationResult::matched(&arc.step, with_params));
 
-                        // In exclusive mode, first match wins
+                        // In exclusive mode, first match wins — but
+                        // we don't `break`; we continue the loop so
+                        // remaining arcs surface as
+                        // not_matched_with_target (the trip wire for
+                        // step.skipped emission).
                         if router_mode == NextMode::Exclusive {
-                            break;
+                            exclusive_matched = true;
                         }
+                    } else {
+                        // Arc's when evaluated false — also emit as
+                        // not_matched_with_target so callers can
+                        // emit step.skipped.  Applies to BOTH
+                        // exclusive (a false when before the
+                        // matched one) AND inclusive modes.
+                        results.push(EvaluationResult::not_matched_with_target(&arc.step));
                     }
                 }
             }
             Some(NextSpec::Targets(targets)) => {
                 // Legacy canonical format: targets with optional when conditions
+                let mut exclusive_matched = false;
                 for target in targets {
+                    if exclusive_matched {
+                        results.push(EvaluationResult::not_matched_with_target(&target.step));
+                        continue;
+                    }
+
                     // Evaluate when condition if present
                     let should_transition = match &target.when {
                         Some(when_expr) => self.evaluate_condition(when_expr, context)?,
@@ -205,10 +259,14 @@ impl ConditionEvaluator {
                         });
                         results.push(EvaluationResult::matched(&target.step, with_params));
 
-                        // In exclusive mode, first match wins
+                        // In exclusive mode, first match wins — but
+                        // continue iterating to surface the unmatched
+                        // siblings (see Router branch above).
                         if next_mode == NextMode::Exclusive {
-                            break;
+                            exclusive_matched = true;
                         }
+                    } else {
+                        results.push(EvaluationResult::not_matched_with_target(&target.step));
                     }
                 }
             }

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -433,21 +433,75 @@ impl WorkflowOrchestrator {
             });
         }
 
-        // Find completed steps that need transition evaluation
+        // #67: pre-compute the per-completed-step eval_results so
+        // we can do TWO ordered passes:
+        //   pass 1 — emit step.skipped for unmatched arc targets,
+        //            so `in_pass_skipped` is fully populated before
+        //            any barrier check;
+        //   pass 2 — dispatch matched arc targets, with the barrier
+        //            able to see every same-pass skip via the
+        //            collected in_pass_skipped set.
+        // Without this two-pass ordering, HashMap iteration order
+        // determined whether `summarize` got dispatched in the same
+        // pass as `start`'s step.skipped for `process_low`.
+        let mut per_step_evals: Vec<(String, &Step, Vec<crate::engine::evaluator::EvaluationResult>)> =
+            Vec::new();
         for step_name in state.steps.keys() {
             if !state.is_step_completed(step_name) {
                 continue;
             }
-
-            // Get step definition
             let step = match steps.get(step_name.as_str()) {
                 Some(s) => *s,
                 None => continue,
             };
-
-            // Evaluate next transitions
             let eval_results = self.evaluator.evaluate_next(step, context)?;
+            per_step_evals.push((step_name.clone(), step, eval_results));
+        }
 
+        // Pass 1: emit step.skipped for every unmatched arc target
+        // across ALL completed steps, before any dispatch barrier
+        // check.  Under `mode: exclusive`, the untaken sibling
+        // arc's target never runs; without step.skipped it would
+        // stay Pending forever and the R4 fan-in barrier on
+        // downstream merge points would deadlock.
+        for (_completed_step_name, _completed_step, eval_results) in &per_step_evals {
+            for result in eval_results {
+                if result.matched {
+                    continue;
+                }
+                let Some(target_name) = &result.next_step else {
+                    continue;
+                };
+                // Skip if already terminal / running / dispatched
+                // (already emitted in this loop).
+                if state.is_step_done(target_name)
+                    || state.running_steps().contains(&target_name.as_str())
+                    || dispatched_in_pass.contains(target_name)
+                {
+                    continue;
+                }
+                if !steps.contains_key(target_name.as_str()) {
+                    continue;
+                }
+                info!(
+                    "Step '{}' skipped (exclusive routing chose a sibling)",
+                    target_name
+                );
+                events_to_emit.push(EventToEmit {
+                    event_type: "step.skipped".to_string(),
+                    node_name: Some(target_name.clone()),
+                    status: "SKIPPED".to_string(),
+                    context: None,
+                    result: None,
+                    error: None,
+                });
+                dispatched_in_pass.insert(target_name.clone());
+            }
+        }
+
+        // Pass 2: dispatch matched arc targets.
+        for (step_name, _step, eval_results) in per_step_evals {
+            let _ = step_name; // kept for parity with old log shape if needed
             for result in eval_results {
                 if !result.matched {
                     continue;
@@ -532,10 +586,31 @@ impl WorkflowOrchestrator {
                     // ExecutionState::Failed first).
                     if let Some(upstreams) = incoming_arcs.get(next_step_name.as_str()) {
                         if upstreams.len() > 1 {
+                            // #67: also treat upstreams that this
+                            // same pass just emitted `step.skipped`
+                            // for as terminal.  Without this, the
+                            // skip event lands in `events_to_emit`
+                            // but `state.is_step_done` won't see it
+                            // until the next orchestrator pass (when
+                            // trigger_orchestrator persists the
+                            // events and re-triggers).  Letting
+                            // `summarize` dispatch in the SAME pass
+                            // is structurally fine — the worker
+                            // pulls commands from NATS after the
+                            // events are persisted, by which point
+                            // the skip event is already durable.
+                            let in_pass_skipped: std::collections::HashSet<&str> =
+                                events_to_emit
+                                    .iter()
+                                    .filter(|e| e.event_type == "step.skipped")
+                                    .filter_map(|e| e.node_name.as_deref())
+                                    .collect();
                             let pending: Vec<&str> = upstreams
                                 .iter()
                                 .copied()
-                                .filter(|up| !state.is_step_done(up))
+                                .filter(|up| {
+                                    !state.is_step_done(up) && !in_pass_skipped.contains(up)
+                                })
                                 .collect();
                             if !pending.is_empty() {
                                 debug!(
@@ -1587,6 +1662,204 @@ mod tests {
                 .collect(),
         }));
         step
+    }
+
+    #[test]
+    fn test_67_exclusive_routing_emits_step_skipped_for_unmatched_siblings() {
+        // noetl/ai-meta#67: under `mode: exclusive` routing, only
+        // one arc fires; the untaken sibling arcs' targets never
+        // run.  Pre-fix the orchestrator silently dropped those
+        // siblings (the R4 fan-in barrier then waited for them
+        // forever on any downstream merge point that joined on
+        // both branches — deadlock).
+        //
+        // This test pins the fix: after start.command.completed,
+        // the orchestrator emits `step.skipped` for the untaken
+        // sibling (`process_low`) in the SAME orchestrator pass.
+        // The downstream merge target (`summarize`) — declared with
+        // two upstreams in the static planner — now dispatches in
+        // the same pass because the barrier check treats
+        // in-pass step.skipped as terminal.
+        //
+        // Reproduces the comprehensive_test.yaml shape: summarize's
+        // `input:` block has a Jinja conditional `{{ A if A else B.x }}`
+        // referencing the untaken sibling — that's the surface
+        // symptom, but the underlying bug was the missing
+        // step.skipped, not the template render.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        // start → process_high (mode: exclusive; only the start
+        // event sets up the routing). process_high → summarize.
+        let start = {
+            let mut s = make_step("start", None);
+            s.next = Some(NextSpec::Router(crate::playbook::types::NextRouter {
+                spec: Some(crate::playbook::types::NextRouterSpec {
+                    mode: Some("exclusive".to_string()),
+                }),
+                arcs: vec![
+                    crate::playbook::types::NextArc {
+                        step: "process_high".to_string(),
+                        when: Some("{{ start.random_value > 10 }}".to_string()),
+                        args: None,
+                    },
+                    crate::playbook::types::NextArc {
+                        step: "process_low".to_string(),
+                        when: Some("{{ start.random_value <= 10 }}".to_string()),
+                        args: None,
+                    },
+                ],
+            }));
+            s
+        };
+        let process_high = make_step("process_high", Some("summarize"));
+        let process_low = make_step("process_low", Some("summarize"));
+        // summarize's tool has `args` with a Jinja conditional that
+        // references the untaken sibling step.  Mirrors the
+        // comprehensive_test fixture.
+        let summarize = {
+            let mut s = make_step("summarize", Some("end"));
+            s.tool = ToolDefinition::Single(ToolSpec {
+                kind: ToolKind::Python,
+                eval: None,
+                auth: None,
+                libs: None,
+                args: Some(serde_json::json!({
+                    "category": "{{ process_high.category if process_high else process_low.category }}",
+                    "final_value": "{{ process_high.processed if process_high else process_low.processed }}"
+                })),
+                code: Some("result = {\"category\": category}".to_string()),
+                url: None,
+                method: None,
+                query: None,
+                command: None,
+                connection: None,
+                params: None,
+                headers: None,
+                output_select: None,
+                extra: HashMap::new(),
+            });
+            s
+        };
+        let end = make_step("end", None);
+
+        // Events: playbook started, start completed (random_value=15
+        // surfaces process_high), process_high completed.
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                e.context = Some(serde_json::json!({
+                    "workload": {"threshold": 10},
+                    "path": "test",
+                    "version": "1"
+                }));
+                e
+            },
+            {
+                let mut e = make_event("call.done", Some("start"));
+                e.result = Some(serde_json::json!({
+                    "status": "COMPLETED",
+                    "context": {
+                        "result": {
+                            "status": "success",
+                            "context": {
+                                "data": {
+                                    "random_value": 15,
+                                    "status": "initialized"
+                                }
+                            }
+                        }
+                    }
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+            {
+                let mut e = make_event("call.done", Some("process_high"));
+                e.result = Some(serde_json::json!({
+                    "status": "COMPLETED",
+                    "context": {
+                        "result": {
+                            "status": "success",
+                            "context": {
+                                "data": {
+                                    "category": "high",
+                                    "original": 15,
+                                    "processed": 30,
+                                    "status": "high_processed"
+                                }
+                            }
+                        }
+                    }
+                }));
+                e
+            },
+            make_event("command.completed", Some("process_high")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "comprehensive_repro".to_string(),
+                path: Some("test/comprehensive_repro".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, process_high, process_low, summarize, end],
+        };
+
+        // Triggered by process_high.command.completed.  Expected
+        // after the #67 fix:
+        // - exactly 1 command for `summarize`
+        // - 1 step.skipped event for `process_low` (the untaken
+        //   exclusive sibling)
+        // - 1 step.enter event for `summarize`
+        // - !should_complete (summarize hasn't run yet)
+        let result = orchestrator
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .expect("evaluate should succeed after #67 fix");
+
+        let commands: Vec<&str> =
+            result.commands.iter().map(|c| c.step_name.as_str()).collect();
+        let skipped: Vec<&str> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.skipped")
+            .filter_map(|e| e.node_name.as_deref())
+            .collect();
+        let entered: Vec<&str> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.enter")
+            .filter_map(|e| e.node_name.as_deref())
+            .collect();
+
+        assert_eq!(
+            commands,
+            vec!["summarize"],
+            "expected 1 command for summarize, got {:?}",
+            commands
+        );
+        assert_eq!(
+            skipped,
+            vec!["process_low"],
+            "expected step.skipped for process_low (the untaken exclusive sibling), got {:?}",
+            skipped
+        );
+        assert!(
+            entered.contains(&"summarize"),
+            "expected step.enter for summarize, got entries: {:?}",
+            entered
+        );
+        assert!(
+            !result.should_complete,
+            "summarize is queued but not yet completed — must not should_complete"
+        );
     }
 
     #[test]

--- a/src/template/jinja.rs
+++ b/src/template/jinja.rs
@@ -736,6 +736,39 @@ mod tests {
     }
 
     #[test]
+    fn test_jinja_conditional_short_circuits_on_undefined_else_branch() {
+        // noetl/ai-meta#67 — pin the renderer's handling of
+        // `{{ A if A else B.x }}` when only A is in the context
+        // and B is undefined.  Expected per Chainable undefined +
+        // Jinja2 semantics: short-circuit picks `A.x`, never
+        // accesses `B.x` → renders to A's value (or attribute).
+        // This is the surface symptom of #67 but NOT the root
+        // cause — the actual bug was upstream in the orchestrator's
+        // R4 fan-in barrier, not the template engine; the renderer
+        // itself is well-behaved.  Test kept to defend against
+        // regression in Chainable semantics.
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "process_high".to_string(),
+            serde_json::json!({
+                "category": "high",
+                "processed": 30
+            }),
+        );
+        // NO process_low in ctx.
+
+        let renderer = TemplateRenderer::new();
+        let s = renderer
+            .render(
+                "{{ process_high.category if process_high else process_low.category }}",
+                &ctx,
+            )
+            .expect("render should succeed under Chainable undefined");
+        println!("PROBE RENDER OUTPUT: {:?}", s);
+        assert_eq!(s, "high", "expected 'high' from short-circuit; got {:?}", s);
+    }
+
+    #[test]
     fn test_simple_variable() {
         let renderer = TemplateRenderer::new();
         let ctx = make_context();


### PR DESCRIPTION
## Summary

Fixes the orchestrator deadlock surfaced by [noetl/ai-meta#67](https://github.com/noetl/ai-meta/issues/67) (regression-rig sweep on `e2e/fixtures/playbooks/comprehensive_test.yaml`).

## Root cause

Under `mode: exclusive` routing, only one arc fires and the static planner (`build_incoming_arcs`) declares the untaken siblings' targets as upstreams of any downstream merge step. The R4 fan-in barrier (server#142) then waits for those untaken siblings to reach a terminal state — but they never run, never emit `command.completed`, never get marked Skipped. Deadlock.

The triggering symptom in `comprehensive_test.yaml`: `summarize`'s `input:` block has `{{ process_high.category if process_high else process_low.category }}`. The Jinja conditional itself is fine (Chainable undefined + Jinja2 short-circuit), but the orchestrator never reached the rendering layer — it `continue`d the dispatch loop on the fan-in barrier before ever calling `build_command`.

Log fingerprint:

```
Orchestrator evaluate complete execution_id=<eid> ... new_commands=0 new_events=0 should_complete=false
Orchestrator generated 0 commands for execution <eid>
```

## Fix

1. **`evaluator::evaluate_next_transitions`**: instead of `break`ing out of the arcs loop on the first exclusive-mode match, walk the entire arcs list. Surface every remaining sibling (and any arc whose `when` evaluated false in inclusive mode) as `EvaluationResult { matched: false, next_step: Some(name) }`. New helper `EvaluationResult::not_matched_with_target`.

2. **`orchestrator::process_in_progress`**: split into two ordered passes:
   - **Pass 1 (new):** emit `step.skipped` for every unmatched arc target across ALL completed steps BEFORE any barrier check runs. Guarded against double-emission via the existing `dispatched_in_pass` set.
   - **Pass 2 (existing):** dispatch matched arc targets. The R4 fan-in barrier now also treats in-pass `step.skipped` events as terminal — so the merge target (`summarize`) dispatches in the SAME orchestrator pass.

The pre-pass design makes the fix `HashMap` iteration-order-independent — without it, the same-pass dispatch hinged on whether `start` was iterated before `process_high` in `state.steps.keys()`.

## Tests

- **`engine::orchestrator::tests::test_67_exclusive_routing_emits_step_skipped_for_unmatched_siblings`** (new): reproduces the `comprehensive_test.yaml` shape; after `start.command.completed` under exclusive routing with only `process_high` matched, asserts:
  - 1 command for `summarize` (the fan-in merge target),
  - 1 `step.skipped` event for `process_low` (the untaken sibling),
  - 1 `step.enter` event for `summarize`,
  - `!should_complete` (summarize hasn't run yet).
- **`template::jinja::tests::test_jinja_conditional_short_circuits_on_undefined_else_branch`** (new defensive): confirms the renderer correctly short-circuits `{{ A if A else B.x }}` when B is undefined. Kept as a regression guard for Chainable semantics, NOT as the fix surface (the orchestrator was the bug; the renderer was fine).

Results:
- `cargo test --lib -- --test-threads=1` → **568/0/0** (was 566, +2 new).
- `cargo build --release --bin noetl-control-plane` → clean.

## Test plan

- [x] Local: `cargo test --lib`, `cargo build --release` — all green.
- [ ] Kind validation (after merge + image build): re-run `comprehensive_test.yaml` from the #67 reproducer and verify the execution reaches `playbook.completed` (was hanging at `process_high.command.completed`).

Closes noetl/ai-meta#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)