### PR TITLE
feat(orchestrator): cursor/claim loop mode (loop.cursor + mode: cursor)

### DIFF
--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppResult;
-use crate::playbook::types::{Step, ToolCall, ToolDefinition, ToolSpec};
+use crate::playbook::types::{CursorClaim, Step, ToolCall, ToolDefinition, ToolSpec};
 use crate::template::TemplateRenderer;
 
 /// Command to be executed by a worker.
@@ -220,6 +220,70 @@ impl CommandBuilder {
             context: Some(render_ctx),
             metadata: None,
             iterator: Some(iterator),
+        })
+    }
+
+    /// Build the claim command for one frame of a `mode: cursor` loop
+    /// (noetl/ai-meta#100).  Runs the `loop.cursor.claim` SQL as a normal
+    /// tool command (default `postgres`); its `RETURNING` rows are the frame
+    /// the orchestrator fans the step body over.  `__frame_max_rows` is
+    /// injected so the claim's `LIMIT {{ __frame_max_rows }}` resolves.  The
+    /// command carries `metadata.cursor = {phase: "claim", frame}` so the
+    /// orchestrator can recognise the completion and continue the loop.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_cursor_claim_command(
+        &self,
+        execution_id: i64,
+        catalog_id: i64,
+        step: &Step,
+        cursor: &CursorClaim,
+        context: &HashMap<String, serde_json::Value>,
+        frame_index: i64,
+        max_rows: i64,
+    ) -> AppResult<Command> {
+        // Inject __frame_max_rows + ctx/workload shims into the render context
+        // so the claim SQL's templates resolve (execution_id, ctx.*, workload.*,
+        // __frame_max_rows).
+        let mut render_ctx = context.clone();
+        render_ctx.insert(
+            "__frame_max_rows".to_string(),
+            serde_json::json!(max_rows),
+        );
+        let ctx_value = serde_json::to_value(&render_ctx).unwrap_or(serde_json::Value::Null);
+        render_ctx
+            .entry("ctx".to_string())
+            .or_insert_with(|| ctx_value.clone());
+        render_ctx
+            .entry("workload".to_string())
+            .or_insert_with(|| ctx_value);
+
+        let claim_sql = self.renderer.render(&cursor.claim, &render_ctx)?;
+
+        let mut config = serde_json::Map::new();
+        config.insert("command".to_string(), serde_json::Value::String(claim_sql));
+        if let Some(auth) = &cursor.auth {
+            config.insert("auth".to_string(), serde_json::Value::String(auth.clone()));
+        }
+        let tool_command = ToolCommand {
+            kind: cursor.kind.clone(),
+            config: Some(serde_json::Value::Object(config)),
+            timeout: None,
+        };
+
+        let metadata = serde_json::json!({
+            "cursor": { "phase": "claim", "step": step.step, "frame": frame_index }
+        });
+
+        Ok(Command {
+            command_id: 0,
+            execution_id,
+            catalog_id,
+            parent_event_id: 0,
+            step_name: step.step.clone(),
+            tool: tool_command,
+            context: Some(render_ctx),
+            metadata: Some(metadata),
+            iterator: None,
         })
     }
 

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -17,7 +17,8 @@ use crate::playbook::types::{LoopMode, NextSpec, Playbook, Step};
 use super::commands::{Command, CommandBuilder, IteratorMetadata};
 use super::evaluator::ConditionEvaluator;
 use super::state::{
-    apply_set_mutations, extract_user_data, ExecutionState, StepState, WorkflowState,
+    apply_set_mutations, extract_command_id, extract_user_data, ExecutionState, StepState,
+    WorkflowState,
 };
 use crate::template::TemplateRenderer;
 
@@ -45,6 +46,95 @@ fn merge_iteration_context(
         serde_json::Value::String(iterator_var.to_string()),
     );
     serde_json::Value::Object(obj)
+}
+
+/// Per-frame progress of a `mode: cursor` loop, reconstructed from the log.
+#[derive(Default)]
+struct CursorFrame {
+    claim_completed: bool,
+    claim_rows: Vec<serde_json::Value>,
+    body_issued: usize,
+    body_completed: usize,
+}
+
+/// Reconstruct a cursor loop's frames for `step_name` from the event log
+/// (noetl/ai-meta#100).  Uses the `cursor` metadata stamped on the
+/// `command.issued` events (phase/frame) and correlates completions back by
+/// `command_id`.  Returns `(entered, frames-by-index)`.
+fn reconstruct_cursor_frames(
+    events: &[Event],
+    step_name: &str,
+) -> (bool, std::collections::BTreeMap<i64, CursorFrame>) {
+    use std::collections::BTreeMap;
+    let mut entered = false;
+    // command_id -> (phase, frame) for issued cursor sub-commands.
+    let mut issued: HashMap<String, (String, i64)> = HashMap::new();
+    let mut completed: HashSet<String> = HashSet::new();
+    let mut frames: BTreeMap<i64, CursorFrame> = BTreeMap::new();
+    for ev in events {
+        if ev.node_name.as_deref() != Some(step_name) {
+            continue;
+        }
+        match ev.event_type.as_str() {
+            "step.enter" | "step_enter" | "step_started" => entered = true,
+            "command.issued" => {
+                let Some(cur) = ev.meta.as_ref().and_then(|m| m.get("cursor")) else {
+                    continue;
+                };
+                let phase = cur
+                    .get("phase")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let frame = cur.get("frame").and_then(|v| v.as_i64()).unwrap_or(0);
+                let Some(cid) = extract_command_id(ev) else { continue };
+                if issued.insert(cid, (phase.clone(), frame)).is_none() {
+                    let f = frames.entry(frame).or_default();
+                    if phase == "body" {
+                        f.body_issued += 1;
+                    }
+                }
+            }
+            // `call.done` carries the tool DATA (the claim's RETURNING rows);
+            // `command.completed` carries only {status, command_id}.  So parse
+            // the claim's frame rows from call.done, keyed by command_id.
+            "call.done" | "action_done" => {
+                let Some(cid) = extract_command_id(ev) else { continue };
+                let Some((phase, frame)) = issued.get(&cid).cloned() else {
+                    continue;
+                };
+                if phase == "claim" {
+                    if let Some(rows) = ev
+                        .result
+                        .as_ref()
+                        .and_then(extract_user_data)
+                        .as_ref()
+                        .and_then(|d| d.get("rows"))
+                        .and_then(|r| r.as_array())
+                    {
+                        frames.entry(frame).or_default().claim_rows = rows.clone();
+                    }
+                }
+            }
+            "command.completed" | "action_completed" => {
+                let Some(cid) = extract_command_id(ev) else { continue };
+                let Some((phase, frame)) = issued.get(&cid).cloned() else {
+                    continue;
+                };
+                if !completed.insert(cid) {
+                    continue; // dedup repeated completion events
+                }
+                let f = frames.entry(frame).or_default();
+                if phase == "claim" {
+                    f.claim_completed = true;
+                } else if phase == "body" {
+                    f.body_completed += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    (entered, frames)
 }
 
 /// Add `ctx` and `workload` namespace shims to a flat variable
@@ -281,7 +371,7 @@ impl WorkflowOrchestrator {
         trigger_event_type: Option<&str>,
     ) -> AppResult<OrchestrationResult> {
         // Reconstruct workflow state from events
-        let state = WorkflowState::from_events(events)
+        let mut state = WorkflowState::from_events(events)
             .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
 
         debug!(
@@ -458,7 +548,13 @@ impl WorkflowOrchestrator {
                     self.dispatch_initial_steps(&state, playbook, &context)?
                 } else {
                     // Process completed steps and determine next steps
-                    self.process_in_progress(&state, &steps, &context, trigger_event_type)?
+                    self.process_in_progress(
+                        &mut state,
+                        &steps,
+                        &context,
+                        trigger_event_type,
+                        events,
+                    )?
                 }
             }
             _ => OrchestrationResult {
@@ -538,10 +634,11 @@ impl WorkflowOrchestrator {
     /// Process an in-progress execution.
     fn process_in_progress(
         &self,
-        state: &WorkflowState,
+        state: &mut WorkflowState,
         steps: &HashMap<&str, &Step>,
         context: &HashMap<String, serde_json::Value>,
         trigger_event_type: Option<&str>,
+        events: &[Event],
     ) -> AppResult<OrchestrationResult> {
         let mut commands = Vec::new();
         let mut events_to_emit = Vec::new();
@@ -722,7 +819,7 @@ impl WorkflowOrchestrator {
 
                 let next_idx = completed as usize;
                 let shimmed = with_ctx_shims(context);
-                let items = self.evaluator.evaluate_loop(&loop_cfg.in_expr, &shimmed)?;
+                let items = self.evaluator.evaluate_loop(loop_cfg.in_expr.as_deref().unwrap_or(""), &shimmed)?;
                 if next_idx >= items.len() {
                     continue;
                 } // safety guard
@@ -753,6 +850,155 @@ impl WorkflowOrchestrator {
                     iter_meta,
                 )?;
                 commands.push(command);
+            }
+        }
+
+        // noetl/ai-meta#100: cursor-loop drive.
+        //
+        // On a completion event, advance each active `mode: cursor` step:
+        //   - claim still in flight        -> wait
+        //   - claim returned 0 rows        -> DRAIN: mark the step completed +
+        //                                     emit a `__cursor_drained` step.exit
+        //                                     so the transition loop below routes
+        //                                     its `next` arcs (event.name=loop.done)
+        //   - claim returned K rows, body
+        //     not all dispatched           -> dispatch body command(s) per row,
+        //                                     bounded by frame.row_concurrency
+        //   - all K body rows done         -> re-claim the next frame
+        // The claim runs as a normal tool command on a worker; no long-lived
+        // worker holds a slot (honors agents/rules/execution-model.md).
+        if matches!(
+            trigger_event_type,
+            Some("command.completed") | Some("action_completed")
+        ) {
+            let drain_ts = events.last().map(|e| e.created_at);
+            let cursor_steps: Vec<String> = state
+                .steps
+                .iter()
+                .filter(|(name, info)| info.is_cursor && !state.is_step_completed(name))
+                .map(|(name, _)| name.clone())
+                .collect();
+
+            for step_name in cursor_steps {
+                let Some(step_def) = steps.get(step_name.as_str()) else {
+                    continue;
+                };
+                let Some(loop_cfg) = step_def.r#loop.as_ref() else {
+                    continue;
+                };
+                let Some(cursor) = loop_cfg.cursor.as_ref() else {
+                    continue;
+                };
+                let frame_spec = loop_cfg.spec.as_ref().and_then(|s| s.frame.as_ref());
+                let max_rows = frame_spec.and_then(|f| f.max_rows).unwrap_or(1).max(1);
+                let row_concurrency = frame_spec
+                    .and_then(|f| f.row_concurrency)
+                    .unwrap_or(1)
+                    .max(1) as usize;
+
+                let (entered, frames) = reconstruct_cursor_frames(events, &step_name);
+                if !entered {
+                    continue;
+                }
+                let Some((&frame_idx, frame)) = frames.iter().next_back() else {
+                    // Entered but no claim issued yet — claim frame 0.
+                    let cmd = self.command_builder.build_cursor_claim_command(
+                        state.execution_id,
+                        state.catalog_id,
+                        step_def,
+                        cursor,
+                        context,
+                        0,
+                        max_rows,
+                    )?;
+                    commands.push(cmd);
+                    continue;
+                };
+                if !frame.claim_completed {
+                    continue; // claim in flight; its completion re-triggers us
+                }
+                let k = frame.claim_rows.len();
+                if k == 0 {
+                    // DRAIN — the claim found no more work.  Complete the step
+                    // in-memory so the transition loop routes it this pass, and
+                    // emit a durable drain step.exit for replay.
+                    if let Some(si) = state.steps.get_mut(&step_name) {
+                        si.state = StepState::Completed;
+                        si.completed_at = drain_ts;
+                        if si.result.is_none() {
+                            si.result = Some(serde_json::json!({
+                                "cursor": "drained",
+                                "frames": frame_idx
+                            }));
+                        }
+                    }
+                    events_to_emit.push(EventToEmit {
+                        event_type: "step.exit".to_string(),
+                        node_name: Some(step_name.clone()),
+                        status: "COMPLETED".to_string(),
+                        context: Some(serde_json::json!({ "__cursor_drained": true })),
+                        result: Some(serde_json::json!({
+                            "cursor": "drained",
+                            "frames": frame_idx
+                        })),
+                        error: None,
+                    });
+                    info!(
+                        "Cursor loop '{}' drained after {} frame(s)",
+                        step_name,
+                        frame_idx + 1
+                    );
+                    continue;
+                }
+                if frame.body_completed >= k {
+                    // Frame fully processed — claim the next frame.
+                    let cmd = self.command_builder.build_cursor_claim_command(
+                        state.execution_id,
+                        state.catalog_id,
+                        step_def,
+                        cursor,
+                        context,
+                        frame_idx + 1,
+                        max_rows,
+                    )?;
+                    commands.push(cmd);
+                    continue;
+                }
+                // Dispatch the next body command(s), bounded by row_concurrency.
+                let in_flight = frame.body_issued.saturating_sub(frame.body_completed);
+                if frame.body_issued < k && in_flight < row_concurrency {
+                    let can_issue =
+                        (row_concurrency - in_flight).min(k - frame.body_issued);
+                    for r in frame.body_issued..(frame.body_issued + can_issue) {
+                        let iter_meta = IteratorMetadata {
+                            parent_execution_id: state.execution_id,
+                            iterator_step: step_name.clone(),
+                            item_var: loop_cfg.iterator.clone(),
+                            item: frame.claim_rows[r].clone(),
+                            index: r,
+                            total: k,
+                        };
+                        let mut body_cmd = self.command_builder.build_iteration_command(
+                            0,
+                            state.execution_id,
+                            state.catalog_id,
+                            0,
+                            step_def,
+                            context,
+                            iter_meta,
+                        )?;
+                        body_cmd.metadata = Some(serde_json::json!({
+                            "cursor": {
+                                "phase": "body",
+                                "step": step_name,
+                                "frame": frame_idx,
+                                "row": r
+                            }
+                        }));
+                        commands.push(body_cmd);
+                    }
+                }
+                // else: body in flight — wait for completions to re-trigger.
             }
         }
 
@@ -1334,10 +1580,60 @@ impl WorkflowOrchestrator {
                     // block above handles subsequent iterations when
                     // each command.completed arrives.
                     if let Some(loop_cfg) = current_step.r#loop.as_ref() {
+                        // noetl/ai-meta#100: `mode: cursor` — claim-based work
+                        // loop.  On entry, emit a `step.enter` carrying the
+                        // `__cursor_loop` marker (so claim/body completions
+                        // don't complete the step) and dispatch the first
+                        // claim command.  The cursor-drive block then fans out
+                        // the body per claimed row, re-claims, and drains.
+                        if loop_cfg.mode() == LoopMode::Cursor {
+                            if let Some(cursor) = loop_cfg.cursor.as_ref() {
+                                let max_rows = loop_cfg
+                                    .spec
+                                    .as_ref()
+                                    .and_then(|s| s.frame.as_ref())
+                                    .and_then(|f| f.max_rows)
+                                    .unwrap_or(1)
+                                    .max(1);
+                                let mut enter_obj = match current_with_params.clone() {
+                                    Some(serde_json::Value::Object(m)) => m,
+                                    _ => serde_json::Map::new(),
+                                };
+                                enter_obj.insert(
+                                    "__cursor_loop".to_string(),
+                                    serde_json::json!(true),
+                                );
+                                events_to_emit.push(EventToEmit {
+                                    event_type: "step.enter".to_string(),
+                                    node_name: Some(current_step_name.clone()),
+                                    status: "ENTERED".to_string(),
+                                    context: Some(serde_json::Value::Object(enter_obj)),
+                                    result: None,
+                                    error: None,
+                                });
+                                let claim_cmd =
+                                    self.command_builder.build_cursor_claim_command(
+                                        state.execution_id,
+                                        state.catalog_id,
+                                        current_step,
+                                        cursor,
+                                        &current_ctx,
+                                        0,
+                                        max_rows,
+                                    )?;
+                                commands.push(claim_cmd);
+                                info!(
+                                    "Cursor loop '{}' entered — claiming frame 0 (max_rows={})",
+                                    current_step_name, max_rows
+                                );
+                                continue;
+                            }
+                        }
+
                         let shimmed_loop = with_ctx_shims(&current_ctx);
                         let items = self
                             .evaluator
-                            .evaluate_loop(&loop_cfg.in_expr, &shimmed_loop)?;
+                            .evaluate_loop(loop_cfg.in_expr.as_deref().unwrap_or(""), &shimmed_loop)?;
                         let total: usize = items.len();
 
                         if total == 0 {
@@ -1642,6 +1938,70 @@ mod tests {
             attempt: None,
             created_at: Utc::now(),
         }
+    }
+
+    #[test]
+    fn cursor_reconstruct_tracks_frames_and_drain() {
+        // noetl/ai-meta#100: reconstruct cursor-loop frame progress from the
+        // event log (claim issued/completed + body issued/completed), keyed by
+        // the `cursor` metadata on command.issued and correlated by command_id.
+        let mut events = vec![make_event("step.enter", Some("cur"))];
+
+        let mut claim0 = make_event("command.issued", Some("cur"));
+        claim0.meta =
+            Some(serde_json::json!({"command_id": "c0", "cursor": {"phase": "claim", "frame": 0}}));
+        events.push(claim0);
+        // The claim's RETURNING rows arrive on call.done (command.completed
+        // carries only {status, command_id}).
+        let mut claim0_data = make_event("call.done", Some("cur"));
+        claim0_data.result = Some(serde_json::json!({
+            "context": {"command_id": "c0", "data": {"rows": [{"id": 1}, {"id": 2}]}}
+        }));
+        events.push(claim0_data);
+        let mut claim0_done = make_event("command.completed", Some("cur"));
+        claim0_done.meta = Some(serde_json::json!({"command_id": "c0"}));
+        events.push(claim0_done);
+
+        // One body row issued + completed.
+        let mut body0 = make_event("command.issued", Some("cur"));
+        body0.meta =
+            Some(serde_json::json!({"command_id": "b0", "cursor": {"phase": "body", "frame": 0}}));
+        events.push(body0);
+        let mut body0_done = make_event("command.completed", Some("cur"));
+        body0_done.meta = Some(serde_json::json!({"command_id": "b0"}));
+        events.push(body0_done);
+
+        let (entered, frames) = reconstruct_cursor_frames(&events, "cur");
+        assert!(entered);
+        let f0 = frames.get(&0).expect("frame 0 present");
+        assert!(f0.claim_completed);
+        assert_eq!(f0.claim_rows.len(), 2, "claim returned 2 rows");
+        assert_eq!(f0.body_issued, 1);
+        assert_eq!(f0.body_completed, 1);
+
+        // Next frame's claim drains (0 rows) → the drive block would complete it.
+        let mut claim1 = make_event("command.issued", Some("cur"));
+        claim1.meta =
+            Some(serde_json::json!({"command_id": "c1", "cursor": {"phase": "claim", "frame": 1}}));
+        events.push(claim1);
+        let mut claim1_data = make_event("call.done", Some("cur"));
+        claim1_data.result =
+            Some(serde_json::json!({"context": {"command_id": "c1", "data": {"rows": []}}}));
+        events.push(claim1_data);
+        let mut claim1_done = make_event("command.completed", Some("cur"));
+        claim1_done.meta = Some(serde_json::json!({"command_id": "c1"}));
+        events.push(claim1_done);
+
+        let (_, frames2) = reconstruct_cursor_frames(&events, "cur");
+        let f1 = frames2.get(&1).expect("frame 1 present");
+        assert!(f1.claim_completed);
+        assert!(f1.claim_rows.is_empty(), "drained frame has no rows");
+        // Repeated completion events for the same command_id are deduped.
+        let mut dup = make_event("command.completed", Some("cur"));
+        dup.meta = Some(serde_json::json!({"command_id": "b0"}));
+        events.push(dup);
+        let (_, frames3) = reconstruct_cursor_frames(&events, "cur");
+        assert_eq!(frames3.get(&0).unwrap().body_completed, 1, "dedup repeat");
     }
 
     #[test]
@@ -2065,11 +2425,13 @@ mod tests {
         let start = make_step("start", Some("looped"));
         let mut looped = make_step("looped", Some("end"));
         looped.r#loop = Some(crate::playbook::types::Loop {
-            in_expr: "{{ [1, 2, 3] }}".to_string(),
+            in_expr: Some("{{ [1, 2, 3] }}".to_string()),
+            cursor: None,
             iterator: "n".to_string(),
             spec: Some(crate::playbook::types::LoopSpec {
                 mode: LoopMode::Parallel,
                 max_in_flight: None,
+                frame: None,
             }),
         });
         let end = make_step("end", None);
@@ -2155,11 +2517,13 @@ mod tests {
         let start = make_step("start", Some("looped"));
         let mut looped = make_step("looped", Some("end"));
         looped.r#loop = Some(crate::playbook::types::Loop {
-            in_expr: "{{ [1, 2, 3] }}".to_string(),
+            in_expr: Some("{{ [1, 2, 3] }}".to_string()),
+            cursor: None,
             iterator: "n".to_string(),
             spec: Some(crate::playbook::types::LoopSpec {
                 mode: LoopMode::Sequential,
                 max_in_flight: None,
+                frame: None,
             }),
         });
         let end = make_step("end", None);
@@ -2243,11 +2607,13 @@ mod tests {
         let start = make_step("start", Some("looped"));
         let mut looped = make_step("looped", Some("end"));
         looped.r#loop = Some(crate::playbook::types::Loop {
-            in_expr: "{{ [10, 20, 30] }}".to_string(),
+            in_expr: Some("{{ [10, 20, 30] }}".to_string()),
+            cursor: None,
             iterator: "n".to_string(),
             spec: Some(crate::playbook::types::LoopSpec {
                 mode: LoopMode::Sequential,
                 max_in_flight: None,
+                frame: None,
             }),
         });
         let end = make_step("end", None);
@@ -2354,11 +2720,13 @@ mod tests {
         let start = make_step("start", Some("looped"));
         let mut looped = make_step("looped", None);
         looped.r#loop = Some(Loop {
-            in_expr: "{{ [10, 20, 30] }}".to_string(),
+            in_expr: Some("{{ [10, 20, 30] }}".to_string()),
+            cursor: None,
             iterator: "n".to_string(),
             spec: Some(LoopSpec {
                 mode: LoopMode::Sequential,
                 max_in_flight: None,
+                frame: None,
             }),
         });
         // next: validate WHEN event.name == "loop.done"
@@ -2459,7 +2827,8 @@ mod tests {
         let start = make_step("start", Some("looped"));
         let mut looped = make_step("looped", Some("end"));
         looped.r#loop = Some(crate::playbook::types::Loop {
-            in_expr: "{{ [1, 2] }}".to_string(),
+            in_expr: Some("{{ [1, 2] }}".to_string()),
+            cursor: None,
             iterator: "x".to_string(),
             spec: None, // default = Sequential
         });
@@ -2519,7 +2888,8 @@ mod tests {
         let start = make_step("start", Some("looped"));
         let mut looped = make_step("looped", Some("end"));
         looped.r#loop = Some(crate::playbook::types::Loop {
-            in_expr: "{{ [] }}".to_string(),
+            in_expr: Some("{{ [] }}".to_string()),
+            cursor: None,
             iterator: "x".to_string(),
             spec: None,
         });
@@ -3512,7 +3882,8 @@ mod tests {
 
         let mut loop_step = make_step("loop_step", Some("end"));
         loop_step.r#loop = Some(Loop {
-            in_expr: "{{ ctx.items }}".to_string(),
+            in_expr: Some("{{ ctx.items }}".to_string()),
+            cursor: None,
             iterator: "item".to_string(),
             spec: None,
         });

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -94,7 +94,15 @@ fn reconstruct_cursor_frames(
             continue;
         }
         match ev.event_type.as_str() {
-            "step.enter" | "step_enter" | "step_started" => entered = true,
+            "step.enter" | "step_enter" | "step_started" => {
+                // Reset on (re-)entry so a loop-back re-run of the cursor step
+                // starts fresh — its frames restart at 0 and must not merge with
+                // a prior drained run's frames (noetl/ai-meta#100 re-entry).
+                entered = true;
+                issued.clear();
+                completed.clear();
+                frames.clear();
+            }
             "command.issued" => {
                 let Some(cur) = ev.meta.as_ref().and_then(|m| m.get("cursor")) else {
                     continue;
@@ -2038,6 +2046,13 @@ mod tests {
         events.push(dup);
         let (_, frames3) = reconstruct_cursor_frames(&events, "cur");
         assert_eq!(frames3.get(&0).unwrap().body_completed, 1, "dedup repeat");
+
+        // Re-entry (loop-back): a fresh step.enter resets frame tracking so the
+        // re-run's frame 0 doesn't merge with the prior run's frame 0.
+        events.push(make_event("step.enter", Some("cur")));
+        let (re_entered, re_frames) = reconstruct_cursor_frames(&events, "cur");
+        assert!(re_entered);
+        assert!(re_frames.is_empty(), "re-entry clears prior frames");
     }
 
     #[test]

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -48,6 +48,24 @@ fn merge_iteration_context(
     serde_json::Value::Object(obj)
 }
 
+/// Build the `output` namespace for a completed step's `when:` / `set:`
+/// rendering (noetl/ai-meta#100 PFT parity).  Exposes the step's unwrapped
+/// tool data both as `output.X` and `output.data.X` (mirrors `build_context`'s
+/// per-step `with_data` shape).  Returns `None` when the step has no result.
+fn output_namespace(state: &WorkflowState, step_name: &str) -> Option<serde_json::Value> {
+    let result = state.steps.get(step_name)?.result.as_ref()?;
+    let data = extract_user_data(result).unwrap_or_else(|| result.clone());
+    let out = match &data {
+        serde_json::Value::Object(m) if !m.contains_key("data") => {
+            let mut o = m.clone();
+            o.insert("data".to_string(), data.clone());
+            serde_json::Value::Object(o)
+        }
+        _ => data,
+    };
+    Some(out)
+}
+
 /// Per-frame progress of a `mode: cursor` loop, reconstructed from the log.
 #[derive(Default)]
 struct CursorFrame {
@@ -475,7 +493,14 @@ impl WorkflowOrchestrator {
             let Some(set_vars) = &step_def.set_vars else {
                 continue;
             };
-            let shimmed = with_ctx_shims(&context);
+            let mut shimmed = with_ctx_shims(&context);
+            // noetl/ai-meta#100 (PFT parity): expose the completing step's
+            // result as `output` so step-level `set:` expressions like
+            // `ctx.facility_mapping_id: {{ output.data.rows[0].facility_mapping_id }}`
+            // resolve to the real value instead of the `else` default.
+            if let Some(out) = output_namespace(&state, step_name) {
+                shimmed.insert("output".to_string(), out);
+            }
             let mut rendered: HashMap<String, serde_json::Value> =
                 HashMap::with_capacity(set_vars.len());
             for (key, val) in set_vars {
@@ -1027,6 +1052,17 @@ impl WorkflowOrchestrator {
                 None => continue,
             };
             let mut shimmed = with_ctx_shims(context);
+            // noetl/ai-meta#100 (PFT parity): expose the producing step's
+            // result as `output` so arc `when:` conditions like
+            // `{{ output.data.row_count }}` resolve.  Python exposes the
+            // just-completed step's result under `output`; the same data is
+            // also available under the step name, but `output` is the
+            // step-agnostic alias the canonical playbooks use.  Without it the
+            // `when` references an undefined `output`, every arc evaluates
+            // false/errors, and the workflow stalls after the step.
+            if let Some(out) = output_namespace(state, step_name) {
+                shimmed.insert("output".to_string(), out);
+            }
             // A completed loop step surfaces `event.name == "loop.done"`
             // to its next-arc conditions — the canonical DSL gate for
             // "after the loop finishes".  The Python runtime emits a

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -170,6 +170,14 @@ pub struct StepInfo {
     /// step.  Always 0 for non-iterator steps.
     #[serde(default, skip_serializing_if = "crate::engine::state::is_zero")]
     pub iterations_dispatched: i32,
+
+    /// True when this step is a `mode: cursor` loop (noetl/ai-meta#100).  Set
+    /// from the `step.enter` context marker `__cursor_loop`.  Cursor steps are
+    /// NOT completed by individual claim/body `command.completed` events — the
+    /// orchestrator's cursor-drive block completes the step via a drain
+    /// `step.exit` carrying `__cursor_drained` once the claim returns no rows.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_cursor: bool,
 }
 
 impl StepInfo {
@@ -188,6 +196,7 @@ impl StepInfo {
             iteration_command_ids: std::collections::HashSet::new(),
             iteration_results: Vec::new(),
             iterations_dispatched: 0,
+            is_cursor: false,
         }
     }
 
@@ -264,7 +273,7 @@ pub struct WorkflowState {
 /// (constraint-compliant envelope), or — in older shapes — on
 /// `result.data`.  Returns the first match.  Used by R3b iterator
 /// state aggregation to deduplicate `command.completed` events.
-fn extract_command_id(event: &Event) -> Option<String> {
+pub(crate) fn extract_command_id(event: &Event) -> Option<String> {
     if let Some(meta) = &event.meta {
         if let Some(s) = meta.get("command_id").and_then(|v| v.as_str()) {
             return Some(s.to_string());
@@ -471,6 +480,25 @@ impl WorkflowState {
                     if let Some(total) = total {
                         step.iterations_expected = Some(total as i32);
                     }
+                    // noetl/ai-meta#100: mark cursor-loop steps from the
+                    // `__cursor_loop` context marker (same dual-shape read).
+                    let cursor_marked = event
+                        .result
+                        .as_ref()
+                        .and_then(|r| r.get("context"))
+                        .and_then(|c| c.get("__cursor_loop"))
+                        .and_then(|v| v.as_bool())
+                        .or_else(|| {
+                            event
+                                .context
+                                .as_ref()
+                                .and_then(|c| c.get("__cursor_loop"))
+                                .and_then(|v| v.as_bool())
+                        })
+                        .unwrap_or(false);
+                    if cursor_marked {
+                        step.is_cursor = true;
+                    }
                 }
             }
             "step.skipped" | "step_skipped" => {
@@ -537,10 +565,35 @@ impl WorkflowState {
             }
             "command.completed" | "action_completed" | "step.exit" | "step_completed" => {
                 if let Some(name) = &event.node_name {
+                    // noetl/ai-meta#100: a `mode: cursor` loop's claim/body
+                    // sub-commands must NOT complete the step.  The step is
+                    // completed only by the orchestrator's drain `step.exit`
+                    // (carrying `__cursor_drained` in its context).  So for a
+                    // cursor step, skip completion unless the event is the drain.
+                    let is_drain = event
+                        .result
+                        .as_ref()
+                        .and_then(|r| r.get("context"))
+                        .and_then(|c| c.get("__cursor_drained"))
+                        .and_then(|v| v.as_bool())
+                        .or_else(|| {
+                            event
+                                .context
+                                .as_ref()
+                                .and_then(|c| c.get("__cursor_drained"))
+                                .and_then(|v| v.as_bool())
+                        })
+                        .unwrap_or(false);
                     let step = self
                         .steps
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
+
+                    if step.is_cursor && !is_drain {
+                        // Cursor sub-command completion — record nothing toward
+                        // step completion; the drive block re-claims / drains.
+                        return;
+                    }
 
                     // R3b iterator-aware completion: if this step is
                     // a loop step (iterations_expected set), count
@@ -615,6 +668,12 @@ impl WorkflowState {
                         .steps
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
+                    // noetl/ai-meta#100: cursor sub-command call.done results
+                    // must not overwrite the cursor step's result (the drive
+                    // block sets it on drain).
+                    if step.is_cursor {
+                        return;
+                    }
                     // For iterator steps the iteration-aware branch
                     // in command.completed builds the per-iteration
                     // result array; leave it alone here.  Plain steps

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -758,6 +758,17 @@ pub(crate) async fn persist_engine_command(
             map.insert("trace".to_string(), trace.clone());
         }
     }
+    // Carry the command's own metadata (e.g. the cursor-loop phase/frame for
+    // mode: cursor, noetl/ai-meta#100) onto the command.issued event meta so a
+    // later orchestrator pass can recognise the claim vs body command by
+    // correlating the completion back to this issued event via command_id.
+    if let Some(serde_json::Value::Object(extra)) = command.metadata.as_ref() {
+        if let serde_json::Value::Object(ref mut map) = cmd_meta {
+            for (k, v) in extra {
+                map.insert(k.clone(), v.clone());
+            }
+        }
+    }
 
     sqlx::query(
         r#"
@@ -879,7 +890,7 @@ async fn generate_initial_commands(
         // ranges and strings to splits), the initial-dispatch boundary
         // enforces strict array typing so callers pass an explicit list.
         let renderer = crate::template::jinja::TemplateRenderer::new();
-        let raw_value = renderer.render_to_value(&loop_cfg.in_expr, &context)?;
+        let raw_value = renderer.render_to_value(loop_cfg.in_expr.as_deref().unwrap_or(""), &context)?;
 
         let items: Vec<serde_json::Value> = match raw_value {
             serde_json::Value::Array(arr) => arr,
@@ -1233,7 +1244,7 @@ mod tests {
         if let Some(loop_cfg) = step.r#loop.as_ref() {
             let renderer = TemplateRenderer::new();
             let raw_value = renderer
-                .render_to_value(&loop_cfg.in_expr, context)
+                .render_to_value(loop_cfg.in_expr.as_deref().unwrap_or(""), context)
                 .map_err(|e| AppError::Internal(e.to_string()))?;
 
             let items: Vec<serde_json::Value> = match raw_value {
@@ -1300,7 +1311,8 @@ mod tests {
     #[test]
     fn test_generate_initial_commands_fans_out_when_start_has_loop() {
         let loop_cfg = Loop {
-            in_expr: "{{ items }}".to_string(),
+            in_expr: Some("{{ items }}".to_string()),
+            cursor: None,
             iterator: "item".to_string(),
             spec: None,
         };
@@ -1348,7 +1360,8 @@ mod tests {
     #[test]
     fn test_generate_initial_commands_rejects_non_array_loop_in() {
         let loop_cfg = Loop {
-            in_expr: "{{ count }}".to_string(),
+            in_expr: Some("{{ count }}".to_string()),
+            cursor: None,
             iterator: "item".to_string(),
             spec: None,
         };

--- a/src/playbook/parser.rs
+++ b/src/playbook/parser.rs
@@ -375,12 +375,14 @@ fn validate_loop_config(
     loop_config: &crate::playbook::types::Loop,
     step_name: &str,
 ) -> AppResult<()> {
-    // Validate in expression
-    if !is_valid_jinja_expression(&loop_config.in_expr) {
-        return Err(AppError::Validation(format!(
-            "Step '{}': loop.in has invalid expression: {}",
-            step_name, loop_config.in_expr
-        )));
+    // Validate in expression (only when present — cursor loops have no `in:`)
+    if let Some(in_expr) = loop_config.in_expr.as_deref() {
+        if !is_valid_jinja_expression(in_expr) {
+            return Err(AppError::Validation(format!(
+                "Step '{}': loop.in has invalid expression: {}",
+                step_name, in_expr
+            )));
+        }
     }
 
     // Validate iterator name
@@ -391,8 +393,25 @@ fn validate_loop_config(
         )));
     }
 
-    // Note: loop.spec.mode validation is done by serde during deserialization
-    // (LoopMode enum only allows "sequential" or "parallel")
+    // mode is validated by serde (LoopMode enum: sequential / parallel / cursor).
+    // Shape requirements differ by mode:
+    //   - cursor: requires `loop.cursor.claim`; `in:` is not used.
+    //   - sequential / parallel: require `in:`; `cursor:` is not used.
+    let is_cursor = loop_config.mode() == crate::playbook::types::LoopMode::Cursor;
+    if is_cursor {
+        if loop_config.cursor.is_none() {
+            return Err(AppError::Validation(format!(
+                "Step '{}': loop.spec.mode=cursor requires a loop.cursor block with a claim query",
+                step_name
+            )));
+        }
+    } else if loop_config.in_expr.as_deref().unwrap_or("").trim().is_empty() {
+        return Err(AppError::Validation(format!(
+            "Step '{}': loop requires `in:` (the collection expression) for mode={:?}",
+            step_name,
+            loop_config.mode()
+        )));
+    }
 
     Ok(())
 }

--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -360,26 +360,89 @@ pub enum LoopMode {
     #[default]
     Sequential,
     Parallel,
+    /// Claim-based work-distribution loop (noetl/ai-meta#100).  Instead of a
+    /// fixed `in:` collection, the orchestrator repeatedly runs the
+    /// `loop.cursor.claim` SQL to lease a frame of work rows, fans out the
+    /// step body per claimed row, then re-claims — until the claim returns
+    /// zero rows (drained).  Honors the Rust execution model: the claim runs
+    /// as a normal postgres tool command on a worker; no long-lived worker.
+    Cursor,
+}
+
+/// Frame sizing / leasing policy for a `mode: cursor` loop.
+///
+/// Only `max_rows` is load-bearing in the orchestrator-driven port (it caps
+/// each claim and is injected as `__frame_max_rows` into the claim render
+/// context).  The lease/heartbeat/byte fields are accepted for playbook
+/// compatibility with the Python engine; stale-reclaim is handled by the
+/// playbook's own claim SQL (its `reclaim_stale` CTE), so they are advisory.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FrameSpec {
+    /// Max rows claimed per frame (the claim SQL's `LIMIT {{ __frame_max_rows }}`).
+    #[serde(default)]
+    pub max_rows: Option<i64>,
+    #[serde(default)]
+    pub max_seconds: Option<f64>,
+    #[serde(default)]
+    pub max_bytes: Option<i64>,
+    #[serde(default)]
+    pub lease_seconds: Option<f64>,
+    #[serde(default)]
+    pub heartbeat_seconds: Option<f64>,
+    /// Rows of one frame to dispatch concurrently (1 = sequential within frame).
+    #[serde(default)]
+    pub row_concurrency: Option<i32>,
+    /// `row` (default) binds `iter.<name>` to one row; `frame` is reserved.
+    #[serde(default)]
+    pub process: Option<String>,
+}
+
+/// The claim block of a `mode: cursor` loop — a SQL tool that atomically
+/// leases a frame of work rows and returns them (its `RETURNING` columns
+/// become the per-row `iter.<iterator>` object).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CursorClaim {
+    /// Tool kind running the claim (default `postgres`).
+    #[serde(default = "default_cursor_kind")]
+    pub kind: String,
+    /// Credential alias for the claim tool.
+    #[serde(default)]
+    pub auth: Option<String>,
+    /// The claim SQL (atomic lease, e.g. `... FOR UPDATE SKIP LOCKED ... RETURNING ...`).
+    pub claim: String,
+}
+
+fn default_cursor_kind() -> String {
+    "postgres".to_string()
 }
 
 /// Loop runtime specification (canonical format).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoopSpec {
-    /// Execution mode: sequential or parallel.
+    /// Execution mode: sequential, parallel, or cursor.
     #[serde(default)]
     pub mode: LoopMode,
 
-    /// Maximum concurrent iterations in parallel mode.
+    /// Maximum concurrent iterations in parallel mode / frames in cursor mode.
     #[serde(default)]
     pub max_in_flight: Option<i32>,
+
+    /// Frame sizing/leasing policy (cursor mode only).
+    #[serde(default)]
+    pub frame: Option<FrameSpec>,
 }
 
 /// Step-level loop configuration (canonical format).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Loop {
-    /// Jinja expression for collection to iterate over.
-    #[serde(rename = "in")]
-    pub in_expr: String,
+    /// Jinja expression for collection to iterate over.  Required for
+    /// `sequential` / `parallel`; absent for `cursor` (which claims work).
+    #[serde(rename = "in", default)]
+    pub in_expr: Option<String>,
+
+    /// Claim block for `mode: cursor` loops.
+    #[serde(default)]
+    pub cursor: Option<CursorClaim>,
 
     /// Variable name for each item.
     pub iterator: String,
@@ -387,6 +450,16 @@ pub struct Loop {
     /// Loop spec with mode (canonical format).
     #[serde(default)]
     pub spec: Option<LoopSpec>,
+}
+
+impl Loop {
+    /// Resolved loop mode (defaults to sequential when no spec).
+    pub fn mode(&self) -> LoopMode {
+        self.spec
+            .as_ref()
+            .map(|s| s.mode.clone())
+            .unwrap_or(LoopMode::Sequential)
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Implements the claim-based work-distribution loop the PFT flow (and the production `state_report_generation` playbook it mirrors) depends on — noetl/ai-meta#100. Previously the parser rejected it (`loop.spec.mode: unknown variant cursor`).

**Orchestrator-driven** (honors `execution-model.md` — no long-lived self-looping worker; the Python frame-leasing worker model is replaced by discrete server-issued commands):

```
entry      -> step.enter(__cursor_loop) + claim frame 0
claim done -> 0 rows : DRAIN (complete step + __cursor_drained step.exit -> route next, event.name=loop.done)
           -> K rows : fan out the step body per claimed row (bounded by frame.row_concurrency)
frame done -> re-claim next frame
```

The claim runs as a normal `postgres` tool command on a worker; its `RETURNING` rows become `iter.<iterator>`. Stale-reclaim is the playbook claim SQL's own `reclaim_stale` CTE — no server-side frame/lease table.

**Files:** `types.rs` (LoopMode::Cursor, CursorClaim, FrameSpec, optional in_expr) · `parser.rs` (cursor validation) · `commands.rs` (build_cursor_claim_command) · `execute.rs` (command metadata → issued event meta) · `state.rs` (is_cursor; claim/body completions don't complete the step; drain via __cursor_drained) · `orchestrator.rs` (entry hook + drive block + reconstruct_cursor_frames).

**Validation:** kind smoke — a 5-row queue drains through 4 frames (max_rows=2, row_concurrency=1): claim→body→re-claim→drain→route next, all rows processed. Unit test `cursor_reconstruct_tracks_frames_and_drain`. `cargo test --lib` 666 pass, clippy clean. GKE validation against the real PFT (`test_pft_flow_v2` vs `paginated-api`) to follow.

Closes noetl/ai-meta#100