### PR TITLE
feat: push-ingress config endpoint + push catalog validation (#90 Phase 3)

### DIFF
--- a/src/handlers/ingress.rs
+++ b/src/handlers/ingress.rs
@@ -1,0 +1,335 @@
+//! Gateway push-ingress config endpoint (`GET /api/internal/ingress/{listener}`).
+//!
+//! Phase 3 of the subscription/listener RFC
+//! ([noetl/ai-meta#90](https://github.com/noetl/ai-meta/issues/90), RFC §6).
+//!
+//! ### Why this exists
+//!
+//! The gateway terminates untrusted inbound push/webhook traffic and is the
+//! component that **verifies** a delivery (RFC §6: "verification lives there").
+//! To do that it needs the subscription's verify scheme + the decrypted verify
+//! secret — but the gateway holds **no** database connection and never reads
+//! domain data directly (`agents/rules/data-access-boundary.md`).  So the
+//! server exposes this single internal endpoint: the gateway calls it (gated by
+//! `RequireInternalApiToken`, the same service-account bearer the
+//! `/api/internal/*` family uses), and the server:
+//!
+//! 1. resolves the `kind: Subscription` whose `spec.ingress.gateway_path`
+//!    trailing segment matches the requested `listener`,
+//! 2. resolves the verify-secret **alias** through the Secrets Wallet
+//!    (`CredentialService`) — never a gateway env var (RFC §6),
+//! 3. idempotently registers the subscription so per-delivery executions get a
+//!    parent-execution lineage + lifecycle events (Mode C parity with Mode B),
+//! 4. returns the verify + dispatch + directive config the gateway needs to
+//!    verify-then-forward.
+//!
+//! The decrypted secret crosses the internal boundary to the gateway because
+//! HMAC/bearer verification genuinely needs the key material at the edge; the
+//! endpoint is privileged (service-account-gated) and the value never reaches
+//! a user-facing response.
+//!
+//! ### Security ordering (RFC §7.5)
+//!
+//! This endpoint returns *config*, including the directive allowlist
+//! (`spec.headers`) verbatim.  The gateway parses + applies those directives
+//! **only after** it verifies the request (auth-gated directive trust).  The
+//! server does not apply directives here — it only hands the gateway the
+//! allowlist to run post-verification.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+use crate::handlers::internal::RequireInternalApiToken;
+use crate::services::CredentialService;
+use crate::state::AppState;
+
+/// Route state: the control-plane state (catalog lookup + register) plus the
+/// credential service (Wallet secret resolution).
+#[derive(Clone)]
+pub struct IngressDeps {
+    pub state: AppState,
+    pub credentials: CredentialService,
+}
+
+/// The verify config the gateway needs to authenticate a delivery (RFC §6).
+#[derive(Debug, Serialize)]
+pub struct VerifyConfig {
+    /// `hmac_sha256` | `bearer` | `pubsub_oidc`.
+    #[serde(rename = "type")]
+    pub verify_type: String,
+    /// HMAC signature header name (hmac_sha256), or the bearer header
+    /// (defaults to `authorization` when absent).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+    /// Decrypted secret (HMAC signing key / expected bearer token).  Absent
+    /// for `pubsub_oidc` (Google JWKS is public; no Wallet secret).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
+    /// Expected OIDC audience (`pubsub_oidc`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audience: Option<String>,
+    /// Expected Google push service-account email (`pubsub_oidc`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_account: Option<String>,
+}
+
+/// The dispatch config the gateway applies per delivery (mirrors the worker's
+/// Mode-B `dispatch` block).
+#[derive(Debug, Serialize)]
+pub struct DispatchConfig {
+    pub playbook: String,
+    pub payload_from: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_pool: Option<String>,
+}
+
+/// The full ingress config response.
+#[derive(Debug, Serialize)]
+pub struct IngressConfig {
+    pub listener: String,
+    pub catalog_path: String,
+    /// Source backend (`webhook` | `pubsub` | ...) — tells the gateway whether
+    /// to unwrap a Pub/Sub push envelope (attributes channel) or treat the body
+    /// as a generic webhook payload (HTTP-header channel).
+    pub source: String,
+    /// Registered subscription id — the parent execution for per-delivery runs.
+    pub subscription_id: String,
+    pub verify: VerifyConfig,
+    pub dispatch: DispatchConfig,
+    /// The raw `spec.headers` directive allowlist (JSON), or null when the
+    /// subscription declares none.  The gateway parses it with its own
+    /// directive engine and applies it **only after** verification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directives: Option<Value>,
+}
+
+/// `GET /api/internal/ingress/{listener}` — resolve the push-ingress config for
+/// the gateway.  Gated by `RequireInternalApiToken`.
+pub async fn get_ingress_config(
+    _auth: RequireInternalApiToken,
+    State(deps): State<IngressDeps>,
+    Path(listener): Path<String>,
+) -> AppResult<Json<IngressConfig>> {
+    let span = tracing::info_span!("gateway.ingress.config", listener = %listener);
+    let _g = span.enter();
+
+    // Find the subscription whose ingress.gateway_path matches this listener.
+    let (catalog_path, spec) = resolve_subscription_by_listener(&deps.state, &listener)
+        .await?
+        .ok_or_else(|| {
+            AppError::NotFound(format!("No push subscription for ingress listener '{}'", listener))
+        })?;
+
+    let ingress = spec
+        .get("ingress")
+        .ok_or_else(|| AppError::Validation("subscription has no 'ingress' block".into()))?;
+    let verify_block = ingress
+        .get("verify")
+        .ok_or_else(|| AppError::Validation("subscription ingress has no 'verify' block".into()))?;
+
+    let verify_type = verify_block
+        .get("type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("ingress.verify.type missing".into()))?
+        .to_string();
+
+    let header = verify_block
+        .get("header")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_ascii_lowercase());
+    let audience = verify_block
+        .get("audience")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let service_account = verify_block
+        .get("service_account")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    // Resolve the verify secret from the Wallet for the schemes that need it.
+    let secret = match verify_type.as_str() {
+        "hmac_sha256" | "bearer" => {
+            let alias = verify_block
+                .get("secret")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    AppError::Validation(format!(
+                        "ingress.verify.secret (Wallet alias) is required for '{}'",
+                        verify_type
+                    ))
+                })?;
+            Some(resolve_secret_alias(&deps.credentials, alias).await?)
+        }
+        "pubsub_oidc" => None,
+        other => {
+            return Err(AppError::Validation(format!(
+                "unsupported ingress.verify.type '{}'",
+                other
+            )))
+        }
+    };
+
+    // dispatch block.
+    let dispatch_block = spec
+        .get("dispatch")
+        .ok_or_else(|| AppError::Validation("subscription has no 'dispatch' block".into()))?;
+    let playbook = dispatch_block
+        .get("playbook")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("dispatch.playbook missing".into()))?
+        .to_string();
+    let payload_from = dispatch_block
+        .get("payload_from")
+        .and_then(|v| v.as_str())
+        .unwrap_or("message.json")
+        .to_string();
+    let execution_pool = dispatch_block
+        .get("execution_pool")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    // The directive allowlist (raw) — gateway applies it post-verification.
+    let directives = spec
+        .get("headers")
+        .map(|h| serde_json::to_value(h).unwrap_or(Value::Null))
+        .filter(|v| !v.is_null());
+
+    // Idempotently register so per-delivery runs get parent lineage + lifecycle.
+    let registered =
+        crate::handlers::subscription::ensure_registered(&deps.state, &catalog_path).await?;
+
+    tracing::info!(
+        listener = %listener,
+        catalog_path = %catalog_path,
+        subscription_id = %registered.subscription_id,
+        verify_type = %verify_type,
+        "Resolved push-ingress config for gateway"
+    );
+
+    let source = spec
+        .get("source")
+        .and_then(|v| v.as_str())
+        .unwrap_or("webhook")
+        .to_string();
+
+    Ok(Json(IngressConfig {
+        listener,
+        catalog_path,
+        source,
+        subscription_id: registered.subscription_id,
+        verify: VerifyConfig {
+            verify_type,
+            header,
+            secret,
+            audience,
+            service_account,
+        },
+        dispatch: DispatchConfig {
+            playbook,
+            payload_from,
+            execution_pool,
+        },
+        directives,
+    }))
+}
+
+/// Scan `kind: subscription` catalog entries (latest version per path) for the
+/// one whose `spec.ingress.gateway_path` trailing segment equals `listener`.
+/// Subscriptions are low-cardinality, so an O(n) scan is fine; the gateway
+/// caches the resolved config so this runs once per listener per cache window.
+async fn resolve_subscription_by_listener(
+    state: &AppState,
+    listener: &str,
+) -> AppResult<Option<(String, serde_yaml::Value)>> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT DISTINCT ON (path) path, content
+        FROM noetl.catalog
+        WHERE LOWER(kind) = 'subscription'
+        ORDER BY path, version DESC
+        "#,
+    )
+    .fetch_all(state.pools.cluster())
+    .await?;
+
+    for (path, content) in rows {
+        let Ok(spec_doc) = serde_yaml::from_str::<serde_yaml::Value>(&content) else {
+            continue;
+        };
+        let Some(spec) = spec_doc.get("spec") else {
+            continue;
+        };
+        let gateway_path = spec
+            .get("ingress")
+            .and_then(|i| i.get("gateway_path"))
+            .and_then(|v| v.as_str());
+        let Some(gp) = gateway_path else { continue };
+        if listener_matches(gp, listener) {
+            return Ok(Some((path, spec.clone())));
+        }
+    }
+    Ok(None)
+}
+
+/// True when `gateway_path`'s trailing segment equals `listener`, or the whole
+/// path equals `/ingress/{listener}` or `/{listener}`.
+fn listener_matches(gateway_path: &str, listener: &str) -> bool {
+    let trimmed = gateway_path.trim_end_matches('/');
+    trimmed
+        .rsplit('/')
+        .next()
+        .map(|seg| seg == listener)
+        .unwrap_or(false)
+}
+
+/// Resolve a verify-secret alias through the Wallet and extract the secret
+/// string.  The credential's decrypted `data` is expected to carry the secret
+/// under `secret` (preferred), `token`, `value`, `key`, or `password`, or be a
+/// bare string.
+async fn resolve_secret_alias(credentials: &CredentialService, alias: &str) -> AppResult<String> {
+    let resolved = credentials.get(alias, true, None).await?;
+    let data = resolved.data.ok_or_else(|| {
+        AppError::Internal(format!("verify secret alias '{}' resolved with no data", alias))
+    })?;
+
+    let value = match &data {
+        Value::String(s) => Some(s.clone()),
+        Value::Object(map) => ["secret", "token", "value", "key", "password"]
+            .iter()
+            .find_map(|k| map.get(*k).and_then(|v| v.as_str()).map(str::to_string)),
+        _ => None,
+    };
+
+    value.ok_or_else(|| {
+        AppError::Validation(format!(
+            "verify secret alias '{}' did not yield a string secret (expected a bare string or a \
+             'secret'/'token'/'value'/'key'/'password' field)",
+            alias
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listener_match_trailing_segment() {
+        assert!(listener_matches("/ingress/stripe", "stripe"));
+        assert!(listener_matches("/ingress/stripe/", "stripe"));
+        assert!(listener_matches("/stripe", "stripe"));
+        assert!(listener_matches("/api/hooks/billing", "billing"));
+    }
+
+    #[test]
+    fn listener_no_false_match() {
+        assert!(!listener_matches("/ingress/stripe", "billing"));
+        assert!(!listener_matches("/ingress/stripe-events", "stripe"));
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod events;
 pub mod execute;
 pub mod executions;
 pub mod health;
+pub mod ingress;
 pub mod internal;
 pub mod keychain;
 pub mod replay;

--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -169,50 +169,65 @@ pub async fn register(
     State(state): State<AppState>,
     Json(req): Json<RegisterRequest>,
 ) -> AppResult<Json<SubscriptionStatus>> {
+    Ok(Json(ensure_registered(&state, &req.path).await?))
+}
+
+/// Register-or-reuse a subscription by catalog path, returning its current
+/// status.  Idempotent: an existing non-deactivated subscription for the same
+/// path is reused (a runtime restart — or a fresh push delivery — doesn't mint
+/// a new id each time); otherwise a snowflake id is minted and the
+/// `subscription.registered` lifecycle event is written.
+///
+/// Shared by `POST /api/subscriptions/register` (the continuous runtime, Mode
+/// B) and the gateway push-ingress config endpoint (`GET
+/// /api/internal/ingress/{listener}`, Mode C) so a push subscription gets the
+/// same event-sourced lifecycle + parent-execution lineage as a pull one
+/// (noetl/ai-meta#90 Phase 3).
+pub async fn ensure_registered(state: &AppState, path: &str) -> AppResult<SubscriptionStatus> {
     // Resolve the catalog entry and confirm it is a subscription.
     let row: Option<(i64, String)> = sqlx::query_as(
         "SELECT catalog_id, kind FROM noetl.catalog WHERE path = $1 ORDER BY version DESC LIMIT 1",
     )
-    .bind(&req.path)
+    .bind(path)
     .fetch_optional(state.pools.cluster())
     .await?;
 
-    let (catalog_id, kind) = row
-        .ok_or_else(|| AppError::NotFound(format!("Subscription not found: {}", req.path)))?;
+    let (catalog_id, kind) =
+        row.ok_or_else(|| AppError::NotFound(format!("Subscription not found: {}", path)))?;
     if kind.to_lowercase() != "subscription" {
         return Err(AppError::Validation(format!(
             "Catalog entry '{}' is kind '{}', not 'subscription'",
-            req.path, kind
+            path, kind
         )));
     }
 
     // Idempotent register: reuse an existing non-deactivated subscription for
     // the same path so a runtime restart doesn't mint a fresh id each time.
-    if let Some(existing) = latest_for_path(&state, &req.path).await? {
+    if let Some(existing) = latest_for_path(state, path).await? {
         if existing.state != SubState::Deactivated {
             tracing::info!(
                 subscription_id = existing.subscription_id,
-                path = %req.path,
+                path = %path,
                 state = existing.state.as_status(),
                 "Subscription already registered — reusing"
             );
-            return Ok(Json(SubscriptionStatus {
+            return Ok(SubscriptionStatus {
                 subscription_id: existing.subscription_id.to_string(),
-                path: req.path,
+                path: path.to_string(),
                 catalog_id: existing.catalog_id.to_string(),
                 state: existing.state.as_status().to_string(),
                 last_event_type: existing.last_event_type,
                 updated_at: existing.updated_at,
-            }));
+            });
         }
     }
 
     let subscription_id = state.snowflake.generate()?;
     write_lifecycle_event(
-        &state,
+        state,
         subscription_id,
         catalog_id,
-        &req.path,
+        path,
         "subscription.registered",
         SubState::Registered,
     )
@@ -220,19 +235,19 @@ pub async fn register(
 
     tracing::info!(
         subscription_id,
-        path = %req.path,
+        path = %path,
         catalog_id,
         "Subscription registered"
     );
 
-    Ok(Json(SubscriptionStatus {
+    Ok(SubscriptionStatus {
         subscription_id: subscription_id.to_string(),
-        path: req.path,
+        path: path.to_string(),
         catalog_id: catalog_id.to_string(),
         state: SubState::Registered.as_status().to_string(),
         last_event_type: "subscription.registered".to_string(),
         updated_at: Some(chrono::Utc::now().to_rfc3339()),
-    }))
+    })
 }
 
 /// `POST /api/subscriptions/{id}/{transition}` — apply a lifecycle transition

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ fn build_router(
             post(handlers::cross_region::resolve),
         )
         .with_state(handlers::cross_region::CrossRegionDeps {
-            credentials: credential_service,
+            credentials: credential_service.clone(),
         });
 
     // Wallet KEK rotation endpoints (Secrets Wallet Phase 7a.2,
@@ -401,6 +401,23 @@ fn build_router(
         )
         .with_state(db_pool.clone());
 
+    // Gateway push-ingress config endpoint (noetl/ai-meta#90 Phase 3).  The
+    // gateway calls GET /api/internal/ingress/{listener} (service-account
+    // gated) to resolve a push subscription's verify scheme + Wallet-resolved
+    // secret + dispatch + directive allowlist, so it can verify-then-forward a
+    // webhook/Pub-Sub-push delivery without holding a DB connection
+    // (data-access-boundary.md).  Carries its own deps state (control-plane
+    // state + credential service).
+    let ingress_routes = Router::new()
+        .route(
+            "/api/internal/ingress/{listener}",
+            get(handlers::ingress::get_ingress_config),
+        )
+        .with_state(handlers::ingress::IngressDeps {
+            state: state.clone(),
+            credentials: credential_service.clone(),
+        });
+
     // System monitoring routes
     let system_routes = Router::new()
         .route("/api/status", get(handlers::system::get_status))
@@ -449,6 +466,7 @@ fn build_router(
         .merge(sharding_routes)
         .merge(database_routes)
         .merge(internal_routes)
+        .merge(ingress_routes)
         .merge(system_routes)
         .merge(dashboard_routes)
         .layer(TraceLayer::new_for_http())

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -221,8 +221,12 @@ fn validate_subscription_spec(yaml: &serde_yaml::Value) -> AppResult<()> {
             }
         }
         "push" => {
-            // Push ingress (Mode C) lands in Phase 3; the type accepts the
-            // shape now so a spec can be registered ahead of the gateway.
+            // Push ingress (Mode C, noetl/ai-meta#90 Phase 3): the spec must
+            // declare how the gateway verifies inbound deliveries before any
+            // directive is honored (RFC §6 / §7.5).  Validate the `ingress`
+            // block shape here so a misconfigured push subscription is
+            // rejected at registration, not at the first webhook.
+            validate_push_ingress(spec)?;
         }
         other => {
             return Err(AppError::Validation(format!(
@@ -274,6 +278,92 @@ fn validate_subscription_spec(yaml: &serde_yaml::Value) -> AppResult<()> {
     Ok(())
 }
 
+/// Verify schemes a push `kind: Subscription` ingress may declare (RFC §6).
+/// `none` is intentionally absent — push ingress always verifies.
+const PUSH_VERIFY_TYPES: &[&str] = &["hmac_sha256", "bearer", "pubsub_oidc"];
+
+/// Validate the push-mode `spec.ingress` block (noetl/ai-meta#90 Phase 3).
+///
+/// The gateway is the only component that terminates untrusted inbound
+/// traffic, so a push subscription must declare *how* the gateway verifies a
+/// delivery (RFC §6) and *where* a verification secret is resolved from the
+/// Secrets Wallet (by alias — never a gateway env var).  This check is
+/// structural: it guarantees the gateway's config endpoint
+/// (`GET /api/internal/ingress/{listener}`) can build a complete verifier.
+///
+/// Per-scheme requirements:
+/// - `hmac_sha256` — `header` (the signature header) + `secret` (Wallet alias).
+/// - `bearer`      — `secret` (Wallet alias for the expected token).
+/// - `pubsub_oidc` — `audience` + `service_account` (Google-signed JWT check;
+///   the JWKS is public, so no Wallet secret).
+fn validate_push_ingress(spec: &serde_yaml::Value) -> AppResult<()> {
+    let ingress = spec.get("ingress").ok_or_else(|| {
+        AppError::Validation(
+            "subscription 'mode: push' requires an 'ingress' block (gateway_path + verify)".into(),
+        )
+    })?;
+
+    let gateway_path = ingress
+        .get("gateway_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AppError::Validation("subscription 'ingress.gateway_path' is required for push".into())
+        })?;
+    if !gateway_path.starts_with('/') {
+        return Err(AppError::Validation(format!(
+            "subscription 'ingress.gateway_path' must be an absolute path starting with '/', got '{}'",
+            gateway_path
+        )));
+    }
+
+    let verify = ingress.get("verify").ok_or_else(|| {
+        AppError::Validation("subscription 'ingress' requires a 'verify' block (push always verifies)".into())
+    })?;
+    let vtype = verify
+        .get("type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Validation("subscription 'ingress.verify.type' is required".into()))?;
+    if !PUSH_VERIFY_TYPES.contains(&vtype) {
+        return Err(AppError::Validation(format!(
+            "subscription 'ingress.verify.type' must be one of {:?}, got '{}' \
+             ('none' is not allowed — push ingress always verifies)",
+            PUSH_VERIFY_TYPES, vtype
+        )));
+    }
+
+    let require = |field: &str| -> AppResult<()> {
+        verify
+            .get(field)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|_| ())
+            .ok_or_else(|| {
+                AppError::Validation(format!(
+                    "subscription 'ingress.verify.{}' is required for verify.type '{}'",
+                    field, vtype
+                ))
+            })
+    };
+
+    match vtype {
+        "hmac_sha256" => {
+            require("header")?;
+            require("secret")?;
+        }
+        "bearer" => {
+            require("secret")?;
+        }
+        "pubsub_oidc" => {
+            require("audience")?;
+            require("service_account")?;
+        }
+        _ => unreachable!("verify.type already validated against PUSH_VERIFY_TYPES"),
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,7 +397,7 @@ spec:
     }
 
     #[test]
-    fn valid_push_subscription() {
+    fn valid_push_subscription_hmac() {
         let v = yaml(
             r#"
 kind: Subscription
@@ -315,10 +405,124 @@ metadata: { name: stripe, path: subscriptions/stripe }
 spec:
   source: webhook
   mode: push
+  ingress:
+    gateway_path: /ingress/stripe
+    verify:
+      type: hmac_sha256
+      header: "Stripe-Signature"
+      secret: "stripe_webhook_secret"
   dispatch: { playbook: domain/handle_stripe }
 "#,
         );
         assert!(validate_subscription_spec(&v).is_ok());
+    }
+
+    #[test]
+    fn valid_push_subscription_bearer() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: webhook
+  mode: push
+  ingress: { gateway_path: /ingress/hook, verify: { type: bearer, secret: "hook_token" } }
+  dispatch: { playbook: domain/handle }
+"#,
+        );
+        assert!(validate_subscription_spec(&v).is_ok());
+    }
+
+    #[test]
+    fn valid_push_subscription_pubsub_oidc() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: pubsub
+  mode: push
+  ingress:
+    gateway_path: /ingress/billing
+    verify:
+      type: pubsub_oidc
+      audience: "https://gw.noetl.acme/ingress/billing"
+      service_account: "pubsub-push@acme.iam.gserviceaccount.com"
+  dispatch: { playbook: domain/handle_billing }
+"#,
+        );
+        assert!(validate_subscription_spec(&v).is_ok());
+    }
+
+    #[test]
+    fn push_without_ingress_rejected() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: webhook\n  mode: push\n  dispatch: { playbook: p }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("ingress"));
+    }
+
+    #[test]
+    fn push_verify_none_rejected() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: webhook
+  mode: push
+  ingress: { gateway_path: /ingress/x, verify: { type: none } }
+  dispatch: { playbook: p }
+"#,
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("verify.type"));
+    }
+
+    #[test]
+    fn push_hmac_missing_secret_rejected() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: webhook
+  mode: push
+  ingress: { gateway_path: /ingress/x, verify: { type: hmac_sha256, header: X-Sig } }
+  dispatch: { playbook: p }
+"#,
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("verify.secret"));
+    }
+
+    #[test]
+    fn push_oidc_missing_audience_rejected() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: pubsub
+  mode: push
+  ingress: { gateway_path: /ingress/x, verify: { type: pubsub_oidc, service_account: sa@x.iam } }
+  dispatch: { playbook: p }
+"#,
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("verify.audience"));
+    }
+
+    #[test]
+    fn push_relative_gateway_path_rejected() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: webhook
+  mode: push
+  ingress: { gateway_path: ingress/x, verify: { type: bearer, secret: t } }
+  dispatch: { playbook: p }
+"#,
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("absolute path"));
     }
 
     #[test]


### PR DESCRIPTION
Server side of gateway push-ingress (Mode C) — noetl/ai-meta#90 Phase 3.

## What
- **Push catalog validation** (`services/catalog.rs`): `mode: push` now requires an `ingress` block with a `verify` scheme (`hmac_sha256` | `bearer` | `pubsub_oidc`; `none` rejected — push always verifies). Per-scheme required fields validated at registration.
- **`GET /api/internal/ingress/{listener}`** (`handlers/ingress.rs`, gated by `RequireInternalApiToken`): resolves the `kind: Subscription` by `ingress.gateway_path` trailing segment, resolves the verify-secret **alias** via the Secrets Wallet (`CredentialService`), idempotently registers the subscription (parent lineage + lifecycle), and returns verify + dispatch + directives + source config to the gateway.
- **`subscription::ensure_registered`** extracted from `register()` and reused so push subscriptions get the same event-sourced lifecycle as pull.

## Boundary
Verify secrets are resolved from the Wallet by alias, never a gateway env var (RFC §6). The gateway holds no DB connection — this endpoint is its config source (`data-access-boundary.md`). Directives are **not** applied here; the server only hands the gateway the allowlist, which the gateway applies post-verification (RFC §7.5).

## Tests
9 push-validation cases + listener-match unit tests. `cargo test` + `clippy` green. Live-validated on kind via the gateway (config resolves the subscription, Wallet secret, dispatch, directives).

Closes noetl/server#181
Refs noetl/ai-meta#90