### PR TITLE
feat: batch execute + opt-in dedup window (subscription scale hardening)

### DIFF
--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -8,4 +8,5 @@ pub mod event;
 pub mod keychain;
 pub mod result_store;
 pub mod secret_audit;
+pub mod subscription_dedup;
 pub mod wallet_rotate;

--- a/src/db/queries/subscription_dedup.rs
+++ b/src/db/queries/subscription_dedup.rs
@@ -1,0 +1,134 @@
+//! `noetl.subscription_dedup` — the opt-in exactly-once dedup window
+//! (noetl/ai-meta#90 Phase 7, RFC §10 OQ1/OQ2).
+//!
+//! All sources NoETL consumes are at-least-once, and the store-and-forward
+//! spool (Phase 4) deliberately *replays*.  For most streams the playbook is
+//! expected to be idempotent (key on `message_id`).  But a low-volume critical
+//! stream can ask the server to collapse a duplicate delivery to a single
+//! execution: when a `kind: Subscription` declares `dedup.enabled: true`, the
+//! continuous runtime stamps each `POST /api/execute` with a `dedup` block
+//! (`{ key, window_secs }`) and the server consults this table.
+//!
+//! The table is **bounded in age**: each access first prunes the scope's rows
+//! older than the window, so a key that re-arrives *outside* the window is
+//! treated as fresh (and the table can't grow without bound).  The dedup
+//! decision is **race-safe**: the claim is an `INSERT … ON CONFLICT DO
+//! NOTHING`, so a duplicate never creates an execution even if two replicas
+//! process the two copies concurrently — the unique `(subscription_id,
+//! dedup_key)` constraint is the arbiter.
+//!
+//! The opt-in design is deliberate: at IoT volume a DB write per message is too
+//! costly, so dedup defaults **off** (RFC §10 OQ1 "offer dedup opt-in for
+//! low-volume critical streams").  The table lives on the cluster pool so it is
+//! a single dedup authority regardless of which shard the child execution
+//! lands on (`agents/rules/data-access-boundary.md`: server owns the table,
+//! workers reach it only through `/api/execute`).
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+
+/// Default dedup window when a subscription opts in without naming one.
+pub const DEFAULT_WINDOW_SECS: u64 = 300;
+
+/// Outcome of a dedup claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DedupOutcome {
+    /// First time this `(subscription, key)` has been seen in the window — the
+    /// caller proceeds to create the execution under `execution_id`.
+    Fresh,
+    /// A live row already holds this key within the window — the caller skips
+    /// execution creation and returns the existing execution id.
+    Duplicate { existing_execution_id: i64 },
+}
+
+/// Idempotent table creation.  Runs once at server startup (mirrors
+/// [`crate::db::queries::secret_audit::ensure_table`]) so the schema lands on
+/// first boot without an out-of-band migration.  The table is
+/// `noetl/server`-owned end to end (only `/api/execute` writes it), so a
+/// `CREATE TABLE IF NOT EXISTS` at startup is the right shape.
+pub async fn ensure_table(pool: &DbPool) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS noetl.subscription_dedup (
+            subscription_id BIGINT      NOT NULL,
+            dedup_key       TEXT        NOT NULL,
+            execution_id    BIGINT      NOT NULL,
+            seen_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (subscription_id, dedup_key)
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    // Prune query filters on (subscription_id, seen_at); index it so the
+    // per-access prune stays cheap even on a busy critical stream.
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS subscription_dedup_scope_seen
+        ON noetl.subscription_dedup (subscription_id, seen_at)
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Attempt to claim `(subscription_id, dedup_key)` for `execution_id` within a
+/// `window_secs` window.
+///
+/// 1. Prune the scope's rows older than the window — bounds the table by age
+///    and lets a key that re-arrives *outside* the window be treated as fresh.
+/// 2. `INSERT … ON CONFLICT DO NOTHING` — the race-safe claim.  One row
+///    affected → [`DedupOutcome::Fresh`]; zero rows → a live duplicate, whose
+///    winning `execution_id` is read back as [`DedupOutcome::Duplicate`].
+///
+/// The caller must have generated `execution_id` *before* calling this (the
+/// snowflake is reserved up front per `observability.md` Principle 3) so the
+/// reserved id is what the table records on the fresh path.
+pub async fn claim(
+    pool: &DbPool,
+    subscription_id: i64,
+    dedup_key: &str,
+    window_secs: u64,
+    execution_id: i64,
+) -> AppResult<DedupOutcome> {
+    // 1. Age out expired entries for this scope (bounded-by-age).
+    sqlx::query(
+        "DELETE FROM noetl.subscription_dedup \
+         WHERE subscription_id = $1 AND seen_at < now() - make_interval(secs => $2)",
+    )
+    .bind(subscription_id)
+    .bind(window_secs as f64)
+    .execute(pool)
+    .await?;
+
+    // 2. Race-safe claim.
+    let inserted = sqlx::query(
+        "INSERT INTO noetl.subscription_dedup (subscription_id, dedup_key, execution_id, seen_at) \
+         VALUES ($1, $2, $3, now()) \
+         ON CONFLICT (subscription_id, dedup_key) DO NOTHING",
+    )
+    .bind(subscription_id)
+    .bind(dedup_key)
+    .bind(execution_id)
+    .execute(pool)
+    .await?;
+
+    if inserted.rows_affected() == 1 {
+        return Ok(DedupOutcome::Fresh);
+    }
+
+    // Lost the race (or a prior delivery already holds the key) — read the
+    // winner so the caller can point this duplicate at the existing execution.
+    let existing: i64 = sqlx::query_scalar(
+        "SELECT execution_id FROM noetl.subscription_dedup \
+         WHERE subscription_id = $1 AND dedup_key = $2",
+    )
+    .bind(subscription_id)
+    .bind(dedup_key)
+    .fetch_one(pool)
+    .await?;
+    Ok(DedupOutcome::Duplicate {
+        existing_execution_id: existing,
+    })
+}

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -43,6 +43,33 @@ pub struct ExecuteRequest {
     /// external join.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace: Option<serde_json::Value>,
+    /// Opt-in exactly-once dedup (noetl/ai-meta#90 Phase 7, RFC §10 OQ1).
+    /// When present, the server consults `noetl.subscription_dedup` scoped by
+    /// `parent_execution_id` (the subscription) and collapses a duplicate
+    /// delivery (same `dedup.key` within `dedup.window_secs`) to a single
+    /// execution — no second `playbook_started`, no second command fan-out.
+    /// Absent → no dedup (the default; at IoT volume a DB write per message
+    /// is too costly, so dedup is opt-in per subscription).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dedup: Option<DedupSpec>,
+}
+
+/// Opt-in dedup directive carried on an execute request (noetl/ai-meta#90
+/// Phase 7).  The continuous subscription runtime stamps this only when the
+/// `kind: Subscription` declares `dedup.enabled: true`; `key` is the resolved
+/// `idempotency_key` header directive, falling back to the source `message_id`
+/// (RFC §10 OQ8).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DedupSpec {
+    /// The idempotency key to dedup on (idempotency_key directive → message_id).
+    pub key: String,
+    /// Window in seconds; a duplicate older than this is treated as fresh.
+    #[serde(default = "default_dedup_window_secs")]
+    pub window_secs: u64,
+}
+
+fn default_dedup_window_secs() -> u64 {
+    crate::db::queries::subscription_dedup::DEFAULT_WINDOW_SECS
 }
 
 /// Per-execution command routing resolved once and threaded through every
@@ -106,6 +133,168 @@ pub async fn execute(
     State(state): State<AppState>,
     Json(request): Json<ExecuteRequest>,
 ) -> Result<Json<ExecuteResponse>, AppError> {
+    let outcome = execute_one(&state, request, "single").await?;
+    Ok(Json(outcome.into_response()))
+}
+
+/// Hard cap on items in one `POST /api/execute/batch` call.  A runaway-loop
+/// backstop set far above any real subscription batch (the runtime caps its
+/// own batch at `RUNTIME_BATCH_DEFAULT`-ish); a larger request is rejected
+/// rather than silently truncated.
+const MAX_BATCH_ITEMS: usize = 1000;
+
+/// Batch execute request (noetl/ai-meta#90 Phase 7, RFC §10 OQ12/#13).
+#[derive(Debug, Deserialize)]
+pub struct BatchExecuteRequest {
+    /// One full execute request per message.  Each carries its own
+    /// `path`/`payload`/`execution_pool`/`trace`/`parent_execution_id`/`dedup`,
+    /// so the directive-resolved per-message routing + trace propagation +
+    /// dedup are preserved inside the batch — a batch is N independent
+    /// executions in one HTTP round-trip, not one shared execution.
+    pub executions: Vec<ExecuteRequest>,
+}
+
+/// Per-item result in a batch response.  Partial failure is first-class: one
+/// bad item yields an `error` entry, the rest still create executions.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchItemResult {
+    /// Position in the request `executions` array — lets the caller correlate
+    /// each result back to the message it submitted.
+    pub index: usize,
+    /// `"started"` | `"duplicate"` | `"error"`.
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<String>,
+    #[serde(default)]
+    pub commands_generated: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Batch execute response — per-item results plus a summary so the caller can
+/// assert N→N without walking every entry.
+#[derive(Debug, Serialize)]
+pub struct BatchExecuteResponse {
+    pub count: usize,
+    pub started: usize,
+    pub duplicates: usize,
+    pub failed: usize,
+    pub results: Vec<BatchItemResult>,
+}
+
+/// Start N executions in one request.
+///
+/// POST /api/execute/batch
+///
+/// Each element is processed independently through [`execute_one`] — the same
+/// wire-format path the single endpoint uses — so per-message event
+/// traceability, the directive/pool routing, the W3C trace propagation, and
+/// the opt-in dedup window all behave exactly as for a one-at-a-time dispatch.
+/// **Partial failure is contained**: a single item that fails to create an
+/// execution becomes an `error` result at its index; the rest still run.  The
+/// data-access boundary is intact — the server still owns every DB write; the
+/// runtime only collapses N HTTP round-trips into one.
+pub async fn execute_batch(
+    State(state): State<AppState>,
+    Json(request): Json<BatchExecuteRequest>,
+) -> Result<Json<BatchExecuteResponse>, AppError> {
+    let n = request.executions.len();
+    if n == 0 {
+        return Err(AppError::Validation(
+            "execute batch requires a non-empty 'executions' array".to_string(),
+        ));
+    }
+    if n > MAX_BATCH_ITEMS {
+        return Err(AppError::Validation(format!(
+            "execute batch size {} exceeds the {} cap",
+            n, MAX_BATCH_ITEMS
+        )));
+    }
+
+    let span = tracing::info_span!("execute.batch", batch_size = n);
+    let _guard = span.enter();
+    crate::metrics::record_execute_batch_size(n);
+
+    let mut results = Vec::with_capacity(n);
+    let mut started = 0usize;
+    let mut duplicates = 0usize;
+    let mut failed = 0usize;
+
+    for (index, req) in request.executions.into_iter().enumerate() {
+        match execute_one(&state, req, "batch").await {
+            Ok(outcome) => {
+                if outcome.status == "duplicate" {
+                    duplicates += 1;
+                } else {
+                    started += 1;
+                }
+                results.push(BatchItemResult {
+                    index,
+                    status: outcome.status.to_string(),
+                    execution_id: Some(outcome.execution_id.to_string()),
+                    commands_generated: outcome.commands_generated,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                failed += 1;
+                crate::metrics::record_execute_outcome("batch", "error");
+                tracing::warn!(index, error = %e, "batch item failed (continuing)");
+                results.push(BatchItemResult {
+                    index,
+                    status: "error".to_string(),
+                    execution_id: None,
+                    commands_generated: 0,
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+
+    info!(
+        batch_size = n,
+        started, duplicates, failed, "execute batch complete"
+    );
+
+    Ok(Json(BatchExecuteResponse {
+        count: n,
+        started,
+        duplicates,
+        failed,
+        results,
+    }))
+}
+
+/// The outcome of creating (or deduplicating) one execution.  Shared by the
+/// single (`/api/execute`) and batch (`/api/execute/batch`) entry points.
+#[derive(Debug, Clone)]
+pub(crate) struct ExecuteOutcome {
+    pub execution_id: i64,
+    /// `"started"` for a fresh execution, `"duplicate"` when the dedup window
+    /// collapsed this delivery onto an existing execution.
+    pub status: &'static str,
+    pub commands_generated: i32,
+}
+
+impl ExecuteOutcome {
+    fn into_response(self) -> ExecuteResponse {
+        ExecuteResponse {
+            execution_id: self.execution_id.to_string(),
+            status: self.status.to_string(),
+            commands_generated: self.commands_generated,
+        }
+    }
+}
+
+/// Create (or dedup) one execution.  Factored out of the `/api/execute`
+/// handler so the batch endpoint can reuse the exact same wire-format logic
+/// per item (noetl/ai-meta#90 Phase 7).  `entry` is the metrics label
+/// (`"single"` | `"batch"`).
+pub(crate) async fn execute_one(
+    state: &AppState,
+    request: ExecuteRequest,
+    entry: &'static str,
+) -> Result<ExecuteOutcome, AppError> {
     // Validate request
     request.validate().map_err(AppError::Validation)?;
 
@@ -114,8 +303,56 @@ pub async fn execute(
         request.path, request.catalog_id
     );
 
+    // Generate execution_id via the application-side snowflake
+    // generator (Phase F R1.5 of noetl/ai-meta#49).  ID is
+    // available before any I/O so spans + metrics can use it
+    // immediately, retries stay idempotent, and the opt-in dedup
+    // window (below) can reserve it before any expensive work.
+    let execution_id = state.snowflake.generate()?;
+
+    // Opt-in exactly-once dedup window (noetl/ai-meta#90 Phase 7, RFC §10
+    // OQ1).  Checked *before* catalog resolution + parse so a duplicate is
+    // cheap — it never touches the catalog, never emits an event, never fans
+    // out a command.  Scope is the subscription (parent_execution_id); the
+    // claim is race-safe (INSERT … ON CONFLICT) so two replicas can't both
+    // create an execution for the same key.
+    if let Some(dedup) = request.dedup.as_ref() {
+        let scope = request.parent_execution_id.unwrap_or(0);
+        use crate::db::queries::subscription_dedup::{claim, DedupOutcome};
+        match claim(
+            state.pools.cluster(),
+            scope,
+            &dedup.key,
+            dedup.window_secs,
+            execution_id,
+        )
+        .await?
+        {
+            DedupOutcome::Duplicate {
+                existing_execution_id,
+            } => {
+                emit_deduplicated_event(state, scope, &dedup.key, existing_execution_id, execution_id)
+                    .await;
+                crate::metrics::record_execute_outcome(entry, "duplicate");
+                info!(
+                    subscription_id = scope,
+                    existing_execution_id,
+                    suppressed_execution_id = execution_id,
+                    dedup_key = %dedup.key,
+                    "dedup window collapsed a duplicate delivery to the existing execution"
+                );
+                return Ok(ExecuteOutcome {
+                    execution_id: existing_execution_id,
+                    status: "duplicate",
+                    commands_generated: 0,
+                });
+            }
+            DedupOutcome::Fresh => { /* reserved execution_id; proceed */ }
+        }
+    }
+
     // Resolve catalog entry
-    let (catalog_id, path) = resolve_catalog(&state, &request).await?;
+    let (catalog_id, path) = resolve_catalog(state, &request).await?;
 
     info!(
         "Starting execution for path={}, catalog_id={}",
@@ -123,16 +360,10 @@ pub async fn execute(
     );
 
     // Get playbook from catalog
-    let playbook_yaml = get_playbook_yaml(&state, catalog_id).await?;
+    let playbook_yaml = get_playbook_yaml(state, catalog_id).await?;
 
     // Parse playbook
     let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
-
-    // Generate execution_id via the application-side snowflake
-    // generator (Phase F R1.5 of noetl/ai-meta#49).  ID is
-    // available before any I/O so spans + metrics can use it
-    // immediately and retries stay idempotent.
-    let execution_id = state.snowflake.generate()?;
 
     // Build the effective workload by merging playbook YAML
     // `workload:` defaults with the request's `payload:` overrides.
@@ -166,7 +397,7 @@ pub async fn execute(
     // the whole playbook nesting (RFC §7.4) bounded by that nesting.
     let trace = match (&request.trace, request.parent_execution_id) {
         (Some(t), _) if !t.is_null() => Some(t.clone()),
-        (_, Some(parent)) => inherit_parent_trace(&state, parent).await,
+        (_, Some(parent)) => inherit_parent_trace(state, parent).await,
         _ => None,
     };
     let routing = CommandRouting {
@@ -179,7 +410,7 @@ pub async fn execute(
 
     // Emit playbook_started event
     let start_event_id = emit_playbook_started_event(
-        &state,
+        state,
         execution_id,
         catalog_id,
         &path,
@@ -191,7 +422,7 @@ pub async fn execute(
 
     // Generate initial commands for the start step
     let commands_generated = generate_initial_commands(
-        &state,
+        state,
         execution_id,
         catalog_id,
         start_event_id,
@@ -206,11 +437,88 @@ pub async fn execute(
         execution_id, commands_generated
     );
 
-    Ok(Json(ExecuteResponse {
-        execution_id: execution_id.to_string(),
-        status: "started".to_string(),
+    crate::metrics::record_execute_outcome(entry, "new");
+    Ok(ExecuteOutcome {
+        execution_id,
+        status: "started",
         commands_generated,
-    }))
+    })
+}
+
+/// Emit a `subscription.message.deduplicated` event on the subscription's
+/// lifecycle log (noetl/ai-meta#90 Phase 7) so a collapsed duplicate is
+/// auditable end to end — which delivery was suppressed, which execution it
+/// folded onto.  Keyed by the subscription id (`scope`); best-effort, since a
+/// failed audit must never turn a correct dedup into an error.  The event type
+/// is intentionally *not* one of the six lifecycle types the subscription
+/// status query matches, so it can share the subscription's `execution_id`
+/// without perturbing its lifecycle state (the Phase-4 fix, server#185).
+async fn emit_deduplicated_event(
+    state: &AppState,
+    scope: i64,
+    dedup_key: &str,
+    existing_execution_id: i64,
+    suppressed_execution_id: i64,
+) {
+    let event_id = match state.snowflake.generate() {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(subscription_id = scope, error = %e, "dedup audit: snowflake gen failed");
+            return;
+        }
+    };
+    // noetl.event.catalog_id is NOT NULL with an FK to noetl.catalog, so the
+    // dedup audit must carry the subscription's own catalog_id.  Read it back
+    // from the subscription scope's lifecycle events (its execution_id ==
+    // scope).  Best-effort: if it can't be resolved, skip the audit rather
+    // than turning a correct dedup into an error.
+    let catalog_id: Option<i64> = sqlx::query_scalar(
+        "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC LIMIT 1",
+    )
+    .bind(scope)
+    .fetch_optional(state.pools.pool_for(scope))
+    .await
+    .ok()
+    .flatten();
+    let Some(catalog_id) = catalog_id else {
+        tracing::debug!(subscription_id = scope, "dedup audit: no catalog_id for scope; skipping audit event");
+        return;
+    };
+    let context = serde_json::json!({
+        "subscription_id": scope.to_string(),
+        "dedup_key": dedup_key,
+        "original_execution_id": existing_execution_id.to_string(),
+        "suppressed_execution_id": suppressed_execution_id.to_string(),
+        "duplicate_suppressed": true,
+    });
+    let meta = serde_json::json!({
+        "emitted_at": chrono::Utc::now().to_rfc3339(),
+        "emitter": "control_plane",
+    });
+    let res = sqlx::query(
+        r#"
+        INSERT INTO noetl.event (
+            execution_id, catalog_id, event_id, event_type, node_id, node_name, node_type,
+            status, context, meta, created_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        "#,
+    )
+    .bind(scope)
+    .bind(catalog_id)
+    .bind(event_id)
+    .bind("subscription.message.deduplicated")
+    .bind("subscription")
+    .bind("ingress")
+    .bind("subscription")
+    .bind("DEDUPLICATED")
+    .bind(&context)
+    .bind(&meta)
+    .bind(chrono::Utc::now())
+    .execute(state.pools.pool_for(scope))
+    .await;
+    if let Err(e) = res {
+        tracing::warn!(subscription_id = scope, error = %e, "dedup audit event insert failed (non-fatal)");
+    }
 }
 
 /// Resolve catalog entry from path or catalog_id.
@@ -1075,6 +1383,7 @@ mod tests {
             parent_execution_id: None,
             execution_pool: None,
             trace: None,
+            dedup: None,
         };
         assert!(request.validate().is_err());
 
@@ -1085,6 +1394,7 @@ mod tests {
             parent_execution_id: None,
             execution_pool: None,
             trace: None,
+            dedup: None,
         };
         assert!(request.validate().is_ok());
 
@@ -1095,6 +1405,7 @@ mod tests {
             parent_execution_id: None,
             execution_pool: None,
             trace: None,
+            dedup: None,
         };
         assert!(request.validate().is_ok());
     }
@@ -1110,5 +1421,112 @@ mod tests {
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("12345"));
         assert!(json.contains("started"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 7 — dedup spec + batch request/response shapes
+    // -----------------------------------------------------------------------
+
+    /// `dedup.window_secs` defaults to the module default when omitted, and an
+    /// explicit value is honored.
+    #[test]
+    fn test_dedup_spec_window_default() {
+        let d: DedupSpec = serde_json::from_str(r#"{"key":"abc"}"#).unwrap();
+        assert_eq!(d.key, "abc");
+        assert_eq!(
+            d.window_secs,
+            crate::db::queries::subscription_dedup::DEFAULT_WINDOW_SECS
+        );
+
+        let d: DedupSpec = serde_json::from_str(r#"{"key":"abc","window_secs":42}"#).unwrap();
+        assert_eq!(d.window_secs, 42);
+    }
+
+    /// An execute request carries an optional `dedup` block; absent → None
+    /// (dedup off, the default), present → parsed.
+    #[test]
+    fn test_execute_request_dedup_optional() {
+        let r: ExecuteRequest = serde_json::from_str(r#"{"path":"p"}"#).unwrap();
+        assert!(r.dedup.is_none());
+
+        let r: ExecuteRequest = serde_json::from_str(
+            r#"{"path":"p","parent_execution_id":7,"dedup":{"key":"k1","window_secs":60}}"#,
+        )
+        .unwrap();
+        let d = r.dedup.expect("dedup present");
+        assert_eq!(d.key, "k1");
+        assert_eq!(d.window_secs, 60);
+    }
+
+    /// A batch request is N independent execute requests, each preserving its
+    /// own per-message path / pool / trace / dedup.
+    #[test]
+    fn test_batch_request_preserves_per_item_routing() {
+        let body = r#"{
+            "executions": [
+                {"path":"domain/a","execution_pool":"iot","payload":{"x":1}},
+                {"path":"domain/b","parent_execution_id":99,"dedup":{"key":"k"}},
+                {"catalog_id":5,"trace":{"traceparent":"00-abc-def-01"}}
+            ]
+        }"#;
+        let req: BatchExecuteRequest = serde_json::from_str(body).unwrap();
+        assert_eq!(req.executions.len(), 3);
+        assert_eq!(req.executions[0].path.as_deref(), Some("domain/a"));
+        assert_eq!(req.executions[0].execution_pool.as_deref(), Some("iot"));
+        assert_eq!(req.executions[1].parent_execution_id, Some(99));
+        assert_eq!(req.executions[1].dedup.as_ref().unwrap().key, "k");
+        assert_eq!(req.executions[2].catalog_id, Some(5));
+        assert!(req.executions[2].trace.is_some());
+    }
+
+    /// The batch response serializes a summary + per-item results; an error
+    /// item carries its message, a started item carries its execution_id.
+    #[test]
+    fn test_batch_response_serialization() {
+        let resp = BatchExecuteResponse {
+            count: 2,
+            started: 1,
+            duplicates: 0,
+            failed: 1,
+            results: vec![
+                BatchItemResult {
+                    index: 0,
+                    status: "started".to_string(),
+                    execution_id: Some("777".to_string()),
+                    commands_generated: 1,
+                    error: None,
+                },
+                BatchItemResult {
+                    index: 1,
+                    status: "error".to_string(),
+                    execution_id: None,
+                    commands_generated: 0,
+                    error: Some("Playbook not found: nope".to_string()),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"count\":2"));
+        assert!(json.contains("\"started\":1"));
+        assert!(json.contains("\"failed\":1"));
+        assert!(json.contains("777"));
+        assert!(json.contains("Playbook not found"));
+        // A started item omits `error`; an error item omits `execution_id`.
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(v["results"][0].get("error").is_none());
+        assert!(v["results"][1].get("execution_id").is_none());
+    }
+
+    #[test]
+    fn test_execute_outcome_into_response() {
+        let outcome = ExecuteOutcome {
+            execution_id: 42,
+            status: "duplicate",
+            commands_generated: 0,
+        };
+        let resp = outcome.into_response();
+        assert_eq!(resp.execution_id, "42");
+        assert_eq!(resp.status, "duplicate");
+        assert_eq!(resp.commands_generated, 0);
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -26,5 +26,5 @@ pub mod variables;
 pub mod wallet_rotate;
 
 pub use events::{get_command, handle_event};
-pub use execute::execute;
+pub use execute::{execute, execute_batch};
 pub use health::{api_health, health_check};

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,6 +207,7 @@ fn build_router(
     // Execution routes (v2 event-driven)
     let execution_routes = Router::new()
         .route("/api/execute", post(handlers::execute))
+        .route("/api/execute/batch", post(handlers::execute_batch))
         .route("/api/events", post(handlers::handle_event))
         .route(
             "/api/events/batch",
@@ -689,6 +690,11 @@ async fn main() -> anyhow::Result<()> {
     // pattern as secret_audit above.  The table is server-owned end-to-end;
     // no out-of-band migration required.
     noetl_server::db::queries::result_store::ensure_table(&db_pool).await?;
+    // Opt-in subscription dedup window (noetl/ai-meta#90 Phase 7, RFC §10
+    // OQ1) — same idempotent startup-DDL pattern.  The table is server-owned
+    // (only /api/execute writes it) and bounded by age; dedup is opt-in per
+    // subscription so the table stays empty unless a critical stream uses it.
+    noetl_server::db::queries::subscription_dedup::ensure_table(&db_pool).await?;
     // kind: Subscription (noetl/ai-meta#90 Phase 2) — seed the `subscription`
     // resource kind so a catalog register doesn't trip the
     // `noetl.catalog.kind -> noetl.resource(name)` FK.  Idempotent.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -810,6 +810,68 @@ pub fn record_secret_refresh_duration(seconds: f64) {
     secret_refresh_duration_seconds().observe(seconds);
 }
 
+// ---------------------------------------------------------------------------
+// Subscription scale hardening (noetl/ai-meta#90 Phase 7)
+// ---------------------------------------------------------------------------
+
+/// Counter: executions created, bucketed by the `/api/execute` entry path
+/// (`single` | `batch`) and the dedup outcome (`new` | `duplicate` | `error`).
+/// Lets an operator see batch-dispatch uptake and how often the opt-in dedup
+/// window is collapsing duplicates without grepping logs.
+pub fn execute_outcomes_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_execute_outcomes_total",
+                "Executions handled by /api/execute(/batch), bucketed by entry path and dedup outcome (noetl/ai-meta#90 Phase 7).",
+            ),
+            &["entry", "outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Histogram: `POST /api/execute/batch` request sizes (number of executions in
+/// one HTTP round-trip).  Answers "is the runtime actually batching, and how
+/// deep" — the whole point of Phase 7's batch dispatch.
+pub fn execute_batch_size() -> &'static HistogramVec {
+    static M: OnceLock<HistogramVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let hist = HistogramVec::new(
+            HistogramOpts::new(
+                "noetl_execute_batch_size",
+                "Number of executions submitted in one POST /api/execute/batch call (noetl/ai-meta#90 Phase 7).",
+            )
+            .buckets(vec![1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]),
+            &[],
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(hist.clone()))
+            .expect("histogram registration must succeed");
+        hist
+    })
+}
+
+/// Record one execution outcome.  `entry` is `"single"` or `"batch"`;
+/// `outcome` is `"new"` (execution created), `"duplicate"` (dedup window
+/// collapsed it), or `"error"`.
+pub fn record_execute_outcome(entry: &str, outcome: &str) {
+    execute_outcomes_total()
+        .with_label_values(&[entry, outcome])
+        .inc();
+}
+
+/// Observe one batch-dispatch request size.
+pub fn record_execute_batch_size(n: usize) {
+    execute_batch_size().with_label_values(&[]).observe(n as f64);
+}
+
 /// Render the global registry as Prometheus text-exposition
 /// format.  Used by the `GET /metrics` handler.
 pub fn gather_text() -> Result<String, prometheus::Error> {

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -248,6 +248,45 @@ fn validate_subscription_spec(yaml: &serde_yaml::Value) -> AppResult<()> {
             AppError::Validation("subscription 'dispatch.playbook' is required".into())
         })?;
 
+    // dispatch.batch_dispatch / batch_max (noetl/ai-meta#90 Phase 7) — optional
+    // scale knobs.  When `batch_dispatch: true` the continuous runtime drains a
+    // backlog via `POST /api/execute/batch` instead of one round-trip per
+    // message; `batch_max` caps how many go in one HTTP call.
+    if let Some(bd) = dispatch.get("batch_dispatch") {
+        if !bd.is_bool() {
+            return Err(AppError::Validation(
+                "subscription 'dispatch.batch_dispatch' must be a boolean".into(),
+            ));
+        }
+    }
+    if let Some(bm) = dispatch.get("batch_max") {
+        let n = bm.as_u64().filter(|n| *n > 0).ok_or_else(|| {
+            AppError::Validation(
+                "subscription 'dispatch.batch_max' must be a positive integer".into(),
+            )
+        })?;
+        if n > 1000 {
+            return Err(AppError::Validation(
+                "subscription 'dispatch.batch_max' must be <= 1000 (the server batch cap)".into(),
+            ));
+        }
+    }
+
+    // dedup (opt-in exactly-once window, noetl/ai-meta#90 Phase 7, RFC §10
+    // OQ1) — optional; structural-only check.  The runtime stamps the dedup
+    // block onto each /api/execute only when `dedup.enabled: true`.
+    if let Some(dedup) = spec.get("dedup") {
+        validate_dedup_config(dedup)?;
+    }
+
+    // limits (per-subscription rate limit / backpressure, noetl/ai-meta#90
+    // Phase 7, RFC §9) — optional; structural-only check.  The runtime
+    // enforces these on its fetch side so an over-limit subscription stops
+    // fetching (source redelivers) rather than dropping.
+    if let Some(limits) = spec.get("limits") {
+        validate_limits_config(limits)?;
+    }
+
     // headers (directive allowlist) — optional; structural-only check here.
     // The strict allowlist/value validation lives in the worker's
     // noetl-tools directive engine (RFC §7); the server only checks shape so
@@ -378,6 +417,65 @@ fn validate_spool_config(spool: &serde_yaml::Value) -> AppResult<()> {
                  'ordering: global'; use 'ordered_then_live' or 'per_key'/'none'"
                     .into(),
             ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the `spec.dedup` block (noetl/ai-meta#90 Phase 7, RFC §10 OQ1).
+///
+/// Opt-in exactly-once dedup for low-volume critical streams.  Structural
+/// only — the runtime owns the key resolution (idempotency_key → message_id)
+/// and the server owns the bounded dedup table.
+///
+/// - `enabled` — optional boolean (defaults false; absent block == off).
+/// - `window_secs` — optional positive integer; the bounded window.
+fn validate_dedup_config(dedup: &serde_yaml::Value) -> AppResult<()> {
+    if !dedup.is_mapping() {
+        return Err(AppError::Validation(
+            "subscription 'dedup' must be a mapping".into(),
+        ));
+    }
+    if let Some(enabled) = dedup.get("enabled") {
+        if !enabled.is_bool() {
+            return Err(AppError::Validation(
+                "subscription 'dedup.enabled' must be a boolean".into(),
+            ));
+        }
+    }
+    if let Some(window) = dedup.get("window_secs") {
+        window.as_u64().filter(|n| *n > 0).ok_or_else(|| {
+            AppError::Validation(
+                "subscription 'dedup.window_secs' must be a positive integer".into(),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Validate the `spec.limits` block (noetl/ai-meta#90 Phase 7, RFC §9).
+///
+/// Per-subscription rate-limit / backpressure safety valves so one firehose
+/// can't starve the shared control plane or a dedicated pool.  Structural
+/// only — the runtime enforces these on its fetch side (stop fetching at the
+/// cap → source redelivers, no loss).
+///
+/// - `max_in_flight` — optional positive integer; the outstanding cap.
+/// - `max_dispatch_per_sec` — optional positive integer; the dispatch rate.
+fn validate_limits_config(limits: &serde_yaml::Value) -> AppResult<()> {
+    if !limits.is_mapping() {
+        return Err(AppError::Validation(
+            "subscription 'limits' must be a mapping".into(),
+        ));
+    }
+    for key in ["max_in_flight", "max_dispatch_per_sec"] {
+        if let Some(v) = limits.get(key) {
+            v.as_u64().filter(|n| *n > 0).ok_or_else(|| {
+                AppError::Validation(format!(
+                    "subscription 'limits.{}' must be a positive integer",
+                    key
+                ))
+            })?;
         }
     }
     Ok(())
@@ -751,6 +849,76 @@ spec:
         );
         let err = validate_subscription_spec(&v).unwrap_err();
         assert!(format!("{err}").contains("activation"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 7 — dedup / limits / batch-dispatch validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn valid_dedup_and_limits_and_batch() {
+        let v = yaml(
+            r#"
+kind: Subscription
+spec:
+  source: nats
+  mode: pull
+  stream: ORDERS
+  consumer: orders-drain
+  dispatch: { playbook: domain/order, batch_dispatch: true, batch_max: 200 }
+  dedup: { enabled: true, window_secs: 600 }
+  limits: { max_in_flight: 1000, max_dispatch_per_sec: 200 }
+"#,
+        );
+        assert!(validate_subscription_spec(&v).is_ok());
+    }
+
+    #[test]
+    fn dedup_bad_window_rejected() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  stream: S\n  consumer: C\n  dispatch: { playbook: p }\n  dedup: { enabled: true, window_secs: 0 }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("dedup.window_secs"));
+    }
+
+    #[test]
+    fn dedup_enabled_must_be_bool() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  stream: S\n  consumer: C\n  dispatch: { playbook: p }\n  dedup: { enabled: \"yes\" }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("dedup.enabled"));
+    }
+
+    #[test]
+    fn limits_bad_rate_rejected() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  stream: S\n  consumer: C\n  dispatch: { playbook: p }\n  limits: { max_dispatch_per_sec: 0 }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("limits.max_dispatch_per_sec"));
+    }
+
+    #[test]
+    fn batch_max_must_be_positive_and_bounded() {
+        let zero = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  stream: S\n  consumer: C\n  dispatch: { playbook: p, batch_max: 0 }\n",
+        );
+        assert!(format!("{}", validate_subscription_spec(&zero).unwrap_err()).contains("batch_max"));
+        let huge = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  stream: S\n  consumer: C\n  dispatch: { playbook: p, batch_max: 5000 }\n",
+        );
+        assert!(format!("{}", validate_subscription_spec(&huge).unwrap_err()).contains("batch_max"));
+    }
+
+    #[test]
+    fn batch_dispatch_must_be_bool() {
+        let v = yaml(
+            "kind: Subscription\nspec:\n  source: nats\n  mode: pull\n  stream: S\n  consumer: C\n  dispatch: { playbook: p, batch_dispatch: 1 }\n",
+        );
+        let err = validate_subscription_spec(&v).unwrap_err();
+        assert!(format!("{err}").contains("batch_dispatch"));
     }
 
     #[test]


### PR DESCRIPTION
Phase 7 of the subscription/listener RFC ([noetl/ai-meta#90](https://github.com/noetl/ai-meta/issues/90)) — server slice. Closes noetl/server#188.

## What

### 1. `POST /api/execute/batch`
Accept N execute requests in one HTTP round-trip and create N executions — so a high-throughput subscription runtime dispatches in batches instead of one round-trip per message. Each element is a full `ExecuteRequest` (its own `path` / `payload` / `execution_pool` / `trace` / `parent_execution_id` / `dedup`), processed through the **same** `execute_one` wire-format path the single endpoint uses, so per-message event traceability, directive/pool routing, and W3C trace propagation behave exactly as one-at-a-time. **Partial failure is contained**: a bad item becomes an `error` result at its index; the rest still run. The data-access boundary is intact — the server still owns every DB write.

### 2. Opt-in exactly-once dedup window (RFC §10 OQ1)
New `noetl.subscription_dedup` table (idempotent startup DDL, bounded by age, server-owned, on the cluster pool so it's a single dedup authority). `execute` accepts an optional `dedup: { key, window_secs }` block, scoped by `parent_execution_id` (the subscription). A duplicate within the window collapses to the existing execution + a `subscription.message.deduplicated` audit event — no second `playbook_started`, no command fan-out. The claim is race-safe (`INSERT … ON CONFLICT DO NOTHING`), so two replicas can't both create an execution for one key. **Default off** — a DB write per message is too costly at IoT scale; opt-in per subscription for low-volume critical streams.

### 3. Validation of the new spec blocks
Structural validation at catalog registration for `dispatch.batch_dispatch` / `batch_max`, `dedup`, and `limits` (the rate-limit knobs the worker runtime enforces).

### Observability
`noetl_execute_outcomes_total{entry,outcome}` + `noetl_execute_batch_size` histogram.

## Tests
Unit: dedup spec window default, execute-request dedup optionality, batch request preserves per-item routing, batch response serialization, the new validation cases (dedup/limits/batch_max bounds). Full server lib suite green; clippy clean.

## Live validation
Live on kind via noetl/e2e `kind_validate_subscription_scale.sh` (batch N→N + per-message traceability; dedup duplicate-collapse; rate-limit no-loss). See noetl/ai-meta#90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)