### PR TITLE
feat(objects): object-store endpoint — the Feather tier (v3.12.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-server"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-server"
-version = "3.11.0"
+version = "3.12.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -7,6 +7,7 @@ pub mod credential;
 pub mod event;
 pub mod keychain;
 pub mod plugin_module;
+pub mod object_store;
 pub mod result_store;
 pub mod secret_audit;
 pub mod subscription_dedup;

--- a/src/db/queries/object_store.rs
+++ b/src/db/queries/object_store.rs
@@ -1,0 +1,100 @@
+//! `noetl.object_store` queries — the durable object tier for large result
+//! payloads (Arrow Feather, etc.), keyed by the §7 physical object key
+//! (noetl/ai-meta#105 Round 5).
+//!
+//! This is the server-mediated backend for a plug-in's `noetl.object_put`
+//! capability: the system worker pool writes the Feather bytes through the
+//! server API at the cell/shard physical key, so placement, audit, and the
+//! [data-access boundary](https://github.com/noetl/noetl/blob/main/agents/rules/data-access-boundary.md)
+//! stay enforced — workers never touch the object store directly.
+//!
+//! This first tier stores bytes as `BYTEA` in Postgres, mirroring
+//! `db::queries::plugin_module` and `result_store`. A gcs / s3 / Ceph backend
+//! behind the same endpoint is a config-swappable follow-up; the HTTP contract
+//! is the stable surface.
+
+use sqlx::Row;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+
+/// A stored object.
+#[derive(Debug, Clone)]
+pub struct ObjectRow {
+    /// SHA-256 hex digest of the bytes.
+    pub digest: String,
+    /// Media type (`application/vnd.apache.arrow.feather`, …).
+    pub media_type: String,
+    /// The object bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// Idempotent table creation at startup; server-owned end to end.
+pub async fn ensure_table(pool: &DbPool) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS noetl.object_store (
+            object_key  TEXT PRIMARY KEY,
+            digest      TEXT NOT NULL,
+            media_type  TEXT NOT NULL DEFAULT 'application/octet-stream',
+            bytes       BYTEA NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Write (or overwrite) the object at `object_key`. Object writes are
+/// content-addressed by the §7 key, so a re-write at the same key (a retry)
+/// replaces the bytes idempotently — `digest` always reflects the current
+/// bytes.
+pub async fn put(
+    pool: &DbPool,
+    object_key: &str,
+    digest: &str,
+    media_type: &str,
+    bytes: &[u8],
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO noetl.object_store (object_key, digest, media_type, bytes)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (object_key) DO UPDATE
+          SET digest = EXCLUDED.digest,
+              media_type = EXCLUDED.media_type,
+              bytes = EXCLUDED.bytes,
+              created_at = now()
+        "#,
+    )
+    .bind(object_key)
+    .bind(digest)
+    .bind(media_type)
+    .bind(bytes)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Fetch the object at `object_key`, or `None` (caller → HTTP 404).
+pub async fn get(pool: &DbPool, object_key: &str) -> AppResult<Option<ObjectRow>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT digest, media_type, bytes
+        FROM noetl.object_store
+        WHERE object_key = $1
+        LIMIT 1
+        "#,
+    )
+    .bind(object_key)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().next().map(|r| ObjectRow {
+        digest: r.get::<String, _>("digest"),
+        media_type: r.get::<String, _>("media_type"),
+        bytes: r.get::<Vec<u8>, _>("bytes"),
+    }))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -16,6 +16,7 @@ pub mod ingress;
 pub mod internal;
 pub mod keychain;
 pub mod plugins;
+pub mod objects;
 pub mod replay;
 pub mod result_store;
 pub mod runtime;

--- a/src/handlers/objects.rs
+++ b/src/handlers/objects.rs
@@ -1,0 +1,76 @@
+//! Object-store endpoints (noetl/ai-meta#105 Round 5) — the server-mediated
+//! backend for a plug-in's `noetl.object_put` capability (the Feather tier).
+//!
+//! - `PUT /api/internal/objects/{*key}` — write an object (raw body) at the §7
+//!   physical key; the server computes the SHA-256 digest and stores it.
+//! - `GET /api/internal/objects/{*key}` — read the object bytes back.
+//!
+//! `{*key}` is a catch-all so the slash-bearing §7 key
+//! (`noetl/env=…/region=…/cell=…/shard=…/…/results/<step>/<frame>/<row>/<attempt>.feather`)
+//! resolves. Under `/api/internal/*`, the service-account-gated family —
+//! workers reach NoETL-owned data only through the server API.
+
+use axum::{
+    body::Bytes,
+    extract::{Path, Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::db::{queries::object_store, DbPool};
+use crate::error::AppResult;
+
+#[derive(Debug, Deserialize)]
+pub struct PutQuery {
+    #[serde(default)]
+    pub media_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PutResponse {
+    pub key: String,
+    pub digest: String,
+    pub bytes: usize,
+}
+
+/// `PUT /api/internal/objects/{*key}` — store the raw body at `key`.
+pub async fn put(
+    State(pool): State<DbPool>,
+    Path(key): Path<String>,
+    Query(q): Query<PutQuery>,
+    body: Bytes,
+) -> AppResult<Json<PutResponse>> {
+    let digest = hex::encode(Sha256::digest(&body));
+    let media_type = q
+        .media_type
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    object_store::put(&pool, &key, &digest, &media_type, &body).await?;
+    tracing::debug!(object_key = %key, digest = %digest, bytes = body.len(), "stored object");
+    Ok(Json(PutResponse {
+        key,
+        digest,
+        bytes: body.len(),
+    }))
+}
+
+/// `GET /api/internal/objects/{*key}` — serve the object bytes, content-typed by
+/// its media type with the digest as an ETag.
+pub async fn get(
+    State(pool): State<DbPool>,
+    Path(key): Path<String>,
+) -> AppResult<Response> {
+    let Some(row) = object_store::get(&pool, &key).await? else {
+        return Ok((StatusCode::NOT_FOUND, format!("object {key} not found")).into_response());
+    };
+    Ok((
+        [
+            (header::CONTENT_TYPE, row.media_type),
+            (header::ETAG, format!("\"{}\"", row.digest)),
+        ],
+        row.bytes,
+    )
+        .into_response())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,6 +411,13 @@ fn build_router(
             "/api/internal/plugins/{*path}",
             post(handlers::plugins::register).get(handlers::plugins::fetch),
         )
+        // Object store (noetl/ai-meta#105 Round 5) — server-mediated backend for
+        // a plug-in's `noetl.object_put` capability (the Feather tier), keyed by
+        // the §7 physical object key.
+        .route(
+            "/api/internal/objects/{*key}",
+            put(handlers::objects::put).get(handlers::objects::get),
+        )
         .with_state(db_pool.clone());
 
     // Gateway push-ingress config endpoint (noetl/ai-meta#90 Phase 3).  The
@@ -711,6 +718,9 @@ async fn main() -> anyhow::Result<()> {
     // for the system worker pool's wasmtime PluginSource.  Same idempotent
     // startup-DDL pattern; server-owned end-to-end.
     noetl_server::db::queries::plugin_module::ensure_table(&db_pool).await?;
+    // Object store (noetl/ai-meta#105 Round 5) — durable Feather tier backing a
+    // plug-in's `noetl.object_put`. Same idempotent startup-DDL pattern.
+    noetl_server::db::queries::object_store::ensure_table(&db_pool).await?;
     // Opt-in subscription dedup window (noetl/ai-meta#90 Phase 7, RFC §10
     // OQ1) — same idempotent startup-DDL pattern.  The table is server-owned
     // (only /api/execute writes it) and bounded by age; dedup is opt-in per


### PR DESCRIPTION
The Feather-tier object store (noetl/ai-meta#105 Round 5) — the
server-mediated backend for a plug-in's `noetl.object_put` capability, so
the system worker pool writes Feather bytes through the server API at the
§7 physical object key rather than touching the object store directly
(data-access boundary).

## What lands

- **`noetl.object_store` table** keyed by the physical `object_key`
  (`db::queries::object_store`) — `digest` (SHA-256), `media_type`, `bytes`
  (BYTEA). Idempotent startup DDL + put/get, mirroring `plugin_module`. The
  first tier is Postgres BYTEA; a **gcs / s3 / Ceph** backend behind the
  same endpoint is a config-swappable follow-up — the HTTP contract is the
  stable surface.
- **`PUT /api/internal/objects/{*key}`** — write the raw body at the key;
  the server is the digest authority.
- **`GET /api/internal/objects/{*key}`** — serve the bytes, content-typed,
  digest as ETag; 404 if absent.

Catch-all `{*key}` so the slash-bearing §7 key
(`noetl/env=…/region=…/…/results/<step>/<frame>/<row>/<attempt>.feather`)
resolves. Under `/api/internal/*` (service-account-gated).

## Validation

Build + clippy clean. The DB path mirrors the proven `plugin_module` +
`result_store` pattern; kind-validated before deploy. Unconsumed until the
worker `apply_intents` repoint (follow-up), so no runtime behavior change
meanwhile.

Closes noetl/server#211
Refs noetl/ai-meta#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)