### PR TITLE
fix: env-gated sqlx statement-cache capacity for transaction-mode poolers

### DIFF
--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -78,6 +78,29 @@ fn default_acquire_timeout() -> u64 {
     30
 }
 
+/// Per-connection prepared-statement-cache capacity, from the
+/// environment.
+///
+/// `NOETL_PG_STATEMENT_CACHE_CAPACITY` controls sqlx's prepared-
+/// statement cache.  Unset → sqlx's own default (100), preserving
+/// existing behaviour for direct/session-mode Postgres (kind, a
+/// dedicated server).
+///
+/// Set it to `0` when the server connects through a **transaction-
+/// mode** connection pooler (e.g. pgbouncer `pool_mode=transaction`
+/// in front of Cloud SQL — the prod path).  Under transaction
+/// pooling a cached prepared statement lives on a backend
+/// connection the pooler can hand to a different client mid-session,
+/// producing `prepared statement "sqlx_s_N" does not exist`.
+/// Capacity `0` makes sqlx use one-shot unnamed statements, which
+/// are safe under transaction pooling.
+fn statement_cache_capacity_from_env() -> usize {
+    std::env::var("NOETL_PG_STATEMENT_CACHE_CAPACITY")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(100)
+}
+
 /// Connection options for a single Postgres host — used by the
 /// per-shard + cluster-wide pools in [`ShardingConfig`].
 ///
@@ -152,6 +175,7 @@ impl ShardConnection {
             .username(&self.user)
             .password(&self.password)
             .database(&self.database)
+            .statement_cache_capacity(statement_cache_capacity_from_env())
     }
 }
 
@@ -270,6 +294,7 @@ impl DatabaseConfig {
             .username(&self.user)
             .password(&self.password)
             .database(&self.database)
+            .statement_cache_capacity(statement_cache_capacity_from_env())
     }
 
     /// Get the connection URL string.


### PR DESCRIPTION
## Problem

The prod control-plane DB (Cloud SQL `noetl-shared-pg`) is reached through **pgbouncer in `pool_mode=transaction`** (via cloud-sql-proxy). sqlx's default keeps a **named prepared-statement cache** (capacity 100) per logical connection; under transaction pooling those named statements live on a backend connection the pooler can hand to a different client mid-session, so the server fails intermittently with:

```
prepared statement "sqlx_s_3" does not exist
```

This blocks pointing the Rust `noetl-server` at the prod pgbouncer for the Phase F R5 cutover ([noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49)). The Python server is unaffected (psycopg doesn't hold persistent prepared statements the same way).

## Fix

Add `NOETL_PG_STATEMENT_CACHE_CAPACITY` (env). **Default 100 = sqlx's existing default — no behaviour change** for direct/session-mode Postgres (kind, a dedicated server). Set it to `0` in the prod manifest so sqlx uses one-shot **unnamed** statements, which are safe behind a transaction-mode pooler. Applied to both connect builders in `src/config/database.rs` (the `DatabaseConfig` pool and the per-shard `ShardConnection` pool).

## Validation

- `cargo check --bin noetl-control-plane` clean; `statement_cache_capacity` is a real `PgConnectOptions` method.
- Prod amd64 image rebuilt from this commit; manifest sets `NOETL_PG_STATEMENT_CACHE_CAPACITY=0` ([noetl/ops](https://github.com/noetl/ops) cutover-prep follow-up).
- Behaviour for existing deployments (unset env) is byte-identical (cache stays 100).

Surfaced live: prod `pgbouncer` deploy has `POOL_MODE=transaction`.

Refs noetl/ai-meta#49