### PR TITLE
feat: kind:Subscription type + lifecycle + pool routing + W3C trace (#90 Phase 2)

### DIFF
--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -4,6 +4,31 @@ use crate::db::models::CatalogEntry;
 use crate::db::DbPool;
 use crate::error::AppResult;
 
+/// Ensure the catalog kinds the Rust server owns exist in
+/// `noetl.resource` (the kind lookup that `noetl.catalog.kind` FK-references).
+///
+/// `noetl.catalog.kind` references `noetl.resource(name)`, so a catalog
+/// register of a `kind: Subscription` (noetl/ai-meta#90 Phase 2) fails with a
+/// foreign-key violation unless `subscription` is a seeded resource type.  The
+/// canonical seed lives in `noetl/noetl`'s `schema_ddl.sql`; this idempotent
+/// startup upsert is the safety net so a `kind: Subscription` registers on any
+/// cluster the Rust server boots against, without an out-of-band migration.
+/// Only kinds the server explicitly knows about are seeded — the FK still
+/// rejects an unknown/typo'd kind.
+pub async fn ensure_builtin_kinds(pool: &DbPool) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.resource (name, meta) VALUES
+            ('subscription', '{"description":"Source-driven subscription/listener workload (noetl/ai-meta#90)","executable":true,"catalog":true}'::jsonb)
+        ON CONFLICT (name) DO UPDATE
+        SET meta = COALESCE(noetl.resource.meta, '{}'::jsonb) || EXCLUDED.meta
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// Get the next version number for a path.
 ///
 /// `noetl.catalog.version` is Postgres `smallint`; using `i16` here

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1478,6 +1478,17 @@ async fn trigger_orchestrator(
         .await?;
     }
 
+    // Recover the per-execution routing (dedicated pool segment + W3C trace)
+    // the `/api/execute` caller supplied, persisted on the `playbook_started`
+    // event meta, so every follow-up command lands on the same segment and
+    // carries the same trace context (noetl/ai-meta#90 Phase 2).
+    let routing = events
+        .iter()
+        .find(|e| e.event_type == "playbook_started")
+        .and_then(|e| e.meta.as_ref())
+        .map(crate::handlers::execute::CommandRouting::from_started_meta)
+        .unwrap_or_default();
+
     // 5. Issue new commands via the shared persist + publish helper.
     let mut commands_generated = 0i32;
     for command in &result.commands {
@@ -1500,6 +1511,7 @@ async fn trigger_orchestrator(
             command,
             &render_context,
             &playbook,
+            &routing,
         )
         .await?;
         commands_generated += 1;

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -26,6 +26,53 @@ pub struct ExecuteRequest {
     /// Parent execution ID (for nested executions).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_execution_id: Option<i64>,
+    /// Dedicated worker pool / command segment for this whole execution
+    /// (noetl/ai-meta#90 Phase 2).  When set, every command of this
+    /// execution publishes to `noetl.commands.<execution_pool>.<eid>`
+    /// instead of the path-derived default (`system` / `shared`).  The
+    /// subscription continuous runtime passes the subscription's
+    /// `dispatch.execution_pool` (or a header-directive `x-noetl-pool`
+    /// override) so the firehose lands on an isolated segment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_pool: Option<String>,
+    /// W3C distributed-trace context to stamp onto this execution's events
+    /// (`meta.trace`) and propagate to its commands + child executions
+    /// (noetl/ai-meta#90 Phase 2, RFC §7.4).  Shape:
+    /// `{ "traceparent": "...", "tracestate": "...", "baggage": {...} }`.
+    /// `execution_id` stays the primary NoETL trace key; this is the
+    /// external join.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace: Option<serde_json::Value>,
+}
+
+/// Per-execution command routing resolved once and threaded through every
+/// `persist_engine_command` call so the initial command (this handler) and
+/// every orchestrator follow-up (`events::trigger_orchestrator`) land on the
+/// same dedicated pool segment and carry the same trace context.
+///
+/// It is persisted on the `playbook_started` event `meta` so the orchestrator
+/// — which rebuilds state from the event log on each pass — can recover it.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CommandRouting {
+    /// Dedicated pool / command-segment override for the whole execution.
+    pub pool: Option<String>,
+    /// W3C trace context (opaque JSON) propagated onto events + commands.
+    pub trace: Option<serde_json::Value>,
+}
+
+impl CommandRouting {
+    /// Recover the routing the `/api/execute` caller supplied from a
+    /// `playbook_started` event's `meta` JSON (used by the orchestrator).
+    pub(crate) fn from_started_meta(meta: &serde_json::Value) -> CommandRouting {
+        CommandRouting {
+            pool: meta
+                .get("execution_pool")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            trace: meta.get("trace").filter(|v| !v.is_null()).cloned(),
+        }
+    }
 }
 
 impl ExecuteRequest {
@@ -113,6 +160,23 @@ pub async fn execute(
     }
     let workload = serde_json::Value::Object(merged_workload);
 
+    // Resolve the per-execution routing once (noetl/ai-meta#90 Phase 2).
+    // A `trace` not supplied explicitly is inherited from the parent
+    // execution when this is a child run, so a W3C trace propagates down
+    // the whole playbook nesting (RFC §7.4) bounded by that nesting.
+    let trace = match (&request.trace, request.parent_execution_id) {
+        (Some(t), _) if !t.is_null() => Some(t.clone()),
+        (_, Some(parent)) => inherit_parent_trace(&state, parent).await,
+        _ => None,
+    };
+    let routing = CommandRouting {
+        pool: request
+            .execution_pool
+            .clone()
+            .filter(|s| !s.is_empty()),
+        trace,
+    };
+
     // Emit playbook_started event
     let start_event_id = emit_playbook_started_event(
         &state,
@@ -121,6 +185,7 @@ pub async fn execute(
         &path,
         &workload,
         request.parent_execution_id,
+        &routing,
     )
     .await?;
 
@@ -132,6 +197,7 @@ pub async fn execute(
         start_event_id,
         &playbook,
         &request.payload,
+        &routing,
     )
     .await?;
 
@@ -214,6 +280,7 @@ async fn emit_playbook_started_event(
     path: &str,
     workload: &serde_json::Value,
     parent_execution_id: Option<i64>,
+    routing: &CommandRouting,
 ) -> AppResult<i64> {
     let event_id = state.snowflake.generate()?;
 
@@ -224,10 +291,22 @@ async fn emit_playbook_started_event(
         "workload": workload,
     });
 
-    let meta = serde_json::json!({
+    // Persist the per-execution routing (pool segment + trace) on the
+    // start event's meta so the orchestrator — which rebuilds state from
+    // the event log on each pass — recovers it for every follow-up command
+    // (noetl/ai-meta#90 Phase 2).
+    let mut meta = serde_json::json!({
         "emitted_at": chrono::Utc::now().to_rfc3339(),
         "emitter": "control_plane",
     });
+    if let serde_json::Value::Object(ref mut m) = meta {
+        if let Some(pool) = routing.pool.as_ref() {
+            m.insert("execution_pool".to_string(), serde_json::json!(pool));
+        }
+        if let Some(trace) = routing.trace.as_ref() {
+            m.insert("trace".to_string(), trace.clone());
+        }
+    }
 
     sqlx::query(
         r#"
@@ -256,6 +335,22 @@ async fn emit_playbook_started_event(
     .await?;
 
     Ok(event_id)
+}
+
+/// Inherit the W3C trace context (RFC §7.4) from a parent execution's
+/// `playbook_started` event so a child run joins the same distributed trace.
+/// Best-effort: a missing parent / missing trace simply yields `None`.
+async fn inherit_parent_trace(state: &AppState, parent_execution_id: i64) -> Option<serde_json::Value> {
+    let meta: Option<serde_json::Value> = sqlx::query_scalar(
+        "SELECT meta FROM noetl.event WHERE execution_id = $1 AND event_type = 'playbook_started' \
+         ORDER BY event_id ASC LIMIT 1",
+    )
+    .bind(parent_execution_id)
+    .fetch_optional(state.pools.pool_for(parent_execution_id))
+    .await
+    .ok()
+    .flatten();
+    meta.and_then(|m| m.get("trace").filter(|v| !v.is_null()).cloned())
 }
 
 /// Persist one engine-generated command + its `command.issued`
@@ -289,6 +384,7 @@ pub(crate) async fn persist_engine_command(
     command: &crate::engine::commands::Command,
     render_context: &HashMap<String, serde_json::Value>,
     playbook: &crate::playbook::types::Playbook,
+    routing: &CommandRouting,
 ) -> AppResult<i64> {
     let event_id = state.snowflake.generate()?;
 
@@ -344,6 +440,14 @@ pub(crate) async fn persist_engine_command(
                 "item_var".to_string(),
                 serde_json::json!(iter.item_var.clone()),
             );
+        }
+    }
+    // Thread the W3C trace context onto the command.issued event meta so the
+    // event log carries the external trace join and the worker can attach it
+    // to its dispatch span (noetl/ai-meta#90 Phase 2, RFC §7.4).
+    if let Some(trace) = routing.trace.as_ref() {
+        if let serde_json::Value::Object(ref mut map) = cmd_meta {
+            map.insert("trace".to_string(), trace.clone());
         }
     }
 
@@ -402,6 +506,7 @@ pub(crate) async fn persist_engine_command(
         &step.step,
         command.tool.kind.as_str(),
         playbook,
+        routing,
     )
     .await?;
 
@@ -423,6 +528,7 @@ async fn generate_initial_commands(
     parent_event_id: i64,
     playbook: &crate::playbook::types::Playbook,
     payload: &HashMap<String, serde_json::Value>,
+    routing: &CommandRouting,
 ) -> AppResult<i32> {
     // Find start step
     let start_step = playbook
@@ -575,6 +681,7 @@ async fn generate_initial_commands(
                 &command,
                 &cmd_render_ctx,
                 playbook,
+                routing,
             )
             .await?;
         }
@@ -607,6 +714,7 @@ async fn generate_initial_commands(
         &command,
         &cmd_render_ctx,
         playbook,
+        routing,
     )
     .await?;
 
@@ -681,6 +789,7 @@ async fn insert_command_row(
 /// notification is skipped with a WARN — caller still records the
 /// `command.issued` event so dashboards work, but no worker will
 /// pick the command up.
+#[allow(clippy::too_many_arguments)]
 async fn publish_command_notification(
     state: &AppState,
     execution_id: i64,
@@ -689,6 +798,7 @@ async fn publish_command_notification(
     step: &str,
     _tool_kind: &str,
     playbook: &crate::playbook::types::Playbook,
+    routing: &CommandRouting,
 ) -> AppResult<()> {
     let Some(nats_client) = state.nats.as_ref() else {
         tracing::warn!(
@@ -699,12 +809,22 @@ async fn publish_command_notification(
         return Ok(());
     };
 
-    // Pool segment from the playbook's catalog path.  The
-    // `Playbook` type's `metadata.path` is `Option<String>`; if
-    // unset we default to `shared` (the same default Python uses).
-    let pool_segment = match playbook.metadata.path.as_deref() {
-        Some(p) if p.starts_with("system/") => "system",
-        _ => "shared",
+    // Pool segment selection (noetl/ai-meta#90 Phase 2).  Precedence:
+    //   1. an explicit per-execution `execution_pool` override (the
+    //      subscription continuous runtime / a header `x-noetl-pool`
+    //      directive) — lands the run on `noetl.commands.<override>.<eid>`,
+    //   2. else the path-derived default: `system/` paths → `system`,
+    //      `subscription/` paths → `subscription`, everything else →
+    //      `shared` (the same default Python uses).
+    // The override isolates a subscription firehose on a dedicated segment
+    // without touching the shared command stream.
+    let pool_segment = match routing.pool.as_deref() {
+        Some(p) if !p.is_empty() => p,
+        _ => match playbook.metadata.path.as_deref() {
+            Some(p) if p.starts_with("system/") => "system",
+            Some(p) if p.starts_with("subscription/") => "subscription",
+            _ => "shared",
+        },
     };
     let subject = format!("noetl.commands.{}.{}", pool_segment, execution_id);
 
@@ -714,13 +834,20 @@ async fn publish_command_notification(
         .clone()
         .unwrap_or_else(|| "http://localhost:8082".to_string());
 
-    let notification = serde_json::json!({
+    let mut notification = serde_json::json!({
         "execution_id": execution_id,
         "event_id": event_id,
         "command_id": command_id,
         "step": step,
         "server_url": server_url,
     });
+    // Carry the W3C trace context on the command notification so the worker
+    // can attach it to its dispatch span (RFC §7.4).
+    if let Some(trace) = routing.trace.as_ref() {
+        if let serde_json::Value::Object(ref mut m) = notification {
+            m.insert("trace".to_string(), trace.clone());
+        }
+    }
     let payload = serde_json::to_vec(&notification)
         .map_err(|e| AppError::Internal(format!("Serialize command notification: {e}")))?;
 
@@ -946,6 +1073,8 @@ mod tests {
             catalog_id: None,
             payload: HashMap::new(),
             parent_execution_id: None,
+            execution_pool: None,
+            trace: None,
         };
         assert!(request.validate().is_err());
 
@@ -954,6 +1083,8 @@ mod tests {
             catalog_id: None,
             payload: HashMap::new(),
             parent_execution_id: None,
+            execution_pool: None,
+            trace: None,
         };
         assert!(request.validate().is_ok());
 
@@ -962,6 +1093,8 @@ mod tests {
             catalog_id: Some(12345),
             payload: HashMap::new(),
             parent_execution_id: None,
+            execution_pool: None,
+            trace: None,
         };
         assert!(request.validate().is_ok());
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -19,6 +19,7 @@ pub mod result_store;
 pub mod runtime;
 pub mod secret_audit;
 pub mod sharding;
+pub mod subscription;
 pub mod system;
 pub mod variables;
 pub mod wallet_rotate;

--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -40,7 +40,7 @@ type ListRow = (
     String,
     String,
     i64,
-    Option<chrono::DateTime<chrono::Utc>>,
+    Option<chrono::NaiveDateTime>,
 );
 
 /// `(event_type, status, catalog_id, node_name, created_at)` — the latest
@@ -50,7 +50,7 @@ type LatestRow = (
     String,
     i64,
     Option<String>,
-    Option<chrono::DateTime<chrono::Utc>>,
+    Option<chrono::NaiveDateTime>,
 );
 
 // ---------------------------------------------------------------------------
@@ -312,7 +312,7 @@ pub async fn list(State(state): State<AppState>) -> AppResult<Json<SubscriptionL
                     .unwrap_or("UNKNOWN")
                     .to_string(),
                 last_event_type: event_type,
-                updated_at: created_at.map(|t| t.to_rfc3339()),
+                updated_at: created_at.map(|t| t.and_utc().to_rfc3339()),
             });
         }
     }
@@ -360,7 +360,7 @@ async fn load_latest(state: &AppState, subscription_id: i64) -> AppResult<Option
         catalog_id,
         path,
         last_event_type: event_type,
-        updated_at: created_at.map(|t| t.to_rfc3339()),
+        updated_at: created_at.map(|t| t.and_utc().to_rfc3339()),
     }))
 }
 

--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -186,6 +186,27 @@ pub async fn register(
         )));
     }
 
+    // Idempotent register: reuse an existing non-deactivated subscription for
+    // the same path so a runtime restart doesn't mint a fresh id each time.
+    if let Some(existing) = latest_for_path(&state, &req.path).await? {
+        if existing.state != SubState::Deactivated {
+            tracing::info!(
+                subscription_id = existing.subscription_id,
+                path = %req.path,
+                state = existing.state.as_status(),
+                "Subscription already registered — reusing"
+            );
+            return Ok(Json(SubscriptionStatus {
+                subscription_id: existing.subscription_id.to_string(),
+                path: req.path,
+                catalog_id: existing.catalog_id.to_string(),
+                state: existing.state.as_status().to_string(),
+                last_event_type: existing.last_event_type,
+                updated_at: existing.updated_at,
+            }));
+        }
+    }
+
     let subscription_id = state.snowflake.generate()?;
     write_lifecycle_event(
         &state,
@@ -329,6 +350,50 @@ struct LatestState {
     path: String,
     last_event_type: String,
     updated_at: Option<String>,
+}
+
+struct LatestForPath {
+    subscription_id: i64,
+    state: SubState,
+    catalog_id: i64,
+    last_event_type: String,
+    updated_at: Option<String>,
+}
+
+/// Find the most recent subscription (by lifecycle event) for a catalog path,
+/// across shards.  Used to make `register` idempotent.
+async fn latest_for_path(state: &AppState, path: &str) -> AppResult<Option<LatestForPath>> {
+    let mut best: Option<(i64, LatestForPath)> = None; // (event_id, state)
+    for (_idx, pool) in state.pools.all_shards() {
+        let row: Option<(i64, i64, String, String, i64, Option<chrono::NaiveDateTime>)> =
+            sqlx::query_as(
+                r#"
+                SELECT event_id, execution_id, event_type, status, catalog_id, created_at
+                FROM noetl.event
+                WHERE node_name = $1 AND event_type LIKE 'subscription.%'
+                ORDER BY event_id DESC
+                LIMIT 1
+                "#,
+            )
+            .bind(path)
+            .fetch_optional(pool)
+            .await?;
+        if let Some((event_id, sid, event_type, status, catalog_id, created_at)) = row {
+            if let Some(st) = SubState::from_status(&status) {
+                let candidate = LatestForPath {
+                    subscription_id: sid,
+                    state: st,
+                    catalog_id,
+                    last_event_type: event_type,
+                    updated_at: created_at.map(|t| t.and_utc().to_rfc3339()),
+                };
+                if best.as_ref().map(|(eid, _)| event_id > *eid).unwrap_or(true) {
+                    best = Some((event_id, candidate));
+                }
+            }
+        }
+    }
+    Ok(best.map(|(_, s)| s))
 }
 
 async fn load_latest(state: &AppState, subscription_id: i64) -> AppResult<Option<LatestState>> {

--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -1,0 +1,462 @@
+//! `kind: Subscription` lifecycle handlers.
+//!
+//! Phase 2 of the subscription/listener RFC
+//! ([noetl/ai-meta#90](https://github.com/noetl/ai-meta/issues/90)).
+//!
+//! A `kind: Subscription` catalog entry is a long-lived, activatable resource
+//! — never dispatched as a one-shot step DAG.  Its lifecycle is a state
+//! machine, **event-sourced** into `noetl.event` so an operator can replay
+//! "when did this subscription activate / pause / drain / go down":
+//!
+//! ```text
+//!  register → activate → (pause ⇄ resume) → drain → deactivate
+//! ```
+//!
+//! Each transition writes a `subscription.<transition>` event keyed by the
+//! subscription's own snowflake id (the subscription is itself a long-lived
+//! "execution" whose event log is its lifecycle; per-message runs are ordinary
+//! child executions with `parent_execution_id` = this id).  Current state is
+//! the latest such event's status — no separate state table, so it stays
+//! replayable and needs no schema migration.
+//!
+//! These routes are the control surface the **continuous subscription
+//! runtime** (worker run-mode, Mode B) drives: it registers + activates on
+//! startup, polls its state to honor pause/resume, and drains + deactivates on
+//! shutdown.  KEDA reads the active set + source backlog to scale the pool.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+
+/// `(subscription_id, event_type, status, catalog_id, created_at)` — one
+/// subscription's latest lifecycle row, for the cross-shard list query.
+type ListRow = (
+    i64,
+    String,
+    String,
+    i64,
+    Option<chrono::DateTime<chrono::Utc>>,
+);
+
+/// `(event_type, status, catalog_id, node_name, created_at)` — the latest
+/// lifecycle event for one subscription.
+type LatestRow = (
+    String,
+    String,
+    i64,
+    Option<String>,
+    Option<chrono::DateTime<chrono::Utc>>,
+);
+
+// ---------------------------------------------------------------------------
+// Lifecycle state machine
+// ---------------------------------------------------------------------------
+
+/// Subscription lifecycle state (the latest transition's status).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubState {
+    Registered,
+    Active,
+    Paused,
+    Draining,
+    Deactivated,
+}
+
+impl SubState {
+    fn as_status(&self) -> &'static str {
+        match self {
+            SubState::Registered => "REGISTERED",
+            SubState::Active => "ACTIVE",
+            SubState::Paused => "PAUSED",
+            SubState::Draining => "DRAINING",
+            SubState::Deactivated => "DEACTIVATED",
+        }
+    }
+
+    fn from_status(s: &str) -> Option<SubState> {
+        match s {
+            "REGISTERED" => Some(SubState::Registered),
+            "ACTIVE" => Some(SubState::Active),
+            "PAUSED" => Some(SubState::Paused),
+            "DRAINING" => Some(SubState::Draining),
+            "DEACTIVATED" => Some(SubState::Deactivated),
+            _ => None,
+        }
+    }
+}
+
+/// A lifecycle transition: its event type, the resulting state, and the set of
+/// states it may be applied from.
+struct Transition {
+    event_type: &'static str,
+    to: SubState,
+    from: &'static [SubState],
+}
+
+fn transition(name: &str) -> Option<Transition> {
+    use SubState::*;
+    Some(match name {
+        "activate" => Transition {
+            event_type: "subscription.activated",
+            to: Active,
+            // Re-activate from a paused/deactivated subscription is allowed.
+            from: &[Registered, Paused, Deactivated, Active],
+        },
+        "pause" => Transition {
+            event_type: "subscription.paused",
+            to: Paused,
+            from: &[Active, Paused],
+        },
+        "resume" => Transition {
+            event_type: "subscription.resumed",
+            to: Active,
+            from: &[Paused, Active],
+        },
+        "drain" => Transition {
+            event_type: "subscription.draining",
+            to: Draining,
+            from: &[Active, Paused, Draining],
+        },
+        "deactivate" => Transition {
+            event_type: "subscription.deactivated",
+            to: Deactivated,
+            from: &[Registered, Active, Paused, Draining, Deactivated],
+        },
+        _ => return None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Request / response shapes
+// ---------------------------------------------------------------------------
+
+/// `POST /api/subscriptions/register`
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    /// Catalog path of the `kind: Subscription` entry.
+    pub path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SubscriptionStatus {
+    pub subscription_id: String,
+    pub path: String,
+    pub catalog_id: String,
+    pub state: String,
+    pub last_event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SubscriptionList {
+    pub subscriptions: Vec<SubscriptionStatus>,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /api/subscriptions/register` — mint a subscription id and write the
+/// `subscription.registered` lifecycle event.  The path must resolve to a
+/// `kind: subscription` catalog entry.
+pub async fn register(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterRequest>,
+) -> AppResult<Json<SubscriptionStatus>> {
+    // Resolve the catalog entry and confirm it is a subscription.
+    let row: Option<(i64, String)> = sqlx::query_as(
+        "SELECT catalog_id, kind FROM noetl.catalog WHERE path = $1 ORDER BY version DESC LIMIT 1",
+    )
+    .bind(&req.path)
+    .fetch_optional(state.pools.cluster())
+    .await?;
+
+    let (catalog_id, kind) = row
+        .ok_or_else(|| AppError::NotFound(format!("Subscription not found: {}", req.path)))?;
+    if kind.to_lowercase() != "subscription" {
+        return Err(AppError::Validation(format!(
+            "Catalog entry '{}' is kind '{}', not 'subscription'",
+            req.path, kind
+        )));
+    }
+
+    let subscription_id = state.snowflake.generate()?;
+    write_lifecycle_event(
+        &state,
+        subscription_id,
+        catalog_id,
+        &req.path,
+        "subscription.registered",
+        SubState::Registered,
+    )
+    .await?;
+
+    tracing::info!(
+        subscription_id,
+        path = %req.path,
+        catalog_id,
+        "Subscription registered"
+    );
+
+    Ok(Json(SubscriptionStatus {
+        subscription_id: subscription_id.to_string(),
+        path: req.path,
+        catalog_id: catalog_id.to_string(),
+        state: SubState::Registered.as_status().to_string(),
+        last_event_type: "subscription.registered".to_string(),
+        updated_at: Some(chrono::Utc::now().to_rfc3339()),
+    }))
+}
+
+/// `POST /api/subscriptions/{id}/{transition}` — apply a lifecycle transition
+/// (activate / pause / resume / drain / deactivate), validated against the
+/// current state, and write its event.
+pub async fn lifecycle(
+    State(state): State<AppState>,
+    Path((subscription_id, action)): Path<(i64, String)>,
+) -> AppResult<Json<SubscriptionStatus>> {
+    let t = transition(&action)
+        .ok_or_else(|| AppError::Validation(format!("Unknown subscription action '{}'", action)))?;
+
+    let current = load_latest(&state, subscription_id).await?.ok_or_else(|| {
+        AppError::NotFound(format!("Subscription {} not registered", subscription_id))
+    })?;
+
+    if !t.from.contains(&current.state) {
+        return Err(AppError::Validation(format!(
+            "Cannot '{}' a subscription in state '{}' (allowed from {:?})",
+            action,
+            current.state.as_status(),
+            t.from.iter().map(|s| s.as_status()).collect::<Vec<_>>()
+        )));
+    }
+
+    write_lifecycle_event(
+        &state,
+        subscription_id,
+        current.catalog_id,
+        &current.path,
+        t.event_type,
+        t.to,
+    )
+    .await?;
+
+    tracing::info!(
+        subscription_id,
+        path = %current.path,
+        action = %action,
+        new_state = t.to.as_status(),
+        "Subscription lifecycle transition"
+    );
+
+    Ok(Json(SubscriptionStatus {
+        subscription_id: subscription_id.to_string(),
+        path: current.path,
+        catalog_id: current.catalog_id.to_string(),
+        state: t.to.as_status().to_string(),
+        last_event_type: t.event_type.to_string(),
+        updated_at: Some(chrono::Utc::now().to_rfc3339()),
+    }))
+}
+
+/// `GET /api/subscriptions/{id}` — current lifecycle state.
+pub async fn get(
+    State(state): State<AppState>,
+    Path(subscription_id): Path<i64>,
+) -> AppResult<Json<SubscriptionStatus>> {
+    let current = load_latest(&state, subscription_id).await?.ok_or_else(|| {
+        AppError::NotFound(format!("Subscription {} not registered", subscription_id))
+    })?;
+    Ok(Json(SubscriptionStatus {
+        subscription_id: subscription_id.to_string(),
+        path: current.path,
+        catalog_id: current.catalog_id.to_string(),
+        state: current.state.as_status().to_string(),
+        last_event_type: current.last_event_type,
+        updated_at: current.updated_at,
+    }))
+}
+
+/// `GET /api/subscriptions` — every registered subscription with its current
+/// state.  Fans out across shards (subscriptions are keyed by their snowflake
+/// id, sharded like any execution).  The runtime + KEDA read this to find the
+/// active set.
+pub async fn list(State(state): State<AppState>) -> AppResult<Json<SubscriptionList>> {
+    let mut subscriptions: Vec<SubscriptionStatus> = Vec::new();
+    for (_idx, pool) in state.pools.all_shards() {
+        let rows: Vec<ListRow> = sqlx::query_as(
+                r#"
+                SELECT DISTINCT ON (execution_id)
+                       execution_id, event_type, status, catalog_id, created_at
+                FROM noetl.event
+                WHERE event_type LIKE 'subscription.%'
+                ORDER BY execution_id, event_id DESC
+                "#,
+            )
+            .fetch_all(pool)
+            .await?;
+        for (sid, event_type, status, catalog_id, created_at) in rows {
+            let path = subscription_path(&state, catalog_id).await.unwrap_or_default();
+            subscriptions.push(SubscriptionStatus {
+                subscription_id: sid.to_string(),
+                path,
+                catalog_id: catalog_id.to_string(),
+                state: SubState::from_status(&status)
+                    .map(|s| s.as_status())
+                    .unwrap_or("UNKNOWN")
+                    .to_string(),
+                last_event_type: event_type,
+                updated_at: created_at.map(|t| t.to_rfc3339()),
+            });
+        }
+    }
+    Ok(Json(SubscriptionList { subscriptions }))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+struct LatestState {
+    state: SubState,
+    catalog_id: i64,
+    path: String,
+    last_event_type: String,
+    updated_at: Option<String>,
+}
+
+async fn load_latest(state: &AppState, subscription_id: i64) -> AppResult<Option<LatestState>> {
+    let row: Option<LatestRow> = sqlx::query_as(
+            r#"
+            SELECT event_type, status, catalog_id, node_name, created_at
+            FROM noetl.event
+            WHERE execution_id = $1 AND event_type LIKE 'subscription.%'
+            ORDER BY event_id DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(subscription_id)
+        .fetch_optional(state.pools.pool_for(subscription_id))
+        .await?;
+
+    let Some((event_type, status, catalog_id, node_name, created_at)) = row else {
+        return Ok(None);
+    };
+    let sub_state = SubState::from_status(&status).ok_or_else(|| {
+        AppError::Internal(format!("Subscription {subscription_id} has unknown status '{status}'"))
+    })?;
+    let path = match node_name {
+        Some(p) if !p.is_empty() => p,
+        _ => subscription_path(state, catalog_id).await.unwrap_or_default(),
+    };
+    Ok(Some(LatestState {
+        state: sub_state,
+        catalog_id,
+        path,
+        last_event_type: event_type,
+        updated_at: created_at.map(|t| t.to_rfc3339()),
+    }))
+}
+
+async fn subscription_path(state: &AppState, catalog_id: i64) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT path FROM noetl.catalog WHERE catalog_id = $1")
+        .bind(catalog_id)
+        .fetch_optional(state.pools.cluster())
+        .await
+        .ok()
+        .flatten()
+}
+
+async fn write_lifecycle_event(
+    state: &AppState,
+    subscription_id: i64,
+    catalog_id: i64,
+    path: &str,
+    event_type: &str,
+    to: SubState,
+) -> AppResult<()> {
+    let event_id = state.snowflake.generate()?;
+    let context = serde_json::json!({
+        "subscription_id": subscription_id.to_string(),
+        "path": path,
+        "catalog_id": catalog_id.to_string(),
+    });
+    let meta = serde_json::json!({
+        "emitted_at": chrono::Utc::now().to_rfc3339(),
+        "emitter": "control_plane",
+        "subscription_lifecycle": true,
+    });
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.event (
+            execution_id, catalog_id, event_id,
+            event_type, node_id, node_name, node_type, status,
+            context, meta, created_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        "#,
+    )
+    .bind(subscription_id)
+    .bind(catalog_id)
+    .bind(event_id)
+    .bind(event_type)
+    .bind("subscription")
+    .bind(path)
+    .bind("subscription")
+    .bind(to.as_status())
+    .bind(&context)
+    .bind(&meta)
+    .bind(chrono::Utc::now())
+    .execute(state.pools.pool_for(subscription_id))
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transition_table_states() {
+        assert_eq!(transition("activate").unwrap().to, SubState::Active);
+        assert_eq!(transition("pause").unwrap().to, SubState::Paused);
+        assert_eq!(transition("resume").unwrap().to, SubState::Active);
+        assert_eq!(transition("drain").unwrap().to, SubState::Draining);
+        assert_eq!(transition("deactivate").unwrap().to, SubState::Deactivated);
+        assert!(transition("bogus").is_none());
+    }
+
+    #[test]
+    fn pause_only_from_active() {
+        let t = transition("pause").unwrap();
+        assert!(t.from.contains(&SubState::Active));
+        assert!(!t.from.contains(&SubState::Registered));
+        assert!(!t.from.contains(&SubState::Deactivated));
+    }
+
+    #[test]
+    fn resume_only_from_paused() {
+        let t = transition("resume").unwrap();
+        assert!(t.from.contains(&SubState::Paused));
+        assert!(!t.from.contains(&SubState::Registered));
+    }
+
+    #[test]
+    fn status_roundtrip() {
+        for s in [
+            SubState::Registered,
+            SubState::Active,
+            SubState::Paused,
+            SubState::Draining,
+            SubState::Deactivated,
+        ] {
+            assert_eq!(SubState::from_status(s.as_status()), Some(s));
+        }
+        assert_eq!(SubState::from_status("NOPE"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -671,6 +671,10 @@ async fn main() -> anyhow::Result<()> {
     // pattern as secret_audit above.  The table is server-owned end-to-end;
     // no out-of-band migration required.
     noetl_server::db::queries::result_store::ensure_table(&db_pool).await?;
+    // kind: Subscription (noetl/ai-meta#90 Phase 2) — seed the `subscription`
+    // resource kind so a catalog register doesn't trip the
+    // `noetl.catalog.kind -> noetl.resource(name)` FK.  Idempotent.
+    noetl_server::db::queries::catalog::ensure_builtin_kinds(&db_pool).await?;
     // Keychain is the execution-scoped cache for credential resolution
     // (Secrets Wallet Phase 3c), so it is built first + shared into the
     // credential service.

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,28 @@ fn build_router(
         )
         .with_state(state.clone());
 
+    // Subscription lifecycle routes (noetl/ai-meta#90 Phase 2).  A
+    // `kind: Subscription` is registered + activated here; the continuous
+    // runtime drives pause/resume/drain/deactivate, each event-logged.
+    let subscription_routes = Router::new()
+        .route(
+            "/api/subscriptions",
+            get(handlers::subscription::list).post(handlers::subscription::register),
+        )
+        .route(
+            "/api/subscriptions/register",
+            post(handlers::subscription::register),
+        )
+        .route(
+            "/api/subscriptions/{id}",
+            get(handlers::subscription::get),
+        )
+        .route(
+            "/api/subscriptions/{id}/{action}",
+            post(handlers::subscription::lifecycle),
+        )
+        .with_state(state.clone());
+
     // Execution management routes
     let executions_routes = Router::new()
         .route("/api/executions", get(handlers::executions::list))
@@ -419,6 +441,7 @@ fn build_router(
         .merge(keychain_routes)
         .merge(execution_routes)
         .merge(executions_routes)
+        .merge(subscription_routes)
         .merge(replay_routes)
         .merge(result_store_routes)
         .merge(variable_routes)

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -54,6 +54,16 @@ impl CatalogService {
             .unwrap_or(&request.resource_type)
             .to_lowercase();
 
+        // A `kind: Subscription` entry is a first-class catalog type
+        // (noetl/ai-meta#90 Phase 2) — it is never dispatched as a step
+        // DAG, so it is validated against the source/mode/dispatch schema
+        // instead of a `workflow:` block.  Reject a malformed spec at
+        // registration so the continuous runtime never activates a broken
+        // subscription.
+        if kind == "subscription" {
+            validate_subscription_spec(&yaml)?;
+        }
+
         // Get next version
         let version = queries::get_next_version(&self.pool, &path).await?;
 
@@ -162,5 +172,221 @@ impl CatalogService {
 
         // Return as-is if not valid base64
         Ok(content.to_string())
+    }
+}
+
+/// Source backends a `kind: Subscription` may declare.
+const SUBSCRIPTION_SOURCES: &[&str] = &["pubsub", "nats", "kafka", "webhook"];
+/// Activation modes for a pull subscription.
+const SUBSCRIPTION_ACTIVATIONS: &[&str] = &["continuous", "scheduled"];
+
+/// Validate a `kind: Subscription` catalog entry against the RFC §4.1 schema
+/// (noetl/ai-meta#90).  This is the **type-level** isolation of the
+/// subscription workload class: it requires the `source` / `mode` / `dispatch`
+/// shape and explicitly does **not** require a `workflow:` step DAG (a
+/// subscription is activated on a runtime, never dispatched as a one-shot
+/// DAG).
+fn validate_subscription_spec(yaml: &serde_yaml::Value) -> AppResult<()> {
+    let spec = yaml
+        .get("spec")
+        .ok_or_else(|| AppError::Validation("kind: Subscription requires a 'spec' block".into()))?;
+
+    // source — required, from the supported set.
+    let source = spec
+        .get("source")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("subscription spec requires 'source'".into()))?;
+    if !SUBSCRIPTION_SOURCES.contains(&source) {
+        return Err(AppError::Validation(format!(
+            "subscription 'source' must be one of {:?}, got '{}'",
+            SUBSCRIPTION_SOURCES, source
+        )));
+    }
+
+    // mode — required, pull | push.
+    let mode = spec
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("subscription spec requires 'mode' (pull | push)".into()))?;
+    match mode {
+        "pull" => {
+            // activation defaults to continuous; validate if present.
+            if let Some(act) = spec.get("activation").and_then(|v| v.as_str()) {
+                if !SUBSCRIPTION_ACTIVATIONS.contains(&act) {
+                    return Err(AppError::Validation(format!(
+                        "subscription 'activation' must be one of {:?}, got '{}'",
+                        SUBSCRIPTION_ACTIVATIONS, act
+                    )));
+                }
+            }
+        }
+        "push" => {
+            // Push ingress (Mode C) lands in Phase 3; the type accepts the
+            // shape now so a spec can be registered ahead of the gateway.
+        }
+        other => {
+            return Err(AppError::Validation(format!(
+                "subscription 'mode' must be 'pull' or 'push', got '{}'",
+                other
+            )));
+        }
+    }
+
+    // dispatch.playbook — required: the ordinary playbook run per message.
+    let dispatch = spec
+        .get("dispatch")
+        .ok_or_else(|| AppError::Validation("subscription spec requires a 'dispatch' block".into()))?;
+    dispatch
+        .get("playbook")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AppError::Validation("subscription 'dispatch.playbook' is required".into())
+        })?;
+
+    // headers (directive allowlist) — optional; structural-only check here.
+    // The strict allowlist/value validation lives in the worker's
+    // noetl-tools directive engine (RFC §7); the server only checks shape so
+    // a malformed block is caught early.
+    if let Some(headers) = spec.get("headers") {
+        if !headers.is_mapping() {
+            return Err(AppError::Validation(
+                "subscription 'headers' must be a mapping".into(),
+            ));
+        }
+        if let Some(directives) = headers.get("directives") {
+            let seq = directives.as_sequence().ok_or_else(|| {
+                AppError::Validation("subscription 'headers.directives' must be a list".into())
+            })?;
+            for (i, d) in seq.iter().enumerate() {
+                let has_header = d.get("header").and_then(|v| v.as_str()).is_some();
+                let has_controls = d.get("controls").and_then(|v| v.as_str()).is_some();
+                if !has_header || !has_controls {
+                    return Err(AppError::Validation(format!(
+                        "subscription 'headers.directives[{}]' requires 'header' and 'controls'",
+                        i
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn yaml(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn valid_pull_continuous_subscription() {
+        let v = yaml(
+            r#"
+apiVersion: noetl.io/v1
+kind: Subscription
+metadata: { name: iot, path: subscriptions/iot }
+spec:
+  source: pubsub
+  mode: pull
+  activation: continuous
+  auth: pubsub_iot
+  subscription: "projects/acme/subscriptions/sensors"
+  dispatch: { playbook: domain/ingest, payload_from: message.json, execution_pool: iot }
+  headers:
+    directives:
+      - header: x-noetl-pool
+        controls: dispatch.execution_pool
+        allowed: ["iot"]
+"#,
+        );
+        assert!(validate_subscription_spec(&v).is_ok());
+    }
+
+    #[test]
+    fn valid_push_subscription() {
+        let v = yaml(
+            r#"
+kind: Subscription
+metadata: { name: stripe, path: subscriptions/stripe }
+spec:
+  source: webhook
+  mode: push
+  dispatch: { playbook: domain/handle_stripe }
+"#,
+        );
+        assert!(validate_subscription_spec(&v).is_ok());
+    }
+
+    #[test]
+    fn missing_spec_rejected() {
+        let v = yaml("kind: Subscription\nmetadata: { name: x, path: p }\n");
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("'spec'"));
+    }
+
+    #[test]
+    fn bad_source_rejected() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: rabbitmq\n  mode: pull\n  dispatch: { playbook: p }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("source"));
+    }
+
+    #[test]
+    fn missing_dispatch_playbook_rejected() {
+        let v = yaml("kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  dispatch: {}\n");
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("dispatch.playbook"));
+    }
+
+    #[test]
+    fn bad_mode_rejected() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: streaming\n  dispatch: { playbook: p }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("mode"));
+    }
+
+    #[test]
+    fn bad_activation_rejected() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  activation: bogus\n  dispatch: { playbook: p }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("activation"));
+    }
+
+    #[test]
+    fn malformed_directives_rejected() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: nats
+  mode: pull
+  dispatch: { playbook: p }
+  headers:
+    directives:
+      - controls: dispatch.playbook
+"#,
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("header"));
+    }
+
+    #[test]
+    fn no_workflow_dag_required() {
+        // A subscription with NO workflow/steps block validates fine — the
+        // type does not require a step DAG.
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: kafka\n  mode: pull\n  dispatch: { playbook: domain/x }\n",
+        );
+        assert!(validate_subscription_spec(&v).is_ok());
     }
 }


### PR DESCRIPTION
Phase 2 server slice of the subscription/listener RFC ([noetl/ai-meta#90](https://github.com/noetl/ai-meta/issues/90)). Builds on the Phase-1 `Subscription` ToolKind (v3.1.0).

## `kind: Subscription` — a first-class catalog type
Catalog `register` validates a `kind: Subscription` entry against the RFC §4.1 schema (`source` ∈ pubsub/nats/kafka/webhook, `mode` pull/push, `dispatch.playbook` required, optional `headers`/`activation`) and **explicitly does not require a `workflow:` step DAG** — a subscription is activated on a runtime, never dispatched as a one-shot DAG. Malformed specs are rejected at registration. (`src/services/catalog.rs`)

## Lifecycle — event-sourced, no schema migration
New `/api/subscriptions` routes: `register → activate → pause/resume → drain → deactivate`, plus `GET /{id}` and `GET /` (cross-shard fan-out). Each transition is validated against the current state and written as a `subscription.<transition>` event keyed by the subscription's own snowflake id, so state is replayable from the event log. (`src/handlers/subscription.rs`)

## Dedicated pool routing + W3C trace (§7.4)
`/api/execute` now accepts:
- `execution_pool` — routes the **whole** execution to `noetl.commands.<pool>.<eid>` so a subscription firehose lands on an isolated segment, never the shared stream.
- `trace` — a W3C context stamped onto `meta.trace` + the `command.issued` meta + the NATS command notification, and **inherited by child executions** when not supplied (bounded by playbook nesting).

Both are persisted on the `playbook_started` event meta and recovered by the orchestrator (`CommandRouting::from_started_meta`) on every pass, so follow-up commands stay on the same segment + trace. (`src/handlers/execute.rs`, `src/handlers/events.rs`)

## Tests
8 catalog-validation + 4 lifecycle-state-machine unit tests; **633 lib tests green; clippy clean** (server slice). Routing + trace + lifecycle validated end-to-end on kind with the worker continuous runtime (worker slice of Phase 2).

The header-directive engine that produces the `execution_pool`/`trace` values lands in noetl-tools; the continuous runtime that drives these endpoints lands in noetl-worker.

Closes noetl/server#179
Refs noetl/ai-meta#90

🤖 Generated with [Claude Code](https://claude.com/claude-code)