### PR TITLE
feat(orchestrator): bounded-memory state + results-by-reference + stall-proof reconcile (#101)

### DIFF
--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -17,8 +17,7 @@ use crate::playbook::types::{LoopMode, NextSpec, Playbook, Step};
 use super::commands::{Command, CommandBuilder, IteratorMetadata};
 use super::evaluator::ConditionEvaluator;
 use super::state::{
-    apply_set_mutations, extract_command_id, extract_user_data, ExecutionState, StepState,
-    WorkflowState,
+    apply_set_mutations, extract_user_data, ExecutionState, StepState, WorkflowState,
 };
 use crate::template::TemplateRenderer;
 
@@ -64,103 +63,6 @@ fn output_namespace(state: &WorkflowState, step_name: &str) -> Option<serde_json
         _ => data,
     };
     Some(out)
-}
-
-/// Per-frame progress of a `mode: cursor` loop, reconstructed from the log.
-#[derive(Default)]
-struct CursorFrame {
-    claim_completed: bool,
-    claim_rows: Vec<serde_json::Value>,
-    body_issued: usize,
-    body_completed: usize,
-}
-
-/// Reconstruct a cursor loop's frames for `step_name` from the event log
-/// (noetl/ai-meta#100).  Uses the `cursor` metadata stamped on the
-/// `command.issued` events (phase/frame) and correlates completions back by
-/// `command_id`.  Returns `(entered, frames-by-index)`.
-fn reconstruct_cursor_frames(
-    events: &[Event],
-    step_name: &str,
-) -> (bool, std::collections::BTreeMap<i64, CursorFrame>) {
-    use std::collections::BTreeMap;
-    let mut entered = false;
-    // command_id -> (phase, frame) for issued cursor sub-commands.
-    let mut issued: HashMap<String, (String, i64)> = HashMap::new();
-    let mut completed: HashSet<String> = HashSet::new();
-    let mut frames: BTreeMap<i64, CursorFrame> = BTreeMap::new();
-    for ev in events {
-        if ev.node_name.as_deref() != Some(step_name) {
-            continue;
-        }
-        match ev.event_type.as_str() {
-            "step.enter" | "step_enter" | "step_started" => {
-                // Reset on (re-)entry so a loop-back re-run of the cursor step
-                // starts fresh — its frames restart at 0 and must not merge with
-                // a prior drained run's frames (noetl/ai-meta#100 re-entry).
-                entered = true;
-                issued.clear();
-                completed.clear();
-                frames.clear();
-            }
-            "command.issued" => {
-                let Some(cur) = ev.meta.as_ref().and_then(|m| m.get("cursor")) else {
-                    continue;
-                };
-                let phase = cur
-                    .get("phase")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let frame = cur.get("frame").and_then(|v| v.as_i64()).unwrap_or(0);
-                let Some(cid) = extract_command_id(ev) else { continue };
-                if issued.insert(cid, (phase.clone(), frame)).is_none() {
-                    let f = frames.entry(frame).or_default();
-                    if phase == "body" {
-                        f.body_issued += 1;
-                    }
-                }
-            }
-            // `call.done` carries the tool DATA (the claim's RETURNING rows);
-            // `command.completed` carries only {status, command_id}.  So parse
-            // the claim's frame rows from call.done, keyed by command_id.
-            "call.done" | "action_done" => {
-                let Some(cid) = extract_command_id(ev) else { continue };
-                let Some((phase, frame)) = issued.get(&cid).cloned() else {
-                    continue;
-                };
-                if phase == "claim" {
-                    if let Some(rows) = ev
-                        .result
-                        .as_ref()
-                        .and_then(extract_user_data)
-                        .as_ref()
-                        .and_then(|d| d.get("rows"))
-                        .and_then(|r| r.as_array())
-                    {
-                        frames.entry(frame).or_default().claim_rows = rows.clone();
-                    }
-                }
-            }
-            "command.completed" | "action_completed" => {
-                let Some(cid) = extract_command_id(ev) else { continue };
-                let Some((phase, frame)) = issued.get(&cid).cloned() else {
-                    continue;
-                };
-                if !completed.insert(cid) {
-                    continue; // dedup repeated completion events
-                }
-                let f = frames.entry(frame).or_default();
-                if phase == "claim" {
-                    f.claim_completed = true;
-                } else if phase == "body" {
-                    f.body_completed += 1;
-                }
-            }
-            _ => {}
-        }
-    }
-    (entered, frames)
 }
 
 /// Add `ctx` and `workload` namespace shims to a flat variable
@@ -396,10 +298,26 @@ impl WorkflowOrchestrator {
         playbook: &Playbook,
         trigger_event_type: Option<&str>,
     ) -> AppResult<OrchestrationResult> {
-        // Reconstruct workflow state from events
+        // Reconstruct workflow state from events (full path — used by tests and
+        // by trigger_orchestrator on a cold cache).
         let mut state = WorkflowState::from_events(events)
             .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
+        let latest_ts = events.last().map(|e| e.created_at);
+        self.evaluate_state(&mut state, latest_ts, playbook, trigger_event_type)
+    }
 
+    /// Orchestrate against an already-built `WorkflowState` (noetl/ai-meta#100
+    /// perf).  `trigger_orchestrator` caches the state per execution and
+    /// advances it by applying only NEW events, then calls this — avoiding the
+    /// O(n) `from_events` rebuild on every trigger.  `latest_ts` is the most
+    /// recent event's timestamp (used to stamp a cursor-drain completion).
+    pub fn evaluate_state(
+        &self,
+        state: &mut WorkflowState,
+        latest_ts: Option<chrono::DateTime<chrono::Utc>>,
+        playbook: &Playbook,
+        trigger_event_type: Option<&str>,
+    ) -> AppResult<OrchestrationResult> {
         debug!(
             "Evaluating execution {}, state: {}, trigger: {:?}",
             state.execution_id, state.state, trigger_event_type
@@ -506,7 +424,7 @@ impl WorkflowOrchestrator {
             // result as `output` so step-level `set:` expressions like
             // `ctx.facility_mapping_id: {{ output.data.rows[0].facility_mapping_id }}`
             // resolve to the real value instead of the `else` default.
-            if let Some(out) = output_namespace(&state, step_name) {
+            if let Some(out) = output_namespace(state, step_name) {
                 shimmed.insert("output".to_string(), out);
             }
             let mut rendered: HashMap<String, serde_json::Value> =
@@ -555,14 +473,14 @@ impl WorkflowOrchestrator {
             }
             if let Some(result) = &info.result {
                 if let Some(user_data) = extract_user_data(result) {
-                    if let serde_json::Value::Object(map) = &user_data {
-                        if let Some(serde_json::Value::Object(updates)) =
-                            map.get("_context_updates")
-                        {
-                            let mutations: HashMap<String, serde_json::Value> =
-                                updates.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                            apply_set_mutations(&mut context, &mutations);
-                        }
+                    if let Some(updates) = user_data
+                        .as_object()
+                        .and_then(|m| m.get("_context_updates"))
+                        .and_then(|v| v.as_object())
+                    {
+                        let mutations: HashMap<String, serde_json::Value> =
+                            updates.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                        apply_set_mutations(&mut context, &mutations);
                     }
                 }
             }
@@ -572,21 +490,21 @@ impl WorkflowOrchestrator {
         let mut result = match state.state {
             ExecutionState::Initial => {
                 // Start first step(s) - always start with "start" step
-                self.dispatch_initial_steps(&state, playbook, &context)?
+                self.dispatch_initial_steps(state, playbook, &context)?
             }
             ExecutionState::InProgress => {
                 // Check if we need to dispatch the initial step
                 // (playbook_started but no steps entered yet)
                 if state.steps.is_empty() {
-                    self.dispatch_initial_steps(&state, playbook, &context)?
+                    self.dispatch_initial_steps(state, playbook, &context)?
                 } else {
                     // Process completed steps and determine next steps
                     self.process_in_progress(
-                        &mut state,
+                        &mut *state,
                         &steps,
                         &context,
                         trigger_event_type,
-                        events,
+                        latest_ts,
                     )?
                 }
             }
@@ -671,7 +589,7 @@ impl WorkflowOrchestrator {
         steps: &HashMap<&str, &Step>,
         context: &HashMap<String, serde_json::Value>,
         trigger_event_type: Option<&str>,
-        events: &[Event],
+        latest_ts: Option<chrono::DateTime<chrono::Utc>>,
     ) -> AppResult<OrchestrationResult> {
         let mut commands = Vec::new();
         let mut events_to_emit = Vec::new();
@@ -904,7 +822,7 @@ impl WorkflowOrchestrator {
             trigger_event_type,
             Some("command.completed") | Some("action_completed")
         ) {
-            let drain_ts = events.last().map(|e| e.created_at);
+            let drain_ts = latest_ts;
             let cursor_steps: Vec<String> = state
                 .steps
                 .iter()
@@ -929,23 +847,30 @@ impl WorkflowOrchestrator {
                     .unwrap_or(1)
                     .max(1) as usize;
 
-                let (entered, frames) = reconstruct_cursor_frames(events, &step_name);
-                if !entered {
-                    continue;
-                }
-                let Some((&frame_idx, frame)) = frames.iter().next_back() else {
-                    // Entered but no claim issued yet — claim frame 0.
-                    let cmd = self.command_builder.build_cursor_claim_command(
-                        state.execution_id,
-                        state.catalog_id,
-                        step_def,
-                        cursor,
-                        context,
-                        0,
-                        max_rows,
-                    )?;
-                    commands.push(cmd);
-                    continue;
+                // Frame state is maintained incrementally on StepInfo by
+                // apply_event (no per-trigger event rescan).  Read the latest
+                // frame (clone so we can mutate state below for the drain).
+                let latest = state
+                    .steps
+                    .get(&step_name)
+                    .and_then(|si| si.cursor_frames.iter().next_back())
+                    .map(|(&idx, f)| (idx, f.clone()));
+                let (frame_idx, frame) = match latest {
+                    Some(v) => v,
+                    None => {
+                        // Entered but no claim issued yet — claim frame 0.
+                        let cmd = self.command_builder.build_cursor_claim_command(
+                            state.execution_id,
+                            state.catalog_id,
+                            step_def,
+                            cursor,
+                            context,
+                            0,
+                            max_rows,
+                        )?;
+                        commands.push(cmd);
+                        continue;
+                    }
                 };
                 if !frame.claim_completed {
                     continue; // claim in flight; its completion re-triggers us
@@ -1985,74 +1910,75 @@ mod tests {
     }
 
     #[test]
-    fn cursor_reconstruct_tracks_frames_and_drain() {
-        // noetl/ai-meta#100: reconstruct cursor-loop frame progress from the
-        // event log (claim issued/completed + body issued/completed), keyed by
-        // the `cursor` metadata on command.issued and correlated by command_id.
-        let mut events = vec![make_event("step.enter", Some("cur"))];
+    fn cursor_frame_tracking_via_apply_event() {
+        // noetl/ai-meta#100: cursor frame progress is maintained INCREMENTALLY
+        // by WorkflowState::apply_event (no per-trigger log rescan).  Drive a
+        // state through the cursor lifecycle and assert StepInfo.cursor_frames.
+        let mut ws = WorkflowState::new(123, 456);
+        // step.enter carrying the __cursor_loop marker -> is_cursor.
+        let mut enter = make_event("step.enter", Some("cur"));
+        enter.result = Some(serde_json::json!({"context": {"__cursor_loop": true}}));
+        ws.apply_event(&enter);
+        assert!(ws.steps.get("cur").unwrap().is_cursor);
 
         let mut claim0 = make_event("command.issued", Some("cur"));
         claim0.meta =
             Some(serde_json::json!({"command_id": "c0", "cursor": {"phase": "claim", "frame": 0}}));
-        events.push(claim0);
-        // The claim's RETURNING rows arrive on call.done (command.completed
-        // carries only {status, command_id}).
+        ws.apply_event(&claim0);
+        // The claim's RETURNING rows arrive on call.done.
         let mut claim0_data = make_event("call.done", Some("cur"));
         claim0_data.result = Some(serde_json::json!({
             "context": {"command_id": "c0", "data": {"rows": [{"id": 1}, {"id": 2}]}}
         }));
-        events.push(claim0_data);
+        ws.apply_event(&claim0_data);
         let mut claim0_done = make_event("command.completed", Some("cur"));
         claim0_done.meta = Some(serde_json::json!({"command_id": "c0"}));
-        events.push(claim0_done);
+        ws.apply_event(&claim0_done);
+
+        let f0 = ws.steps.get("cur").unwrap().cursor_frames[&0].clone();
+        assert!(f0.claim_completed);
+        assert_eq!(f0.claim_rows.len(), 2, "claim returned 2 rows");
+        // The cursor sub-command completions must NOT complete the step.
+        assert_ne!(ws.steps.get("cur").unwrap().state, StepState::Completed);
 
         // One body row issued + completed.
         let mut body0 = make_event("command.issued", Some("cur"));
         body0.meta =
             Some(serde_json::json!({"command_id": "b0", "cursor": {"phase": "body", "frame": 0}}));
-        events.push(body0);
+        ws.apply_event(&body0);
         let mut body0_done = make_event("command.completed", Some("cur"));
         body0_done.meta = Some(serde_json::json!({"command_id": "b0"}));
-        events.push(body0_done);
-
-        let (entered, frames) = reconstruct_cursor_frames(&events, "cur");
-        assert!(entered);
-        let f0 = frames.get(&0).expect("frame 0 present");
-        assert!(f0.claim_completed);
-        assert_eq!(f0.claim_rows.len(), 2, "claim returned 2 rows");
+        ws.apply_event(&body0_done);
+        let f0 = ws.steps.get("cur").unwrap().cursor_frames[&0].clone();
         assert_eq!(f0.body_issued, 1);
         assert_eq!(f0.body_completed, 1);
 
-        // Next frame's claim drains (0 rows) → the drive block would complete it.
+        // Repeated completion events for the same command_id are deduped.
+        ws.apply_event(&body0_done);
+        assert_eq!(
+            ws.steps.get("cur").unwrap().cursor_frames[&0].body_completed,
+            1,
+            "dedup repeat"
+        );
+
+        // Drain frame 1 (0 rows).
         let mut claim1 = make_event("command.issued", Some("cur"));
         claim1.meta =
             Some(serde_json::json!({"command_id": "c1", "cursor": {"phase": "claim", "frame": 1}}));
-        events.push(claim1);
+        ws.apply_event(&claim1);
         let mut claim1_data = make_event("call.done", Some("cur"));
         claim1_data.result =
             Some(serde_json::json!({"context": {"command_id": "c1", "data": {"rows": []}}}));
-        events.push(claim1_data);
+        ws.apply_event(&claim1_data);
         let mut claim1_done = make_event("command.completed", Some("cur"));
         claim1_done.meta = Some(serde_json::json!({"command_id": "c1"}));
-        events.push(claim1_done);
+        ws.apply_event(&claim1_done);
+        let f1 = ws.steps.get("cur").unwrap().cursor_frames[&1].clone();
+        assert!(f1.claim_completed && f1.claim_rows.is_empty());
 
-        let (_, frames2) = reconstruct_cursor_frames(&events, "cur");
-        let f1 = frames2.get(&1).expect("frame 1 present");
-        assert!(f1.claim_completed);
-        assert!(f1.claim_rows.is_empty(), "drained frame has no rows");
-        // Repeated completion events for the same command_id are deduped.
-        let mut dup = make_event("command.completed", Some("cur"));
-        dup.meta = Some(serde_json::json!({"command_id": "b0"}));
-        events.push(dup);
-        let (_, frames3) = reconstruct_cursor_frames(&events, "cur");
-        assert_eq!(frames3.get(&0).unwrap().body_completed, 1, "dedup repeat");
-
-        // Re-entry (loop-back): a fresh step.enter resets frame tracking so the
-        // re-run's frame 0 doesn't merge with the prior run's frame 0.
-        events.push(make_event("step.enter", Some("cur")));
-        let (re_entered, re_frames) = reconstruct_cursor_frames(&events, "cur");
-        assert!(re_entered);
-        assert!(re_frames.is_empty(), "re-entry clears prior frames");
+        // Re-entry (loop-back): a fresh step.enter resets frame tracking.
+        ws.apply_event(&enter);
+        assert!(ws.steps.get("cur").unwrap().cursor_frames.is_empty());
     }
 
     #[test]

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -178,6 +178,31 @@ pub struct StepInfo {
     /// `step.exit` carrying `__cursor_drained` once the claim returns no rows.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_cursor: bool,
+
+    // -------- Cursor-loop frame tracking (noetl/ai-meta#100) --------
+    //
+    // Maintained INCREMENTALLY by `apply_event` so the orchestrator never
+    // re-scans the whole event log to rebuild cursor progress (the per-trigger
+    // O(n) scan was the scaling bottleneck).  Reset on each `step.enter`
+    // (loop-back re-entry starts fresh).
+    /// Issued cursor sub-commands: command_id -> (phase "claim"|"body", frame).
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub cursor_issued: std::collections::HashMap<String, (String, i64)>,
+    /// Completed cursor sub-command command_ids (dedup repeated completions).
+    #[serde(default, skip_serializing_if = "std::collections::HashSet::is_empty")]
+    pub cursor_completed: std::collections::HashSet<String>,
+    /// Per-frame progress, keyed by frame index.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub cursor_frames: std::collections::BTreeMap<i64, CursorFrame>,
+}
+
+/// Per-frame progress of a `mode: cursor` loop (noetl/ai-meta#100).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CursorFrame {
+    pub claim_completed: bool,
+    pub claim_rows: Vec<serde_json::Value>,
+    pub body_issued: usize,
+    pub body_completed: usize,
 }
 
 impl StepInfo {
@@ -197,6 +222,9 @@ impl StepInfo {
             iteration_results: Vec::new(),
             iterations_dispatched: 0,
             is_cursor: false,
+            cursor_issued: std::collections::HashMap::new(),
+            cursor_completed: std::collections::HashSet::new(),
+            cursor_frames: std::collections::BTreeMap::new(),
         }
     }
 
@@ -498,6 +526,12 @@ impl WorkflowState {
                         .unwrap_or(false);
                     if cursor_marked {
                         step.is_cursor = true;
+                        // Loop-back re-entry: a fresh step.enter resets frame
+                        // tracking so the re-run's frame 0 doesn't merge with a
+                        // prior drained run's frames.
+                        step.cursor_issued.clear();
+                        step.cursor_completed.clear();
+                        step.cursor_frames.clear();
                     }
                 }
             }
@@ -530,6 +564,20 @@ impl WorkflowState {
             }
             "command.issued" => {
                 if let Some(name) = &event.node_name {
+                    // noetl/ai-meta#100: incrementally track cursor sub-command
+                    // dispatch (phase/frame) from the command.issued meta so the
+                    // orchestrator never rescans the log to rebuild frame state.
+                    let cursor_meta = event
+                        .meta
+                        .as_ref()
+                        .and_then(|m| m.get("cursor"))
+                        .map(|c| {
+                            (
+                                c.get("phase").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                                c.get("frame").and_then(|v| v.as_i64()).unwrap_or(0),
+                            )
+                        });
+                    let cid = extract_command_id(event);
                     let step = self
                         .steps
                         .entry(name.clone())
@@ -539,6 +587,18 @@ impl WorkflowState {
                     // sequential-mode guard in orchestrator.rs.
                     if step.is_iterator() {
                         step.iterations_dispatched += 1;
+                    }
+                    if let (Some((phase, frame)), Some(cid)) = (cursor_meta, cid) {
+                        if step
+                            .cursor_issued
+                            .insert(cid, (phase.clone(), frame))
+                            .is_none()
+                        {
+                            let f = step.cursor_frames.entry(frame).or_default();
+                            if phase == "body" {
+                                f.body_issued += 1;
+                            }
+                        }
                     }
                 }
             }
@@ -584,12 +644,27 @@ impl WorkflowState {
                                 .and_then(|v| v.as_bool())
                         })
                         .unwrap_or(false);
+                    // Correlate a cursor sub-command completion to its frame
+                    // (claim done / one more body row done) — incremental.
+                    let cid = extract_command_id(event);
                     let step = self
                         .steps
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
 
                     if step.is_cursor && !is_drain {
+                        if let Some(cid) = cid {
+                            if let Some((phase, frame)) = step.cursor_issued.get(&cid).cloned() {
+                                if step.cursor_completed.insert(cid) {
+                                    let f = step.cursor_frames.entry(frame).or_default();
+                                    if phase == "claim" {
+                                        f.claim_completed = true;
+                                    } else if phase == "body" {
+                                        f.body_completed += 1;
+                                    }
+                                }
+                            }
+                        }
                         // Cursor sub-command completion — record nothing toward
                         // step completion; the drive block re-claims / drains.
                         return;
@@ -664,6 +739,17 @@ impl WorkflowState {
                 // (above) flips to Completed.  This event's purpose
                 // here is data attachment only.
                 if let Some(name) = &event.node_name {
+                    // The claim's RETURNING rows arrive on call.done (not
+                    // command.completed).  Capture them into the frame.
+                    let cid = extract_command_id(event);
+                    let rows = event
+                        .result
+                        .as_ref()
+                        .and_then(extract_user_data)
+                        .as_ref()
+                        .and_then(|d| d.get("rows"))
+                        .and_then(|r| r.as_array())
+                        .cloned();
                     let step = self
                         .steps
                         .entry(name.clone())
@@ -672,6 +758,13 @@ impl WorkflowState {
                     // must not overwrite the cursor step's result (the drive
                     // block sets it on drain).
                     if step.is_cursor {
+                        if let (Some(cid), Some(rows)) = (cid, rows) {
+                            if let Some((phase, frame)) = step.cursor_issued.get(&cid).cloned() {
+                                if phase == "claim" {
+                                    step.cursor_frames.entry(frame).or_default().claim_rows = rows;
+                                }
+                            }
+                        }
                         return;
                     }
                     // For iterator steps the iteration-aware branch

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1283,6 +1283,117 @@ fn event_status_from_name(event_name: &str) -> &'static str {
 /// triggered this evaluation pass (usually the `command.completed`
 /// row).  It's used as the `parent_event_id` for newly-inserted
 /// events so the event log forms a proper causal chain.
+/// Resolve any `{status, reference: {ref: "noetl://..."}}` results in `events`
+/// back to the inline `{status, context: <data>}` shape the orchestrator reads.
+///
+/// Results-by-reference: the worker stages an over-budget tool result in the
+/// result store and emits only a small reference on the event (keeping the
+/// event log lean).  The orchestrator needs the data to evaluate `output.*`
+/// guards / `set:` and to dispatch cursor bodies, so it rehydrates the
+/// reference here — only for the events it's about to apply, not the whole log.
+/// Inline results (no `reference`) and unresolvable refs are left untouched.
+/// Resolve over-budget result references inline before the orchestrator
+/// applies the events.
+///
+/// The worker stages results larger than its inline budget in the durable
+/// result store and emits a `{data: {_ref}}` placeholder plus a sibling
+/// `reference` block instead of the data (see
+/// `repos/worker/src/executor/command.rs` `build_reference_or_inline`).  The
+/// orchestrator's state machine (`extract_user_data`, the cursor drive,
+/// `build_context`) reads the actual data out of the event — a placeholder
+/// makes a cursor claim look like it returned zero rows, which stalls the
+/// loop.  So before `from_events` / `evaluate_state` see the events, we swap
+/// each placeholder for the resolved data.
+///
+/// The reference sits at one of two paths depending on how the `call.done`
+/// envelope wrapped the tool result. Nested (the standard envelope) puts the
+/// tool result under `context.result`, so the reference is at
+/// `result.context.result.reference` and the placeholder at
+/// `result.context.result.context.data._ref`. Top-level (an un-wrapped tool
+/// result) puts the reference at `result.reference` and the placeholder at
+/// `result.context.data._ref`.
+///
+/// In both cases `reference.ref` is the `noetl://` URI and the sibling
+/// `context` is replaced with the resolved store payload (`{data: {...}}`),
+/// then the `reference` block is dropped so the result reads like an inline
+/// one.
+async fn hydrate_result_references(
+    events: &mut [crate::db::models::Event],
+    result_store: &crate::services::result_store::ResultStoreService,
+) {
+    use crate::services::result_store::parse_noetl_ref;
+
+    enum Shape {
+        /// reference at `result.context.result.reference`
+        Nested,
+        /// reference at `result.reference`
+        TopLevel,
+    }
+
+    let mut hydrated = 0usize;
+    for ev in events.iter_mut() {
+        let Some(result) = ev.result.as_mut() else {
+            continue;
+        };
+        // Locate the reference URI + remember which envelope shape carried it.
+        let (shape, ref_uri) = if let Some(u) = result
+            .pointer("/context/result/reference/ref")
+            .and_then(|v| v.as_str())
+        {
+            (Shape::Nested, u.to_string())
+        } else if let Some(u) = result.pointer("/reference/ref").and_then(|v| v.as_str()) {
+            (Shape::TopLevel, u.to_string())
+        } else {
+            continue;
+        };
+
+        let parsed = match parse_noetl_ref(&ref_uri) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(execution_id = ev.execution_id, ref_uri, %e, "unparseable result reference; left as-is");
+                continue;
+            }
+        };
+        let resolved = match result_store.resolve(&parsed).await {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                warn!(execution_id = ev.execution_id, ref_uri, "result reference not found in store; left as-is");
+                continue;
+            }
+            Err(e) => {
+                warn!(execution_id = ev.execution_id, ref_uri, %e, "result reference resolution failed; left as-is");
+                continue;
+            }
+        };
+
+        // Splice the resolved payload over the `{data: {_ref}}` placeholder
+        // and drop the `reference` block so the event reads as inline.
+        match shape {
+            Shape::Nested => {
+                if let Some(inner) = result
+                    .get_mut("context")
+                    .and_then(|c| c.get_mut("result"))
+                    .and_then(|r| r.as_object_mut())
+                {
+                    inner.insert("context".to_string(), resolved);
+                    inner.remove("reference");
+                    hydrated += 1;
+                }
+            }
+            Shape::TopLevel => {
+                if let Some(obj) = result.as_object_mut() {
+                    obj.insert("context".to_string(), resolved);
+                    obj.remove("reference");
+                    hydrated += 1;
+                }
+            }
+        }
+    }
+    if hydrated > 0 {
+        debug!(hydrated, "hydrate_result_references: resolved over-budget result references");
+    }
+}
+
 async fn trigger_orchestrator(
     state: &AppState,
     execution_id: i64,
@@ -1296,76 +1407,143 @@ async fn trigger_orchestrator(
         trigger_event_id, "trigger_orchestrator: loading events"
     );
 
-    // 1. Load all events for this execution.
+    // 1. Incremental state (noetl/ai-meta#100 perf).
     //
-    // `attempt` is stored inside `meta` JSONB (no dedicated column on
-    // noetl.event today — same shape Python projector uses), so we
-    // source it via `meta->>'attempt'` cast to int.
-    let rows = sqlx::query(
-        r#"
+    // Reloading + replaying the whole event log on every completion is O(n)
+    // per trigger (O(n²) over a run) and, under high concurrency, the many
+    // simultaneous full loads spike memory and OOM the server.  Instead we
+    // cache the reconstructed `WorkflowState` per execution behind a
+    // per-execution lock (serialising one execution's triggers) and advance it
+    // by applying only events newer than `last_event_id`.
+    //
+    // `attempt` is stored inside `meta` JSONB (no dedicated column), sourced
+    // via `meta->>'attempt'` cast to int.
+    let parse_rows = |rows: Vec<sqlx::postgres::PgRow>| -> Vec<crate::db::models::Event> {
+        rows.into_iter()
+            .map(|r| crate::db::models::Event {
+                id: r.try_get("event_id").unwrap_or(0),
+                execution_id: r.try_get("execution_id").unwrap_or(0),
+                catalog_id: r.try_get("catalog_id").unwrap_or(0),
+                event_id: r.try_get("event_id").unwrap_or(0),
+                parent_event_id: r.try_get("parent_event_id").ok(),
+                parent_execution_id: r.try_get("parent_execution_id").ok(),
+                event_type: r.try_get("event_type").unwrap_or_default(),
+                node_id: r.try_get("node_id").ok(),
+                node_name: r.try_get("node_name").ok(),
+                node_type: r.try_get("node_type").ok(),
+                status: r.try_get("status").unwrap_or_default(),
+                context: r.try_get("context").ok(),
+                meta: r.try_get("meta").ok(),
+                result: r.try_get("result").ok(),
+                worker_id: r.try_get("worker_id").ok(),
+                attempt: r.try_get("attempt").ok(),
+                created_at: r
+                    .try_get("created_at")
+                    .unwrap_or_else(|_| chrono::Utc::now()),
+            })
+            .collect()
+    };
+    const EVENT_COLS: &str = r#"
         SELECT event_id, execution_id, catalog_id,
                parent_event_id, parent_execution_id,
                event_type, node_id, node_name, node_type, status,
                context, meta, result, worker_id,
                NULLIF(meta->>'attempt', '')::int AS attempt,
                created_at
-        FROM noetl.event
-        WHERE execution_id = $1
-        ORDER BY event_id ASC
-        "#,
-    )
-    .bind(execution_id)
-    .fetch_all(state.pools.pool_for(execution_id))
-    .await?;
+        FROM noetl.event "#;
 
-    let events: Vec<crate::db::models::Event> = rows
-        .into_iter()
-        .map(|r| crate::db::models::Event {
-            id: r.try_get("event_id").unwrap_or(0),
-            execution_id: r.try_get("execution_id").unwrap_or(0),
-            catalog_id: r.try_get("catalog_id").unwrap_or(0),
-            event_id: r.try_get("event_id").unwrap_or(0),
-            parent_event_id: r.try_get("parent_event_id").ok(),
-            parent_execution_id: r.try_get("parent_execution_id").ok(),
-            event_type: r.try_get("event_type").unwrap_or_default(),
-            node_id: r.try_get("node_id").ok(),
-            node_name: r.try_get("node_name").ok(),
-            node_type: r.try_get("node_type").ok(),
-            status: r.try_get("status").unwrap_or_default(),
-            context: r.try_get("context").ok(),
-            meta: r.try_get("meta").ok(),
-            result: r.try_get("result").ok(),
-            worker_id: r.try_get("worker_id").ok(),
-            attempt: r.try_get("attempt").ok(),
-            created_at: r
-                .try_get("created_at")
-                .unwrap_or_else(|_| chrono::Utc::now()),
-        })
-        .collect();
+    let pool = state.pools.pool_for(execution_id);
+    // Results-by-reference: an over-budget tool result is stored in the result
+    // store and the event carries `{status, reference}` (no inline data).  The
+    // orchestrator resolves those references back to inline data before reading
+    // them so referenced results are transparent to state/templates.
+    let result_store = crate::services::result_store::ResultStoreService::new(
+        pool.clone(),
+        state.snowflake.clone(),
+    );
 
-    if events.is_empty() {
-        debug!(
-            execution_id,
-            "No events to evaluate — orchestrator exit early"
-        );
+    // Per-execution lock: serialises this execution's concurrent completion
+    // triggers so only one advances the cached state at a time.
+    let cache_slot = state.orch_cache.entry(execution_id);
+    let mut cache = cache_slot.lock().await;
+
+    // Live event count + the events newer than what we've applied.
+    let total: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
+            .bind(execution_id)
+            .fetch_one(pool)
+            .await?;
+    let since = if cache.state.is_some() {
+        cache.last_event_id
+    } else {
+        0
+    };
+    let mut new_events: Vec<crate::db::models::Event> = parse_rows(
+        sqlx::query(&format!(
+            "{EVENT_COLS} WHERE execution_id = $1 AND event_id > $2 ORDER BY event_id ASC"
+        ))
+        .bind(execution_id)
+        .bind(since)
+        .fetch_all(pool)
+        .await?,
+    );
+    hydrate_result_references(&mut new_events, &result_store).await;
+
+    if new_events.is_empty() {
+        debug!(execution_id, "No new events to evaluate — orchestrator exit early");
         return Ok(0);
     }
 
-    // 2. Look up catalog_id + playbook content.
-    let catalog_id = events
-        .iter()
-        .find_map(|e| {
-            if e.catalog_id > 0 {
-                Some(e.catalog_id)
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| {
-            AppError::Internal(format!(
-                "No catalog_id found in events for execution {execution_id}"
+    // Trigger type + latest timestamp from the new events (the trigger event is
+    // the one that fired this pass; it is among the new events).
+    let trigger_ev = new_events.iter().find(|e| e.event_id == trigger_event_id);
+    let trigger_event_type = trigger_ev
+        .map(|e| e.event_type.clone())
+        .unwrap_or_else(|| "command.completed".to_string());
+    let latest_ts = new_events.last().map(|e| e.created_at);
+
+    // Incremental is correct only if applying the new events accounts for ALL
+    // events — otherwise a straggler (event_id <= last_event_id inserted late,
+    // possible with worker-generated snowflake ids interleaving) would be
+    // missed.  On mismatch (or a cold cache) rebuild from the full log.
+    let can_incremental =
+        cache.state.is_some() && cache.applied_count + new_events.len() as i64 == total;
+
+    if can_incremental {
+        let ws = cache.state.as_mut().unwrap();
+        for e in &new_events {
+            ws.apply_event(e);
+        }
+        cache.applied_count += new_events.len() as i64;
+        cache.last_event_id = new_events.last().map(|e| e.event_id).unwrap_or(since);
+    } else {
+        let mut all_events = parse_rows(
+            sqlx::query(&format!(
+                "{EVENT_COLS} WHERE execution_id = $1 ORDER BY event_id ASC"
             ))
-        })?;
+            .bind(execution_id)
+            .fetch_all(pool)
+            .await?,
+        );
+        hydrate_result_references(&mut all_events, &result_store).await;
+        let ws = crate::engine::state::WorkflowState::from_events(&all_events)
+            .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
+        cache.applied_count = all_events.len() as i64;
+        cache.last_event_id = all_events.last().map(|e| e.event_id).unwrap_or(0);
+        cache.routing_meta = all_events
+            .iter()
+            .find(|e| e.event_type == "playbook_started")
+            .and_then(|e| e.meta.clone());
+        cache.state = Some(ws);
+    }
+
+    // 2. Look up catalog_id (from the cached state) + playbook content.
+    let catalog_id = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
+    if catalog_id == 0 {
+        return Err(AppError::Internal(format!(
+            "No catalog_id found for execution {execution_id}"
+        )));
+    }
 
     // Phase F R4-3: noetl.catalog is a cluster-wide table.
     let playbook_yaml: String =
@@ -1380,22 +1558,15 @@ async fn trigger_orchestrator(
             })?;
     let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
 
-    // 3. Evaluate.
-    //
-    // Resolve the real trigger event's type from the loaded events
-    // list instead of hard-coding `command.completed` — the same
-    // path serves `command.failed` triggers (noetl/ai-meta#58) and
-    // future trigger sources (e.g. `iterator_completed`,
-    // `step.exit`).  Without this lookup, a failure trigger would
-    // be misreported as a completion to the orchestrator, and the
-    // failure-termination branch would never run.
-    let trigger_event_type = events
-        .iter()
-        .find(|e| e.event_id == trigger_event_id)
-        .map(|e| e.event_type.as_str())
-        .unwrap_or("command.completed");
+    // 3. Evaluate against the cached state.
     let orchestrator = WorkflowOrchestrator::new();
-    let result = match orchestrator.evaluate(&events, &playbook, Some(trigger_event_type)) {
+    let ws = cache.state.as_mut().unwrap();
+    let result = match orchestrator.evaluate_state(
+        ws,
+        latest_ts,
+        &playbook,
+        Some(trigger_event_type.as_str()),
+    ) {
         Ok(r) => r,
         Err(e) => {
             // A deterministic orchestrator evaluate failure (invalid
@@ -1482,10 +1653,9 @@ async fn trigger_orchestrator(
     // the `/api/execute` caller supplied, persisted on the `playbook_started`
     // event meta, so every follow-up command lands on the same segment and
     // carries the same trace context (noetl/ai-meta#90 Phase 2).
-    let routing = events
-        .iter()
-        .find(|e| e.event_type == "playbook_started")
-        .and_then(|e| e.meta.as_ref())
+    let routing = cache
+        .routing_meta
+        .as_ref()
         .map(crate::handlers::execute::CommandRouting::from_started_meta)
         .unwrap_or_default();
 
@@ -1551,6 +1721,10 @@ async fn trigger_orchestrator(
             terminal_event = %event_type,
             "Orchestrator marked execution as terminal"
         );
+        // Free the cached state for a terminal execution (noetl/ai-meta#100).
+        // Drop the guard first so the slot's Arc refcount can fall to zero.
+        drop(cache);
+        state.orch_cache.evict(execution_id);
     }
 
     Ok(commands_generated)

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1394,56 +1394,9 @@ async fn hydrate_result_references(
     }
 }
 
-async fn trigger_orchestrator(
-    state: &AppState,
-    execution_id: i64,
-    trigger_event_id: i64,
-) -> AppResult<i32> {
-    use crate::engine::WorkflowOrchestrator;
-    use sqlx::Row;
-
-    debug!(
-        execution_id,
-        trigger_event_id, "trigger_orchestrator: loading events"
-    );
-
-    // 1. Incremental state (noetl/ai-meta#100 perf).
-    //
-    // Reloading + replaying the whole event log on every completion is O(n)
-    // per trigger (O(n²) over a run) and, under high concurrency, the many
-    // simultaneous full loads spike memory and OOM the server.  Instead we
-    // cache the reconstructed `WorkflowState` per execution behind a
-    // per-execution lock (serialising one execution's triggers) and advance it
-    // by applying only events newer than `last_event_id`.
-    //
-    // `attempt` is stored inside `meta` JSONB (no dedicated column), sourced
-    // via `meta->>'attempt'` cast to int.
-    let parse_rows = |rows: Vec<sqlx::postgres::PgRow>| -> Vec<crate::db::models::Event> {
-        rows.into_iter()
-            .map(|r| crate::db::models::Event {
-                id: r.try_get("event_id").unwrap_or(0),
-                execution_id: r.try_get("execution_id").unwrap_or(0),
-                catalog_id: r.try_get("catalog_id").unwrap_or(0),
-                event_id: r.try_get("event_id").unwrap_or(0),
-                parent_event_id: r.try_get("parent_event_id").ok(),
-                parent_execution_id: r.try_get("parent_execution_id").ok(),
-                event_type: r.try_get("event_type").unwrap_or_default(),
-                node_id: r.try_get("node_id").ok(),
-                node_name: r.try_get("node_name").ok(),
-                node_type: r.try_get("node_type").ok(),
-                status: r.try_get("status").unwrap_or_default(),
-                context: r.try_get("context").ok(),
-                meta: r.try_get("meta").ok(),
-                result: r.try_get("result").ok(),
-                worker_id: r.try_get("worker_id").ok(),
-                attempt: r.try_get("attempt").ok(),
-                created_at: r
-                    .try_get("created_at")
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-            })
-            .collect()
-    };
-    const EVENT_COLS: &str = r#"
+/// Columns the orchestrator reads from `noetl.event`, in the order
+/// [`parse_event_rows`] expects.
+const ORCH_EVENT_COLS: &str = r#"
         SELECT event_id, execution_id, catalog_id,
                parent_event_id, parent_execution_id,
                event_type, node_id, node_name, node_type, status,
@@ -1451,6 +1404,212 @@ async fn trigger_orchestrator(
                NULLIF(meta->>'attempt', '')::int AS attempt,
                created_at
         FROM noetl.event "#;
+
+/// Map rows selected via [`ORCH_EVENT_COLS`] into `Event`s.  `attempt` lives in
+/// `meta` JSONB (no dedicated column), sourced via the `NULLIF(...)::int` alias.
+fn parse_event_rows(rows: Vec<sqlx::postgres::PgRow>) -> Vec<crate::db::models::Event> {
+    use sqlx::Row;
+    rows.into_iter()
+        .map(|r| crate::db::models::Event {
+            id: r.try_get("event_id").unwrap_or(0),
+            execution_id: r.try_get("execution_id").unwrap_or(0),
+            catalog_id: r.try_get("catalog_id").unwrap_or(0),
+            event_id: r.try_get("event_id").unwrap_or(0),
+            parent_event_id: r.try_get("parent_event_id").ok(),
+            parent_execution_id: r.try_get("parent_execution_id").ok(),
+            event_type: r.try_get("event_type").unwrap_or_default(),
+            node_id: r.try_get("node_id").ok(),
+            node_name: r.try_get("node_name").ok(),
+            node_type: r.try_get("node_type").ok(),
+            status: r.try_get("status").unwrap_or_default(),
+            context: r.try_get("context").ok(),
+            meta: r.try_get("meta").ok(),
+            result: r.try_get("result").ok(),
+            worker_id: r.try_get("worker_id").ok(),
+            attempt: r.try_get("attempt").ok(),
+            created_at: r
+                .try_get("created_at")
+                .unwrap_or_else(|_| chrono::Utc::now()),
+        })
+        .collect()
+}
+
+/// Outcome of a bounded state rebuild (noetl/ai-meta#101 block b).  The caller
+/// sets `applied_count = total` (the live event count) after a rebuild: a
+/// rebuild folds in every event after the snapshot, so the state reflects all
+/// events; any straggler the window still missed is caught by the next
+/// trigger's count mismatch.
+struct RebuildResult {
+    state: crate::engine::state::WorkflowState,
+    last_event_id: i64,
+    snapshot_version: i64,
+    routing_meta: Option<serde_json::Value>,
+}
+
+/// Margin (seconds) the snapshot rebuild re-scans behind the snapshot's write
+/// time.  A straggler that lands below the snapshot `version` *after* the
+/// snapshot is written carries a recent-ish `created_at` (the column is the
+/// event's emit time, not its snowflake id), so loading events with
+/// `created_at > snapshot.updated_at - MARGIN` catches it.  Covers worker
+/// clock skew + emit-to-insert latency; re-applying the overlap is safe because
+/// cursor counters are gated by the snapshot's `cursor_issued`/`cursor_completed`
+/// id-sets.  Bounded small: machine-id interleaving makes a straggler's
+/// `created_at` only milliseconds off; the margin only needs to cover
+/// emit-to-insert latency + worker clock skew (NTP keeps this sub-second).
+const REBUILD_STRAGGLER_MARGIN_SECS: i64 = 30;
+
+/// Rebuild orchestrator state with a **bounded** event load: from the latest
+/// `projection_snapshot` + the events after it (by id, plus a `created_at`
+/// margin window to catch below-watermark stragglers), or — when no snapshot
+/// exists yet — the full (still-small) early log.  This replaced the unbounded
+/// full-log replay that OOM'd the server at scale: a straggler below the
+/// incremental watermark used to trigger a reload of the entire (growing) event
+/// log on nearly every completion under high concurrency.
+async fn rebuild_state(
+    pool: &crate::db::DbPool,
+    result_store: &crate::services::result_store::ResultStoreService,
+    execution_id: i64,
+) -> AppResult<RebuildResult> {
+    use crate::services::orch_snapshot;
+    match orch_snapshot::load_latest(pool, execution_id).await? {
+        Some(snap) => {
+            // Events after the snapshot: newer by id, OR (straggler) below the
+            // version watermark but emitted within the margin of the snapshot.
+            let margin_floor =
+                snap.updated_at - chrono::Duration::seconds(REBUILD_STRAGGLER_MARGIN_SECS);
+            let mut events_since = parse_event_rows(
+                sqlx::query(&format!(
+                    "{ORCH_EVENT_COLS} WHERE execution_id = $1 \
+                       AND (event_id > $2 OR created_at > $3) ORDER BY event_id ASC"
+                ))
+                .bind(execution_id)
+                .bind(snap.version)
+                .bind(margin_floor)
+                .fetch_all(pool)
+                .await?,
+            );
+            hydrate_result_references(&mut events_since, result_store).await;
+            let mut ws = snap.state;
+            for e in &events_since {
+                ws.apply_event(e);
+            }
+            // The window includes everything after the snapshot, so the highest
+            // loaded id is the current head.
+            let last_event_id = events_since
+                .iter()
+                .map(|e| e.event_id)
+                .max()
+                .unwrap_or(snap.version);
+            Ok(RebuildResult {
+                state: ws,
+                last_event_id,
+                snapshot_version: snap.version,
+                routing_meta: snap.routing_meta,
+            })
+        }
+        None => {
+            let mut all_events = parse_event_rows(
+                sqlx::query(&format!(
+                    "{ORCH_EVENT_COLS} WHERE execution_id = $1 ORDER BY event_id ASC"
+                ))
+                .bind(execution_id)
+                .fetch_all(pool)
+                .await?,
+            );
+            hydrate_result_references(&mut all_events, result_store).await;
+            let state = crate::engine::state::WorkflowState::from_events(&all_events)
+                .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
+            let last_event_id = all_events.last().map(|e| e.event_id).unwrap_or(0);
+            let routing_meta = all_events
+                .iter()
+                .find(|e| e.event_type == "playbook_started")
+                .and_then(|e| e.meta.clone());
+            Ok(RebuildResult {
+                state,
+                last_event_id,
+                snapshot_version: 0,
+                routing_meta,
+            })
+        }
+    }
+}
+
+async fn trigger_orchestrator(
+    state: &AppState,
+    execution_id: i64,
+    trigger_event_id: i64,
+) -> AppResult<i32> {
+    trigger_orchestrator_inner(state, execution_id, trigger_event_id, false).await
+}
+
+/// Background reconcile poller (noetl/ai-meta#101 block b — small-tier
+/// resilience).  Guarantees the orchestrator never permanently stalls.
+///
+/// The hot path advances state incrementally and only does the (O(events))
+/// consistency `COUNT` on a throttle, so a non-triggering straggler that lands
+/// in a throttle gap can leave a cursor unable to fan out — and once the cursor
+/// stops, no further `command.completed` events arrive, so there is no trigger
+/// to retry on.  On a constrained backend (e.g. a small Cloud SQL tier behind
+/// PgBouncer, where DB latency widens the gap) this is exactly the deadlock that
+/// stopped a 10×1000 run.
+///
+/// This task periodically force-reconciles every cached (non-terminal)
+/// execution: a fresh `COUNT` + bounded rebuild folds in any missed straggler
+/// and re-evaluates, so processing always resumes — slow under backpressure is
+/// fine; stopping is not.  Cost is bounded: one cheap rebuild per active
+/// execution per tick.
+pub fn spawn_orchestrator_reconciler(state: AppState) {
+    tokio::spawn(async move {
+        const RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(8);
+        loop {
+            tokio::time::sleep(RECONCILE_INTERVAL).await;
+            for execution_id in state.orch_cache.active_executions() {
+                // `i64::MAX` as the trigger id keeps the immediate-straggler
+                // shortcut from firing on an already-applied event.
+                match trigger_orchestrator_inner(&state, execution_id, i64::MAX, true).await {
+                    Ok(n) if n > 0 => {
+                        info!(execution_id, commands = n, "reconcile poller advanced a stuck execution")
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!(execution_id, %e, "reconcile poller: orchestrator trigger failed")
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Orchestrator trigger.  `force_count` is set by the background reconcile
+/// poller ([`spawn_orchestrator_reconciler`]): it forces a fresh consistency
+/// `COUNT` (bypassing the throttle) and proceeds to evaluate even when no new
+/// events arrived, so a stuck execution — one whose cursor missed a
+/// non-triggering straggler and therefore stopped emitting events, leaving no
+/// trigger to retry on — is reconciled and advanced.  The poller passes
+/// `trigger_event_id = i64::MAX` so the immediate-straggler shortcut is skipped.
+async fn trigger_orchestrator_inner(
+    state: &AppState,
+    execution_id: i64,
+    trigger_event_id: i64,
+    force_count: bool,
+) -> AppResult<i32> {
+    use crate::engine::WorkflowOrchestrator;
+
+    debug!(
+        execution_id,
+        trigger_event_id, force_count, "trigger_orchestrator: loading events"
+    );
+
+    // 1. Incremental state with bounded rebuild (noetl/ai-meta#100, #101 block b).
+    //
+    // The cached `WorkflowState` advances by applying only events newer than
+    // `last_event_id` behind a per-execution lock (serialising one execution's
+    // triggers).  When the cache is cold, or a straggler is detected (an event
+    // below the incremental watermark — workers' snowflake ids from different
+    // machines in the same millisecond interleave), it rebuilds from the latest
+    // `projection_snapshot` + events-since (bounded), NOT the whole event log:
+    // the unbounded replay spiked memory and OOM'd the server at scale.  See
+    // `rebuild_state` + `services::orch_snapshot`.
 
     let pool = state.pools.pool_for(execution_id);
     // Results-by-reference: an over-budget tool result is stored in the result
@@ -1467,74 +1626,169 @@ async fn trigger_orchestrator(
     let cache_slot = state.orch_cache.entry(execution_id);
     let mut cache = cache_slot.lock().await;
 
-    // Live event count + the events newer than what we've applied.
-    let total: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
-            .bind(execution_id)
-            .fetch_one(pool)
-            .await?;
-    let since = if cache.state.is_some() {
-        cache.last_event_id
+    // The consistency `COUNT(*)` over this execution's event partition is
+    // O(events) — ≈27ms at 60k events — and only detects a *non-triggering*
+    // straggler (an event type that doesn't fire the orchestrator, inserted
+    // below the high-water mark).  Running it on every trigger throttles the
+    // whole orchestrator on a large log.  So throttle it: a fresh `total` gates
+    // the mismatch→rebuild + snapshot paths; between checks the incremental
+    // apply + the immediate straggler handling below carry correctness.  Cold
+    // cache always counts (it needs `total` to seed `applied_count`).
+    const COUNT_THROTTLE: std::time::Duration = std::time::Duration::from_millis(1000);
+    let now = std::time::Instant::now();
+    let do_count = force_count
+        || cache.state.is_none()
+        || cache
+            .last_count_check
+            .is_none_or(|t| now.duration_since(t) >= COUNT_THROTTLE);
+    let total: Option<i64> = if do_count {
+        cache.last_count_check = Some(now);
+        Some(
+            sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
+                .bind(execution_id)
+                .fetch_one(pool)
+                .await?,
+        )
     } else {
-        0
+        None
     };
-    let mut new_events: Vec<crate::db::models::Event> = parse_rows(
+
+    // Warm a cold cache from the latest snapshot + events-since (bounded), or
+    // the full (still-small) early log when no snapshot exists yet.
+    let mut did_rebuild = false;
+    if cache.state.is_none() {
+        let r = rebuild_state(pool, &result_store, execution_id).await?;
+        cache.state = Some(r.state);
+        cache.last_event_id = r.last_event_id;
+        cache.applied_count = total.unwrap_or(0);
+        cache.snapshot_version = r.snapshot_version;
+        cache.routing_meta = r.routing_meta;
+        did_rebuild = true;
+    }
+
+    // Immediate straggler: the event that fired this trigger is at/below the
+    // watermark (a late insert below the high-water mark — interleaved snowflake
+    // ids).  It is not in the `> watermark` load below, so apply it directly.
+    // `command.completed`/`failed` are the only types that trigger, so this
+    // catches the cursor-relevant stragglers (body completions) with no COUNT
+    // and no rebuild.  Idempotent: cursor counters are gated by the
+    // `cursor_issued`/`cursor_completed` id-sets.
+    let mut straggler_applied = false;
+    if !did_rebuild && trigger_event_id <= cache.last_event_id {
+        let mut strag = parse_event_rows(
+            sqlx::query(&format!(
+                "{ORCH_EVENT_COLS} WHERE execution_id = $1 AND event_id = $2"
+            ))
+            .bind(execution_id)
+            .bind(trigger_event_id)
+            .fetch_all(pool)
+            .await?,
+        );
+        hydrate_result_references(&mut strag, &result_store).await;
+        if let Some(ws) = cache.state.as_mut() {
+            for e in &strag {
+                ws.apply_event(e);
+            }
+        }
+        straggler_applied = !strag.is_empty();
+        // Count the straggler so the next consistency check matches and does NOT
+        // fire an (expensive) bounded rebuild for an event we already applied.
+        // The straggler is below the watermark, so it is never in the
+        // `> watermark` load — no double count.  A rare double-trigger overcount
+        // self-heals: the next check mismatches once and the rebuild resets
+        // `applied_count = total`.
+        cache.applied_count += strag.len() as i64;
+    }
+
+    // Events newer than what's applied.
+    let mut new_events: Vec<crate::db::models::Event> = parse_event_rows(
         sqlx::query(&format!(
-            "{EVENT_COLS} WHERE execution_id = $1 AND event_id > $2 ORDER BY event_id ASC"
+            "{ORCH_EVENT_COLS} WHERE execution_id = $1 AND event_id > $2 ORDER BY event_id ASC"
         ))
         .bind(execution_id)
-        .bind(since)
+        .bind(cache.last_event_id)
         .fetch_all(pool)
         .await?,
     );
     hydrate_result_references(&mut new_events, &result_store).await;
 
-    if new_events.is_empty() {
-        debug!(execution_id, "No new events to evaluate — orchestrator exit early");
-        return Ok(0);
-    }
-
-    // Trigger type + latest timestamp from the new events (the trigger event is
-    // the one that fired this pass; it is among the new events).
-    let trigger_ev = new_events.iter().find(|e| e.event_id == trigger_event_id);
-    let trigger_event_type = trigger_ev
+    // Trigger type + drain timestamp.  The trigger event is normally among the
+    // new events; after a cold rebuild / straggler apply that already folded it
+    // in, fall back to a default type (and a None drain timestamp).
+    let trigger_event_type = new_events
+        .iter()
+        .find(|e| e.event_id == trigger_event_id)
         .map(|e| e.event_type.clone())
         .unwrap_or_else(|| "command.completed".to_string());
     let latest_ts = new_events.last().map(|e| e.created_at);
 
-    // Incremental is correct only if applying the new events accounts for ALL
-    // events — otherwise a straggler (event_id <= last_event_id inserted late,
-    // possible with worker-generated snowflake ids interleaving) would be
-    // missed.  On mismatch (or a cold cache) rebuild from the full log.
-    let can_incremental =
-        cache.state.is_some() && cache.applied_count + new_events.len() as i64 == total;
-
-    if can_incremental {
+    // Consistency.  With a fresh `total`, applying the new events should account
+    // for ALL events; a shortfall means a straggler is below the watermark — and
+    // crucially it may be a *non-triggering* one (the cursor claim's `call.done`
+    // carrying the row batch), which would otherwise leave the cursor unable to
+    // fan out and stop emitting events entirely.  A bounded rebuild re-scans the
+    // recent window and folds it in.  This check runs whether or not there are
+    // new events, so the reconcile poller (no new events, fresh count) still
+    // catches a stuck execution.  Without a fresh `total` (throttled), trust the
+    // incremental apply.
+    let mismatch = matches!(total, Some(t) if cache.applied_count + new_events.len() as i64 != t);
+    if mismatch {
+        let r = rebuild_state(pool, &result_store, execution_id).await?;
+        cache.state = Some(r.state);
+        cache.last_event_id = r.last_event_id;
+        cache.applied_count = total.unwrap_or(cache.applied_count);
+        cache.snapshot_version = r.snapshot_version;
+        cache.routing_meta = r.routing_meta;
+        did_rebuild = true;
+    } else if !new_events.is_empty() {
         let ws = cache.state.as_mut().unwrap();
         for e in &new_events {
             ws.apply_event(e);
         }
         cache.applied_count += new_events.len() as i64;
-        cache.last_event_id = new_events.last().map(|e| e.event_id).unwrap_or(since);
-    } else {
-        let mut all_events = parse_rows(
-            sqlx::query(&format!(
-                "{EVENT_COLS} WHERE execution_id = $1 ORDER BY event_id ASC"
-            ))
-            .bind(execution_id)
-            .fetch_all(pool)
-            .await?,
-        );
-        hydrate_result_references(&mut all_events, &result_store).await;
-        let ws = crate::engine::state::WorkflowState::from_events(&all_events)
-            .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
-        cache.applied_count = all_events.len() as i64;
-        cache.last_event_id = all_events.last().map(|e| e.event_id).unwrap_or(0);
-        cache.routing_meta = all_events
-            .iter()
-            .find(|e| e.event_type == "playbook_started")
-            .and_then(|e| e.meta.clone());
-        cache.state = Some(ws);
+        cache.last_event_id = new_events
+            .last()
+            .map(|e| e.event_id)
+            .unwrap_or(cache.last_event_id);
+    }
+
+    // Nothing changed and this is not a forced reconcile → exit early.  A forced
+    // reconcile still evaluates (to drive a cursor that may now advance).
+    if new_events.is_empty() && !did_rebuild && !straggler_applied && !force_count {
+        debug!(execution_id, "No new events to evaluate — orchestrator exit early");
+        return Ok(0);
+    }
+
+    // Persist a snapshot once enough events have accrued since the last one,
+    // gated on a *fresh* `total` confirming the state is fully consistent (no
+    // outstanding straggler) — so the snapshot is a clean base for rebuilds.
+    // Best-effort: a snapshot failure must not fail the trigger.
+    const SNAPSHOT_INTERVAL_EVENTS: i64 = 500;
+    if total == Some(cache.applied_count)
+        && cache.last_event_id - cache.snapshot_version >= SNAPSHOT_INTERVAL_EVENTS
+    {
+        let version = cache.last_event_id;
+        let applied = cache.applied_count;
+        let routing = cache.routing_meta.clone();
+        let saved = if let Some(ws) = cache.state.as_ref() {
+            crate::services::orch_snapshot::save(
+                pool,
+                execution_id,
+                version,
+                applied,
+                routing.as_ref(),
+                ws,
+            )
+            .await
+        } else {
+            Ok(())
+        };
+        match saved {
+            Ok(()) => cache.snapshot_version = version,
+            Err(e) => {
+                warn!(execution_id, %e, "orch_snapshot.save failed; continuing without snapshot")
+            }
+        }
     }
 
     // 2. Look up catalog_id (from the cached state) + playbook content.

--- a/src/main.rs
+++ b/src/main.rs
@@ -676,6 +676,12 @@ async fn main() -> anyhow::Result<()> {
     // ids take a clone of `state.snowflake` (an `Arc`).
     let state = AppState::new(db_pool.clone(), pools, app_config.clone(), nats_client);
 
+    // Background reconcile poller (noetl/ai-meta#101 block b): periodically
+    // force-advances any cached execution that got stuck on a missed
+    // non-triggering straggler, so the orchestrator never permanently stalls
+    // under DB backpressure (e.g. a small Cloud SQL tier behind PgBouncer).
+    handlers::events::spawn_orchestrator_reconciler(state.clone());
+
     // Create services. The wallet's envelope cipher is built once over the
     // configured KEK provider (NOETL_KMS_PROVIDER: `local` default, or
     // `gcp-kms` over Cloud KMS — noetl/ai-meta#61 Phase 2) and shared between

--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -353,8 +353,19 @@ impl ExecutionService {
                 .fetch_optional(self.pools.cluster())
                 .await?;
 
-        // Get all events for this execution
-        let event_rows: Vec<(
+        // Get the most recent events for this execution.
+        //
+        // Loading the WHOLE log was an O(events) memory bomb: a high-volume run
+        // (e.g. a 10×1000 cursor flow at ~200k events) blew past the server's
+        // memory limit and OOM-killed it whenever this endpoint was hit.  The
+        // response only needs the recent tail: `determine_status` scans from the
+        // newest event backward for a terminal / FAILED marker (which is always
+        // recent), and `completed_at` reads the terminal event's time.  So cap
+        // the load to the most recent rows — ordered DESC for the LIMIT, then
+        // reversed back to ASC for the response.  A future paginated
+        // `/api/executions/{id}/events` endpoint can serve the full history.
+        const MAX_EVENTS_RETURNED: i64 = 2000;
+        let mut event_rows: Vec<(
             i64,
             String,
             Option<String>,
@@ -374,12 +385,16 @@ impl ExecutionService {
                     error
                 FROM noetl.event
                 WHERE execution_id = $1
-                ORDER BY created_at ASC
+                ORDER BY created_at DESC
+                LIMIT $2
                 "#,
         )
         .bind(execution_id)
+        .bind(MAX_EVENTS_RETURNED)
         .fetch_all(self.pool_for(execution_id))
         .await?;
+        // Restore chronological (ASC) order for the response.
+        event_rows.reverse();
 
         let events: Vec<ExecutionEvent> = event_rows
             .into_iter()

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod execution;
 pub mod internal;
 pub mod keychain;
 pub mod keychain_refresh;
+pub mod orch_snapshot;
 pub mod replay;
 pub mod result_store;
 pub mod runtime;

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -1,0 +1,159 @@
+//! Orchestrator state snapshots (noetl/ai-meta#101, block b).
+//!
+//! Persists the orchestrator's reconstructed [`WorkflowState`] to
+//! `noetl.projection_snapshot` so the per-execution rebuild path is
+//! **bounded**: instead of replaying the whole event log (which OOM'd the
+//! server at scale — a 10×1000 PFT crashed the server at ~19k events), a
+//! rebuild loads the latest snapshot + only the events newer than the
+//! snapshot's `version` (the highest `event_id` folded into it).
+//!
+//! The snapshot is a generic event-sourcing aggregate row keyed by
+//! `(tenant_id, organization_id, aggregate_type, aggregate_id)` — we use
+//! `aggregate_type = "orchestrator_workflow_state"` and
+//! `aggregate_id = execution_id`. `version` is the snapshot watermark
+//! (highest applied `event_id`); `meta.applied_count` carries the number of
+//! events folded in so the caller can detect stragglers after a rebuild.
+
+use sha2::{Digest, Sha256};
+use sqlx::Row;
+
+use crate::db::DbPool;
+use crate::engine::state::WorkflowState;
+use crate::error::{AppError, AppResult};
+
+const AGGREGATE_TYPE: &str = "orchestrator_workflow_state";
+
+/// A snapshot loaded back from the store.
+pub struct LoadedSnapshot {
+    pub state: WorkflowState,
+    /// Highest `event_id` folded into the snapshot.
+    pub version: i64,
+    /// Number of events folded in (for straggler detection on rebuild).
+    pub applied_count: i64,
+    /// Wall-clock time the snapshot was written.  The rebuild re-scans events
+    /// with `created_at` newer than this minus a margin, so a straggler that
+    /// landed *below* `version` *after* the snapshot was taken is still caught
+    /// (re-applying overlap is safe — cursor counters are gated by the
+    /// `cursor_issued`/`cursor_completed` id-sets that the snapshot carries).
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    /// The `playbook_started` event's meta (pool segment + trace routing),
+    /// carried on the snapshot because that event predates every snapshot and
+    /// so is never re-loaded in the events-since window.
+    pub routing_meta: Option<serde_json::Value>,
+}
+
+/// Upsert the orchestrator state snapshot for an execution.
+///
+/// One row per execution (the PK collapses to `aggregate_id` once
+/// `tenant_id`/`organization_id`/`aggregate_type` are fixed), so each save
+/// overwrites the previous snapshot with a newer watermark.
+pub async fn save(
+    pool: &DbPool,
+    execution_id: i64,
+    version: i64,
+    applied_count: i64,
+    routing_meta: Option<&serde_json::Value>,
+    state: &WorkflowState,
+) -> AppResult<()> {
+    let snapshot = serde_json::to_value(state)
+        .map_err(|e| AppError::Internal(format!("orch_snapshot.save: serialise: {e}")))?;
+    let checksum = {
+        let bytes = serde_json::to_vec(&snapshot).unwrap_or_default();
+        hex::encode(Sha256::digest(&bytes))
+    };
+    let meta = serde_json::json!({
+        "applied_count": applied_count,
+        "routing_meta": routing_meta,
+    });
+
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.projection_snapshot
+            (aggregate_id, aggregate_type, version, snapshot, checksum, meta, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, now())
+        ON CONFLICT (tenant_id, organization_id, aggregate_type, aggregate_id)
+        DO UPDATE SET
+            version = EXCLUDED.version,
+            snapshot = EXCLUDED.snapshot,
+            checksum = EXCLUDED.checksum,
+            meta = EXCLUDED.meta,
+            updated_at = now()
+        "#,
+    )
+    .bind(execution_id.to_string())
+    .bind(AGGREGATE_TYPE)
+    .bind(version)
+    .bind(&snapshot)
+    .bind(&checksum)
+    .bind(&meta)
+    .execute(pool)
+    .await
+    .map_err(|e| AppError::Internal(format!("orch_snapshot.save: upsert: {e}")))?;
+
+    Ok(())
+}
+
+/// Load the latest orchestrator state snapshot for an execution, if any.
+///
+/// Returns `None` when no snapshot exists yet (early in a run, before the
+/// first save) — the caller then rebuilds from the full (still-small) log.
+pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<LoadedSnapshot>> {
+    let row = sqlx::query(
+        r#"
+        SELECT version, snapshot, meta, updated_at
+        FROM noetl.projection_snapshot
+        WHERE aggregate_type = $1 AND aggregate_id = $2
+          AND tenant_id = 'default' AND organization_id = 'default'
+        "#,
+    )
+    .bind(AGGREGATE_TYPE)
+    .bind(execution_id.to_string())
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(format!("orch_snapshot.load_latest: query: {e}")))?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let version: i64 = row.try_get("version").unwrap_or(0);
+    let updated_at: chrono::DateTime<chrono::Utc> =
+        row.try_get("updated_at").unwrap_or_else(|_| chrono::Utc::now());
+    let snapshot: serde_json::Value = row
+        .try_get("snapshot")
+        .map_err(|e| AppError::Internal(format!("orch_snapshot.load_latest: snapshot col: {e}")))?;
+    let meta: serde_json::Value = row.try_get("meta").unwrap_or(serde_json::Value::Null);
+    let applied_count = meta
+        .get("applied_count")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    let routing_meta = meta
+        .get("routing_meta")
+        .filter(|v| !v.is_null())
+        .cloned();
+
+    // A snapshot that fails to deserialise (e.g. a WorkflowState shape change
+    // across a deploy) is treated as absent — the caller falls back to a full
+    // rebuild, which is always correct, just slower.  Better than erroring the
+    // whole trigger.
+    let state: WorkflowState = match serde_json::from_value(snapshot) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                execution_id,
+                version,
+                %e,
+                "orch_snapshot.load_latest: snapshot deserialise failed; ignoring (full rebuild)"
+            );
+            return Ok(None);
+        }
+    };
+
+    Ok(Some(LoadedSnapshot {
+        state,
+        version,
+        applied_count,
+        updated_at,
+        routing_meta,
+    }))
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -81,6 +81,60 @@ pub struct AppState {
 
     /// Server start time for uptime calculation
     pub start_time: std::time::Instant,
+
+    /// Per-execution orchestrator state cache (noetl/ai-meta#100 perf).  The
+    /// orchestrator advances a cached `WorkflowState` by applying only NEW
+    /// events each trigger instead of reloading + replaying the whole event
+    /// log (the per-trigger O(n) rebuild + the concurrent-completion memory
+    /// spike were the scaling bottleneck — a high-concurrency run OOM'd the
+    /// server).  The per-execution lock inside also serialises a single
+    /// execution's concurrent completion triggers.
+    pub orch_cache: Arc<OrchStateCache>,
+}
+
+/// Cached orchestrator state for one execution, advanced incrementally.
+#[derive(Default)]
+pub struct ExecOrchState {
+    /// The reconstructed workflow state (None until first built).
+    pub state: Option<crate::engine::state::WorkflowState>,
+    /// Highest event_id applied to `state`.
+    pub last_event_id: i64,
+    /// Number of events applied — compared against the live event COUNT to
+    /// detect a straggler (an event with id <= last_event_id inserted late);
+    /// on mismatch the cache falls back to a full rebuild for correctness.
+    pub applied_count: i64,
+    /// The `playbook_started` event's meta (pool segment + W3C trace routing),
+    /// cached so follow-up command dispatch needn't reload the first event.
+    pub routing_meta: Option<serde_json::Value>,
+}
+
+
+/// Per-execution orchestrator state cache.  The outer `std::Mutex` guards a
+/// short get-or-insert; the inner per-execution `tokio::Mutex` is held across
+/// the orchestrator's DB round-trips so a single execution's triggers serialise
+/// (different executions never contend).
+#[derive(Default)]
+pub struct OrchStateCache {
+    map: std::sync::Mutex<
+        std::collections::HashMap<i64, Arc<tokio::sync::Mutex<ExecOrchState>>>,
+    >,
+}
+
+impl OrchStateCache {
+    /// Get (or create) the per-execution state slot.
+    pub fn entry(&self, execution_id: i64) -> Arc<tokio::sync::Mutex<ExecOrchState>> {
+        self.map
+            .lock()
+            .unwrap()
+            .entry(execution_id)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(ExecOrchState::default())))
+            .clone()
+    }
+
+    /// Drop a terminal execution's cached state (frees memory).
+    pub fn evict(&self, execution_id: i64) {
+        self.map.lock().unwrap().remove(&execution_id);
+    }
 }
 
 impl AppState {
@@ -169,6 +223,7 @@ impl AppState {
             snowflake: Arc::new(snowflake),
             shard: Arc::new(shard),
             start_time: std::time::Instant::now(),
+            orch_cache: Arc::new(OrchStateCache::default()),
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -106,6 +106,19 @@ pub struct ExecOrchState {
     /// The `playbook_started` event's meta (pool segment + W3C trace routing),
     /// cached so follow-up command dispatch needn't reload the first event.
     pub routing_meta: Option<serde_json::Value>,
+    /// Highest `event_id` folded into the last persisted
+    /// `projection_snapshot` (noetl/ai-meta#101 block b).  A rebuild loads
+    /// that snapshot + only events newer than this, so the rebuild cost is
+    /// bounded by the snapshot interval instead of the whole (growing) event
+    /// log — which is what OOM'd the server at scale.
+    pub snapshot_version: i64,
+    /// Last time the O(events) consistency `COUNT(*)` ran for this execution
+    /// (noetl/ai-meta#101 block b throughput).  That count grows with the log
+    /// (≈27ms at 60k events) and would dominate the hot path if run on every
+    /// trigger, so it's throttled; between checks the incremental apply + the
+    /// immediate `trigger_event_id`-straggler handling carry correctness.  Not
+    /// serialized (in-memory only).
+    pub last_count_check: Option<std::time::Instant>,
 }
 
 
@@ -134,6 +147,15 @@ impl OrchStateCache {
     /// Drop a terminal execution's cached state (frees memory).
     pub fn evict(&self, execution_id: i64) {
         self.map.lock().unwrap().remove(&execution_id);
+    }
+
+    /// Snapshot of the currently-cached (i.e. non-terminal, not-yet-evicted)
+    /// execution ids.  The background reconcile poller iterates these to
+    /// force-advance any execution that got stuck — e.g. a cursor that missed a
+    /// non-triggering straggler and stopped emitting events, so no trigger would
+    /// otherwise retry.  Cheap: a short lock + clone of the keys.
+    pub fn active_executions(&self) -> Vec<i64> {
+        self.map.lock().unwrap().keys().copied().collect()
     }
 }
 


### PR DESCRIPTION
Block a + b of noetl/ai-meta#101 — make the Rust orchestrator hold up at scale
and never permanently stall, validated 10×1000 on kind and on GKE
db-g1-small + PgBouncer.

## What's in here

1. **Incremental orchestrator state** — per-execution `OrchStateCache` advances by
   applying only new events behind a per-execution lock (was: full event-log
   replay per trigger → O(n²), OOM under concurrency).
2. **Results-by-reference resolution** — `hydrate_result_references` resolves the
   worker's over-budget `{data:{_ref}}` references (nested + top-level envelope)
   from `noetl.result_store` before the orchestrator reads events, so a cursor
   claim returning rows by reference is no longer seen as zero rows.
3. **Projection-snapshot bounded rebuild** (`services/orch_snapshot.rs`) — snapshot
   `WorkflowState` to `noetl.projection_snapshot` every 500 events; rebuild loads
   snapshot + events-since (+ a `created_at` window for below-watermark
   stragglers), never the whole log. Memory flat: 167KB snapshot at 200k events
   (was: OOM at ~19k).
4. **Throttled consistency COUNT** — the O(events) `COUNT(*)` is throttled off the
   hot path (~27ms at 60k events was the throughput killer).
5. **Background reconcile poller** (`spawn_orchestrator_reconciler`) — force-
   reconciles every active execution every 8s, so a cursor that missed a
   non-triggering straggler can't permanently deadlock under DB backpressure
   (observed + fixed on GKE's slow tier; the poller was seen breaking a transient
   stall). Slow is fine; stopping is not.
6. **`GET /api/executions/{id}` memory-bomb fix** — capped the response to the
   recent 2000 events (was loading all 200k → ~1GB / OOM when polled).

## Validation

- kind 10×1000: memory flat (0 orchestrator OOMs across 200k events).
- GKE db-g1-small + PgBouncer 10×200: cleared the prior deadlock point
  (`fetch_vital_signs`), poller observed advancing a stuck execution, 0 fails,
  0 restarts, Cloud SQL connections bounded ~15 (PgBouncer fronts the worker
  `demo_noetl` pool; server keeps its own small `noetl` pool).
- server 666 tests pass, clippy clean.

Refs noetl/ai-meta#101