### PR TITLE
feat(orchestrate-core): move the playbook type model into the core (#108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,9 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "minijinja",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 2.0.18",
 ]
 

--- a/orchestrate-core/Cargo.toml
+++ b/orchestrate-core/Cargo.toml
@@ -11,6 +11,10 @@ license = "Apache-2.0"
 # for the filter set the evaluator uses.  Proven to compile to wasm32-unknown-unknown
 # with no WASI imports (noetl/ai-meta#108 spike).
 minijinja = { version = "2.5", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.22"
 thiserror = "2.0"
+
+[dev-dependencies]
+serde_yaml = "0.9"

--- a/orchestrate-core/src/lib.rs
+++ b/orchestrate-core/src/lib.rs
@@ -16,4 +16,5 @@
 //! the first slice; `evaluator`, `state`, `commands`, and `orchestrator` follow.
 
 pub mod error;
+pub mod playbook;
 pub mod template;

--- a/orchestrate-core/src/playbook.rs
+++ b/orchestrate-core/src/playbook.rs
@@ -11,6 +11,37 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Residency policy for a [`KeychainDef`] — part of the playbook model, so it
+/// lives in the core with the rest of the types (noetl/ai-meta#108).  The
+/// server's `secrets::residency` module re-exports this enum and holds the
+/// region-check *logic* (which needs server-only deps); the enum itself is pure
+/// data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Residency {
+    /// No check; resolution proceeds regardless of server region.
+    /// Back-compat default for entries without an explicit policy.
+    #[default]
+    None,
+    /// Check but proceed on mismatch — observability without enforcement.
+    /// Used during the migration window before flipping to `strict`.
+    Advisory,
+    /// Fail-closed on mismatch; resolution short-circuits before any provider
+    /// call (the server maps this to an `AppError::ResidencyViolation`).
+    Strict,
+}
+
+impl Residency {
+    /// Stable metric label for this policy.
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Residency::None => "none",
+            Residency::Advisory => "advisory",
+            Residency::Strict => "strict",
+        }
+    }
+}
+
 /// Supported tool kinds.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -713,7 +744,7 @@ pub struct KeychainDef {
     /// server in a different region than this entry's `region` is allowed
     /// to resolve it.  See [`crate::secrets::residency::Residency`].
     #[serde(default)]
-    pub residency: crate::secrets::residency::Residency,
+    pub residency: Residency,
 
     /// Secrets Wallet Phase 6c — extra regions (besides the entry's own
     /// `region`) from which resolution is allowed when `residency` is

--- a/src/playbook/mod.rs
+++ b/src/playbook/mod.rs
@@ -6,7 +6,11 @@
 //! - Validation
 
 pub mod parser;
-pub mod types;
+// The playbook type model moved into the pure `noetl-orchestrate-core` crate
+// (so `evaluate` + the drive core use it on both native and wasm32 —
+// noetl/ai-meta#108).  Re-exported here as `types` so every
+// `crate::playbook::types::*` call site is unchanged.
+pub use noetl_orchestrate_core::playbook as types;
 
 pub use parser::{extract_kind, extract_metadata, parse_playbook, validate_playbook};
 pub use types::{

--- a/src/secrets/residency.rs
+++ b/src/secrets/residency.rs
@@ -28,38 +28,17 @@
 //! a broker in B that re-seals to A's worker."  Until that ships, `strict`
 //! mode is a fail-closed boundary, not a routed-around constraint.
 
-use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
 use crate::metrics::record_secret_residency_check;
 use crate::playbook::types::KeychainDef;
 use crate::secrets::server_region;
 
-/// Residency policy for a [`KeychainDef`].  See module docs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum Residency {
-    /// No check; resolution proceeds regardless of server region.
-    /// Back-compat default for entries without an explicit policy.
-    #[default]
-    None,
-    /// Check but proceed on mismatch — observability without enforcement.
-    /// Used during the migration window before flipping to `strict`.
-    Advisory,
-    /// Fail-closed on mismatch; resolution short-circuits with
-    /// [`AppError::ResidencyViolation`] before any provider call.
-    Strict,
-}
+/// The `Residency` policy enum is part of the playbook model and lives in
+/// `noetl-orchestrate-core` (noetl/ai-meta#108); re-exported here so this
+/// module's region-check logic and `KeychainDef.residency` keep using it.
+pub use noetl_orchestrate_core::playbook::Residency;
 
-impl Residency {
-    fn as_label(self) -> &'static str {
-        match self {
-            Residency::None => "none",
-            Residency::Advisory => "advisory",
-            Residency::Strict => "strict",
-        }
-    }
-}
 
 /// Outcome of [`evaluate`] — used by the resolver to decide whether to
 /// proceed and which metric label to record.  Not `Clone`/`PartialEq`


### PR DESCRIPTION
**Second slice** of the drive-core extraction ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)): the playbook type model (`Playbook`, `Step`, `ToolSpec`, `ToolKind`, `CursorClaim`, `Command`, …) moves from `src/playbook/types.rs` into `noetl-orchestrate-core`. It's the input to `evaluate`, and `commands`/`evaluator`/`state` all depend on it, so it has to live in the core (native + wasm32).

**The one coupling, untangled:** the model was pure serde except `KeychainDef.residency: crate::secrets::residency::Residency`. The `Residency` enum is itself part of the playbook model (a keychain's region policy) and pure data — so it moves into the core too (with its lone `as_label` helper, now `pub`). The server's `secrets::residency` **re-exports** the enum and keeps the region-check *logic* (which needs `AppError`/metrics/`server_region`). `crate::playbook::types` is re-exported via `pub use noetl_orchestrate_core::playbook as types`, so all 7 call sites + the parser are untouched.

**Verified:** 632 server lib + 40 core tests green (the model's ~19 tests moved with it); core still compiles to `wasm32-unknown-unknown` (no WASI); clippy clean. Pure refactor, byte-identical runtime.

Next slice: `commands` — now both its dependencies (the renderer + the type model) are in the core.

Refs noetl/ai-meta#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)