### PR TITLE
fix: subscription lifecycle status must ignore spool/circuit/message events (#90 Phase 4)

### DIFF
--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -331,7 +331,7 @@ pub async fn list(State(state): State<AppState>) -> AppResult<Json<SubscriptionL
                 SELECT DISTINCT ON (execution_id)
                        execution_id, event_type, status, catalog_id, created_at
                 FROM noetl.event
-                WHERE event_type LIKE 'subscription.%'
+                WHERE event_type IN ('subscription.registered','subscription.activated','subscription.paused','subscription.resumed','subscription.draining','subscription.deactivated')
                 ORDER BY execution_id, event_id DESC
                 "#,
             )
@@ -385,7 +385,7 @@ async fn latest_for_path(state: &AppState, path: &str) -> AppResult<Option<Lates
                 r#"
                 SELECT event_id, execution_id, event_type, status, catalog_id, created_at
                 FROM noetl.event
-                WHERE node_name = $1 AND event_type LIKE 'subscription.%'
+                WHERE node_name = $1 AND event_type IN ('subscription.registered','subscription.activated','subscription.paused','subscription.resumed','subscription.draining','subscription.deactivated')
                 ORDER BY event_id DESC
                 LIMIT 1
                 "#,
@@ -416,7 +416,7 @@ async fn load_latest(state: &AppState, subscription_id: i64) -> AppResult<Option
             r#"
             SELECT event_type, status, catalog_id, node_name, created_at
             FROM noetl.event
-            WHERE execution_id = $1 AND event_type LIKE 'subscription.%'
+            WHERE execution_id = $1 AND event_type IN ('subscription.registered','subscription.activated','subscription.paused','subscription.resumed','subscription.draining','subscription.deactivated')
             ORDER BY event_id DESC
             LIMIT 1
             "#,


### PR DESCRIPTION
## Bug
The Phase-4 spool/circuit events (`subscription.circuit.opened/closed`, `subscription.message.spooled/replayed/dead_lettered`, `subscription.spool.draining`) share the subscription's `execution_id` but are **not** lifecycle transitions. The three lifecycle-status reconstruction queries matched them with `event_type LIKE 'subscription.%'`, so once a circuit opened, the latest "lifecycle" event was `subscription.circuit.opened` (status `OPEN`) → `load_latest` / `get` / `activate` **500'd** with `unknown status 'OPEN'` and the subscription runtime crashed on (re)activation.

## Fix
Restrict the three queries (`load_latest`, `list`, `latest_for_path`) to the six actual lifecycle event types (registered / activated / paused / resumed / draining / deactivated).

Surfaced + fixed during the **Phase-4 live kind outage validation** — with this fix the runtime activates, cycles the circuit (open → spool → close → drain), and deactivates cleanly. The live proof is green: 6 buffered during the outage, 6 drained+replayed on recovery, no data loss, idempotency held.

Refs noetl/ai-meta#90

🤖 Generated with [Claude Code](https://claude.com/claude-code)