### PR TITLE
feat(orchestrate-core): move commands + evaluator into the core (#108)

### DIFF
--- a/orchestrate-core/src/commands.rs
+++ b/orchestrate-core/src/commands.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::AppResult;
-use crate::playbook::types::{CursorClaim, Step, ToolCall, ToolDefinition, ToolSpec};
+use crate::error::CoreResult;
+use crate::playbook::{CursorClaim, Step, ToolCall, ToolDefinition, ToolSpec};
 use crate::template::TemplateRenderer;
 
 /// Command to be executed by a worker.
@@ -96,7 +96,7 @@ impl CommandBuilder {
         step: &Step,
         context: &HashMap<String, serde_json::Value>,
         metadata: Option<&serde_json::Value>,
-    ) -> AppResult<Command> {
+    ) -> CoreResult<Command> {
         // Build a render context that includes `ctx` and `workload` namespace
         // aliases pointing at the flat dispatch context, mirroring Python's
         // `context["ctx"] = state.variables` + `context["workload"] = state.variables`
@@ -152,7 +152,7 @@ impl CommandBuilder {
         step: &Step,
         context: &HashMap<String, serde_json::Value>,
         iterator: IteratorMetadata,
-    ) -> AppResult<Command> {
+    ) -> CoreResult<Command> {
         // Build context with iterator variables.
         // Insert both at the top level (so `{{ num }}` works) AND
         // under an `iter` namespace map (so `{{ iter.num }}` works).
@@ -245,7 +245,7 @@ impl CommandBuilder {
         context: &HashMap<String, serde_json::Value>,
         frame_index: i64,
         max_rows: i64,
-    ) -> AppResult<Command> {
+    ) -> CoreResult<Command> {
         // Inject __frame_max_rows + ctx/workload shims into the render context
         // so the claim SQL's templates resolve (execution_id, ctx.*, workload.*,
         // __frame_max_rows).
@@ -297,7 +297,7 @@ impl CommandBuilder {
         &self,
         tool: &ToolDefinition,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<ToolCommand> {
+    ) -> CoreResult<ToolCommand> {
         match tool {
             ToolDefinition::Single(spec) => self.build_tool_command(spec, context),
             ToolDefinition::Pipeline(tasks) => {
@@ -329,7 +329,7 @@ impl CommandBuilder {
         &self,
         tool: &ToolSpec,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<ToolCommand> {
+    ) -> CoreResult<ToolCommand> {
         // Get kind as string
         let kind = tool.kind.to_string();
 
@@ -436,10 +436,10 @@ fn render_pipeline_config(
     renderer: &TemplateRenderer,
     config: &serde_json::Value,
     context: &HashMap<String, serde_json::Value>,
-) -> AppResult<serde_json::Value> {
+) -> CoreResult<serde_json::Value> {
     let arr = match config.as_array() {
         Some(a) => a,
-        None => return renderer.render_value(config, context).map_err(Into::into),
+        None => return renderer.render_value(config, context),
     };
 
     let mut result = Vec::with_capacity(arr.len());
@@ -545,7 +545,7 @@ fn render_pipeline_config(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::playbook::types::ToolKind;
+    use crate::playbook::ToolKind;
 
     #[test]
     fn test_command_serialization() {
@@ -758,8 +758,8 @@ mod tests {
             set_vars: None,
             r#loop: None,
             tool: ToolDefinition::Pipeline(vec![
-                crate::playbook::types::PipelineItem::Nested(fetch_task),
-                crate::playbook::types::PipelineItem::Nested(transform_task),
+                crate::playbook::PipelineItem::Nested(fetch_task),
+                crate::playbook::PipelineItem::Nested(transform_task),
             ]),
             next: None,
         };

--- a/orchestrate-core/src/error.rs
+++ b/orchestrate-core/src/error.rs
@@ -8,6 +8,11 @@ pub enum CoreError {
     /// Template parse / render / condition-evaluation failure.
     #[error("Template error: {0}")]
     Template(String),
+
+    /// Invalid playbook shape / drive precondition (e.g. a malformed loop or
+    /// command spec).  Maps to the server's `AppError::Validation`.
+    #[error("Validation error: {0}")]
+    Validation(String),
 }
 
 /// Result alias for the core.

--- a/orchestrate-core/src/evaluator.rs
+++ b/orchestrate-core/src/evaluator.rs
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::{AppError, AppResult};
-use crate::playbook::types::{NextSpec, Step};
+use crate::error::{CoreError, CoreResult};
+use crate::playbook::{NextSpec, Step};
 use crate::template::TemplateRenderer;
 
 /// Result of evaluating a condition.
@@ -150,8 +150,8 @@ impl ConditionEvaluator {
         &self,
         condition: &str,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<bool> {
-        self.renderer.evaluate_condition(condition, context).map_err(Into::into)
+    ) -> CoreResult<bool> {
+        self.renderer.evaluate_condition(condition, context)
     }
 
     /// Evaluate step enable guard (step.when).
@@ -162,7 +162,7 @@ impl ConditionEvaluator {
         &self,
         step: &Step,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<bool> {
+    ) -> CoreResult<bool> {
         match &step.when {
             Some(when_expr) => self.evaluate_condition(when_expr, context),
             None => Ok(true), // No guard = always execute
@@ -180,7 +180,7 @@ impl ConditionEvaluator {
         &self,
         step: &Step,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<Vec<EvaluationResult>> {
+    ) -> CoreResult<Vec<EvaluationResult>> {
         let mut results = Vec::new();
 
         // Determine next_mode
@@ -317,7 +317,7 @@ impl ConditionEvaluator {
         &self,
         step: &Step,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<Vec<EvaluationResult>> {
+    ) -> CoreResult<Vec<EvaluationResult>> {
         // Delegate to the canonical evaluation method
         self.evaluate_next_transitions(step, context)
     }
@@ -329,7 +329,7 @@ impl ConditionEvaluator {
         &self,
         loop_expr: &str,
         context: &HashMap<String, serde_json::Value>,
-    ) -> AppResult<Vec<serde_json::Value>> {
+    ) -> CoreResult<Vec<serde_json::Value>> {
         // Render the loop expression to get the collection
         let value = self.renderer.render_to_value(loop_expr, context)?;
 
@@ -360,7 +360,7 @@ impl ConditionEvaluator {
                 let n = n.as_u64().unwrap_or(0) as usize;
                 Ok((0..n).map(|i| serde_json::json!(i)).collect())
             }
-            _ => Err(AppError::Validation(format!(
+            _ => Err(CoreError::Validation(format!(
                 "Loop expression did not evaluate to an iterable: {}",
                 loop_expr
             ))),

--- a/orchestrate-core/src/lib.rs
+++ b/orchestrate-core/src/lib.rs
@@ -15,6 +15,8 @@
 //! noetl/ai-meta#108.  The migration is incremental: the template renderer is
 //! the first slice; `evaluator`, `state`, `commands`, and `orchestrator` follow.
 
+pub mod commands;
 pub mod error;
+pub mod evaluator;
 pub mod playbook;
 pub mod template;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,12 +7,14 @@
 //! - **Evaluator**: Evaluates conditions and case/when/then logic
 //! - **Commands**: Generates commands for workers
 
-pub mod commands;
-pub mod evaluator;
+// `commands` + `evaluator` moved into the pure `noetl-orchestrate-core` crate
+// (noetl/ai-meta#108); re-exported here so `crate::engine::commands` /
+// `super::commands` call sites (orchestrator, handlers) are unchanged.
+pub use noetl_orchestrate_core::{commands, evaluator};
 pub mod orchestrator;
 pub mod state;
 
-pub use commands::{Command, CommandBuilder};
-pub use evaluator::ConditionEvaluator;
+pub use noetl_orchestrate_core::commands::{Command, CommandBuilder};
+pub use noetl_orchestrate_core::evaluator::ConditionEvaluator;
 pub use orchestrator::WorkflowOrchestrator;
 pub use state::{ExecutionState, StepState, WorkflowState};

--- a/src/error.rs
+++ b/src/error.rs
@@ -221,6 +221,7 @@ impl From<noetl_orchestrate_core::error::CoreError> for AppError {
     fn from(e: noetl_orchestrate_core::error::CoreError) -> Self {
         match e {
             noetl_orchestrate_core::error::CoreError::Template(msg) => AppError::Template(msg),
+            noetl_orchestrate_core::error::CoreError::Validation(msg) => AppError::Validation(msg),
         }
     }
 }


### PR DESCRIPTION
**Slices 3+4** of the drive-core extraction ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)): the command builders (`Command`, `CommandBuilder`, `IteratorMetadata`) and the condition evaluator (`ConditionEvaluator`) move into `noetl-orchestrate-core`.

Both were clean — after the template + model slices their only remaining coupling was the error type (`AppError::{Template,Validation}`). `CoreError` gains a `Validation` variant; the server's `From<CoreError>` maps it back. `crate::engine::{commands,evaluator}` re-export from the core so `super::commands` in the orchestrator + the handler call sites are unchanged.

**Now all four of `evaluate`'s dependencies — renderer, type model, commands, evaluator — live in the core**, compiling to native + wasm32 from one source.

**Verified:** 57 core + 615 server lib tests green; core compiles to `wasm32-unknown-unknown` (no WASI); clippy clean. Pure refactor, byte-identical runtime.

**Remaining for the live plug-in:** `state` + `orchestrator`/`evaluate`, which need the `Event` type — currently `sqlx::FromRow`-bound. The next round defines the pure core event shape (the Event-ABI boundary) before those two follow. This PR is a natural **e2e checkpoint**: four of six modules extracted, the server's orchestrator driving through all of them.

Refs noetl/ai-meta#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)