### PR TITLE
feat(orchestrate-core): core event type + db::Event boundary (#109)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ name = "noetl-orchestrate-core"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "chrono",
  "minijinja",
  "serde",
  "serde_json",

--- a/orchestrate-core/Cargo.toml
+++ b/orchestrate-core/Cargo.toml
@@ -14,6 +14,7 @@ minijinja = { version = "2.5", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/orchestrate-core/src/event.rs
+++ b/orchestrate-core/src/event.rs
@@ -1,0 +1,46 @@
+//! The pure event type the drive core reads.
+//!
+//! `evaluate`/`state` consume the event log, but the server's `db::Event` is
+//! `sqlx::FromRow` — native-only — so it can't compile into the wasm core.  This
+//! is the db-free read-shape `evaluate` actually needs (noetl/ai-meta#109,
+//! design: `orchestrate_core_event_abi.md`).
+//!
+//! **Named to converge.**  The field set deliberately mirrors the CQRS
+//! materializer's `EventEnvelope`, under the canonical name `event::Event`, so
+//! when the JetStream WAL record becomes the system's one true event
+//! (noetl/ai-meta#104) this is the seed to *promote*, not a fourth shape to
+//! reconcile.  The server converts its `db::Event` into this at the
+//! `trigger_orchestrator` boundary via a `From` impl.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One event in an execution's log, as the drive core reads it.  A pure subset
+/// of the server's `db::Event` — no DB serial `id`, `catalog_id`, `parent_event_id`,
+/// `node_id`, `node_type`, or `worker_id` (the drive never reads those).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Event {
+    /// Application-side snowflake id — the drive's ordering key.
+    pub event_id: i64,
+    pub execution_id: i64,
+    pub event_type: String,
+    /// The step name (`node_name` in the DB / envelope).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_name: Option<String>,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Value>,
+    /// Event-sourced timestamp — the drive reads this, never `Utc::now()`.  The
+    /// DB column is `created_at`; the WAL/envelope name is `timestamp`, so accept
+    /// both on the wire to converge cleanly with #104.
+    #[serde(alias = "created_at")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_execution_id: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<i32>,
+}

--- a/orchestrate-core/src/lib.rs
+++ b/orchestrate-core/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod commands;
 pub mod error;
+pub mod event;
 pub mod evaluator;
 pub mod playbook;
 pub mod template;

--- a/src/db/models/event.rs
+++ b/src/db/models/event.rs
@@ -377,3 +377,74 @@ mod tests {
         assert_eq!(EventStatus::from("Failed"), EventStatus::Failed);
     }
 }
+
+/// Convert a persisted `db::Event` into the pure drive-core event the
+/// orchestrator reads (noetl/ai-meta#109).  A field copy that drops the DB-only
+/// columns the drive never touches (`id`, `catalog_id`, `parent_event_id`,
+/// `node_id`, `node_type`, `worker_id`).  `trigger_orchestrator` maps a bounded
+/// event slice through this before calling `evaluate`; the `context`/`result`
+/// clones are cheap because references-in-state keeps those small.
+impl From<&Event> for noetl_orchestrate_core::event::Event {
+    fn from(e: &Event) -> Self {
+        noetl_orchestrate_core::event::Event {
+            event_id: e.event_id,
+            execution_id: e.execution_id,
+            event_type: e.event_type.clone(),
+            node_name: e.node_name.clone(),
+            status: e.status.clone(),
+            context: e.context.clone(),
+            result: e.result.clone(),
+            meta: e.meta.clone(),
+            timestamp: e.created_at,
+            parent_execution_id: e.parent_execution_id,
+            attempt: e.attempt,
+        }
+    }
+}
+
+#[cfg(test)]
+mod drive_event_conversion_tests {
+    use super::*;
+
+    #[test]
+    fn db_event_converts_to_core_drive_event() {
+        let db = Event {
+            id: 7,
+            execution_id: 42,
+            catalog_id: 99,
+            event_id: 1000,
+            parent_event_id: Some(1),
+            parent_execution_id: Some(2),
+            event_type: "call.done".to_string(),
+            node_id: Some("n1".to_string()),
+            node_name: Some("fetch".to_string()),
+            node_type: Some("python".to_string()),
+            status: "COMPLETED".to_string(),
+            context: Some(serde_json::json!({"k": "v"})),
+            meta: None,
+            result: Some(serde_json::json!({"rows": 3})),
+            worker_id: Some("w1".to_string()),
+            attempt: Some(0),
+            created_at: chrono::Utc::now(),
+        };
+        let core: noetl_orchestrate_core::event::Event = (&db).into();
+        // the read-set carries over ...
+        assert_eq!(core.event_id, 1000);
+        assert_eq!(core.execution_id, 42);
+        assert_eq!(core.event_type, "call.done");
+        assert_eq!(core.node_name.as_deref(), Some("fetch"));
+        assert_eq!(core.status, "COMPLETED");
+        assert_eq!(core.result, Some(serde_json::json!({"rows": 3})));
+        assert_eq!(core.timestamp, db.created_at);
+        // ... and `created_at` is accepted as the `timestamp` alias on the wire.
+        let wire = serde_json::to_value(&core).unwrap();
+        assert!(wire.get("timestamp").is_some());
+        let back: noetl_orchestrate_core::event::Event =
+            serde_json::from_value(serde_json::json!({
+                "event_id": 1, "execution_id": 1, "event_type": "x",
+                "status": "OK", "created_at": "2026-06-17T00:00:00Z"
+            }))
+            .expect("created_at alias deserializes");
+        assert_eq!(back.event_id, 1);
+    }
+}


### PR DESCRIPTION
**Slice 1** of the Event-ABI round ([noetl/ai-meta#109](https://github.com/noetl/ai-meta/issues/109), final slices of [#108](https://github.com/noetl/ai-meta/issues/108)): the pure event type the drive core reads.

`core::event::Event` = the drive read-set (drops the DB-only columns), **named to converge** with the CQRS `EventEnvelope` (`timestamp` + a `created_at` serde alias) so #104's WAL record *promotes* it instead of reconciling a 4th shape. `chrono` added with **no `clock`/`wasmbind`** (DateTime as data, never `now()`) → still compiles to `wasm32-unknown-unknown`. The server converts `db::Event → core::event::Event` via `From<&Event>`; the 8 `query_as` sites are untouched.

Additive (slices 2-3 move `state` + `evaluate` onto it). **Determinism audit:** the drive's only real-output `now()` is a generated-event timestamp (the shadow-diff normalizes it); 6 of 8 orchestrator sites are tests — the drive is already nearly deterministic.

616 server + 57 core tests green; wasm32 clean (no WASI); clippy clean.

Refs noetl/ai-meta#109

🤖 Generated with [Claude Code](https://claude.com/claude-code)