### PR TITLE
feat(internal): POST /api/internal/cleanup/purge for scheduled retention

### DIFF
--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -293,6 +293,38 @@ pub async fn events_project(
     }))
 }
 
+/// `POST /api/internal/cleanup/purge`
+///
+/// Scheduled-cleanup entry point for the system worker pool
+/// (noetl/ai-meta#96).  Deletes clearly-transient `noetl.*` rows per the
+/// retention policy in the request body (terminal `noetl.command` rows, dead
+/// `noetl.runtime` worker registrations, and — opt-in only — old `noetl.event`
+/// rows).  An empty body uses safe defaults (commands 7d, runtime 60m, events
+/// skipped).  Per data-access-boundary.md this is the only path the
+/// `system/scheduled_cleanup` playbook uses to touch these tables.
+#[tracing::instrument(skip(pool, _token))]
+pub async fn cleanup_purge(
+    State(pool): State<DbPool>,
+    _token: RequireInternalApiToken,
+    body: Option<Json<svc::CleanupPolicy>>,
+) -> AppResult<Json<svc::CleanupResult>> {
+    let policy = body.map(|Json(p)| p).unwrap_or_default();
+    let result = svc::purge_stale(&pool, &policy).await?;
+    crate::metrics::record_cleanup_purged("command", result.commands_purged);
+    crate::metrics::record_cleanup_purged("runtime", result.runtime_purged);
+    crate::metrics::record_cleanup_purged("event", result.events_purged);
+    info!(
+        commands_purged = result.commands_purged,
+        runtime_purged = result.runtime_purged,
+        events_purged = result.events_purged,
+        command_retention_days = policy.command_retention_days,
+        runtime_stale_minutes = policy.runtime_stale_minutes,
+        event_retention_days = policy.event_retention_days,
+        "cleanup/purge done"
+    );
+    Ok(Json(result))
+}
+
 // ===========================================================================
 // Tests — auth extractor (the only logic that doesn't need a real DB)
 // ===========================================================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,10 @@ fn build_router(
             "/api/internal/events/project",
             post(handlers::internal::events_project),
         )
+        .route(
+            "/api/internal/cleanup/purge",
+            post(handlers::internal::cleanup_purge),
+        )
         .with_state(db_pool.clone());
 
     // Gateway push-ingress config endpoint (noetl/ai-meta#90 Phase 3).  The

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -90,6 +90,34 @@ pub fn events_ingested_total() -> &'static IntCounterVec {
     })
 }
 
+/// Counter: rows purged by `POST /api/internal/cleanup/purge`, bucketed by
+/// the `noetl.*` table they were purged from.  Lets retention runs be
+/// observed without per-delete log lines (noetl/ai-meta#96).
+pub fn cleanup_rows_purged_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_cleanup_rows_purged_total",
+                "Total rows deleted by the scheduled-cleanup internal endpoint, by table.",
+            ),
+            &["table"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record the rows purged from one table by a cleanup run.
+pub fn record_cleanup_purged(table: &str, rows: u64) {
+    cleanup_rows_purged_total()
+        .with_label_values(&[table])
+        .inc_by(rows);
+}
+
 /// Histogram: wall-clock time spent inside the `POST /api/events` handler.
 pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
     static M: OnceLock<HistogramVec> = OnceLock::new();

--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -20,6 +20,119 @@ use crate::db::DbPool;
 use crate::error::AppResult;
 
 // ---------------------------------------------------------------------------
+// Scheduled cleanup (noetl/ai-meta#96)
+// ---------------------------------------------------------------------------
+
+/// Retention policy for one cleanup run.  All windows are inclusive of "older
+/// than"; a `0` / `None` window means **skip that table** so an empty body is
+/// a safe no-op and the event log is never purged unless explicitly asked.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CleanupPolicy {
+    /// Purge terminal (`completed_at IS NOT NULL`) `noetl.command` rows older
+    /// than this many days.  These are transient queue entries — the durable
+    /// audit trail lives in `noetl.event`.  Default 7.
+    #[serde(default = "default_command_days")]
+    pub command_retention_days: i64,
+    /// Purge `noetl.runtime` `worker_pool` rows whose heartbeat is older than
+    /// this many minutes (dead/scaled-down worker registrations).  Default 60.
+    #[serde(default = "default_runtime_minutes")]
+    pub runtime_stale_minutes: i64,
+    /// Purge `noetl.event` rows older than this many days.  **Opt-in**: `0`
+    /// (the default) skips the event log entirely, because it is the
+    /// append-only source of truth and purging it makes those executions
+    /// un-replayable.  Set a large value (e.g. 365) deliberately.
+    #[serde(default)]
+    pub event_retention_days: i64,
+}
+
+fn default_command_days() -> i64 {
+    7
+}
+fn default_runtime_minutes() -> i64 {
+    60
+}
+
+impl Default for CleanupPolicy {
+    fn default() -> Self {
+        Self {
+            command_retention_days: default_command_days(),
+            runtime_stale_minutes: default_runtime_minutes(),
+            event_retention_days: 0,
+        }
+    }
+}
+
+/// Per-table purge counts returned by [`purge_stale`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CleanupResult {
+    pub commands_purged: u64,
+    pub runtime_purged: u64,
+    pub events_purged: u64,
+}
+
+/// Delete clearly-transient `noetl.*` rows per the retention policy.
+///
+/// Conservative by design: only terminal command rows, dead worker
+/// registrations, and (opt-in) old event rows are touched. A window of `<= 0`
+/// skips that table. Counts are returned per table so the caller can record
+/// metrics + a single structured log line instead of per-delete logging.
+pub async fn purge_stale(pool: &DbPool, policy: &CleanupPolicy) -> AppResult<CleanupResult> {
+    let commands_purged = if policy.command_retention_days > 0 {
+        sqlx::query(
+            r#"
+            DELETE FROM noetl.command
+            WHERE completed_at IS NOT NULL
+              AND completed_at < now() - make_interval(days => $1::int)
+            "#,
+        )
+        .bind(policy.command_retention_days as i32)
+        .execute(pool)
+        .await?
+        .rows_affected()
+    } else {
+        0
+    };
+
+    let runtime_purged = if policy.runtime_stale_minutes > 0 {
+        sqlx::query(
+            r#"
+            DELETE FROM noetl.runtime
+            WHERE kind = 'worker_pool'
+              AND heartbeat < now() - make_interval(mins => $1::int)
+            "#,
+        )
+        .bind(policy.runtime_stale_minutes as i32)
+        .execute(pool)
+        .await?
+        .rows_affected()
+    } else {
+        0
+    };
+
+    // Event log is opt-in only — default policy never purges it.
+    let events_purged = if policy.event_retention_days > 0 {
+        sqlx::query(
+            r#"
+            DELETE FROM noetl.event
+            WHERE created_at < now() - make_interval(days => $1::int)
+            "#,
+        )
+        .bind(policy.event_retention_days as i32)
+        .execute(pool)
+        .await?
+        .rows_affected()
+    } else {
+        0
+    };
+
+    Ok(CleanupResult {
+        commands_purged,
+        runtime_purged,
+        events_purged,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Outbox claim
 // ---------------------------------------------------------------------------
 
@@ -345,6 +458,34 @@ pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResul
 
 #[cfg(test)]
 mod tests {
+    use super::CleanupPolicy;
+
+    #[test]
+    fn cleanup_empty_body_uses_safe_defaults_and_skips_events() {
+        // An empty `{}` body must deserialize to the safe defaults: prune
+        // transient command + dead runtime rows, but NEVER touch the event
+        // log (source of truth) unless explicitly asked.
+        let p: CleanupPolicy = serde_json::from_str("{}").unwrap();
+        assert_eq!(p.command_retention_days, 7);
+        assert_eq!(p.runtime_stale_minutes, 60);
+        assert_eq!(p.event_retention_days, 0, "event log must be opt-in");
+        // The `Default` impl agrees with the serde defaults.
+        let d = CleanupPolicy::default();
+        assert_eq!(d.command_retention_days, 7);
+        assert_eq!(d.runtime_stale_minutes, 60);
+        assert_eq!(d.event_retention_days, 0);
+    }
+
+    #[test]
+    fn cleanup_event_retention_is_explicit_opt_in() {
+        let p: CleanupPolicy =
+            serde_json::from_str(r#"{"event_retention_days": 365}"#).unwrap();
+        assert_eq!(p.event_retention_days, 365);
+        // Other fields still fall back to safe defaults.
+        assert_eq!(p.command_retention_days, 7);
+        assert_eq!(p.runtime_stale_minutes, 60);
+    }
+
     /// Verify the exponential-backoff math matches the Python side's
     /// `min(max_delay, 2 ** min(8, max(0, attempts-1)))`.
     fn compute_delay(attempts: i32, max_delay: i32) -> i64 {


### PR DESCRIPTION
## Context

After the Phase F R5 cutover (noetl/ai-meta#49), the Python-era system pool's
outbox-publisher / projector playbooks are obsolete in the Rust stack — the
server publishes commands directly to NATS (`execute.rs`) and writes events
inline via `/api/events`; nothing writes `noetl.outbox`. The system worker
pool's real remaining job is **scheduled retention/cleanup** of the transient
`noetl.*` tables (the 122-day prod cluster has no cleanup mechanism today).

This adds the server-side endpoint that the `system/scheduled_cleanup` playbook
calls (per data-access-boundary.md: system playbooks touch `noetl.*` only via
`/api/internal/*`). Umbrella: noetl/ai-meta#96.

## Endpoint

`POST /api/internal/cleanup/purge` — gated by `RequireInternalApiToken`.

Request body (all fields optional; empty body = safe defaults):

```json
{ "command_retention_days": 7, "runtime_stale_minutes": 60, "event_retention_days": 0 }
```

Purges (conservative by design):

- terminal `noetl.command` rows (`completed_at` older than N days) — transient
  queue entries; the durable audit trail lives in `noetl.event`.
- dead `noetl.runtime` `worker_pool` registrations (heartbeat older than N min).
- `noetl.event` rows older than N days — **opt-in only**; `0` (default) never
  touches the append-only source of truth (purging it makes those executions
  un-replayable).

Returns per-table purge counts. A window `<= 0` skips that table.

## Observability (per observability.md)

- span: `#[tracing::instrument]` on the handler.
- metric: `noetl_cleanup_rows_purged_total{table}` counter.
- one structured `cleanup/purge done` log with the counts + policy.

## Tests

`cargo test --lib internal` — 17 pass, incl. the two new
`cleanup_*` tests asserting empty-body defaults skip the event log and event
retention is explicit opt-in. `cargo build` + `clippy` clean (the one clippy
warning is pre-existing in `orchestrator.rs`).

Refs noetl/ai-meta#96