### PR TITLE
feat(cqrs): shared event normalization + /events/materialize (2d-2)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -43,6 +43,18 @@ pub struct AppConfig {
     #[serde(default)]
     pub disable_metrics: bool,
 
+    /// CQRS read-model ownership (noetl/ai-meta#103 phase 2b).  When true, the
+    /// `system/projector` playbook owns `noetl.projection_snapshot` (it folds
+    /// the `noetl_events` stream and advances the snapshot via
+    /// `POST /api/internal/projection/advance`), so the orchestrator **stops
+    /// self-writing** the snapshot in `trigger_orchestrator` and only reads it.
+    /// Envy maps `NOETL_PROJECTOR_OWNS_SNAPSHOT`.  **Default false** — the
+    /// orchestrator self-writes exactly as block-b does today; flip on only once
+    /// the projector is confirmed running, or the snapshot stops advancing and
+    /// rebuild cost grows.
+    #[serde(default)]
+    pub projector_owns_snapshot: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -153,6 +165,7 @@ impl Default for AppConfig {
             nats_url: None,
             enable_gcp_token_api: true,
             disable_metrics: false,
+            projector_owns_snapshot: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1534,6 +1534,59 @@ async fn rebuild_state(
     }
 }
 
+/// Outcome of advancing one execution's projection snapshot.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SnapshotAdvance {
+    pub execution_id: i64,
+    /// Snapshot version after the advance (the highest `event_id` folded).
+    pub version: i64,
+    /// Events folded into the saved snapshot (the execution's event count).
+    pub events: i64,
+}
+
+/// Advance one execution's `projection_snapshot` from the event log — the
+/// CQRS read-model write the `system/projector` playbook drives
+/// (noetl/ai-meta#103 phase 2b) via `POST /api/internal/projection/advance`.
+///
+/// This is the orchestrator's snapshot-write half **without** command dispatch:
+/// load the latest snapshot + apply events-since (the bounded [`rebuild_state`]
+/// path) and re-save it.  Reuses the block-b machinery verbatim, so the snapshot
+/// the projector writes is byte-for-byte what the orchestrator would have written
+/// itself — the orchestrator just stops doing so when
+/// `projector_owns_snapshot` is set, and reads this instead.
+///
+/// Idempotent: [`orch_snapshot::save`] is a monotonic upsert, so re-advancing
+/// an execution (a redelivered stream batch) is a no-op or a forward move.
+pub(crate) async fn advance_snapshot(
+    state: &AppState,
+    execution_id: i64,
+) -> AppResult<SnapshotAdvance> {
+    let pool = state.pools.pool_for(execution_id);
+    let result_store = crate::services::result_store::ResultStoreService::new(
+        pool.clone(),
+        state.snowflake.clone(),
+    );
+    let r = rebuild_state(pool, &result_store, execution_id).await?;
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
+        .bind(execution_id)
+        .fetch_one(pool)
+        .await?;
+    crate::services::orch_snapshot::save(
+        pool,
+        execution_id,
+        r.last_event_id,
+        count,
+        r.routing_meta.as_ref(),
+        &r.state,
+    )
+    .await?;
+    Ok(SnapshotAdvance {
+        execution_id,
+        version: r.last_event_id,
+        events: count,
+    })
+}
+
 async fn trigger_orchestrator(
     state: &AppState,
     execution_id: i64,
@@ -1763,8 +1816,16 @@ async fn trigger_orchestrator_inner(
     // gated on a *fresh* `total` confirming the state is fully consistent (no
     // outstanding straggler) — so the snapshot is a clean base for rebuilds.
     // Best-effort: a snapshot failure must not fail the trigger.
+    //
+    // CQRS read-model ownership (noetl/ai-meta#103 phase 2b): when
+    // `projector_owns_snapshot` is set, the system/projector playbook folds the
+    // `noetl_events` stream and advances `projection_snapshot` (via
+    // `/api/internal/projection/advance`), so the orchestrator stops self-writing
+    // it here and only reads it.  Default off → the orchestrator self-writes
+    // exactly as block-b does.
     const SNAPSHOT_INTERVAL_EVENTS: i64 = 500;
-    if total == Some(cache.applied_count)
+    if !state.config.projector_owns_snapshot
+        && total == Some(cache.applied_count)
         && cache.last_event_id - cache.snapshot_version >= SNAPSHOT_INTERVAL_EVENTS
     {
         let version = cache.last_event_id;

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -486,6 +486,92 @@ pub async fn handle_event(
 ///
 /// Split out so the wrapper can record metrics on both Ok and Err
 /// paths without coupling the body to the recording call.
+/// The normalized `noetl.event` row fields derived from an
+/// [`EventRequest`] (which a native `ExecutorEvent` deserializes into).
+///
+/// This is the shared normalization that the synchronous ingest path
+/// (`handle_event_inner`) and the CQRS write-path materializer
+/// (`/api/internal/events/materialize`, noetl/ai-meta#103 phase 2d) both
+/// apply — so the row materialized from a producer's *native* event is
+/// byte-identical to the one the synchronous path writes.  Without a
+/// single normalization point the two paths would drift (different
+/// `status` derivation, `result` envelope, `meta` shape, `catalog_id`).
+pub(crate) struct NormalizedEventRow {
+    pub event_id: i64,
+    pub execution_id: i64,
+    pub catalog_id: Option<i64>,
+    pub event_type: String,
+    /// `noetl.event.node_id` + `node_name` both take the step name.
+    pub node_name: String,
+    pub status: String,
+    pub result: serde_json::Value,
+    pub meta: serde_json::Value,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Normalize an [`EventRequest`] into the `noetl.event` row shape: derive
+/// the lifecycle `status`, build + sanitize the `result` envelope, resolve
+/// the `event_id` (producer-stamped or server snowflake), look up the
+/// `catalog_id`, and assemble + sanitize `meta`.  Mirrors the inline logic
+/// `handle_event_inner` ran before this was extracted.
+pub(crate) async fn normalize_event_to_row(
+    state: &AppState,
+    request: &EventRequest,
+) -> Result<NormalizedEventRow, AppError> {
+    let execution_id: i64 = request
+        .execution_id
+        .parse()
+        .map_err(|_| AppError::Validation("Invalid execution_id".to_string()))?;
+
+    // Prefer the application-supplied status; fall back to name-based
+    // derivation for pre-PR-EE producers.
+    let status: String = request
+        .status
+        .clone()
+        .unwrap_or_else(|| event_status_from_name(&request.event_type).to_string());
+
+    // Result envelope (must carry a top-level string `status` for the
+    // `chk_event_result_shape` constraint) + credential scrub.
+    let result = sanitize_sensitive_data(&build_result_object(request, &status));
+
+    // Producer-stamped event_id, else a server-side snowflake.
+    let event_id: i64 = match request.event_id.as_deref() {
+        Some(raw) => raw
+            .parse()
+            .map_err(|_| AppError::Validation(format!("Invalid event_id: {raw}")))?,
+        None => state.snowflake.generate()?,
+    };
+
+    let catalog_id = get_catalog_id(state, execution_id).await?;
+
+    let mut meta = request.meta.clone().unwrap_or_else(|| serde_json::json!({}));
+    if let serde_json::Value::Object(ref mut map) = meta {
+        map.insert("actionable".to_string(), serde_json::json!(request.actionable));
+        map.insert(
+            "informative".to_string(),
+            serde_json::json!(request.informative),
+        );
+        if let Some(ref worker_id) = request.worker_id {
+            map.insert("worker_id".to_string(), serde_json::json!(worker_id));
+        }
+    }
+    let meta = sanitize_sensitive_data(&meta);
+
+    let created_at = request.created_at.unwrap_or_else(chrono::Utc::now);
+
+    Ok(NormalizedEventRow {
+        event_id,
+        execution_id,
+        catalog_id,
+        event_type: request.event_type.clone(),
+        node_name: request.step.clone(),
+        status,
+        result,
+        meta,
+        created_at,
+    })
+}
+
 async fn handle_event_inner(
     State(state): State<AppState>,
     Json(request): Json<EventRequest>,
@@ -523,71 +609,12 @@ async fn handle_event_inner(
         }
     }
 
-    // Resolve status BEFORE building the result so the result
-    // envelope can include it (the DB constraint
-    // chk_event_result_shape requires every result row to carry
-    // a string `status` key at the top level).
-    //
-    // R-1.2 PR-EE-2: prefer the application-supplied status when
-    // present (so the worker can distinguish STARTED vs RUNNING
-    // explicitly); fall back to name-based derivation when
-    // omitted for pre-PR-EE clients.
-    let derived_status: String = request
-        .status
-        .clone()
-        .unwrap_or_else(|| event_status_from_name(&request.event_type).to_string());
-
-    // Build result object based on kind, embedding the resolved
-    // status.  See noetl/server#29 — previous shapes
-    // (`{kind, data}`, etc.) violated `chk_event_result_shape`.
-    let result_obj_raw = build_result_object(&request, &derived_status);
-    // SECURITY: Sanitize result data to remove sensitive information (tokens, passwords, etc.)
-    let result_obj = sanitize_sensitive_data(&result_obj_raw);
-
-    // Resolve event_id.  Producers may stamp it client-side per
-    // `agents/rules/observability.md` Principle 3 (worker, CLI in
-    // distributed mode); when omitted, the server now stamps via
-    // its own application-side `SnowflakeGenerator` instead of
-    // the DB-side `noetl.snowflake_id()` function.  Phase F R1.5
-    // (noetl/ai-meta#49) moved the fallback path here so the id
-    // is available before the INSERT span opens and so per-shard
-    // generation can be controlled via `NOETL_SERVER_MACHINE_ID`.
-    let event_id: i64 = match request.event_id.as_deref() {
-        Some(raw) => raw
-            .parse()
-            .map_err(|_| AppError::Validation(format!("Invalid event_id: {raw}")))?,
-        None => state.snowflake.generate()?,
-    };
-
-    // Get catalog_id from existing events
-    let catalog_id = get_catalog_id(&state, execution_id).await?;
-
-    // Build meta object with control flags
-    let mut meta_obj = request.meta.clone().unwrap_or(serde_json::json!({}));
-    if let serde_json::Value::Object(ref mut map) = meta_obj {
-        map.insert(
-            "actionable".to_string(),
-            serde_json::json!(request.actionable),
-        );
-        map.insert(
-            "informative".to_string(),
-            serde_json::json!(request.informative),
-        );
-        if let Some(ref worker_id) = request.worker_id {
-            map.insert("worker_id".to_string(), serde_json::json!(worker_id));
-        }
-    }
-    // SECURITY: Sanitize meta data to remove sensitive information
-    let meta_obj = sanitize_sensitive_data(&meta_obj);
-
-    // `derived_status` is computed earlier (before the result
-    // envelope build) so the constraint-required top-level
-    // `status` key can be embedded; reused here as the `status`
-    // column value.
-
-    // Resolve created_at — prefer the application-supplied stamp
-    // (avoids server-clock skew when ordering bursts).
-    let created_at = request.created_at.unwrap_or_else(chrono::Utc::now);
+    // Normalize into the `noetl.event` row shape via the shared fn (the
+    // same one the CQRS materializer applies to native producer events,
+    // #103 phase 2d) so the synchronous + materialized writes are
+    // byte-identical.
+    let row = normalize_event_to_row(&state, &request).await?;
+    let event_id = row.event_id;
 
     // Persist the event
     sqlx::query(
@@ -598,16 +625,16 @@ async fn handle_event_inner(
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
         "#,
     )
-    .bind(event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind(&request.event_type)
-    .bind(&request.step)
-    .bind(&request.step)
-    .bind(&derived_status)
-    .bind(&result_obj)
-    .bind(&meta_obj)
-    .bind(created_at)
+    .bind(row.event_id)
+    .bind(row.execution_id)
+    .bind(row.catalog_id)
+    .bind(&row.event_type)
+    .bind(&row.node_name)
+    .bind(&row.node_name)
+    .bind(&row.status)
+    .bind(&row.result)
+    .bind(&row.meta)
+    .bind(row.created_at)
     .execute(state.pools.pool_for(execution_id))
     .await?;
 

--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -209,6 +209,15 @@ pub struct ProjectionAdvanceFailure {
     pub error: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct EventsMaterializeResponse {
+    /// Rows actually inserted into `noetl.event` this batch.
+    pub materialized: i64,
+    /// Rows that collided with an existing `(execution_id, event_id)` (already
+    /// materialized — the idempotent re-delivery path).
+    pub duplicates: i64,
+}
+
 // ===========================================================================
 // Route handlers
 // ===========================================================================
@@ -357,6 +366,71 @@ pub async fn projection_advance(
         "projection/advance done"
     );
     Ok(Json(ProjectionAdvanceResponse { advanced, failed }))
+}
+
+/// `POST /api/internal/events/materialize`
+///
+/// CQRS write-path cutover (noetl/ai-meta#103 phase 2d).  Materializes
+/// `noetl.event` rows from a batch of **native producer events** (the worker's
+/// `ExecutorEvent` shape, which deserializes into `EventRequest`).  Each event
+/// is normalized via the **same** `normalize_event_to_row` the synchronous
+/// `POST /api/events` path applies — deriving `status`, building the `result`
+/// envelope, sanitizing `meta`, resolving `catalog_id` — then batch-inserted
+/// idempotently (`ON CONFLICT DO NOTHING` on the `(execution_id, event_id)` PK).
+/// So the materialized log is byte-identical to the synchronous path.
+///
+/// Differs from `events_project` (inserts already-row-shaped envelopes, e.g. the
+/// tailer's `to_jsonb` rows) by **normalizing native shapes**; differs from the
+/// synchronous ingest by **not triggering the orchestrator** — the materializer
+/// only writes the durable log (the orchestrator advances off the stream).
+pub async fn events_materialize(
+    State(state): State<AppState>,
+    _token: RequireInternalApiToken,
+    Json(requests): Json<Vec<crate::handlers::events::EventRequest>>,
+) -> AppResult<Json<EventsMaterializeResponse>> {
+    if requests.is_empty() {
+        return Ok(Json(EventsMaterializeResponse {
+            materialized: 0,
+            duplicates: 0,
+        }));
+    }
+    let total = requests.len() as i64;
+
+    // Normalize each native event into the noetl.event row shape.
+    let mut rows = Vec::with_capacity(requests.len());
+    for req in &requests {
+        rows.push(crate::handlers::events::normalize_event_to_row(&state, req).await?);
+    }
+
+    // Idempotent batch insert.  Single pool (state.db) mirrors `events_project`;
+    // sharding would group by `pool_for(execution_id)` — a shared follow-up with
+    // that endpoint, out of scope here.
+    let mut qb = sqlx::QueryBuilder::new(
+        "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
+         node_id, node_name, status, result, meta, created_at) ",
+    );
+    qb.push_values(rows.iter(), |mut b, r| {
+        b.push_bind(r.event_id)
+            .push_bind(r.execution_id)
+            .push_bind(r.catalog_id)
+            .push_bind(&r.event_type)
+            .push_bind(&r.node_name)
+            .push_bind(&r.node_name)
+            .push_bind(&r.status)
+            .push_bind(&r.result)
+            .push_bind(&r.meta)
+            .push_bind(r.created_at);
+    });
+    qb.push(" ON CONFLICT DO NOTHING");
+    let result = qb.build().execute(&state.db).await?;
+    let materialized = result.rows_affected() as i64;
+    let duplicates = (total - materialized).max(0);
+    crate::metrics::record_events_materialized(materialized as u64);
+    info!(materialized, duplicates, "events/materialize done");
+    Ok(Json(EventsMaterializeResponse {
+        materialized,
+        duplicates,
+    }))
 }
 
 /// `POST /api/internal/cleanup/purge`

--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -25,6 +25,7 @@ use tracing::{debug, info, warn};
 use crate::db::DbPool;
 use crate::error::AppResult;
 use crate::services::internal as svc;
+use crate::state::AppState;
 
 const TOKEN_ENV: &str = "NOETL_INTERNAL_API_TOKEN";
 
@@ -187,6 +188,27 @@ pub struct EventsProjectResponse {
     pub duplicates: i64,
 }
 
+/// Request for `POST /api/internal/projection/advance` (noetl/ai-meta#103
+/// phase 2b).  The `system/projector` playbook extracts the distinct
+/// `execution_id`s from a `noetl_events` stream batch and posts them here; the
+/// server recomputes + saves each one's `projection_snapshot`.
+#[derive(Debug, Deserialize)]
+pub struct ProjectionAdvanceRequest {
+    pub execution_ids: Vec<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectionAdvanceResponse {
+    pub advanced: Vec<crate::handlers::events::SnapshotAdvance>,
+    pub failed: Vec<ProjectionAdvanceFailure>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectionAdvanceFailure {
+    pub execution_id: i64,
+    pub error: String,
+}
+
 // ===========================================================================
 // Route handlers
 // ===========================================================================
@@ -291,6 +313,50 @@ pub async fn events_project(
         projected,
         duplicates,
     }))
+}
+
+/// `POST /api/internal/projection/advance`
+///
+/// CQRS read-model write (noetl/ai-meta#103 phase 2b).  For each (deduped)
+/// `execution_id` the `system/projector` playbook extracted from a
+/// `noetl_events` stream batch, recompute + save `projection_snapshot` via the
+/// orchestrator's bounded-rebuild machinery (no command dispatch).  Idempotent
+/// (monotonic snapshot upsert), so a redelivered batch is a forward no-op.  A
+/// per-execution failure is reported in `failed` without aborting the batch, so
+/// one bad execution can't block the projector's progress on the rest.
+pub async fn projection_advance(
+    State(state): State<AppState>,
+    _token: RequireInternalApiToken,
+    Json(request): Json<ProjectionAdvanceRequest>,
+) -> AppResult<Json<ProjectionAdvanceResponse>> {
+    let mut seen = std::collections::HashSet::new();
+    let mut advanced = Vec::new();
+    let mut failed = Vec::new();
+    for execution_id in request
+        .execution_ids
+        .into_iter()
+        .filter(|e| seen.insert(*e))
+    {
+        match crate::handlers::events::advance_snapshot(&state, execution_id).await {
+            Ok(a) => {
+                crate::metrics::record_projection_advanced(a.version);
+                advanced.push(a);
+            }
+            Err(e) => {
+                warn!(execution_id, %e, "projection/advance: execution failed");
+                failed.push(ProjectionAdvanceFailure {
+                    execution_id,
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+    info!(
+        advanced = advanced.len(),
+        failed = failed.len(),
+        "projection/advance done"
+    );
+    Ok(Json(ProjectionAdvanceResponse { advanced, failed }))
 }
 
 /// `POST /api/internal/cleanup/purge`

--- a/src/main.rs
+++ b/src/main.rs
@@ -682,6 +682,16 @@ async fn main() -> anyhow::Result<()> {
     // under DB backpressure (e.g. a small Cloud SQL tier behind PgBouncer).
     handlers::events::spawn_orchestrator_reconciler(state.clone());
 
+    // CQRS write-path producer (noetl/ai-meta#103 phase 2a): a background tailer
+    // that batch-publishes committed `noetl.event` rows onto the `noetl_events`
+    // JetStream stream for the system/projector playbook to fold.  Default OFF
+    // (`NOETL_EVENT_STREAM_ENABLED` unset) so landing 2a publishes nothing until
+    // ops opts the cluster into the CQRS write path; no-op without NATS.
+    noetl_server::services::event_stream::spawn_event_stream_tailer(
+        state.clone(),
+        noetl_server::services::event_stream::EventStreamConfig::from_env(),
+    );
+
     // Create services. The wallet's envelope cipher is built once over the
     // configured KEK provider (NOETL_KMS_PROVIDER: `local` default, or
     // `gcp-kms` over Cloud KMS — noetl/ai-meta#61 Phase 2) and shared between

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,12 @@ fn build_router(
             "/api/internal/projection/advance",
             post(handlers::internal::projection_advance),
         )
+        // CQRS write-path cutover (#103 phase 2d): materialize noetl.event from
+        // native producer events (normalized via the shared ingest path).
+        .route(
+            "/api/internal/events/materialize",
+            post(handlers::internal::events_materialize),
+        )
         .with_state(state.clone());
 
     // Keychain routes

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,18 @@ fn build_router(
         )
         .with_state(state.clone());
 
+    // CQRS read-model advance endpoint (noetl/ai-meta#103 phase 2b).  The
+    // system/projector playbook posts the execution_ids from a noetl_events
+    // stream batch; the server recomputes + saves each one's
+    // projection_snapshot.  Carries AppState (needs pools + snowflake), so it's
+    // a separate router from the DbPool-stated internal group above.
+    let projection_routes = Router::new()
+        .route(
+            "/api/internal/projection/advance",
+            post(handlers::internal::projection_advance),
+        )
+        .with_state(state.clone());
+
     // Keychain routes
     let keychain_routes = Router::new()
         .route(
@@ -460,6 +472,7 @@ fn build_router(
         .merge(wallet_rotate_routes)
         .merge(secret_audit_routes)
         .merge(container_callback_routes)
+        .merge(projection_routes)
         .merge(keychain_routes)
         .merge(execution_routes)
         .merge(executions_routes)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -53,7 +53,9 @@
 
 use std::sync::OnceLock;
 
-use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder};
+use prometheus::{
+    HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder,
+};
 
 /// Bucket boundaries for the event-ingest histogram (seconds).
 ///
@@ -152,6 +154,54 @@ pub fn record_event_ingest(event_type: &str, status: &str, duration_seconds: f64
     event_ingest_duration_seconds()
         .with_label_values(&[event_type])
         .observe(duration_seconds);
+}
+
+/// Counter: events published onto the `noetl_events` JetStream stream by the
+/// CQRS write-path tailer (noetl/ai-meta#103 phase 2a), by event type.  Lets the
+/// producer's throughput be observed without a log line per event.
+pub fn event_stream_published_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_event_stream_published_total",
+                "Total events published to the noetl_events JetStream stream by the CQRS write-path tailer, by event type.",
+            ),
+            &["event_type"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Gauge: the tailer's current cursor (`noetl.event.id` last published).  Pair
+/// with the table's `MAX(id)` to read publish lag.  Single series (no labels) —
+/// one tailer per server.
+pub fn event_stream_cursor() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let gauge = IntGauge::new(
+            "noetl_event_stream_cursor",
+            "noetl.event.id last published to the noetl_events stream by the CQRS write-path tailer.",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(gauge.clone()))
+            .expect("gauge registration must succeed");
+        gauge
+    })
+}
+
+/// Record a batch published by the tailer: bump the per-type counter for each
+/// event and advance the cursor gauge.
+pub fn record_event_stream_published(event_type: &str, count: u64, cursor: i64) {
+    event_stream_published_total()
+        .with_label_values(&[event_type])
+        .inc_by(count);
+    event_stream_cursor().set(cursor);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -204,6 +204,34 @@ pub fn record_event_stream_published(event_type: &str, count: u64, cursor: i64) 
     event_stream_cursor().set(cursor);
 }
 
+/// Counter: events the tailer SKIPPED (payload over NATS max), by type.  A
+/// non-zero rate means oversized events aren't reaching the stream — visible
+/// rather than silently wedging the cursor (noetl/ai-meta#103).
+pub fn event_stream_skipped_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_event_stream_skipped_total",
+                "Events the CQRS write-path tailer skipped because the payload exceeded the NATS max, by event type.",
+            ),
+            &["event_type"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one event skipped by the tailer (oversized payload).
+pub fn record_event_stream_skipped(event_type: &str) {
+    event_stream_skipped_total()
+        .with_label_values(&[event_type])
+        .inc();
+}
+
 /// Counter: executions whose `projection_snapshot` was advanced by the
 /// `system/projector` playbook via `/api/internal/projection/advance`
 /// (noetl/ai-meta#103 phase 2b).  No labels — one global rate.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -227,6 +227,29 @@ pub fn record_projection_advanced(_version: i64) {
     projection_advanced_total().inc();
 }
 
+/// Counter: `noetl.event` rows materialized from the stream by the
+/// `system/event_materializer` playbook via `/api/internal/events/materialize`
+/// (noetl/ai-meta#103 phase 2d).  No labels — one global rate.
+pub fn events_materialized_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_events_materialized_total",
+            "noetl.event rows materialized from the noetl_events stream by the system/event_materializer playbook.",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record a batch of materialized event rows.
+pub fn record_events_materialized(rows: u64) {
+    events_materialized_total().inc_by(rows);
+}
+
 // ---------------------------------------------------------------------------
 // Round 2 — generic write-endpoint surface
 // ---------------------------------------------------------------------------

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -204,6 +204,29 @@ pub fn record_event_stream_published(event_type: &str, count: u64, cursor: i64) 
     event_stream_cursor().set(cursor);
 }
 
+/// Counter: executions whose `projection_snapshot` was advanced by the
+/// `system/projector` playbook via `/api/internal/projection/advance`
+/// (noetl/ai-meta#103 phase 2b).  No labels — one global rate.
+pub fn projection_advanced_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_projection_advanced_total",
+            "Executions whose projection_snapshot was advanced by the system/projector playbook.",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one execution's projection advance.
+pub fn record_projection_advanced(_version: i64) {
+    projection_advanced_total().inc();
+}
+
 // ---------------------------------------------------------------------------
 // Round 2 — generic write-endpoint surface
 // ---------------------------------------------------------------------------

--- a/src/nats/event_publisher.rs
+++ b/src/nats/event_publisher.rs
@@ -45,6 +45,12 @@ pub const EVENT_SUBJECT_PREFIX: &str = "noetl.events";
 /// Wildcard the stream binds.
 pub const EVENT_SUBJECT_WILDCARD: &str = "noetl.events.>";
 
+/// Durable pull consumer the `system/projector` playbook drains
+/// (noetl/ai-meta#103 phase 2b).  `js_consume` / `tool: subscription` require
+/// the consumer to pre-exist; the server creates it alongside the stream so the
+/// playbook stays a pure consumer.
+pub const PROJECTOR_CONSUMER: &str = "noetl_projector";
+
 /// Publishes full events onto the `noetl_events` JetStream stream.
 #[derive(Clone)]
 pub struct EventStreamPublisher {
@@ -65,7 +71,34 @@ impl EventStreamPublisher {
     ) -> Result<Self, NatsError> {
         let js = jetstream::new((*client).clone());
         Self::ensure_stream(&js, dedup_window, max_age).await?;
+        Self::ensure_projector_consumer(&js).await?;
         Ok(Self { js })
+    }
+
+    /// Ensure the durable `noetl_projector` pull consumer exists on the stream.
+    /// Idempotent: `create_consumer` with a stable durable name + config is a
+    /// no-op when it already exists.  Explicit-ack so the projector controls
+    /// when a batch is acked (the `tool: subscription` poll acks on success).
+    async fn ensure_projector_consumer(js: &Context) -> Result<(), NatsError> {
+        let stream = js
+            .get_stream(EVENT_STREAM)
+            .await
+            .map_err(|e| NatsError::JetStream(e.to_string()))?;
+        stream
+            .create_consumer(jetstream::consumer::pull::Config {
+                durable_name: Some(PROJECTOR_CONSUMER.to_string()),
+                filter_subject: EVENT_SUBJECT_WILDCARD.to_string(),
+                ack_policy: jetstream::consumer::AckPolicy::Explicit,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| NatsError::JetStream(e.to_string()))?;
+        tracing::debug!(
+            stream = EVENT_STREAM,
+            consumer = PROJECTOR_CONSUMER,
+            "ensured projector pull consumer"
+        );
+        Ok(())
     }
 
     /// Ensure the `noetl_events` stream exists with the dedup window + retention

--- a/src/nats/event_publisher.rs
+++ b/src/nats/event_publisher.rs
@@ -1,0 +1,149 @@
+//! NATS JetStream event-log publisher — the CQRS write-path queue
+//! (noetl/ai-meta#103 phase 2a).
+//!
+//! Where [`crate::nats::publisher`] publishes *lightweight* command
+//! notifications (workers fetch the detail by id), this publishes the **full
+//! event** onto a durable JetStream stream so the read side can be derived from
+//! the stream alone.  The `system/projector` playbook (phase 2b) is a batch
+//! consumer of this stream: it pulls N messages, folds them into the projection
+//! in one transaction via `/api/internal/events/project`, and acks.
+//!
+//! ## Why a stream and not the DB trigger it replaces
+//!
+//! A trigger welds the producer to Postgres internals — invisible, vendor-
+//! specific, and it doesn't travel across a storage-type change.  A JetStream
+//! stream is a storage-agnostic queue (swap it for Kafka behind the same
+//! publish/consume contract) and is the design-note's stated write side.  At the
+//! 2d cutover the *worker* publishes here directly and the synchronous
+//! `noetl.event` INSERT goes away — the stream the [`EventStreamPublisher`]
+//! fills in 2a is the same stream the worker fills in 2d, so nothing downstream
+//! changes.
+//!
+//! ## Idempotency
+//!
+//! Each event is published with the JetStream **message-id** set to its
+//! `event_id` (`Nats-Msg-Id` header).  The stream's dedup window collapses
+//! re-publishes — so the tailer ([`crate::services::event_stream`]) can re-scan
+//! an overlapping window after a restart without double-delivering, and the
+//! projector folds each event exactly once.
+
+use async_nats::HeaderMap;
+use async_nats::jetstream::{self, Context};
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::publisher::NatsError;
+
+/// JetStream stream name for the event log.
+pub const EVENT_STREAM: &str = "noetl_events";
+
+/// Subject prefix.  Events publish to `noetl.events.<event_type>`; the stream
+/// binds the wildcard `noetl.events.>` so every type lands in one stream while
+/// consumers can filter by subject if they want a slice.
+pub const EVENT_SUBJECT_PREFIX: &str = "noetl.events";
+
+/// Wildcard the stream binds.
+pub const EVENT_SUBJECT_WILDCARD: &str = "noetl.events.>";
+
+/// Publishes full events onto the `noetl_events` JetStream stream.
+#[derive(Clone)]
+pub struct EventStreamPublisher {
+    js: Context,
+}
+
+impl EventStreamPublisher {
+    /// Build the publisher from a connected NATS client, ensuring the stream
+    /// exists.  Mirrors [`crate::nats::publisher::NatsPublisher::new`].
+    ///
+    /// `dedup_window` sizes the stream's message-id dedup window — it must be
+    /// at least as long as the tailer's re-scan lookback so an overlapping
+    /// re-publish after a restart is collapsed rather than re-delivered.
+    pub async fn new(
+        client: Arc<async_nats::Client>,
+        dedup_window: Duration,
+        max_age: Duration,
+    ) -> Result<Self, NatsError> {
+        let js = jetstream::new((*client).clone());
+        Self::ensure_stream(&js, dedup_window, max_age).await?;
+        Ok(Self { js })
+    }
+
+    /// Ensure the `noetl_events` stream exists with the dedup window + retention
+    /// we need.  If it already exists we leave its config untouched (an operator
+    /// may have tuned retention); we only create on absence, same shape as the
+    /// command stream.
+    async fn ensure_stream(
+        js: &Context,
+        dedup_window: Duration,
+        max_age: Duration,
+    ) -> Result<(), NatsError> {
+        match js.get_stream(EVENT_STREAM).await {
+            Ok(_) => {
+                tracing::debug!(stream = EVENT_STREAM, "Using existing event stream");
+                Ok(())
+            }
+            Err(_) => {
+                let config = jetstream::stream::Config {
+                    name: EVENT_STREAM.to_string(),
+                    subjects: vec![EVENT_SUBJECT_WILDCARD.to_string()],
+                    // File storage: the stream is a durable write log, not a
+                    // best-effort notification channel like noetl_commands.
+                    storage: jetstream::stream::StorageType::File,
+                    // Dedup by Nats-Msg-Id (= event_id) so the tailer's restart
+                    // re-scan can't double-deliver.
+                    duplicate_window: dedup_window,
+                    // Retention bounds the stream; the projector folds into the
+                    // durable projection tables well inside this window.  During
+                    // dual-write noetl.event remains the source of truth, so the
+                    // stream is allowed to age out.
+                    max_age,
+                    ..Default::default()
+                };
+                js.create_stream(config)
+                    .await
+                    .map_err(|e| NatsError::JetStream(e.to_string()))?;
+                tracing::info!(
+                    stream = EVENT_STREAM,
+                    subject = EVENT_SUBJECT_WILDCARD,
+                    "Created event stream (CQRS write-path queue, #103 phase 2a)"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// Publish one event's full JSON payload, keyed by `event_id` for dedup.
+    /// `event_type` selects the subject suffix.
+    pub async fn publish_event(
+        &self,
+        event_id: i64,
+        event_type: &str,
+        payload: &[u8],
+    ) -> Result<(), NatsError> {
+        let subject = format!("{EVENT_SUBJECT_PREFIX}.{event_type}");
+        let mut headers = HeaderMap::new();
+        // JetStream message-dedup key.
+        headers.insert("Nats-Msg-Id", event_id.to_string().as_str());
+
+        self.js
+            .publish_with_headers(subject, headers, payload.to_vec().into())
+            .await
+            .map_err(|e| NatsError::Publish(e.to_string()))?
+            .await
+            .map_err(|e| NatsError::Publish(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_constants_are_stable() {
+        assert_eq!(EVENT_STREAM, "noetl_events");
+        assert_eq!(EVENT_SUBJECT_WILDCARD, "noetl.events.>");
+        // The wildcard must cover the prefixed subjects the publisher emits.
+        assert!(EVENT_SUBJECT_WILDCARD.starts_with(EVENT_SUBJECT_PREFIX));
+    }
+}

--- a/src/nats/event_publisher.rs
+++ b/src/nats/event_publisher.rs
@@ -51,6 +51,13 @@ pub const EVENT_SUBJECT_WILDCARD: &str = "noetl.events.>";
 /// playbook stays a pure consumer.
 pub const PROJECTOR_CONSUMER: &str = "noetl_projector";
 
+/// Durable pull consumer the `system/event_materializer` playbook drains
+/// (noetl/ai-meta#103 phase 2d-1).  Separate from [`PROJECTOR_CONSUMER`] so the
+/// materializer (batch-writes `noetl.event` from the stream) and the projector
+/// (advances `projection_snapshot`) drain the same stream independently — each
+/// has its own ack cursor.
+pub const MATERIALIZER_CONSUMER: &str = "noetl_materializer";
+
 /// Publishes full events onto the `noetl_events` JetStream stream.
 #[derive(Clone)]
 pub struct EventStreamPublisher {
@@ -71,33 +78,32 @@ impl EventStreamPublisher {
     ) -> Result<Self, NatsError> {
         let js = jetstream::new((*client).clone());
         Self::ensure_stream(&js, dedup_window, max_age).await?;
-        Self::ensure_projector_consumer(&js).await?;
+        // Both system-pool consumers drain the same stream independently — the
+        // projector (→ projection_snapshot) and the materializer (→ noetl.event).
+        Self::ensure_consumer(&js, PROJECTOR_CONSUMER).await?;
+        Self::ensure_consumer(&js, MATERIALIZER_CONSUMER).await?;
         Ok(Self { js })
     }
 
-    /// Ensure the durable `noetl_projector` pull consumer exists on the stream.
-    /// Idempotent: `create_consumer` with a stable durable name + config is a
-    /// no-op when it already exists.  Explicit-ack so the projector controls
-    /// when a batch is acked (the `tool: subscription` poll acks on success).
-    async fn ensure_projector_consumer(js: &Context) -> Result<(), NatsError> {
+    /// Ensure a durable pull consumer exists on the stream.  Idempotent:
+    /// `create_consumer` with a stable durable name + config is a no-op when it
+    /// already exists.  Explicit-ack so the draining playbook controls when a
+    /// batch is acked (the `tool: subscription` poll acks on success).
+    async fn ensure_consumer(js: &Context, name: &str) -> Result<(), NatsError> {
         let stream = js
             .get_stream(EVENT_STREAM)
             .await
             .map_err(|e| NatsError::JetStream(e.to_string()))?;
         stream
             .create_consumer(jetstream::consumer::pull::Config {
-                durable_name: Some(PROJECTOR_CONSUMER.to_string()),
+                durable_name: Some(name.to_string()),
                 filter_subject: EVENT_SUBJECT_WILDCARD.to_string(),
                 ack_policy: jetstream::consumer::AckPolicy::Explicit,
                 ..Default::default()
             })
             .await
             .map_err(|e| NatsError::JetStream(e.to_string()))?;
-        tracing::debug!(
-            stream = EVENT_STREAM,
-            consumer = PROJECTOR_CONSUMER,
-            "ensured projector pull consumer"
-        );
+        tracing::debug!(stream = EVENT_STREAM, consumer = name, "ensured pull consumer");
         Ok(())
     }
 

--- a/src/nats/mod.rs
+++ b/src/nats/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! Provides command notification publishing to workers via NATS JetStream.
 
+pub mod event_publisher;
 pub mod publisher;
 
+pub use event_publisher::EventStreamPublisher;
 pub use publisher::NatsPublisher;

--- a/src/services/event_stream.rs
+++ b/src/services/event_stream.rs
@@ -1,0 +1,317 @@
+//! Event-log → JetStream tailer — the CQRS write-path producer
+//! (noetl/ai-meta#103 phase 2a).
+//!
+//! A background task that reads newly-committed `noetl.event` rows by a
+//! persisted cursor and batch-publishes them onto the `noetl_events` JetStream
+//! stream ([`crate::nats::EventStreamPublisher`]) for the `system/projector`
+//! playbook (phase 2b) to fold into the read model.
+//!
+//! ## Why a tailer (not a DB trigger, not an in-process channel)
+//!
+//! - **Not a trigger:** a trigger is a Postgres-internal object — invisible,
+//!   vendor-specific, and it doesn't travel across a storage-type change.  The
+//!   tailer is ordinary application code; at the 2d cutover (worker publishes
+//!   straight to JetStream) it is simply deleted.
+//! - **Not an in-process channel fed at the 17 insert sites:** that would couple
+//!   every emit path to the producer and lose in-flight events on a crash.  The
+//!   tailer reads *committed* rows, so nothing is lost — a restart resumes from
+//!   the persisted cursor and re-scans a small overlap window, which the
+//!   stream's `event_id` message-dedup collapses.
+//!
+//! ## Cursor + ordering
+//!
+//! The cursor is the `noetl.event.id` (BIGSERIAL insert order), persisted in
+//! `noetl.stream_cursor`.  Each poll reads `WHERE id > cursor ORDER BY id ASC
+//! LIMIT batch` and advances the cursor to the max id published.  A row that
+//! commits out of `id` order (a transaction that drew a low `id` but committed
+//! late) could in principle sit just behind the cursor; the projector mirrors
+//! block-b's straggler handling and the stream dedup makes a periodic
+//! re-scan safe, so no event is permanently skipped.  During dual-write
+//! `noetl.event` remains the source of truth, so any stream gap is recoverable.
+//!
+//! ## Default off
+//!
+//! Gated by `NOETL_EVENT_STREAM_ENABLED` (default off): landing 2a publishes
+//! nothing until ops opts in.  First enable starts the cursor at `MAX(id)` (tail
+//! from now, no history replay) unless `NOETL_EVENT_STREAM_BACKFILL=true`.
+
+use std::time::Duration;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::nats::EventStreamPublisher;
+use crate::state::AppState;
+
+/// Cursor name in `noetl.stream_cursor` for this tailer.
+const CURSOR_NAME: &str = "event_stream_tailer";
+
+/// Tailer configuration, all from the environment with safe defaults.
+#[derive(Debug, Clone)]
+pub struct EventStreamConfig {
+    /// Master gate.  Off → the tailer task is not spawned.
+    pub enabled: bool,
+    /// Max events published per poll.
+    pub batch_size: i64,
+    /// Sleep between polls when caught up.
+    pub poll_interval: Duration,
+    /// On first run (no persisted cursor), start at id 0 to replay the whole
+    /// history instead of tailing from now.
+    pub backfill: bool,
+    /// Stream message-dedup window (≥ the restart re-scan overlap).
+    pub dedup_window: Duration,
+    /// Stream retention.
+    pub max_age: Duration,
+}
+
+impl EventStreamConfig {
+    /// Read config from the process environment.
+    pub fn from_env() -> Self {
+        Self::from_lookup(|k| std::env::var(k).ok())
+    }
+
+    /// Pure parse over a key→value lookup — `from_env` delegates here, and tests
+    /// drive it with an in-memory map so they never mutate global env (which
+    /// races other env-reading tests under parallel execution).
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let flag = |key: &str| {
+            lookup(key)
+                .map(|v| {
+                    let v = v.trim().to_ascii_lowercase();
+                    v == "true" || v == "1" || v == "yes" || v == "on"
+                })
+                .unwrap_or(false)
+        };
+        let num = |key: &str, default: u64| {
+            lookup(key)
+                .and_then(|v| v.trim().parse().ok())
+                .unwrap_or(default)
+        };
+        Self {
+            enabled: flag("NOETL_EVENT_STREAM_ENABLED"),
+            batch_size: num("NOETL_EVENT_STREAM_BATCH", 500) as i64,
+            poll_interval: Duration::from_millis(num("NOETL_EVENT_STREAM_POLL_MS", 500)),
+            backfill: flag("NOETL_EVENT_STREAM_BACKFILL"),
+            dedup_window: Duration::from_secs(num("NOETL_EVENT_STREAM_DEDUP_SECS", 120)),
+            max_age: Duration::from_secs(num("NOETL_EVENT_STREAM_RETENTION_SECS", 86_400)),
+        }
+    }
+}
+
+/// Idempotent startup DDL for the tailer's durable cursor.  Same pattern as the
+/// other `ensure_*` startup helpers; the table is one row per named cursor.
+pub async fn ensure_cursor_table(pool: &DbPool) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS noetl.stream_cursor (
+            name        TEXT        PRIMARY KEY,
+            position    BIGINT      NOT NULL,
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Load the persisted cursor, or initialise it: `MAX(id)` (tail from now) unless
+/// `backfill`, in which case 0 (replay history).  The initial value is persisted
+/// so a later restart resumes rather than re-deriving "now".
+async fn load_or_init_cursor(pool: &DbPool, backfill: bool) -> AppResult<i64> {
+    if let Some((pos,)) =
+        sqlx::query_as::<_, (i64,)>("SELECT position FROM noetl.stream_cursor WHERE name = $1")
+            .bind(CURSOR_NAME)
+            .fetch_optional(pool)
+            .await?
+    {
+        return Ok(pos);
+    }
+    let start: i64 = if backfill {
+        0
+    } else {
+        sqlx::query_as::<_, (Option<i64>,)>("SELECT MAX(id) FROM noetl.event")
+            .fetch_one(pool)
+            .await?
+            .0
+            .unwrap_or(0)
+    };
+    save_cursor(pool, start).await?;
+    Ok(start)
+}
+
+/// Persist the cursor (upsert).
+async fn save_cursor(pool: &DbPool, position: i64) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.stream_cursor (name, position, updated_at)
+        VALUES ($1, $2, now())
+        ON CONFLICT (name) DO UPDATE SET position = EXCLUDED.position, updated_at = now()
+        "#,
+    )
+    .bind(CURSOR_NAME)
+    .bind(position)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// One row of the tail read.
+#[derive(sqlx::FromRow)]
+struct TailRow {
+    id: i64,
+    event_id: i64,
+    event_type: String,
+}
+
+/// Spawn the tailer if enabled and NATS is connected.  No-op (with a log) when
+/// disabled or when the server runs without NATS.
+pub fn spawn_event_stream_tailer(state: AppState, config: EventStreamConfig) {
+    if !config.enabled {
+        tracing::info!(
+            target: "noetl_server::startup",
+            "event-stream tailer disabled (NOETL_EVENT_STREAM_ENABLED unset) — CQRS write path inert"
+        );
+        return;
+    }
+    let Some(client) = state.nats.clone() else {
+        tracing::warn!(
+            target: "noetl_server::startup",
+            "event-stream tailer enabled but NATS is not connected — producer cannot run"
+        );
+        return;
+    };
+
+    tokio::spawn(async move {
+        let publisher =
+            match EventStreamPublisher::new(client, config.dedup_window, config.max_age).await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::error!(%e, "event-stream tailer: failed to ensure noetl_events stream; producer not started");
+                    return;
+                }
+            };
+
+        let pool = &state.db;
+        if let Err(e) = ensure_cursor_table(pool).await {
+            tracing::error!(%e, "event-stream tailer: failed to ensure cursor table; producer not started");
+            return;
+        }
+        let mut cursor = match load_or_init_cursor(pool, config.backfill).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(%e, "event-stream tailer: failed to load cursor; producer not started");
+                return;
+            }
+        };
+        tracing::info!(
+            target: "noetl_server::startup",
+            start_cursor = cursor,
+            batch = config.batch_size,
+            "event-stream tailer started (CQRS write-path producer, #103 phase 2a)"
+        );
+
+        loop {
+            match publish_batch(pool, &publisher, cursor, config.batch_size).await {
+                Ok(Some(new_cursor)) => {
+                    cursor = new_cursor;
+                    if let Err(e) = save_cursor(pool, cursor).await {
+                        tracing::warn!(%e, cursor, "event-stream tailer: cursor persist failed; will retry");
+                    }
+                    // Drained a full batch → likely more waiting; poll again
+                    // immediately rather than sleeping.
+                    continue;
+                }
+                Ok(None) => {} // caught up
+                Err(e) => {
+                    tracing::warn!(%e, cursor, "event-stream tailer: batch publish failed; backing off");
+                }
+            }
+            tokio::time::sleep(config.poll_interval).await;
+        }
+    });
+}
+
+/// Read and publish one batch. Returns `Some(new_cursor)` if it published a full
+/// batch (caller should poll again immediately), `None` if caught up.
+async fn publish_batch(
+    pool: &DbPool,
+    publisher: &EventStreamPublisher,
+    cursor: i64,
+    batch_size: i64,
+) -> AppResult<Option<i64>> {
+    let rows: Vec<TailRow> = sqlx::query_as(
+        r#"
+        SELECT id, event_id, event_type
+        FROM noetl.event
+        WHERE id > $1
+        ORDER BY id ASC
+        LIMIT $2
+        "#,
+    )
+    .bind(cursor)
+    .bind(batch_size)
+    .fetch_all(pool)
+    .await?;
+
+    if rows.is_empty() {
+        return Ok(None);
+    }
+
+    let mut max_id = cursor;
+    for row in &rows {
+        // Fetch the full event JSON for the payload.  (The id-only tail above
+        // keeps the hot scan narrow; the payload load is per-published-event.)
+        let payload: Option<(serde_json::Value,)> = sqlx::query_as(
+            "SELECT to_jsonb(e) FROM noetl.event e WHERE id = $1",
+        )
+        .bind(row.id)
+        .fetch_optional(pool)
+        .await?;
+        let Some((json,)) = payload else { continue };
+        let bytes = serde_json::to_vec(&json).map_err(|e| {
+            crate::error::AppError::Internal(format!("event payload encode: {e}"))
+        })?;
+        publisher
+            .publish_event(row.event_id, &row.event_type, &bytes)
+            .await
+            .map_err(|e| crate::error::AppError::Internal(format!("event publish: {e}")))?;
+        crate::metrics::record_event_stream_published(&row.event_type, 1, row.id);
+        max_id = max_id.max(row.id);
+    }
+
+    Ok(Some(max_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults_are_safe() {
+        // Empty lookup → producer off, knobs sane.  Pure (no global env).
+        let c = EventStreamConfig::from_lookup(|_| None);
+        assert!(!c.enabled, "default must be off");
+        assert_eq!(c.batch_size, 500);
+        assert_eq!(c.poll_interval, Duration::from_millis(500));
+        assert!(!c.backfill);
+        assert_eq!(c.dedup_window, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn config_parses_overrides() {
+        let map = |k: &str| -> Option<String> {
+            match k {
+                "NOETL_EVENT_STREAM_ENABLED" => Some("yes".into()),
+                "NOETL_EVENT_STREAM_BATCH" => Some("1000".into()),
+                "NOETL_EVENT_STREAM_POLL_MS" => Some("250".into()),
+                "NOETL_EVENT_STREAM_BACKFILL" => Some("true".into()),
+                _ => None,
+            }
+        };
+        let c = EventStreamConfig::from_lookup(map);
+        assert!(c.enabled);
+        assert_eq!(c.batch_size, 1000);
+        assert_eq!(c.poll_interval, Duration::from_millis(250));
+        assert!(c.backfill);
+    }
+}

--- a/src/services/event_stream.rs
+++ b/src/services/event_stream.rs
@@ -20,20 +20,27 @@
 //!
 //! ## Cursor + ordering
 //!
-//! The cursor is the `noetl.event.id` (BIGSERIAL insert order), persisted in
-//! `noetl.stream_cursor`.  Each poll reads `WHERE id > cursor ORDER BY id ASC
-//! LIMIT batch` and advances the cursor to the max id published.  A row that
-//! commits out of `id` order (a transaction that drew a low `id` but committed
-//! late) could in principle sit just behind the cursor; the projector mirrors
-//! block-b's straggler handling and the stream dedup makes a periodic
-//! re-scan safe, so no event is permanently skipped.  During dual-write
-//! `noetl.event` remains the source of truth, so any stream gap is recoverable.
+//! `noetl.event` has no monotonic insert-order column — its PK is
+//! `(execution_id, event_id)` and it is `PARTITION BY RANGE (execution_id)`.
+//! The cursor is therefore the globally-unique snowflake `event_id`, persisted
+//! in `noetl.stream_cursor`.  Each poll reads `WHERE event_id > cursor ORDER BY
+//! event_id ASC LIMIT batch` and advances to the max `event_id` published.
+//!
+//! Snowflake ids from different worker machines in the same millisecond
+//! interleave, so a below-watermark `event_id` could be inserted late and sit
+//! just behind the cursor (the same straggler shape block-b handles).  That does
+//! NOT corrupt the projection: the `/projection/advance` endpoint recomputes
+//! each snapshot from `noetl.event` via `rebuild_state`, whose `created_at`
+//! margin re-reads the straggler — the stream is only a *"this execution
+//! changed"* trigger, not the projection's source of truth during dual-write.
+//! Each event is published with `Nats-Msg-Id = event_id`, so a re-scan after a
+//! restart is collapsed by the stream's dedup window.
 //!
 //! ## Default off
 //!
 //! Gated by `NOETL_EVENT_STREAM_ENABLED` (default off): landing 2a publishes
-//! nothing until ops opts in.  First enable starts the cursor at `MAX(id)` (tail
-//! from now, no history replay) unless `NOETL_EVENT_STREAM_BACKFILL=true`.
+//! nothing until ops opts in.  First enable starts the cursor at `MAX(event_id)`
+//! (tail from now, no history replay) unless `NOETL_EVENT_STREAM_BACKFILL=true`.
 
 use std::time::Duration;
 
@@ -129,7 +136,7 @@ async fn load_or_init_cursor(pool: &DbPool, backfill: bool) -> AppResult<i64> {
     let start: i64 = if backfill {
         0
     } else {
-        sqlx::query_as::<_, (Option<i64>,)>("SELECT MAX(id) FROM noetl.event")
+        sqlx::query_as::<_, (Option<i64>,)>("SELECT MAX(event_id) FROM noetl.event")
             .fetch_one(pool)
             .await?
             .0
@@ -155,12 +162,12 @@ async fn save_cursor(pool: &DbPool, position: i64) -> AppResult<()> {
     Ok(())
 }
 
-/// One row of the tail read.
+/// One row of the tail read — the full event JSON published to the stream.
 #[derive(sqlx::FromRow)]
 struct TailRow {
-    id: i64,
     event_id: i64,
     event_type: String,
+    payload: serde_json::Value,
 }
 
 /// Spawn the tailer if enabled and NATS is connected.  No-op (with a log) when
@@ -241,10 +248,10 @@ async fn publish_batch(
 ) -> AppResult<Option<i64>> {
     let rows: Vec<TailRow> = sqlx::query_as(
         r#"
-        SELECT id, event_id, event_type
-        FROM noetl.event
-        WHERE id > $1
-        ORDER BY id ASC
+        SELECT event_id, COALESCE(event_type, 'unknown') AS event_type, to_jsonb(e) AS payload
+        FROM noetl.event e
+        WHERE event_id > $1
+        ORDER BY event_id ASC
         LIMIT $2
         "#,
     )
@@ -259,24 +266,15 @@ async fn publish_batch(
 
     let mut max_id = cursor;
     for row in &rows {
-        // Fetch the full event JSON for the payload.  (The id-only tail above
-        // keeps the hot scan narrow; the payload load is per-published-event.)
-        let payload: Option<(serde_json::Value,)> = sqlx::query_as(
-            "SELECT to_jsonb(e) FROM noetl.event e WHERE id = $1",
-        )
-        .bind(row.id)
-        .fetch_optional(pool)
-        .await?;
-        let Some((json,)) = payload else { continue };
-        let bytes = serde_json::to_vec(&json).map_err(|e| {
+        let bytes = serde_json::to_vec(&row.payload).map_err(|e| {
             crate::error::AppError::Internal(format!("event payload encode: {e}"))
         })?;
         publisher
             .publish_event(row.event_id, &row.event_type, &bytes)
             .await
             .map_err(|e| crate::error::AppError::Internal(format!("event publish: {e}")))?;
-        crate::metrics::record_event_stream_published(&row.event_type, 1, row.id);
-        max_id = max_id.max(row.id);
+        crate::metrics::record_event_stream_published(&row.event_type, 1, row.event_id);
+        max_id = max_id.max(row.event_id);
     }
 
     Ok(Some(max_id))

--- a/src/services/event_stream.rs
+++ b/src/services/event_stream.rs
@@ -269,6 +269,27 @@ async fn publish_batch(
         let bytes = serde_json::to_vec(&row.payload).map_err(|e| {
             crate::error::AppError::Internal(format!("event payload encode: {e}"))
         })?;
+        // NATS rejects messages over its `max_payload` (1MB default) with a hard
+        // "Maximum Payload Violation" — a permanent error that would wedge the
+        // cursor forever if we failed the batch on it.  Pre-skip oversized events
+        // (advance past them) so one fat event can't stop the whole write path.
+        // During dual-write `noetl.event` is the source of truth, so a skipped
+        // stream event is recoverable (the projector advances off `noetl.event`).
+        // The 2d-3 cutover — where the stream becomes the source — needs real
+        // handling (chunk or publish-by-reference); tracked on noetl/ai-meta#103.
+        if bytes.len() > MAX_EVENT_PAYLOAD_BYTES {
+            tracing::warn!(
+                event_id = row.event_id,
+                event_type = %row.event_type,
+                bytes = bytes.len(),
+                "event-stream tailer: payload over max; skipping (recoverable from noetl.event during dual-write)"
+            );
+            crate::metrics::record_event_stream_skipped(&row.event_type);
+            max_id = max_id.max(row.event_id);
+            continue;
+        }
+        // Transient publish errors (timeouts, reconnects) still fail the batch so
+        // the caller backs off and retries — no event silently lost on a blip.
         publisher
             .publish_event(row.event_id, &row.event_type, &bytes)
             .await
@@ -279,6 +300,10 @@ async fn publish_batch(
 
     Ok(Some(max_id))
 }
+
+/// Skip events whose JSON payload exceeds this — below NATS's 1MB default
+/// `max_payload` with headroom for the subject + headers.
+const MAX_EVENT_PAYLOAD_BYTES: usize = 900 * 1024;
 
 #[cfg(test)]
 mod tests {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,6 +6,7 @@
 pub mod catalog;
 pub mod credential;
 pub mod event;
+pub mod event_stream;
 pub mod execution;
 pub mod internal;
 pub mod keychain;


### PR DESCRIPTION
## What

Phase **2d-2** of [noetl/ai-meta#103](https://github.com/noetl/ai-meta/issues/103) — the server foundation for the write-path cutover. Stacked on the CQRS stack ([server#205](https://github.com/noetl/server/pull/205)).

- **`normalize_event_to_row`** — extracts `handle_event_inner`'s `ExecutorEvent` → `noetl.event` normalization (derive `status`, build + sanitize the `result` envelope, sanitize `meta`, resolve `catalog_id`, resolve `event_id`) into one shared fn. `handle_event_inner` now calls it (no behavior change).
- **`POST /api/internal/events/materialize`** — applies that same fn to a batch of **native producer events** (the worker's `ExecutorEvent`, which deserializes into `EventRequest`), then idempotently batch-inserts `noetl.event`. So at 2d-3 — when the worker publishes its native shape and the synchronous INSERT is dropped — the materialized row is **byte-identical** to the synchronous path. Differs from `events_project` (already-row-shaped envelopes) by normalizing; differs from `POST /api/events` by not triggering the orchestrator.
- Metric `noetl_events_materialized_total`.

## Plus a tailer robustness fix (belongs on 2a #202 — cherry-pick)

Live validation caught the 2a tailer **wedging** on a `Maximum Payload Violation`: an event whose `to_jsonb` payload exceeds NATS `max_payload` (1MB) failed the whole batch and backed off forever. Now it **pre-skips oversized payloads** (>900KB) with a WARN + `noetl_event_stream_skipped_total` metric and advances; transient errors still retry. Recoverable during dual-write (projector advances off `noetl.event`).

> **Finding for 2d-3:** the oversized events are the orchestrator's **`command.issued`** at **5.4MB / 4.7MB** — the cursor fan-out's rendered context. At the cutover (stream = source) these need real handling (chunk / publish-by-reference); likely `command.issued` context should use results-by-reference too. Noted on #103.

## Validation (live, kind)

- Build + **669 tests** + clippy green.
- Small PFT **COMPLETED, 217 events** — the refactored `handle_event` + shared `normalize_event_to_row` work, no regression.
- `/events/materialize` wired + auth-gated (HTTP 403 without token).
- Tailer fix confirmed: skips the 5.4MB `command.issued`, cursor advanced `325318409057210368` → `325353618960027650`, stream unblocked.

Refs noetl/ai-meta#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)