### PR TITLE
feat(playbook): accept tool_kind "wasm" in the playbook schema

### DIFF
--- a/src/playbook/types.rs
+++ b/src/playbook/types.rs
@@ -43,6 +43,12 @@ pub enum ToolKind {
     /// through the noetl-tools registry; the server only needs to accept
     /// the kind so playbook validation passes.
     Subscription,
+    /// Compiled WASM system plug-in (noetl/ai-meta#105). The step's tool
+    /// carries `plugin: { path, version }` (+ optional `input`); the server
+    /// only accepts the kind so playbook validation passes, and the worker's
+    /// `wasm-plugin` dispatcher routes `tool_kind: "wasm"` to the host (load
+    /// from the catalog → run → flush capability intents).
+    Wasm,
 }
 
 impl std::fmt::Display for ToolKind {
@@ -72,6 +78,7 @@ impl std::fmt::Display for ToolKind {
             ToolKind::TaskSequence => "task_sequence",
             ToolKind::Rhai => "rhai",
             ToolKind::Subscription => "subscription",
+            ToolKind::Wasm => "wasm",
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
The strict `ToolKind` enum rejected `tool: { kind: wasm }` at playbook
registration ("did not match any variant of ToolDefinition"), blocking the
WASM dispatch path (noetl/ai-meta#105). Adds a `Wasm` variant — same
pattern as `Subscription`: the server only accepts the kind so validation
passes; it renders to `"wasm"` in the command, and the worker's
`wasm-plugin` dispatcher routes it to the host.

## Validated live on kind (the WASM capstone)

With the feature-on worker (v5.30.0, `wasm-plugin` default) + the server's
plug-in registry + object-store endpoints (v3.12.0):

1. Registered the reference plug-in: `POST /api/internal/plugins/system/reference-materializer?version=1` (digest `c6bd7d05…`).
2. Ran a `tool: { kind: wasm, plugin: { path: system/reference-materializer, version: 1 } }` playbook.
3. Result: **`playbook.completed`**; the step shows `command.issued → claimed → started → call.done`; the plug-in's `object_put` **landed in `noetl.object_store`** at `noetl/results/reference/0/0/1.feather`.

End to end: server accepts the wasm tool → emits `tool_kind: "wasm"` →
worker routes to the host → digest resolved from the registry → plug-in
loaded + run → capability flushed to the object store.

Closes noetl/server#213
Refs noetl/ai-meta#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)