### PR TITLE
fix: Python-compatible truthiness in evaluate_condition (auth playbook stall)

### DIFF
--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1523,6 +1523,129 @@ mod tests {
     }
 
     #[test]
+    fn test_auth_login_start_error_survives_apply_event_into_arc_context() {
+        // Repro of the prod auth0_login stall (noetl/ai-meta#49): the
+        // `start` step errors (empty token → {"error": "Invalid JWT format"}),
+        // emitted on `call.done`; `command.completed` carries only
+        // {status, command_id} (no data).  next.arcs gate on
+        // `{{ start.error is defined }}` — which must resolve true so the
+        // error-callback arc fires instead of all arcs skipping.
+        let mut state = WorkflowState::new(1, 1);
+
+        // call.done — rich envelope carrying the user error data.
+        let mut call_done = make_event("call.done", Some("start"));
+        call_done.event_id = 1;
+        call_done.result = Some(serde_json::json!({
+            "status": "COMPLETED",
+            "context": {
+                "result": {
+                    "status": "success",
+                    "context": {
+                        "data": { "error": "Invalid JWT format" },
+                        "status": "success",
+                        "stderr": "",
+                        "stdout": ""
+                    }
+                }
+            }
+        }));
+        // command.completed — no user data (just status + command_id).
+        let mut cmd_completed = make_event("command.completed", Some("start"));
+        cmd_completed.event_id = 2;
+        cmd_completed.result = Some(serde_json::json!({
+            "status": "success",
+            "context": { "status": "success", "command_id": "x:start:y" }
+        }));
+
+        state.apply_event(&call_done);
+        state.apply_event(&cmd_completed);
+
+        let ctx = state.build_context();
+        let start = ctx.get("start").expect("`start` step entry exposed");
+        assert!(
+            start.get("error").and_then(|v| v.as_str()) == Some("Invalid JWT format"),
+            "start.error must resolve for arc routing; got start = {start:?}"
+        );
+    }
+
+    #[test]
+    fn test_auth0_login_full_orchestrator_arc_routing_repro() {
+        use crate::engine::WorkflowOrchestrator;
+        let yaml = r#"
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: t
+  path: t
+workload:
+  request_id: "req-123"
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: |
+        result = {"error": "Invalid JWT format"}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: err_cb
+          when: "{{ (start.error is defined) and request_id }}"
+        - step: end_step
+          when: "{{ start.error is defined and not request_id }}"
+        - step: create
+          when: "{{ start.sub is defined }}"
+  - step: err_cb
+    tool: { kind: python, code: "result = {}" }
+  - step: end_step
+    tool: { kind: python, code: "result = {}" }
+  - step: create
+    tool: { kind: python, code: "result = {}" }
+"#;
+        let playbook = crate::playbook::parser::parse_playbook(yaml).unwrap();
+
+        let mut e_started = make_event("playbook_started", None);
+        e_started.event_id = 1;
+        e_started.context = Some(serde_json::json!({
+            "workload": { "request_id": "req-123" },
+            "path": "t"
+        }));
+        let mut e_issued = make_event("command.issued", Some("start"));
+        e_issued.event_id = 2;
+        let mut e_done = make_event("call.done", Some("start"));
+        e_done.event_id = 3;
+        e_done.result = Some(serde_json::json!({
+            "status": "COMPLETED",
+            "context": { "result": { "status": "success", "context": {
+                "data": { "error": "Invalid JWT format" }, "status": "success" } } }
+        }));
+        let mut e_completed = make_event("command.completed", Some("start"));
+        e_completed.event_id = 4;
+        e_completed.result = Some(serde_json::json!({
+            "status": "success", "context": { "status": "success", "command_id": "x" }
+        }));
+
+        let events = vec![e_started, e_issued, e_done, e_completed];
+        let orch = WorkflowOrchestrator::new();
+        let result = orch
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .expect("evaluate ok");
+
+        let skipped: Vec<String> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.skipped")
+            .filter_map(|e| e.node_name.clone())
+            .collect();
+        let cmds: Vec<String> = result.commands.iter().map(|c| c.step_name.clone()).collect();
+        assert!(
+            !skipped.contains(&"err_cb".to_string()),
+            "err_cb arc must fire (start.error defined + request_id truthy), not skip. \
+             skipped={skipped:?} commands={cmds:?}"
+        );
+    }
+
+    #[test]
     fn test_build_context_data_accessor_does_not_clobber_existing_data_field() {
         // Edge case: the task_sequence flatten path already merges a
         // `.data` key in for labeled sub-task results.  The #66 fix

--- a/src/template/jinja.rs
+++ b/src/template/jinja.rs
@@ -221,8 +221,21 @@ impl TemplateRenderer {
         let rendered = self.render(&template, context)?;
         let trimmed = rendered.trim().to_lowercase();
 
-        // Evaluate as boolean
-        Ok(matches!(trimmed.as_str(), "true" | "1" | "yes"))
+        // Python-compatible truthiness.  A condition like
+        // `{{ (start.error is defined) and request_id }}` renders to the
+        // *value* of the truthy operand (e.g. "req-123"), NOT the literal
+        // "true" — minijinja's `and`/`or` return the operand, like Python's.
+        // The reference Python orchestrator applies `bool(...)` to the
+        // rendered value, so any non-empty, non-false-like string is truthy.
+        // Treating only "true"/"1"/"yes" as true silently skipped every arc
+        // whose `when` resolved to such a value (e.g. the auth0_login routing
+        // — noetl/ai-meta#49), stalling the playbook.  The falsy set mirrors
+        // Python `bool()` on the stringified value plus the false-like
+        // keywords Jinja emits and empty containers.
+        Ok(!matches!(
+            trimmed.as_str(),
+            "" | "false" | "0" | "no" | "none" | "null" | "off" | "{}" | "[]"
+        ))
     }
 }
 


### PR DESCRIPTION
## Problem

After the Rust-server production cutover ([noetl/ai-meta#49](https://github.com/noetl/ai-meta/issues/49)), **login broke**: the gateway's `auth0_login` playbook stalled (12s timeout, gateway returned 503). The execution trace showed the `start` step completing then **all 3 `next.arcs` emitting `step.skipped`** with no next command — a dead-end stall.

## Root cause

`TemplateRenderer::evaluate_condition` rendered the `when:` expression then accepted it as true **only if the output was exactly `"true"`/`"1"`/`"yes"`**. But minijinja's `and`/`or` return the **operand value** (like Python), so `{{ (start.error is defined) and request_id }}` renders to the request_id string (e.g. `"req-123"`) — which isn't `"true"` → condition false → arc skipped → stall. The Python reference orchestrator applies `bool(...)` to the rendered value, so any non-empty/non-false string is truthy; that's why it worked pre-cutover.

## Fix

Python-compatible truthiness: the rendered value is falsy only for `""`, `false`, `0`, `no`, `none`, `null`, `off`, `{}`, `[]`; truthy otherwise. Boolean conditions (`{{ x > 5 }}` → `"true"`/`"false"`) are unaffected.

## Tests

Two regression tests reproduce the prod auth0_login routing stall (full `orchestrator.evaluate` over the start step + 3 conditional arcs with the exact prod `call.done` envelope). Full lib suite: **662 passed**.

Refs noetl/ai-meta#49