### PR TITLE
fix(container-callback): insert call.done with deployed event schema

### DIFF
--- a/src/handlers/container_callback.rs
+++ b/src/handlers/container_callback.rs
@@ -227,7 +227,7 @@ pub async fn container_callback(
     let event_id = state.snowflake.generate().map_err(|e| {
         AppError::Internal(format!("container-callback: snowflake generate failed: {e}"))
     })?;
-    let context = serde_json::json!({
+    let terminal_context = serde_json::json!({
         "terminal_state": request.state.as_str(),
         "job_name": request.job_name,
         "job_uid": request.job_uid,
@@ -243,6 +243,16 @@ pub async fn container_callback(
         "FAILED"
     };
 
+    // The `result` column carries a constraint-shaped envelope
+    // (`chk_event_result_shape`): a top-level string `status` plus an
+    // optional object `context`.  Mirror handlers::events so the
+    // call.done row validates and the orchestrator reads the terminal
+    // outcome the same way it reads every other call.done.
+    let result_obj = serde_json::json!({
+        "status": status_label,
+        "context": terminal_context,
+    });
+
     // catalog_id is required by the schema; resolve from the
     // execution's existing events (the start event carries it).
     let catalog_id: i64 = sqlx::query_as::<_, (i64,)>(
@@ -256,24 +266,32 @@ pub async fn container_callback(
     .map(|(c,)| c)
     .unwrap_or(0);
 
-    crate::db::queries::event::insert_event(
-        pool,
-        event_id,
-        execution_id,
-        catalog_id,
-        None,
-        None,
-        "call.done",
-        None,
-        Some(&step),
-        Some("container"),
-        status_label,
-        Some(&context),
-        None,
-        None,
-        None,
-        None,
+    // Persist the resume `call.done` using the deployed `noetl.event`
+    // column set (matches handlers::events).  The previous path went
+    // through `db::queries::event::insert_event`, whose SQL targets
+    // `attempt` + `id` columns that do not exist on the deployed
+    // schema — so every callback POST 500'd with
+    // `column "attempt" of relation "event" does not exist`, which
+    // blocked the noetl/ai-meta#43 container-callback chain end to end.
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.event (
+            event_id, execution_id, catalog_id, event_type,
+            node_id, node_name, status, result, meta, created_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        "#,
     )
+    .bind(event_id)
+    .bind(execution_id)
+    .bind(catalog_id)
+    .bind("call.done")
+    .bind(&step)
+    .bind(&step)
+    .bind(status_label)
+    .bind(&result_obj)
+    .bind(serde_json::json!({ "node_type": "container" }))
+    .bind(chrono::Utc::now())
+    .execute(pool)
     .await?;
 
     crate::metrics::record_container_callback(request.state.as_str());


### PR DESCRIPTION
## Problem

The container-callback handler emitted its resume `call.done` event through `db::queries::event::insert_event`, whose SQL targets `attempt` + `id` columns and `RETURNING id` — **none of which exist on the deployed `noetl.event` schema** (PK is `(execution_id, event_id)`; no `attempt`, no `id`). That `db/queries/event.rs` module is stale relative to the schema the rest of the server writes to.

Result: every watcher callback POST returned **HTTP 500**:

```
Database error: column "attempt" of relation "event" does not exist
```

The normal ingestion path (`handlers::events`) inserts the correct column set and works fine — only the container-callback handler wired into the stale module. Because `record_container_callback` runs only *after* the insert's `.await?`, the 500 meant `noetl_container_callback_total` never bumped, blocking the noetl/ai-meta#43 chain end to end. This surfaced once the watcher image fix (noetl/ops) made the POST actually reach the server.

## Fix

Replace the `insert_event` call with an inline `INSERT` matching the working ingestion path's deployed column set:

```
event_id, execution_id, catalog_id, event_type,
node_id, node_name, status, result, meta, created_at
```

The terminal outcome rides in a constraint-shaped `result` envelope (`{status, context}`) so the row satisfies `chk_event_result_shape` and the orchestrator reads it the same way as every other `call.done`; `node_type` moves to `meta`.

`cargo build`, `cargo clippy --all-targets` (no new warnings), and the 7 `container_callback` unit tests all pass.

## Validation

`repos/e2e/scripts/kind_validate_container_callback.sh` on the local kind cluster (rebuilt server image loaded into kind) — **both probes green**:

```
kind-val: PASS — happy_path   (state=succeeded  counter delta = 1)
kind-val: PASS — oom          (state=failed_oom counter delta = 1)
kind-val: ALL PROBES PASS — Container Tool Callback chain green
```

Refs noetl/ai-meta#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)