### PR TITLE
feat(plugins): plug-in module registry endpoints (v3.11.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-server"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-server"
-version = "3.10.0"
+version = "3.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -43,6 +43,19 @@ pub struct AppConfig {
     #[serde(default)]
     pub disable_metrics: bool,
 
+    /// References-in-state (noetl/ai-meta#101 phase 2).  When true, the
+    /// orchestrator stops resolving over-budget result references back to inline
+    /// data — it keeps `{reference, extracted}` on the event so the state +
+    /// command context carry references, not bulk payloads (a 1.7MB step output
+    /// no longer balloons every `command.issued`).  The orchestrator evaluates
+    /// `when:`/`set:` off the small `extracted` predicate block; the worker
+    /// resolves the full reference at render time.  Envy maps
+    /// `NOETL_REFS_IN_STATE`.  **Default false** — preserves block-b's
+    /// resolve-inline behavior exactly until the consume side (worker resolve +
+    /// cursor-claim handling) is in place.
+    #[serde(default)]
+    pub refs_in_state: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -153,6 +166,7 @@ impl Default for AppConfig {
             nats_url: None,
             enable_gcp_token_api: true,
             disable_metrics: false,
+            refs_in_state: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -6,6 +6,7 @@ pub mod catalog;
 pub mod credential;
 pub mod event;
 pub mod keychain;
+pub mod plugin_module;
 pub mod result_store;
 pub mod secret_audit;
 pub mod subscription_dedup;

--- a/src/db/queries/plugin_module.rs
+++ b/src/db/queries/plugin_module.rs
@@ -1,0 +1,109 @@
+//! `noetl.plugin_module` queries — the server-side plug-in module registry
+//! (noetl/ai-meta#105 Round 4).
+//!
+//! This is the durable backing for the worker's `PluginSource`: the system
+//! worker pool's wasmtime host fetches a compiled plug-in module by
+//! `(path, version)` and verifies its `digest`, then caches it by
+//! `(path, version, digest)`. A catalog version bump publishes a new row, so the
+//! next worker claim fetches + compiles the new module — the hot-reload path.
+//!
+//! Per [the data-access boundary](https://github.com/noetl/noetl/blob/main/agents/rules/data-access-boundary.md)
+//! plug-in modules are NoETL-owned data: workers reach them through the server
+//! API, never the table directly. The module bytes are stored as `BYTEA` (wasm
+//! or, during the hybrid phase, WAT the host compiles).
+//!
+//! Pattern mirrors `db::queries::result_store` — startup-time `CREATE TABLE IF
+//! NOT EXISTS`, no out-of-band migration file.
+
+use sqlx::Row;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+
+/// A stored plug-in module.
+#[derive(Debug, Clone)]
+pub struct PluginModuleRow {
+    /// SHA-256 hex digest of `bytes` — the integrity check the worker pins in
+    /// its cache key.
+    pub digest: String,
+    /// Media type (`application/wasm`, or `text/wat` during the hybrid phase).
+    pub media_type: String,
+    /// The module bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// Idempotent table creation. Runs once at startup so the schema lands on first
+/// boot without an out-of-band migration step. Owned end-to-end by noetl-server.
+pub async fn ensure_table(pool: &DbPool) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS noetl.plugin_module (
+            path        TEXT NOT NULL,
+            version     INTEGER NOT NULL,
+            digest      TEXT NOT NULL,
+            media_type  TEXT NOT NULL DEFAULT 'application/wasm',
+            bytes       BYTEA NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (path, version)
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Register (or replace) a module at `(path, version)`. A version is normally
+/// immutable — the hot-reload model bumps the version rather than mutating a
+/// row — but `ON CONFLICT DO UPDATE` keeps registration idempotent and allows
+/// dev-time fixups; the `digest` always reflects the current bytes.
+pub async fn upsert(
+    pool: &DbPool,
+    path: &str,
+    version: i32,
+    digest: &str,
+    media_type: &str,
+    bytes: &[u8],
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.plugin_module (path, version, digest, media_type, bytes)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (path, version) DO UPDATE
+          SET digest = EXCLUDED.digest,
+              media_type = EXCLUDED.media_type,
+              bytes = EXCLUDED.bytes,
+              created_at = now()
+        "#,
+    )
+    .bind(path)
+    .bind(version)
+    .bind(digest)
+    .bind(media_type)
+    .bind(bytes)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Fetch the module at `(path, version)`, or `None` (caller → HTTP 404).
+pub async fn get(pool: &DbPool, path: &str, version: i32) -> AppResult<Option<PluginModuleRow>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT digest, media_type, bytes
+        FROM noetl.plugin_module
+        WHERE path = $1 AND version = $2
+        LIMIT 1
+        "#,
+    )
+    .bind(path)
+    .bind(version)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().next().map(|r| PluginModuleRow {
+        digest: r.get::<String, _>("digest"),
+        media_type: r.get::<String, _>("media_type"),
+        bytes: r.get::<Vec<u8>, _>("bytes"),
+    }))
+}

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -203,6 +203,14 @@ pub struct CursorFrame {
     pub claim_rows: Vec<serde_json::Value>,
     pub body_issued: usize,
     pub body_completed: usize,
+    /// References-in-state (noetl/ai-meta#101 phase 2): when the claim result is
+    /// over budget the orchestrator keeps the reference instead of the inline
+    /// rows, so `claim_rows` can't be filled in the sync `apply_event` pass.
+    /// The `noetl://` URI is stashed here; `trigger_orchestrator` resolves it
+    /// (async) into `claim_rows` before the cursor drive runs.  `None` on the
+    /// common inline path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_ref: Option<String>,
 }
 
 impl StepInfo {
@@ -750,6 +758,16 @@ impl WorkflowState {
                         .and_then(|d| d.get("rows"))
                         .and_then(|r| r.as_array())
                         .cloned();
+                    // References-in-state (noetl/ai-meta#101 phase 2): when the
+                    // claim is over budget the orchestrator kept the reference,
+                    // so there are no inline `rows` here.  Capture the URI so the
+                    // async pre-drive pass can resolve it into `claim_rows` —
+                    // otherwise the cursor would see 0 rows and wrongly DRAIN.
+                    let claim_ref = if rows.is_none() {
+                        event.result.as_ref().and_then(result_reference_uri)
+                    } else {
+                        None
+                    };
                     let step = self
                         .steps
                         .entry(name.clone())
@@ -758,10 +776,15 @@ impl WorkflowState {
                     // must not overwrite the cursor step's result (the drive
                     // block sets it on drain).
                     if step.is_cursor {
-                        if let (Some(cid), Some(rows)) = (cid, rows) {
+                        if let Some(cid) = cid {
                             if let Some((phase, frame)) = step.cursor_issued.get(&cid).cloned() {
                                 if phase == "claim" {
-                                    step.cursor_frames.entry(frame).or_default().claim_rows = rows;
+                                    let f = step.cursor_frames.entry(frame).or_default();
+                                    if let Some(rows) = rows {
+                                        f.claim_rows = rows;
+                                    } else if let Some(cref) = claim_ref {
+                                        f.claim_ref = Some(cref);
+                                    }
                                 }
                             }
                         }
@@ -1057,6 +1080,17 @@ pub fn apply_set_mutations(
 /// that reference `{{ step_name.field }}` in next.arcs / step.when
 /// see an undefined value because the envelope's `status` /
 /// `context` keys swallowed the user fields.
+/// Locate a `noetl://` result-reference URI on an event result envelope
+/// (references-in-state, noetl/ai-meta#101 phase 2).  Nested envelope:
+/// `context.result.reference.ref`; top-level: `reference.ref`.
+pub(crate) fn result_reference_uri(result: &serde_json::Value) -> Option<String> {
+    result
+        .pointer("/context/result/reference/ref")
+        .and_then(|v| v.as_str())
+        .or_else(|| result.pointer("/reference/ref").and_then(|v| v.as_str()))
+        .map(str::to_string)
+}
+
 pub(crate) fn extract_user_data(result: &serde_json::Value) -> Option<serde_json::Value> {
     if result.is_null() {
         return None;

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1320,6 +1320,7 @@ fn event_status_from_name(event_name: &str) -> &'static str {
 async fn hydrate_result_references(
     events: &mut [crate::db::models::Event],
     result_store: &crate::services::result_store::ResultStoreService,
+    keep_refs: bool,
 ) {
     use crate::services::result_store::parse_noetl_ref;
 
@@ -1331,6 +1332,7 @@ async fn hydrate_result_references(
     }
 
     let mut hydrated = 0usize;
+    let mut kept = 0usize;
     for ev in events.iter_mut() {
         let Some(result) = ev.result.as_mut() else {
             continue;
@@ -1346,6 +1348,45 @@ async fn hydrate_result_references(
         } else {
             continue;
         };
+
+        // References-in-state (noetl/ai-meta#101 phase 2): when gated on AND the
+        // reference carries an `extracted` predicate block (phase 1), keep the
+        // reference and surface `extracted` as the readable `context.data` —
+        // instead of resolving the full payload inline.  `extract_user_data`
+        // then reads `extracted` for `when:`/`set:` evaluation; the reference
+        // block stays on the event so `build_context` carries it and the worker
+        // resolves the bulk payload at render time.  No `extracted` (pre-phase-1
+        // refs) falls through to the resolve path below for back-compat.
+        if keep_refs {
+            let extracted = match shape {
+                Shape::Nested => result
+                    .pointer("/context/result/reference/extracted")
+                    .cloned(),
+                Shape::TopLevel => result.pointer("/reference/extracted").cloned(),
+            };
+            if let Some(extracted) = extracted {
+                let data = serde_json::json!({ "data": extracted });
+                match shape {
+                    Shape::Nested => {
+                        if let Some(inner) = result
+                            .get_mut("context")
+                            .and_then(|c| c.get_mut("result"))
+                            .and_then(|r| r.as_object_mut())
+                        {
+                            inner.insert("context".to_string(), data);
+                            kept += 1;
+                        }
+                    }
+                    Shape::TopLevel => {
+                        if let Some(obj) = result.as_object_mut() {
+                            obj.insert("context".to_string(), data);
+                            kept += 1;
+                        }
+                    }
+                }
+                continue; // keep the reference; do not resolve
+            }
+        }
 
         let parsed = match parse_noetl_ref(&ref_uri) {
             Ok(p) => p,
@@ -1389,8 +1430,11 @@ async fn hydrate_result_references(
             }
         }
     }
-    if hydrated > 0 {
-        debug!(hydrated, "hydrate_result_references: resolved over-budget result references");
+    if hydrated > 0 || kept > 0 {
+        debug!(
+            hydrated,
+            kept, "hydrate_result_references: resolved / kept-by-reference over-budget results"
+        );
     }
 }
 
@@ -1469,6 +1513,7 @@ async fn rebuild_state(
     pool: &crate::db::DbPool,
     result_store: &crate::services::result_store::ResultStoreService,
     execution_id: i64,
+    keep_refs: bool,
 ) -> AppResult<RebuildResult> {
     use crate::services::orch_snapshot;
     match orch_snapshot::load_latest(pool, execution_id).await? {
@@ -1488,7 +1533,7 @@ async fn rebuild_state(
                 .fetch_all(pool)
                 .await?,
             );
-            hydrate_result_references(&mut events_since, result_store).await;
+            hydrate_result_references(&mut events_since, result_store, keep_refs).await;
             let mut ws = snap.state;
             for e in &events_since {
                 ws.apply_event(e);
@@ -1516,7 +1561,7 @@ async fn rebuild_state(
                 .fetch_all(pool)
                 .await?,
             );
-            hydrate_result_references(&mut all_events, result_store).await;
+            hydrate_result_references(&mut all_events, result_store, keep_refs).await;
             let state = crate::engine::state::WorkflowState::from_events(&all_events)
                 .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
             let last_event_id = all_events.last().map(|e| e.event_id).unwrap_or(0);
@@ -1657,7 +1702,7 @@ async fn trigger_orchestrator_inner(
     // the full (still-small) early log when no snapshot exists yet.
     let mut did_rebuild = false;
     if cache.state.is_none() {
-        let r = rebuild_state(pool, &result_store, execution_id).await?;
+        let r = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await?;
         cache.state = Some(r.state);
         cache.last_event_id = r.last_event_id;
         cache.applied_count = total.unwrap_or(0);
@@ -1684,7 +1729,7 @@ async fn trigger_orchestrator_inner(
             .fetch_all(pool)
             .await?,
         );
-        hydrate_result_references(&mut strag, &result_store).await;
+        hydrate_result_references(&mut strag, &result_store, state.config.refs_in_state).await;
         if let Some(ws) = cache.state.as_mut() {
             for e in &strag {
                 ws.apply_event(e);
@@ -1710,7 +1755,7 @@ async fn trigger_orchestrator_inner(
         .fetch_all(pool)
         .await?,
     );
-    hydrate_result_references(&mut new_events, &result_store).await;
+    hydrate_result_references(&mut new_events, &result_store, state.config.refs_in_state).await;
 
     // Trigger type + drain timestamp.  The trigger event is normally among the
     // new events; after a cold rebuild / straggler apply that already folded it
@@ -1733,7 +1778,7 @@ async fn trigger_orchestrator_inner(
     // incremental apply.
     let mismatch = matches!(total, Some(t) if cache.applied_count + new_events.len() as i64 != t);
     if mismatch {
-        let r = rebuild_state(pool, &result_store, execution_id).await?;
+        let r = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await?;
         cache.state = Some(r.state);
         cache.last_event_id = r.last_event_id;
         cache.applied_count = total.unwrap_or(cache.applied_count);

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1509,6 +1509,61 @@ const REBUILD_STRAGGLER_MARGIN_SECS: i64 = 30;
 /// full-log replay that OOM'd the server at scale: a straggler below the
 /// incremental watermark used to trigger a reload of the entire (growing) event
 /// log on nearly every completion under high concurrency.
+/// Resolve over-budget cursor claim references into inline `claim_rows` before
+/// the drive runs (references-in-state, noetl/ai-meta#101 phase 2).  A referenced
+/// claim has `claim_ref` set + empty `claim_rows` (the sync `apply_event` can't
+/// resolve); this async pass fills the rows so the cursor fans out instead of
+/// wrongly draining.  No-op unless the flag kept a claim reference.
+async fn resolve_cursor_claim_refs(
+    ws: &mut crate::engine::state::WorkflowState,
+    result_store: &crate::services::result_store::ResultStoreService,
+) {
+    use crate::services::result_store::parse_noetl_ref;
+    for step in ws.steps.values_mut() {
+        if !step.is_cursor {
+            continue;
+        }
+        for frame in step.cursor_frames.values_mut() {
+            if !frame.claim_rows.is_empty() {
+                continue;
+            }
+            let Some(uri) = frame.claim_ref.clone() else {
+                continue;
+            };
+            let parsed = match parse_noetl_ref(&uri) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(uri, %e, "cursor claim reference unparseable; left as drain");
+                    continue;
+                }
+            };
+            match result_store.resolve(&parsed).await {
+                Ok(Some(data)) => match extract_claim_rows(&data) {
+                    Some(rows) => {
+                        frame.claim_rows = rows;
+                        frame.claim_ref = None;
+                    }
+                    None => warn!(uri, "cursor claim reference resolved but no rows array found"),
+                },
+                Ok(None) => warn!(uri, "cursor claim reference not found in store"),
+                Err(e) => warn!(uri, %e, "cursor claim reference resolve failed"),
+            }
+        }
+    }
+}
+
+/// Pull the claimed rows array out of a resolved claim payload, trying the
+/// common shapes the store may hold for a tool result.
+fn extract_claim_rows(data: &serde_json::Value) -> Option<Vec<serde_json::Value>> {
+    for ptr in ["/rows", "/data/rows", "/result/rows", "/context/data/rows"] {
+        if let Some(arr) = data.pointer(ptr).and_then(|v| v.as_array()) {
+            return Some(arr.clone());
+        }
+    }
+    crate::engine::state::extract_user_data(data)
+        .and_then(|d| d.get("rows").and_then(|r| r.as_array()).cloned())
+}
+
 async fn rebuild_state(
     pool: &crate::db::DbPool,
     result_store: &crate::services::result_store::ResultStoreService,
@@ -1860,6 +1915,12 @@ async fn trigger_orchestrator_inner(
     // 3. Evaluate against the cached state.
     let orchestrator = WorkflowOrchestrator::new();
     let ws = cache.state.as_mut().unwrap();
+    // References-in-state (noetl/ai-meta#101 phase 2): resolve any over-budget
+    // cursor claim references into inline rows before the drive reads them — a
+    // referenced claim has `claim_ref` set + empty `claim_rows`, and without
+    // this the cursor would see 0 rows and wrongly DRAIN.  No-op unless the flag
+    // kept a claim reference (flag-off claims are resolved inline by hydrate).
+    resolve_cursor_claim_refs(ws, &result_store).await;
     let result = match orchestrator.evaluate_state(
         ws,
         latest_ts,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod health;
 pub mod ingress;
 pub mod internal;
 pub mod keychain;
+pub mod plugins;
 pub mod replay;
 pub mod result_store;
 pub mod runtime;

--- a/src/handlers/plugins.rs
+++ b/src/handlers/plugins.rs
@@ -1,0 +1,114 @@
+//! Plug-in module registry endpoints (noetl/ai-meta#105 Round 4) — the live
+//! `PluginSource` backend the system worker pool's wasmtime host fetches from.
+//!
+//! - `POST /api/internal/plugins/{*path}?version=N` — register a compiled module
+//!   (raw wasm/WAT body); the server computes the SHA-256 digest and stores it.
+//! - `GET  /api/internal/plugins/{*path}?version=N[&digest=X]` — serve the module
+//!   bytes; if `digest` is supplied it must match (the worker pins it in its
+//!   cache key), else 409.
+//!
+//! `{*path}` is a catch-all so plug-in paths with slashes (`system/materialiser`)
+//! resolve. These live under `/api/internal/*`, the same service-account-gated
+//! family as the other internal endpoints — per
+//! [the data-access boundary](https://github.com/noetl/noetl/blob/main/agents/rules/data-access-boundary.md)
+//! workers reach NoETL-owned data only through the server API.
+
+use axum::{
+    body::Bytes,
+    extract::{Path, Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::db::{queries::plugin_module, DbPool};
+use crate::error::AppResult;
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterQuery {
+    pub version: i32,
+    #[serde(default)]
+    pub media_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegisterResponse {
+    pub path: String,
+    pub version: i32,
+    pub digest: String,
+    pub bytes: usize,
+}
+
+/// `POST /api/internal/plugins/{*path}?version=N` — register a module from the
+/// raw request body. The server is the digest authority: it hashes the bytes
+/// and stores `(path, version, digest, bytes)`.
+pub async fn register(
+    State(pool): State<DbPool>,
+    Path(path): Path<String>,
+    Query(q): Query<RegisterQuery>,
+    body: Bytes,
+) -> AppResult<Json<RegisterResponse>> {
+    let digest = hex::encode(Sha256::digest(&body));
+    let media_type = q
+        .media_type
+        .unwrap_or_else(|| "application/wasm".to_string());
+    plugin_module::upsert(&pool, &path, q.version, &digest, &media_type, &body).await?;
+    tracing::info!(
+        plugin_path = %path,
+        version = q.version,
+        digest = %digest,
+        bytes = body.len(),
+        "registered plug-in module"
+    );
+    Ok(Json(RegisterResponse {
+        path,
+        version: q.version,
+        digest,
+        bytes: body.len(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FetchQuery {
+    pub version: i32,
+    #[serde(default)]
+    pub digest: Option<String>,
+}
+
+/// `GET /api/internal/plugins/{*path}?version=N[&digest=X]` — serve the module
+/// bytes, content-typed by its media type and carrying the digest as an ETag.
+pub async fn fetch(
+    State(pool): State<DbPool>,
+    Path(path): Path<String>,
+    Query(q): Query<FetchQuery>,
+) -> AppResult<Response> {
+    let Some(row) = plugin_module::get(&pool, &path, q.version).await? else {
+        return Ok((
+            StatusCode::NOT_FOUND,
+            format!("plug-in {path}@{} not found", q.version),
+        )
+            .into_response());
+    };
+    if let Some(expected) = q.digest.as_deref() {
+        if expected != row.digest {
+            return Ok((
+                StatusCode::CONFLICT,
+                format!(
+                    "digest mismatch for {path}@{}: stored {}, requested {}",
+                    q.version, row.digest, expected
+                ),
+            )
+                .into_response());
+        }
+    }
+    Ok((
+        [
+            (header::CONTENT_TYPE, row.media_type),
+            (header::ETAG, format!("\"{}\"", row.digest)),
+        ],
+        row.bytes,
+    )
+        .into_response())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,6 +404,13 @@ fn build_router(
             "/api/internal/cleanup/purge",
             post(handlers::internal::cleanup_purge),
         )
+        // Plug-in module registry (noetl/ai-meta#105 Round 4) — the live
+        // PluginSource backend the system worker pool's wasmtime host fetches
+        // from. Catch-all `{*path}` so `system/materialiser`-style paths resolve.
+        .route(
+            "/api/internal/plugins/{*path}",
+            post(handlers::plugins::register).get(handlers::plugins::fetch),
+        )
         .with_state(db_pool.clone());
 
     // Gateway push-ingress config endpoint (noetl/ai-meta#90 Phase 3).  The
@@ -700,6 +707,10 @@ async fn main() -> anyhow::Result<()> {
     // pattern as secret_audit above.  The table is server-owned end-to-end;
     // no out-of-band migration required.
     noetl_server::db::queries::result_store::ensure_table(&db_pool).await?;
+    // Plug-in module registry (noetl/ai-meta#105 Round 4) — the durable backing
+    // for the system worker pool's wasmtime PluginSource.  Same idempotent
+    // startup-DDL pattern; server-owned end-to-end.
+    noetl_server::db::queries::plugin_module::ensure_table(&db_pool).await?;
     // Opt-in subscription dedup window (noetl/ai-meta#90 Phase 7, RFC §10
     // OQ1) — same idempotent startup-DDL pattern.  The table is server-owned
     // (only /api/execute writes it) and bounded by age; dedup is opt-in per


### PR DESCRIPTION
The server-side half of the WASM plug-in capability (noetl/ai-meta#105 Round 4):
the durable backing for the system worker pool's `PluginSource`, so the
wasmtime host (shipped in [noetl/worker#93](https://github.com/noetl/worker/pull/93))
can fetch a compiled module by catalog identity and pin its digest.

## What lands

- **`noetl.plugin_module` table** (`db::queries::plugin_module`) — keyed by
  `(path, version)`, stores `digest` (SHA-256 of the bytes), `media_type`, and
  the module `bytes` (BYTEA: wasm, or WAT during the hybrid phase). Idempotent
  startup DDL + insert/get, mirroring `result_store`; server-owned end-to-end.
- **`POST /api/internal/plugins/{*path}?version=N`** — register a module from the
  raw body; the server is the digest authority (hashes + stores).
- **`GET /api/internal/plugins/{*path}?version=N[&digest=X]`** — serve the bytes,
  content-typed by media type, digest as ETag; 404 if absent, 409 on digest
  mismatch (the worker pins the digest in its cache key).

Catch-all `{*path}` so `system/materialiser`-style paths resolve. Under
`/api/internal/*`, the service-account-gated family — workers reach NoETL-owned
data only through the server API (data-access boundary).

## Validation

Build + clippy clean; 666 existing tests unaffected. The endpoint mirrors the
proven `result_store` DDL+insert+get pattern. The live DB path is validated on
kind before deploy; it is **unconsumed** until the worker HTTP `PluginSource`
lands (Round 4b), so it cannot change runtime behavior meanwhile.

Closes noetl/server#209
Refs noetl/ai-meta#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)