### PR TITLE
fix(cqrs): pass refs_in_state to rebuild_state (unbreak v3.15.0 build)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1693,7 +1693,7 @@ pub(crate) async fn advance_snapshot(
         pool.clone(),
         state.snowflake.clone(),
     );
-    let r = rebuild_state(pool, &result_store, execution_id).await?;
+    let r = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await?;
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
         .bind(execution_id)
         .fetch_one(pool)


### PR DESCRIPTION
The #215 rebase added a `rebuild_state` call in the projection/advance handler with the old 3-arg signature; main's `rebuild_state` now takes a 4th `keep_refs: bool`. v3.15.0 shipped non-compiling. Pass `state.config.refs_in_state` (matching the sibling call sites). Lib builds clean.

Refs noetl/ai-meta#103