### PR TITLE
Fix all pre-existing clippy warnings under -D warnings

### DIFF
--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -328,8 +328,10 @@ mod tests {
 
     #[test]
     fn test_connection_url() {
-        let mut config = DatabaseConfig::default();
-        config.password = "secret".to_string();
+        let config = DatabaseConfig {
+            password: "secret".to_string(),
+            ..DatabaseConfig::default()
+        };
         assert_eq!(
             config.connection_url(),
             "postgres://noetl:secret@localhost:5432/noetl"

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -331,7 +331,7 @@ impl DbPoolMap {
         F: FnMut(u32, DbPool) -> Fut,
         Fut: std::future::Future<Output = Result<Option<T>, E>>,
     {
-        let results = self.for_each_shard(|idx, pool| f(idx, pool)).await?;
+        let results = self.for_each_shard(&mut f).await?;
         Ok(results
             .into_iter()
             .find_map(|(idx, opt)| opt.map(|t| (idx, t))))

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -387,7 +387,7 @@ mod tests {
             args: None,
             vars: None,
             r#loop: None,
-            tool: ToolDefinition::Single(ToolSpec {
+            tool: ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Http,
                 auth: None,
                 libs: None,
@@ -403,7 +403,7 @@ mod tests {
                 eval: None,
                 output_select: None,
                 extra: HashMap::new(),
-            }),
+            })),
             next: None,
         };
 
@@ -436,7 +436,7 @@ mod tests {
             args: None,
             vars: None,
             r#loop: None,
-            tool: ToolDefinition::Single(ToolSpec {
+            tool: ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Python,
                 auth: None,
                 libs: None,
@@ -452,7 +452,7 @@ mod tests {
                 eval: None,
                 output_select: None,
                 extra: HashMap::new(),
-            }),
+            })),
             next: None,
         };
 
@@ -582,7 +582,7 @@ mod tests {
             args: None,
             vars: None,
             r#loop: None,
-            tool: ToolDefinition::Single(ToolSpec {
+            tool: ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Http,
                 auth: None,
                 libs: None,
@@ -598,7 +598,7 @@ mod tests {
                 eval: None,
                 output_select: None,
                 extra: HashMap::new(),
-            }),
+            })),
             next: None,
         }
     }

--- a/src/engine/evaluator.rs
+++ b/src/engine/evaluator.rs
@@ -117,8 +117,8 @@ pub enum NextMode {
 }
 
 impl NextMode {
-    /// Parse from string.
-    pub fn from_str(s: &str) -> Self {
+    /// Parse from string value.
+    pub fn parse(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "inclusive" => NextMode::Inclusive,
             _ => NextMode::Exclusive,
@@ -188,7 +188,7 @@ impl ConditionEvaluator {
             .spec
             .as_ref()
             .and_then(|s| s.next_mode.as_ref())
-            .map(|m| NextMode::from_str(m))
+            .map(|m| NextMode::parse(m))
             .unwrap_or_default();
 
         match &step.next {
@@ -209,7 +209,7 @@ impl ConditionEvaluator {
                     .spec
                     .as_ref()
                     .and_then(|s| s.mode.as_ref())
-                    .map(|m| NextMode::from_str(m))
+                    .map(|m| NextMode::parse(m))
                     .unwrap_or(next_mode);
 
                 // #67 fix: emit `EvaluationResult { matched: false,
@@ -436,10 +436,10 @@ mod tests {
 
     #[test]
     fn test_next_mode_parsing() {
-        assert_eq!(NextMode::from_str("exclusive"), NextMode::Exclusive);
-        assert_eq!(NextMode::from_str("inclusive"), NextMode::Inclusive);
-        assert_eq!(NextMode::from_str("EXCLUSIVE"), NextMode::Exclusive);
-        assert_eq!(NextMode::from_str("INCLUSIVE"), NextMode::Inclusive);
-        assert_eq!(NextMode::from_str("unknown"), NextMode::Exclusive); // default
+        assert_eq!(NextMode::parse("exclusive"), NextMode::Exclusive);
+        assert_eq!(NextMode::parse("inclusive"), NextMode::Inclusive);
+        assert_eq!(NextMode::parse("EXCLUSIVE"), NextMode::Exclusive);
+        assert_eq!(NextMode::parse("INCLUSIVE"), NextMode::Inclusive);
+        assert_eq!(NextMode::parse("unknown"), NextMode::Exclusive); // default
     }
 }

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -1188,7 +1188,7 @@ mod tests {
             args: None,
             vars: None,
             r#loop: None,
-            tool: ToolDefinition::Single(ToolSpec {
+            tool: ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Python,
                 eval: None,
                 auth: None,
@@ -1204,7 +1204,7 @@ mod tests {
                 headers: None,
                 output_select: None,
                 extra: HashMap::new(),
-            }),
+            })),
             next: next.map(|n| NextSpec::Single(n.to_string())),
         }
     }
@@ -1300,7 +1300,7 @@ mod tests {
 
         let bad_step = {
             let mut s = make_step("bad_step", Some("end"));
-            s.tool = ToolDefinition::Single(ToolSpec {
+            s.tool = ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Python,
                 eval: None,
                 auth: None,
@@ -1316,7 +1316,7 @@ mod tests {
                 headers: None,
                 output_select: None,
                 extra: HashMap::new(),
-            });
+            }));
             s
         };
 
@@ -2124,7 +2124,7 @@ mod tests {
         // comprehensive_test fixture.
         let summarize = {
             let mut s = make_step("summarize", Some("end"));
-            s.tool = ToolDefinition::Single(ToolSpec {
+            s.tool = ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Python,
                 eval: None,
                 auth: None,
@@ -2143,7 +2143,7 @@ mod tests {
                 headers: None,
                 output_select: None,
                 extra: HashMap::new(),
-            });
+            }));
             s
         };
         let end = make_step("end", None);
@@ -2770,7 +2770,7 @@ mod tests {
         // `end` is referenced only from `reduce` (single upstream).
         assert_eq!(incoming.get("end").map(|u| u.len()).unwrap_or(0), 1);
         // `start` has no upstreams.
-        assert!(incoming.get("start").is_none());
+        assert!(!incoming.contains_key("start"));
     }
 
     #[test]
@@ -2812,7 +2812,7 @@ mod tests {
         // use_vars step reads x from its input template.
         let use_vars = {
             let mut s = make_step("use_vars", Some("end"));
-            s.tool = ToolDefinition::Single(ToolSpec {
+            s.tool = ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Python,
                 eval: None,
                 auth: None,
@@ -2833,7 +2833,7 @@ mod tests {
                 headers: None,
                 output_select: None,
                 extra: HashMap::new(),
-            });
+            }));
             s
         };
 

--- a/src/handlers/cross_region.rs
+++ b/src/handlers/cross_region.rs
@@ -109,9 +109,8 @@ pub async fn resolve(
         .credentials
         .get(&body.alias, true, body.execution_id)
         .await
-        .map_err(|e| {
+        .inspect_err(|_e| {
             crate::metrics::record_cross_region_broker_call(my_region, "resolve_error");
-            e
         })?;
 
     // (4) — seal.  Identical to the Phase-5b primitive: serialise the
@@ -123,9 +122,8 @@ pub async fn resolve(
         crate::metrics::record_cross_region_broker_call(my_region, "serialize_error");
         AppError::Internal(format!("cross-region: serialise credential: {e}"))
     })?;
-    let envelope = sealed_seal(&recipient, &plaintext).map_err(|e| {
+    let envelope = sealed_seal(&recipient, &plaintext).inspect_err(|_e| {
         crate::metrics::record_cross_region_broker_call(my_region, "seal_error");
-        e
     })?;
     crate::metrics::record_cross_region_broker_call(my_region, "ok");
     Ok(Json(envelope))

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1170,12 +1170,12 @@ async fn check_already_claimed(
 ///
 /// Mapping:
 /// - `result_kind = "ref"`  + `result_uri` set
-///       → `{status, reference: {store_tier, logical_uri}}`
+///   → `{status, reference: {store_tier, logical_uri}}`
 /// - `result_kind = "refs"` + `event_ids` set
-///       → `{status, reference: {event_ids, total_parts}}`
+///   → `{status, reference: {event_ids, total_parts}}`
 /// - default (`"data"` or unknown):
-///   - `payload` is a non-null object → `{status, context: <payload>}`
-///   - `payload` is null/non-object   → `{status}`
+///     - `payload` is a non-null object → `{status, context: <payload>}`
+///     - `payload` is null/non-object   → `{status}`
 fn build_result_object(request: &EventRequest, status: &str) -> serde_json::Value {
     let mut result = serde_json::Map::new();
     result.insert(

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -103,11 +103,9 @@ pub async fn execute(
     // returned an empty `{}` and Jinja templates referencing
     // workload fields rendered to None.  See noetl/ai-meta#56.
     let mut merged_workload = serde_json::Map::new();
-    if let Some(playbook_workload) = &playbook.workload {
-        if let serde_json::Value::Object(map) = playbook_workload {
-            for (k, v) in map {
-                merged_workload.insert(k.clone(), v.clone());
-            }
+    if let Some(serde_json::Value::Object(map)) = &playbook.workload {
+        for (k, v) in map {
+            merged_workload.insert(k.clone(), v.clone());
         }
     }
     for (k, v) in &request.payload {
@@ -436,11 +434,9 @@ async fn generate_initial_commands(
     let mut context = HashMap::new();
 
     // First, add playbook workload defaults
-    if let Some(workload) = &playbook.workload {
-        if let serde_json::Value::Object(map) = workload {
-            for (k, v) in map {
-                context.insert(k.clone(), v.clone());
-            }
+    if let Some(serde_json::Value::Object(map)) = &playbook.workload {
+        for (k, v) in map {
+            context.insert(k.clone(), v.clone());
         }
     }
 
@@ -753,7 +749,7 @@ mod tests {
             args: None,
             vars: None,
             r#loop: loop_cfg,
-            tool: ToolDefinition::Single(ToolSpec {
+            tool: ToolDefinition::Single(Box::new(ToolSpec {
                 kind: ToolKind::Python,
                 auth: None,
                 libs: None,
@@ -769,7 +765,7 @@ mod tests {
                 eval: None,
                 output_select: None,
                 extra: HashMap::new(),
-            }),
+            })),
             next: None,
         }
     }

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -137,7 +137,7 @@ pub async fn pool_status(State(state): State<AppState>) -> Json<PoolStatusRespon
     // /metrics (per-shard gauge labels) or a follow-up
     // /api/pool/status/shards endpoint.
     let cluster = state.pools.cluster();
-    let pool_size = u32::try_from(cluster.size()).unwrap_or(u32::MAX);
+    let pool_size = cluster.size();
     let pool_available = u32::try_from(cluster.num_idle()).unwrap_or(u32::MAX);
     let pool_max = pool_size.max(pool_available);
     let pool_min = 0;

--- a/src/handlers/replay.rs
+++ b/src/handlers/replay.rs
@@ -107,7 +107,7 @@ pub async fn replay_state(
         ));
     }
 
-    let projection = ReplayProjection::from_str(&query.projection).ok_or_else(|| {
+    let projection = ReplayProjection::parse_wire(&query.projection).ok_or_else(|| {
         AppError::BadRequest(format!(
             "unknown projection {:?}; expected one of: execution, stage, frame, command, business_object, loop, all",
             query.projection

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ fn init_tracing() {
 }
 
 /// Build the application router with all routes.
+#[allow(clippy::too_many_arguments)]
 fn build_router(
     state: AppState,
     db_pool: DbPool,

--- a/src/playbook/parser.rs
+++ b/src/playbook/parser.rs
@@ -127,7 +127,7 @@ fn resolve_workbook_references(playbook: &mut crate::playbook::types::Playbook) 
         // doesn't carry the now-resolved reference.
         let mut substituted = resolved_tool;
         substituted.args = merged_args;
-        step.tool = ToolDefinition::Single(substituted);
+        step.tool = ToolDefinition::Single(Box::new(substituted));
     }
 
     Ok(())

--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -236,7 +236,7 @@ pub struct PipelineTask {
 #[serde(untagged)]
 pub enum ToolDefinition {
     /// Single tool (shorthand).
-    Single(ToolSpec),
+    Single(Box<ToolSpec>),
 
     /// Pipeline - list of labeled tasks.
     ///
@@ -288,7 +288,7 @@ pub enum PipelineItem {
     /// the fields are an inline `ToolSpec`.  Stored via `ToolSpec.extra`
     /// (the `#[serde(flatten)] HashMap` catch-all), so no schema change
     /// is needed on ToolSpec itself.
-    Flat(ToolSpec),
+    Flat(Box<ToolSpec>),
 
     /// Nested shape: `{ "label": { kind: "python", code: "...", ... } }`.
     /// Single-key map — the key is the label, the value is the spec.

--- a/src/secrets/broker.rs
+++ b/src/secrets/broker.rs
@@ -91,6 +91,12 @@ impl BrokerRegistry {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
+
+    /// Whether the broker map is empty.  Required by clippy alongside `len()`.
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
 }
 
 /// Body of the cross-region resolution request.

--- a/src/services/replay.rs
+++ b/src/services/replay.rs
@@ -88,7 +88,7 @@ impl ReplayCutoff {
 /// `All` is requested, the other map fields are returned empty.
 /// Round 2 fleshes out `Stage`/`Frame`/`Command`; Round 3 adds
 /// `Loop` + `BusinessObject`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReplayProjection {
     Execution,
@@ -97,13 +97,8 @@ pub enum ReplayProjection {
     Command,
     BusinessObject,
     Loop,
+    #[default]
     All,
-}
-
-impl Default for ReplayProjection {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl ReplayProjection {
@@ -124,7 +119,7 @@ impl ReplayProjection {
     /// Parse a wire value.  Accepts the canonical Python names +
     /// the underscore alias `business_object`.  Returns `None`
     /// on unknown — the endpoint surfaces this as a 400.
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse_wire(s: &str) -> Option<Self> {
         match s {
             "execution" => Some(Self::Execution),
             "stage" => Some(Self::Stage),
@@ -1939,22 +1934,22 @@ mod tests {
     #[test]
     fn projection_from_str_accepts_canonical_names() {
         assert_eq!(
-            ReplayProjection::from_str("execution"),
+            ReplayProjection::parse_wire("execution"),
             Some(ReplayProjection::Execution)
         );
         assert_eq!(
-            ReplayProjection::from_str("business_object"),
+            ReplayProjection::parse_wire("business_object"),
             Some(ReplayProjection::BusinessObject)
         );
         assert_eq!(
-            ReplayProjection::from_str("loop"),
+            ReplayProjection::parse_wire("loop"),
             Some(ReplayProjection::Loop)
         );
         assert_eq!(
-            ReplayProjection::from_str("all"),
+            ReplayProjection::parse_wire("all"),
             Some(ReplayProjection::All)
         );
-        assert!(ReplayProjection::from_str("garbage").is_none());
+        assert!(ReplayProjection::parse_wire("garbage").is_none());
     }
 
     #[test]

--- a/src/services/ui_schema.rs
+++ b/src/services/ui_schema.rs
@@ -562,10 +562,10 @@ mod tests {
 
     #[test]
     fn number_field() {
-        let yaml = "workload:\n  ratio: 3.14\n";
+        let yaml = "workload:\n  ratio: 2.72\n";
         let f = first_field(yaml);
         assert_eq!(f.kind, "number");
-        assert_eq!(f.default, serde_json::json!(3.14));
+        assert_eq!(f.default, serde_json::json!(2.72));
     }
 
     #[test]

--- a/src/sharding.rs
+++ b/src/sharding.rs
@@ -142,7 +142,7 @@ impl ShardConfig {
 
     /// Wrap this config in an [`Arc`] for sharing across handlers
     /// + services.  Sibling to `AppState`'s `Arc<SnowflakeGenerator>`
-    /// pattern.
+    ///   pattern.
     pub fn into_arc(self) -> Arc<Self> {
         Arc::new(self)
     }


### PR DESCRIPTION
## Summary

- Resolves 15 categories of clippy lint across 17 files so `cargo clippy --lib --tests --release -- -D warnings` passes clean
- Box large enum variants (`ToolDefinition::Single`, `PipelineItem::Flat`) to reduce stack size — wraps all construction sites in `Box::new()`
- Mechanical fixes: `inspect_err`, inherent method renames, collapsed `if let`, `#[derive(Default)]`, struct update syntax, doc indentation, `contains_key`, `is_empty`, approximate-constant avoidance, `#[allow(too_many_arguments)]`
- Zero behavior changes — all 615 tests pass

## Test plan

- [x] `cargo clippy --lib --release -- -D warnings` passes clean
- [x] `cargo clippy --tests --release -- -D warnings` passes clean
- [x] `cargo test --release` — 615 passed, 0 failed

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)