### PR TITLE
feat(playbook): accept `subscription` tool kind in ToolKind validation (#90 Phase 1)

### DIFF
--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -38,6 +38,11 @@ pub enum ToolKind {
     Noop,
     TaskSequence,
     Rhai,
+    /// Bounded-drain message subscription poll (NATS / Pub/Sub / Kafka).
+    /// noetl/ai-meta#90 Phase 1 — dispatched generically by the worker
+    /// through the noetl-tools registry; the server only needs to accept
+    /// the kind so playbook validation passes.
+    Subscription,
 }
 
 impl std::fmt::Display for ToolKind {
@@ -66,6 +71,7 @@ impl std::fmt::Display for ToolKind {
             ToolKind::Noop => "noop",
             ToolKind::TaskSequence => "task_sequence",
             ToolKind::Rhai => "rhai",
+            ToolKind::Subscription => "subscription",
         };
         write!(f, "{}", s)
     }
@@ -937,6 +943,36 @@ fn default_attempt() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_tool_kind_subscription_parses() {
+        // noetl/ai-meta#90 Phase 1: the `subscription` tool kind must be
+        // accepted by the server's typed ToolKind so a playbook using it
+        // passes validation (the worker dispatches it generically).
+        let kind: ToolKind = serde_json::from_str("\"subscription\"").unwrap();
+        assert_eq!(kind, ToolKind::Subscription);
+        assert_eq!(ToolKind::Subscription.to_string(), "subscription");
+
+        // A full ToolSpec with the subscription drain fields round-trips
+        // (source/operation/stream/consumer/batch/timeout_ms/ack land in
+        // the flattened `extra` and pass through to the worker).
+        let spec_yaml = r#"
+kind: subscription
+source: nats
+operation: poll
+auth: "nats_main"
+stream: ORDERS
+consumer: orders-drain
+batch: 50
+timeout_ms: 3000
+ack: on_success
+"#;
+        let spec: ToolSpec = serde_yaml::from_str(spec_yaml).unwrap();
+        assert_eq!(spec.kind, ToolKind::Subscription);
+        assert_eq!(spec.auth, Some(serde_json::json!("nats_main")));
+        assert_eq!(spec.extra.get("source").unwrap(), "nats");
+        assert_eq!(spec.extra.get("consumer").unwrap(), "orders-drain");
+    }
 
     #[test]
     fn test_parse_simple_playbook() {


### PR DESCRIPTION
## What

Adds the `Subscription` variant to the server's typed `ToolKind` enum so a
playbook using the new **`subscription`** tool (noetl-tools v3.2.0,
[noetl/tools#50](https://github.com/noetl/tools/pull/50)) passes server-side
validation. Phase 1 of the subscription/listener RFC
([noetl/ai-meta#90](https://github.com/noetl/ai-meta/issues/90)).

## Why

The worker dispatches tools generically through the noetl-tools registry, but
the **server orchestrator** parses every step's `tool.kind` into the typed
`ToolKind` enum (`ToolDefinition::Single(ToolSpec)`). An unknown kind fails
deserialization and `POST /api/execute` returns:

```
HTTP 400 — data did not match any variant of untagged enum ToolDefinition
```

So a playbook with `kind: subscription` could not run even though the worker
can execute it. This was surfaced by the in-cluster playbook-dispatch E2E for
the subscription tool — unit tests and the live-NATS integration test
exercise the tool directly and don't go through server validation.

## Change

One enum variant + its `Display` arm + a parse test. No orchestration change —
the bounded-drain fields (`source`/`operation`/`stream`/`consumer`/`batch`/
`timeout_ms`/`ack`) land in `ToolSpec`'s flattened `extra` and pass through to
the worker unchanged, exactly like the existing `nats` tool's fields.

## Tests

`test_tool_kind_subscription_parses` (kind + full ToolSpec round-trip); 620
lib tests green; clippy no new findings.

See noetl/ai-meta#90