### PR TITLE
feat(cqrs): projector owns projection_snapshot (advance endpoint + gated self-write)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -43,6 +43,18 @@ pub struct AppConfig {
     #[serde(default)]
     pub disable_metrics: bool,
 
+    /// CQRS read-model ownership (noetl/ai-meta#103 phase 2b).  When true, the
+    /// `system/projector` playbook owns `noetl.projection_snapshot` (it folds
+    /// the `noetl_events` stream and advances the snapshot via
+    /// `POST /api/internal/projection/advance`), so the orchestrator **stops
+    /// self-writing** the snapshot in `trigger_orchestrator` and only reads it.
+    /// Envy maps `NOETL_PROJECTOR_OWNS_SNAPSHOT`.  **Default false** — the
+    /// orchestrator self-writes exactly as block-b does today; flip on only once
+    /// the projector is confirmed running, or the snapshot stops advancing and
+    /// rebuild cost grows.
+    #[serde(default)]
+    pub projector_owns_snapshot: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -153,6 +165,7 @@ impl Default for AppConfig {
             nats_url: None,
             enable_gcp_token_api: true,
             disable_metrics: false,
+            projector_owns_snapshot: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1534,6 +1534,59 @@ async fn rebuild_state(
     }
 }
 
+/// Outcome of advancing one execution's projection snapshot.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SnapshotAdvance {
+    pub execution_id: i64,
+    /// Snapshot version after the advance (the highest `event_id` folded).
+    pub version: i64,
+    /// Events folded into the saved snapshot (the execution's event count).
+    pub events: i64,
+}
+
+/// Advance one execution's `projection_snapshot` from the event log — the
+/// CQRS read-model write the `system/projector` playbook drives
+/// (noetl/ai-meta#103 phase 2b) via `POST /api/internal/projection/advance`.
+///
+/// This is the orchestrator's snapshot-write half **without** command dispatch:
+/// load the latest snapshot + apply events-since (the bounded [`rebuild_state`]
+/// path) and re-save it.  Reuses the block-b machinery verbatim, so the snapshot
+/// the projector writes is byte-for-byte what the orchestrator would have written
+/// itself — the orchestrator just stops doing so when
+/// `projector_owns_snapshot` is set, and reads this instead.
+///
+/// Idempotent: [`orch_snapshot::save`] is a monotonic upsert, so re-advancing
+/// an execution (a redelivered stream batch) is a no-op or a forward move.
+pub(crate) async fn advance_snapshot(
+    state: &AppState,
+    execution_id: i64,
+) -> AppResult<SnapshotAdvance> {
+    let pool = state.pools.pool_for(execution_id);
+    let result_store = crate::services::result_store::ResultStoreService::new(
+        pool.clone(),
+        state.snowflake.clone(),
+    );
+    let r = rebuild_state(pool, &result_store, execution_id).await?;
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
+        .bind(execution_id)
+        .fetch_one(pool)
+        .await?;
+    crate::services::orch_snapshot::save(
+        pool,
+        execution_id,
+        r.last_event_id,
+        count,
+        r.routing_meta.as_ref(),
+        &r.state,
+    )
+    .await?;
+    Ok(SnapshotAdvance {
+        execution_id,
+        version: r.last_event_id,
+        events: count,
+    })
+}
+
 async fn trigger_orchestrator(
     state: &AppState,
     execution_id: i64,
@@ -1763,8 +1816,16 @@ async fn trigger_orchestrator_inner(
     // gated on a *fresh* `total` confirming the state is fully consistent (no
     // outstanding straggler) — so the snapshot is a clean base for rebuilds.
     // Best-effort: a snapshot failure must not fail the trigger.
+    //
+    // CQRS read-model ownership (noetl/ai-meta#103 phase 2b): when
+    // `projector_owns_snapshot` is set, the system/projector playbook folds the
+    // `noetl_events` stream and advances `projection_snapshot` (via
+    // `/api/internal/projection/advance`), so the orchestrator stops self-writing
+    // it here and only reads it.  Default off → the orchestrator self-writes
+    // exactly as block-b does.
     const SNAPSHOT_INTERVAL_EVENTS: i64 = 500;
-    if total == Some(cache.applied_count)
+    if !state.config.projector_owns_snapshot
+        && total == Some(cache.applied_count)
         && cache.last_event_id - cache.snapshot_version >= SNAPSHOT_INTERVAL_EVENTS
     {
         let version = cache.last_event_id;

--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -25,6 +25,7 @@ use tracing::{debug, info, warn};
 use crate::db::DbPool;
 use crate::error::AppResult;
 use crate::services::internal as svc;
+use crate::state::AppState;
 
 const TOKEN_ENV: &str = "NOETL_INTERNAL_API_TOKEN";
 
@@ -187,6 +188,27 @@ pub struct EventsProjectResponse {
     pub duplicates: i64,
 }
 
+/// Request for `POST /api/internal/projection/advance` (noetl/ai-meta#103
+/// phase 2b).  The `system/projector` playbook extracts the distinct
+/// `execution_id`s from a `noetl_events` stream batch and posts them here; the
+/// server recomputes + saves each one's `projection_snapshot`.
+#[derive(Debug, Deserialize)]
+pub struct ProjectionAdvanceRequest {
+    pub execution_ids: Vec<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectionAdvanceResponse {
+    pub advanced: Vec<crate::handlers::events::SnapshotAdvance>,
+    pub failed: Vec<ProjectionAdvanceFailure>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectionAdvanceFailure {
+    pub execution_id: i64,
+    pub error: String,
+}
+
 // ===========================================================================
 // Route handlers
 // ===========================================================================
@@ -291,6 +313,50 @@ pub async fn events_project(
         projected,
         duplicates,
     }))
+}
+
+/// `POST /api/internal/projection/advance`
+///
+/// CQRS read-model write (noetl/ai-meta#103 phase 2b).  For each (deduped)
+/// `execution_id` the `system/projector` playbook extracted from a
+/// `noetl_events` stream batch, recompute + save `projection_snapshot` via the
+/// orchestrator's bounded-rebuild machinery (no command dispatch).  Idempotent
+/// (monotonic snapshot upsert), so a redelivered batch is a forward no-op.  A
+/// per-execution failure is reported in `failed` without aborting the batch, so
+/// one bad execution can't block the projector's progress on the rest.
+pub async fn projection_advance(
+    State(state): State<AppState>,
+    _token: RequireInternalApiToken,
+    Json(request): Json<ProjectionAdvanceRequest>,
+) -> AppResult<Json<ProjectionAdvanceResponse>> {
+    let mut seen = std::collections::HashSet::new();
+    let mut advanced = Vec::new();
+    let mut failed = Vec::new();
+    for execution_id in request
+        .execution_ids
+        .into_iter()
+        .filter(|e| seen.insert(*e))
+    {
+        match crate::handlers::events::advance_snapshot(&state, execution_id).await {
+            Ok(a) => {
+                crate::metrics::record_projection_advanced(a.version);
+                advanced.push(a);
+            }
+            Err(e) => {
+                warn!(execution_id, %e, "projection/advance: execution failed");
+                failed.push(ProjectionAdvanceFailure {
+                    execution_id,
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+    info!(
+        advanced = advanced.len(),
+        failed = failed.len(),
+        "projection/advance done"
+    );
+    Ok(Json(ProjectionAdvanceResponse { advanced, failed }))
 }
 
 /// `POST /api/internal/cleanup/purge`

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,18 @@ fn build_router(
         )
         .with_state(state.clone());
 
+    // CQRS read-model advance endpoint (noetl/ai-meta#103 phase 2b).  The
+    // system/projector playbook posts the execution_ids from a noetl_events
+    // stream batch; the server recomputes + saves each one's
+    // projection_snapshot.  Carries AppState (needs pools + snowflake), so it's
+    // a separate router from the DbPool-stated internal group above.
+    let projection_routes = Router::new()
+        .route(
+            "/api/internal/projection/advance",
+            post(handlers::internal::projection_advance),
+        )
+        .with_state(state.clone());
+
     // Keychain routes
     let keychain_routes = Router::new()
         .route(
@@ -460,6 +472,7 @@ fn build_router(
         .merge(wallet_rotate_routes)
         .merge(secret_audit_routes)
         .merge(container_callback_routes)
+        .merge(projection_routes)
         .merge(keychain_routes)
         .merge(execution_routes)
         .merge(executions_routes)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -204,6 +204,29 @@ pub fn record_event_stream_published(event_type: &str, count: u64, cursor: i64) 
     event_stream_cursor().set(cursor);
 }
 
+/// Counter: executions whose `projection_snapshot` was advanced by the
+/// `system/projector` playbook via `/api/internal/projection/advance`
+/// (noetl/ai-meta#103 phase 2b).  No labels — one global rate.
+pub fn projection_advanced_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_projection_advanced_total",
+            "Executions whose projection_snapshot was advanced by the system/projector playbook.",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one execution's projection advance.
+pub fn record_projection_advanced(_version: i64) {
+    projection_advanced_total().inc();
+}
+
 // ---------------------------------------------------------------------------
 // Round 2 — generic write-endpoint surface
 // ---------------------------------------------------------------------------

--- a/src/nats/event_publisher.rs
+++ b/src/nats/event_publisher.rs
@@ -45,6 +45,12 @@ pub const EVENT_SUBJECT_PREFIX: &str = "noetl.events";
 /// Wildcard the stream binds.
 pub const EVENT_SUBJECT_WILDCARD: &str = "noetl.events.>";
 
+/// Durable pull consumer the `system/projector` playbook drains
+/// (noetl/ai-meta#103 phase 2b).  `js_consume` / `tool: subscription` require
+/// the consumer to pre-exist; the server creates it alongside the stream so the
+/// playbook stays a pure consumer.
+pub const PROJECTOR_CONSUMER: &str = "noetl_projector";
+
 /// Publishes full events onto the `noetl_events` JetStream stream.
 #[derive(Clone)]
 pub struct EventStreamPublisher {
@@ -65,7 +71,34 @@ impl EventStreamPublisher {
     ) -> Result<Self, NatsError> {
         let js = jetstream::new((*client).clone());
         Self::ensure_stream(&js, dedup_window, max_age).await?;
+        Self::ensure_projector_consumer(&js).await?;
         Ok(Self { js })
+    }
+
+    /// Ensure the durable `noetl_projector` pull consumer exists on the stream.
+    /// Idempotent: `create_consumer` with a stable durable name + config is a
+    /// no-op when it already exists.  Explicit-ack so the projector controls
+    /// when a batch is acked (the `tool: subscription` poll acks on success).
+    async fn ensure_projector_consumer(js: &Context) -> Result<(), NatsError> {
+        let stream = js
+            .get_stream(EVENT_STREAM)
+            .await
+            .map_err(|e| NatsError::JetStream(e.to_string()))?;
+        stream
+            .create_consumer(jetstream::consumer::pull::Config {
+                durable_name: Some(PROJECTOR_CONSUMER.to_string()),
+                filter_subject: EVENT_SUBJECT_WILDCARD.to_string(),
+                ack_policy: jetstream::consumer::AckPolicy::Explicit,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| NatsError::JetStream(e.to_string()))?;
+        tracing::debug!(
+            stream = EVENT_STREAM,
+            consumer = PROJECTOR_CONSUMER,
+            "ensured projector pull consumer"
+        );
+        Ok(())
     }
 
     /// Ensure the `noetl_events` stream exists with the dedup window + retention


### PR DESCRIPTION
## What

CQRS read-model write path — phase **2b-1** of [noetl/ai-meta#103](https://github.com/noetl/ai-meta/issues/103). Lets the `system/projector` playbook own `noetl.projection_snapshot` — the table the orchestrator reads — so *"orchestrator reads the projection"* becomes literally true.

> **Stacked on [server#202](https://github.com/noetl/server/pull/202)** (the 2a tailer). Base will retarget to `main` once #202 merges; review the [2b-1 diff](https://github.com/noetl/server/compare/feat/cqrs-2a-event-stream...feat/cqrs-2b-projector-snapshot).

## How

- **`POST /api/internal/projection/advance`** — takes the distinct `execution_id`s the projector extracted from a `noetl_events` stream batch and, for each, recomputes + saves `projection_snapshot` via the orchestrator's **existing bounded-rebuild machinery** (`rebuild_state` + `orch_snapshot::save`) **without** command dispatch. Idempotent (monotonic snapshot upsert) so a redelivered batch is a forward no-op; a per-execution failure is reported in `failed` without aborting the batch.
- **`NOETL_PROJECTOR_OWNS_SNAPSHOT`** (AppConfig, default **false**) — when set, the orchestrator **stops self-writing** the snapshot in `trigger_orchestrator` and only reads it.

Because it reuses `rebuild_state` + `orch_snapshot::save` verbatim, the snapshot the projector writes is byte-for-byte what the orchestrator would have written itself.

## Safety — default off preserves block-b exactly

The gate defaults **off**: the orchestrator self-writes the snapshot exactly as block-b (the OOM fix) does today. Flip on only once the projector is confirmed running — otherwise the snapshot stops advancing and *rebuild* cost grows (steady-state orchestrator memory stays bounded by its in-memory cache regardless). This makes the ownership transfer a deliberate, reversible operational step, not a code-coupled atomic change.

## Observability

`noetl_projection_advanced_total` counter.

## Validation

- `cargo build` + **669** tests + clippy green.
- Live flag-on validation (set `NOETL_PROJECTOR_OWNS_SNAPSHOT=true`, run a PFT, watch the projector advance the snapshot + the orchestrator read it) rides **2b-2** — it needs the `system/projector` playbook to call this endpoint.

## Wiki

`deployment-specification` → `NOETL_PROJECTOR_OWNS_SNAPSHOT` + the `/api/internal/projection/advance` endpoint (rides this change set).

Closes noetl/server#203
Refs noetl/ai-meta#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)