### PR TITLE
feat(refs): gated hydrate keeps references + extracted (references-in-state phase 2, server)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -43,6 +43,19 @@ pub struct AppConfig {
     #[serde(default)]
     pub disable_metrics: bool,
 
+    /// References-in-state (noetl/ai-meta#101 phase 2).  When true, the
+    /// orchestrator stops resolving over-budget result references back to inline
+    /// data — it keeps `{reference, extracted}` on the event so the state +
+    /// command context carry references, not bulk payloads (a 1.7MB step output
+    /// no longer balloons every `command.issued`).  The orchestrator evaluates
+    /// `when:`/`set:` off the small `extracted` predicate block; the worker
+    /// resolves the full reference at render time.  Envy maps
+    /// `NOETL_REFS_IN_STATE`.  **Default false** — preserves block-b's
+    /// resolve-inline behavior exactly until the consume side (worker resolve +
+    /// cursor-claim handling) is in place.
+    #[serde(default)]
+    pub refs_in_state: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -153,6 +166,7 @@ impl Default for AppConfig {
             nats_url: None,
             enable_gcp_token_api: true,
             disable_metrics: false,
+            refs_in_state: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -203,6 +203,14 @@ pub struct CursorFrame {
     pub claim_rows: Vec<serde_json::Value>,
     pub body_issued: usize,
     pub body_completed: usize,
+    /// References-in-state (noetl/ai-meta#101 phase 2): when the claim result is
+    /// over budget the orchestrator keeps the reference instead of the inline
+    /// rows, so `claim_rows` can't be filled in the sync `apply_event` pass.
+    /// The `noetl://` URI is stashed here; `trigger_orchestrator` resolves it
+    /// (async) into `claim_rows` before the cursor drive runs.  `None` on the
+    /// common inline path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_ref: Option<String>,
 }
 
 impl StepInfo {
@@ -750,6 +758,16 @@ impl WorkflowState {
                         .and_then(|d| d.get("rows"))
                         .and_then(|r| r.as_array())
                         .cloned();
+                    // References-in-state (noetl/ai-meta#101 phase 2): when the
+                    // claim is over budget the orchestrator kept the reference,
+                    // so there are no inline `rows` here.  Capture the URI so the
+                    // async pre-drive pass can resolve it into `claim_rows` —
+                    // otherwise the cursor would see 0 rows and wrongly DRAIN.
+                    let claim_ref = if rows.is_none() {
+                        event.result.as_ref().and_then(result_reference_uri)
+                    } else {
+                        None
+                    };
                     let step = self
                         .steps
                         .entry(name.clone())
@@ -758,10 +776,15 @@ impl WorkflowState {
                     // must not overwrite the cursor step's result (the drive
                     // block sets it on drain).
                     if step.is_cursor {
-                        if let (Some(cid), Some(rows)) = (cid, rows) {
+                        if let Some(cid) = cid {
                             if let Some((phase, frame)) = step.cursor_issued.get(&cid).cloned() {
                                 if phase == "claim" {
-                                    step.cursor_frames.entry(frame).or_default().claim_rows = rows;
+                                    let f = step.cursor_frames.entry(frame).or_default();
+                                    if let Some(rows) = rows {
+                                        f.claim_rows = rows;
+                                    } else if let Some(cref) = claim_ref {
+                                        f.claim_ref = Some(cref);
+                                    }
                                 }
                             }
                         }
@@ -1057,6 +1080,17 @@ pub fn apply_set_mutations(
 /// that reference `{{ step_name.field }}` in next.arcs / step.when
 /// see an undefined value because the envelope's `status` /
 /// `context` keys swallowed the user fields.
+/// Locate a `noetl://` result-reference URI on an event result envelope
+/// (references-in-state, noetl/ai-meta#101 phase 2).  Nested envelope:
+/// `context.result.reference.ref`; top-level: `reference.ref`.
+pub(crate) fn result_reference_uri(result: &serde_json::Value) -> Option<String> {
+    result
+        .pointer("/context/result/reference/ref")
+        .and_then(|v| v.as_str())
+        .or_else(|| result.pointer("/reference/ref").and_then(|v| v.as_str()))
+        .map(str::to_string)
+}
+
 pub(crate) fn extract_user_data(result: &serde_json::Value) -> Option<serde_json::Value> {
     if result.is_null() {
         return None;

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1320,6 +1320,7 @@ fn event_status_from_name(event_name: &str) -> &'static str {
 async fn hydrate_result_references(
     events: &mut [crate::db::models::Event],
     result_store: &crate::services::result_store::ResultStoreService,
+    keep_refs: bool,
 ) {
     use crate::services::result_store::parse_noetl_ref;
 
@@ -1331,6 +1332,7 @@ async fn hydrate_result_references(
     }
 
     let mut hydrated = 0usize;
+    let mut kept = 0usize;
     for ev in events.iter_mut() {
         let Some(result) = ev.result.as_mut() else {
             continue;
@@ -1346,6 +1348,45 @@ async fn hydrate_result_references(
         } else {
             continue;
         };
+
+        // References-in-state (noetl/ai-meta#101 phase 2): when gated on AND the
+        // reference carries an `extracted` predicate block (phase 1), keep the
+        // reference and surface `extracted` as the readable `context.data` —
+        // instead of resolving the full payload inline.  `extract_user_data`
+        // then reads `extracted` for `when:`/`set:` evaluation; the reference
+        // block stays on the event so `build_context` carries it and the worker
+        // resolves the bulk payload at render time.  No `extracted` (pre-phase-1
+        // refs) falls through to the resolve path below for back-compat.
+        if keep_refs {
+            let extracted = match shape {
+                Shape::Nested => result
+                    .pointer("/context/result/reference/extracted")
+                    .cloned(),
+                Shape::TopLevel => result.pointer("/reference/extracted").cloned(),
+            };
+            if let Some(extracted) = extracted {
+                let data = serde_json::json!({ "data": extracted });
+                match shape {
+                    Shape::Nested => {
+                        if let Some(inner) = result
+                            .get_mut("context")
+                            .and_then(|c| c.get_mut("result"))
+                            .and_then(|r| r.as_object_mut())
+                        {
+                            inner.insert("context".to_string(), data);
+                            kept += 1;
+                        }
+                    }
+                    Shape::TopLevel => {
+                        if let Some(obj) = result.as_object_mut() {
+                            obj.insert("context".to_string(), data);
+                            kept += 1;
+                        }
+                    }
+                }
+                continue; // keep the reference; do not resolve
+            }
+        }
 
         let parsed = match parse_noetl_ref(&ref_uri) {
             Ok(p) => p,
@@ -1389,8 +1430,11 @@ async fn hydrate_result_references(
             }
         }
     }
-    if hydrated > 0 {
-        debug!(hydrated, "hydrate_result_references: resolved over-budget result references");
+    if hydrated > 0 || kept > 0 {
+        debug!(
+            hydrated,
+            kept, "hydrate_result_references: resolved / kept-by-reference over-budget results"
+        );
     }
 }
 
@@ -1469,6 +1513,7 @@ async fn rebuild_state(
     pool: &crate::db::DbPool,
     result_store: &crate::services::result_store::ResultStoreService,
     execution_id: i64,
+    keep_refs: bool,
 ) -> AppResult<RebuildResult> {
     use crate::services::orch_snapshot;
     match orch_snapshot::load_latest(pool, execution_id).await? {
@@ -1488,7 +1533,7 @@ async fn rebuild_state(
                 .fetch_all(pool)
                 .await?,
             );
-            hydrate_result_references(&mut events_since, result_store).await;
+            hydrate_result_references(&mut events_since, result_store, keep_refs).await;
             let mut ws = snap.state;
             for e in &events_since {
                 ws.apply_event(e);
@@ -1516,7 +1561,7 @@ async fn rebuild_state(
                 .fetch_all(pool)
                 .await?,
             );
-            hydrate_result_references(&mut all_events, result_store).await;
+            hydrate_result_references(&mut all_events, result_store, keep_refs).await;
             let state = crate::engine::state::WorkflowState::from_events(&all_events)
                 .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
             let last_event_id = all_events.last().map(|e| e.event_id).unwrap_or(0);
@@ -1657,7 +1702,7 @@ async fn trigger_orchestrator_inner(
     // the full (still-small) early log when no snapshot exists yet.
     let mut did_rebuild = false;
     if cache.state.is_none() {
-        let r = rebuild_state(pool, &result_store, execution_id).await?;
+        let r = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await?;
         cache.state = Some(r.state);
         cache.last_event_id = r.last_event_id;
         cache.applied_count = total.unwrap_or(0);
@@ -1684,7 +1729,7 @@ async fn trigger_orchestrator_inner(
             .fetch_all(pool)
             .await?,
         );
-        hydrate_result_references(&mut strag, &result_store).await;
+        hydrate_result_references(&mut strag, &result_store, state.config.refs_in_state).await;
         if let Some(ws) = cache.state.as_mut() {
             for e in &strag {
                 ws.apply_event(e);
@@ -1710,7 +1755,7 @@ async fn trigger_orchestrator_inner(
         .fetch_all(pool)
         .await?,
     );
-    hydrate_result_references(&mut new_events, &result_store).await;
+    hydrate_result_references(&mut new_events, &result_store, state.config.refs_in_state).await;
 
     // Trigger type + drain timestamp.  The trigger event is normally among the
     // new events; after a cold rebuild / straggler apply that already folded it
@@ -1733,7 +1778,7 @@ async fn trigger_orchestrator_inner(
     // incremental apply.
     let mismatch = matches!(total, Some(t) if cache.applied_count + new_events.len() as i64 != t);
     if mismatch {
-        let r = rebuild_state(pool, &result_store, execution_id).await?;
+        let r = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await?;
         cache.state = Some(r.state);
         cache.last_event_id = r.last_event_id;
         cache.applied_count = total.unwrap_or(cache.applied_count);

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1509,6 +1509,61 @@ const REBUILD_STRAGGLER_MARGIN_SECS: i64 = 30;
 /// full-log replay that OOM'd the server at scale: a straggler below the
 /// incremental watermark used to trigger a reload of the entire (growing) event
 /// log on nearly every completion under high concurrency.
+/// Resolve over-budget cursor claim references into inline `claim_rows` before
+/// the drive runs (references-in-state, noetl/ai-meta#101 phase 2).  A referenced
+/// claim has `claim_ref` set + empty `claim_rows` (the sync `apply_event` can't
+/// resolve); this async pass fills the rows so the cursor fans out instead of
+/// wrongly draining.  No-op unless the flag kept a claim reference.
+async fn resolve_cursor_claim_refs(
+    ws: &mut crate::engine::state::WorkflowState,
+    result_store: &crate::services::result_store::ResultStoreService,
+) {
+    use crate::services::result_store::parse_noetl_ref;
+    for step in ws.steps.values_mut() {
+        if !step.is_cursor {
+            continue;
+        }
+        for frame in step.cursor_frames.values_mut() {
+            if !frame.claim_rows.is_empty() {
+                continue;
+            }
+            let Some(uri) = frame.claim_ref.clone() else {
+                continue;
+            };
+            let parsed = match parse_noetl_ref(&uri) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(uri, %e, "cursor claim reference unparseable; left as drain");
+                    continue;
+                }
+            };
+            match result_store.resolve(&parsed).await {
+                Ok(Some(data)) => match extract_claim_rows(&data) {
+                    Some(rows) => {
+                        frame.claim_rows = rows;
+                        frame.claim_ref = None;
+                    }
+                    None => warn!(uri, "cursor claim reference resolved but no rows array found"),
+                },
+                Ok(None) => warn!(uri, "cursor claim reference not found in store"),
+                Err(e) => warn!(uri, %e, "cursor claim reference resolve failed"),
+            }
+        }
+    }
+}
+
+/// Pull the claimed rows array out of a resolved claim payload, trying the
+/// common shapes the store may hold for a tool result.
+fn extract_claim_rows(data: &serde_json::Value) -> Option<Vec<serde_json::Value>> {
+    for ptr in ["/rows", "/data/rows", "/result/rows", "/context/data/rows"] {
+        if let Some(arr) = data.pointer(ptr).and_then(|v| v.as_array()) {
+            return Some(arr.clone());
+        }
+    }
+    crate::engine::state::extract_user_data(data)
+        .and_then(|d| d.get("rows").and_then(|r| r.as_array()).cloned())
+}
+
 async fn rebuild_state(
     pool: &crate::db::DbPool,
     result_store: &crate::services::result_store::ResultStoreService,
@@ -1860,6 +1915,12 @@ async fn trigger_orchestrator_inner(
     // 3. Evaluate against the cached state.
     let orchestrator = WorkflowOrchestrator::new();
     let ws = cache.state.as_mut().unwrap();
+    // References-in-state (noetl/ai-meta#101 phase 2): resolve any over-budget
+    // cursor claim references into inline rows before the drive reads them — a
+    // referenced claim has `claim_ref` set + empty `claim_rows`, and without
+    // this the cursor would see 0 rows and wrongly DRAIN.  No-op unless the flag
+    // kept a claim reference (flag-off claims are resolved inline by hydrate).
+    resolve_cursor_claim_refs(ws, &result_store).await;
     let result = match orchestrator.evaluate_state(
         ws,
         latest_ts,


### PR DESCRIPTION
## What

**Phase 2 (orchestrator side)** of references-in-state ([noetl/ai-meta#101](https://github.com/noetl/ai-meta/issues/101)) — the core mechanism. New `NOETL_REFS_IN_STATE` flag (default **off**). When on, `hydrate_result_references` **stops resolving** over-budget result references back to inline data: if the reference carries an `extracted` predicate block ([worker#91](https://github.com/noetl/worker/pull/91), phase 1), it sets the readable `context.data` to `extracted` and **keeps** the `reference` block — instead of splicing the full payload into the event (and thus the state + every command context).

Clean seam: `extract_user_data` reads `context.data` (now `extracted`) for `when:`/`set:`/`output` evaluation **with no change**; `build_context` carries the reference through. References without `extracted` (pre-phase-1) fall back to resolve, so behavior is unchanged there.

## Why this is the core fix

The orchestrator deliberately rehydrates over-budget references to inline data so it can evaluate guards / fan out cursors — which re-injects megabytes into the state and every `command.issued` (a 1.7MB drain → 5MB command). With `extracted` available, the orchestrator evaluates off the small predicate block and leaves the bulk payload in the store.

## Default off — safe

The gate defaults off → block-b's resolve-inline behavior is preserved **exactly**. **666 tests + clippy green** (no regression). Threaded `keep_refs` through `rebuild_state` + the 4 hydrate sites + 2 `rebuild_state` callers.

## Remaining for the flag-on path (follow-ups, scoped on #101)

The flag-on path is **not yet end-to-end** — it needs:
1. **Worker resolve** — resolve `reference` blocks in `render_context` at render time so full-data templates (`{{ drain.messages }}`) still get the payload (the worker has no automatic resolution today — only the explicit `artifact` tool).
2. **Cursor-claim handling** — referenced claims fan out as per-row references.

So this PR is safe to land (default off) as the orchestrator-side foundation; the flag flips on once the worker piece lands.

> Note: `advance_snapshot` (on the CQRS stack, not this off-main branch) also calls `rebuild_state` — its call site needs `keep_refs` threaded at merge.

Refs noetl/ai-meta#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)