### PR TITLE
fix: pin time =0.3.47 to dodge async-nats 0.38 E0119 build break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -1413,6 +1414,7 @@ dependencies = [
  "subtle",
  "sysinfo",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-test",
  "tower",
@@ -2723,11 +2725,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.48"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2737,15 +2740,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.28"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,14 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # NATS messaging
 async-nats = "0.38"
 
+# Build-fix pin (NOT used directly).  time 0.3.48 (2026-06-12) collides with
+# async-nats 0.38.0's blanket `From<Kind> for Error<Kind>` under rustc 1.91+
+# (E0119, HourBase).  Pin the transitive dep to the last good release so a
+# fresh CI / image build stays off 0.3.48.  Mirrors the same pin in
+# noetl-tools 3.7.1+, noetl-worker, and noetl-gateway.  Revisit when
+# async-nats ships a fix.
+time = "=0.3.47"
+
 # Templating (Jinja2-style)
 minijinja = { version = "2.5", features = ["loader"] }
 


### PR DESCRIPTION
## Problem

A fresh container/CI build of `noetl/server` at v3.5.0 (`7b217d8`) **fails to compile**:

```
error[E0119]: conflicting implementations of trait ... (HourBase)
error: could not compile `async-nats` (lib) due to 1 previous error
The command 'cargo chef cook --release' returned a non-zero code: 101
```

`time 0.3.48` (released 2026-06-12) collides with `async-nats 0.38.0`'s blanket `From<Kind> for Error<Kind>` under rustc 1.91+ (E0119). This is the same regression already pinned around in **noetl-tools 3.7.1+**, **noetl-worker**, and **noetl-gateway** — `noetl/server` just never received the pin, so it's the last repo still pulling `time 0.3.48` and the only Rust binary that can't be image-built right now.

## Fix

One-line transitive-dep pin (`time = "=0.3.47"`) in `Cargo.toml` + the matching `Cargo.lock` downgrade. `time` is not used directly; the pin only keeps a fresh build off 0.3.48. Mirrors the sibling repos' comment + pin verbatim. Revert when async-nats ships a fix.

## Validation

- `cargo build -p async-nats` now compiles cleanly under rustc 1.92.0 (previously E0119).
- Full prod amd64 image build via Cloud Build (`server-rust:4644c49` / `:v3.5.0`) — surfaced the break, then succeeds with this pin.

Surfaced while preparing the Phase F R5 production cutover image for noetl/ai-meta#49 (building the v3.5.0 server image for GKE).

Refs noetl/ai-meta#49