### PR TITLE
feat(orchestrate-core): move WorkflowState into the core on the pure event (#109)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/orchestrate-core/Cargo.toml
+++ b/orchestrate-core/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 thiserror = "2.0"
+tracing = "0.1"
 
 [dev-dependencies]
 serde_yaml = "0.9"

--- a/orchestrate-core/src/event.rs
+++ b/orchestrate-core/src/event.rs
@@ -23,6 +23,10 @@ pub struct Event {
     /// Application-side snowflake id — the drive's ordering key.
     pub event_id: i64,
     pub execution_id: i64,
+    /// Catalog (playbook) id — the drive seeds WorkflowState with it.  Defaulted
+    /// so a wire event that omits it still deserializes.
+    #[serde(default)]
+    pub catalog_id: i64,
     pub event_type: String,
     /// The step name (`node_name` in the DB / envelope).
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/orchestrate-core/src/lib.rs
+++ b/orchestrate-core/src/lib.rs
@@ -20,4 +20,5 @@ pub mod error;
 pub mod event;
 pub mod evaluator;
 pub mod playbook;
+pub mod state;
 pub mod template;

--- a/orchestrate-core/src/state.rs
+++ b/orchestrate-core/src/state.rs
@@ -3,15 +3,14 @@
 //! Provides state reconstruction for event-sourced workflow execution.
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::db::models::Event;
+use crate::event::Event;
 
 /// Serde skip predicate for `i32` fields that default to 0.
-pub(crate) fn is_zero(v: &i32) -> bool {
+pub fn is_zero(v: &i32) -> bool {
     *v == 0
 }
 
@@ -111,7 +110,7 @@ pub struct StepInfo {
     ///
     /// noetl/ai-meta#85: used as the **stable** per-completion key for
     /// durable `set:` persistence.  `completed_at` derives from
-    /// `event.created_at`, which the event loader fills with
+    /// `event.timestamp`, which the event loader fills with
     /// `Utc::now()` when the row's `created_at` is unreadable — so it is
     /// NOT stable across reconstructions and can't gate once-per-
     /// completion emission.  `event_id` is the row's snowflake primary
@@ -168,7 +167,7 @@ pub struct StepInfo {
     // consulted.  Non-iterator steps leave it at 0.
     /// Number of `command.issued` events observed for this iterator
     /// step.  Always 0 for non-iterator steps.
-    #[serde(default, skip_serializing_if = "crate::engine::state::is_zero")]
+    #[serde(default, skip_serializing_if = "crate::state::is_zero")]
     pub iterations_dispatched: i32,
 
     /// True when this step is a `mode: cursor` loop (noetl/ai-meta#100).  Set
@@ -309,7 +308,7 @@ pub struct WorkflowState {
 /// (constraint-compliant envelope), or — in older shapes — on
 /// `result.data`.  Returns the first match.  Used by R3b iterator
 /// state aggregation to deduplicate `command.completed` events.
-pub(crate) fn extract_command_id(event: &Event) -> Option<String> {
+pub fn extract_command_id(event: &Event) -> Option<String> {
     if let Some(meta) = &event.meta {
         if let Some(s) = meta.get("command_id").and_then(|v| v.as_str()) {
             return Some(s.to_string());
@@ -355,7 +354,8 @@ impl WorkflowState {
 
     /// Reconstruct workflow state from a list of events.
     pub fn from_events(events: &[Event]) -> Option<Self> {
-        let start = Instant::now();
+        #[cfg(not(target_arch = "wasm32"))]
+        let start = std::time::Instant::now();
 
         if events.is_empty() {
             return None;
@@ -370,29 +370,35 @@ impl WorkflowState {
             state.apply_event(event);
         }
 
-        let duration = start.elapsed();
-        let event_count = events.len();
+        // Perf logging — native only.  `Instant` isn't portable to
+        // wasm32-unknown-unknown (no clock); in the plug-in the host times the
+        // invoke instead, so this self-timing is compiled out (noetl/ai-meta#109).
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let duration = start.elapsed();
+            let event_count = events.len();
 
-        // Log performance metrics for state reconstruction
-        tracing::info!(
-            target: "noetl.performance",
-            execution_id = %first.execution_id,
-            phase = "state_reconstruction",
-            event_count = %event_count,
-            step_count = %state.steps.len(),
-            duration_ms = %duration.as_millis(),
-            "State reconstructed from events"
-        );
-
-        // Warn if reconstruction is slow (potential bottleneck)
-        if duration.as_millis() > 100 || event_count > 50 {
-            tracing::warn!(
+            // Log performance metrics for state reconstruction
+            tracing::info!(
                 target: "noetl.performance",
                 execution_id = %first.execution_id,
+                phase = "state_reconstruction",
                 event_count = %event_count,
+                step_count = %state.steps.len(),
                 duration_ms = %duration.as_millis(),
-                "Slow state reconstruction detected - consider optimizing event loading"
+                "State reconstructed from events"
             );
+
+            // Warn if reconstruction is slow (potential bottleneck)
+            if duration.as_millis() > 100 || event_count > 50 {
+                tracing::warn!(
+                    target: "noetl.performance",
+                    execution_id = %first.execution_id,
+                    event_count = %event_count,
+                    duration_ms = %duration.as_millis(),
+                    "Slow state reconstruction detected - consider optimizing event loading"
+                );
+            }
         }
 
         Some(state)
@@ -403,7 +409,7 @@ impl WorkflowState {
         match event.event_type.as_str() {
             "playbook_started" => {
                 self.state = ExecutionState::InProgress;
-                self.started_at = Some(event.created_at);
+                self.started_at = Some(event.timestamp);
                 self.parent_execution_id = event.parent_execution_id;
 
                 // Extract workload from context
@@ -421,15 +427,15 @@ impl WorkflowState {
             }
             "playbook_completed" | "playbook.completed" => {
                 self.state = ExecutionState::Completed;
-                self.completed_at = Some(event.created_at);
+                self.completed_at = Some(event.timestamp);
             }
             "playbook_failed" | "playbook.failed" => {
                 self.state = ExecutionState::Failed;
-                self.completed_at = Some(event.created_at);
+                self.completed_at = Some(event.timestamp);
             }
             "playbook.cancelled" => {
                 self.state = ExecutionState::Cancelled;
-                self.completed_at = Some(event.created_at);
+                self.completed_at = Some(event.timestamp);
             }
             "ctx.updated" => {
                 // noetl/ai-meta#85: durable loop-variable propagation.
@@ -482,7 +488,7 @@ impl WorkflowState {
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
                     step.state = StepState::Entered;
-                    step.entered_at = Some(event.created_at);
+                    step.entered_at = Some(event.timestamp);
                     // R3b iterator fan-out: orchestrator stamps the
                     // iteration total onto the step.enter event so
                     // state reconstruction knows how many
@@ -566,8 +572,8 @@ impl WorkflowState {
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
                     step.state = StepState::Skipped;
-                    step.entered_at = Some(event.created_at);
-                    step.completed_at = Some(event.created_at);
+                    step.entered_at = Some(event.timestamp);
+                    step.completed_at = Some(event.timestamp);
                 }
             }
             "command.issued" => {
@@ -704,7 +710,7 @@ impl WorkflowState {
                         }
                         if step.iterations_completed() >= expected {
                             step.state = StepState::Completed;
-                            step.completed_at = Some(event.created_at);
+                            step.completed_at = Some(event.timestamp);
                             step.completed_event_id = Some(event.event_id);
                             // Aggregate result = list of per-iteration
                             // results in arrival order (may not match
@@ -719,7 +725,7 @@ impl WorkflowState {
                     } else {
                         // Plain (non-iterator) step.
                         step.state = StepState::Completed;
-                        step.completed_at = Some(event.created_at);
+                        step.completed_at = Some(event.timestamp);
                         step.completed_event_id = Some(event.event_id);
                         // Only overwrite step.result with command.completed's
                         // envelope if the user-data hasn't been written yet
@@ -808,7 +814,7 @@ impl WorkflowState {
                         .entry(name.clone())
                         .or_insert_with(|| StepInfo::new(name));
                     step.state = StepState::Failed;
-                    step.completed_at = Some(event.created_at);
+                    step.completed_at = Some(event.timestamp);
                     // Extract error from result.  Two shapes seen in
                     // the wild — top-level `result.error` and the
                     // nested `result.context.error` (the worker's
@@ -1083,7 +1089,7 @@ pub fn apply_set_mutations(
 /// Locate a `noetl://` result-reference URI on an event result envelope
 /// (references-in-state, noetl/ai-meta#101 phase 2).  Nested envelope:
 /// `context.result.reference.ref`; top-level: `reference.ref`.
-pub(crate) fn result_reference_uri(result: &serde_json::Value) -> Option<String> {
+pub fn result_reference_uri(result: &serde_json::Value) -> Option<String> {
     result
         .pointer("/context/result/reference/ref")
         .and_then(|v| v.as_str())
@@ -1091,7 +1097,7 @@ pub(crate) fn result_reference_uri(result: &serde_json::Value) -> Option<String>
         .map(str::to_string)
 }
 
-pub(crate) fn extract_user_data(result: &serde_json::Value) -> Option<serde_json::Value> {
+pub fn extract_user_data(result: &serde_json::Value) -> Option<serde_json::Value> {
     if result.is_null() {
         return None;
     }
@@ -1172,23 +1178,19 @@ mod tests {
 
     fn make_event(event_type: &str, node_name: Option<&str>) -> Event {
         Event {
-            id: 1,
+            event_id: 1,
             execution_id: 12345,
             catalog_id: 67890,
-            event_id: 1,
-            parent_event_id: None,
-            parent_execution_id: None,
             event_type: event_type.to_string(),
-            node_id: None,
             node_name: node_name.map(|s| s.to_string()),
-            node_type: None,
             status: "".to_string(),
             context: None,
-            meta: None,
             result: None,
-            worker_id: None,
+            meta: None,
+            // Fixed epoch — the core has no clock (deterministic fixtures).
+            timestamp: DateTime::from_timestamp(0, 0).unwrap(),
+            parent_execution_id: None,
             attempt: None,
-            created_at: Utc::now(),
         }
     }
 
@@ -1754,82 +1756,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_auth0_login_full_orchestrator_arc_routing_repro() {
-        use crate::engine::WorkflowOrchestrator;
-        let yaml = r#"
-apiVersion: noetl.io/v2
-kind: Playbook
-metadata:
-  name: t
-  path: t
-workload:
-  request_id: "req-123"
-workflow:
-  - step: start
-    tool:
-      kind: python
-      code: |
-        result = {"error": "Invalid JWT format"}
-    next:
-      spec:
-        mode: exclusive
-      arcs:
-        - step: err_cb
-          when: "{{ (start.error is defined) and request_id }}"
-        - step: end_step
-          when: "{{ start.error is defined and not request_id }}"
-        - step: create
-          when: "{{ start.sub is defined }}"
-  - step: err_cb
-    tool: { kind: python, code: "result = {}" }
-  - step: end_step
-    tool: { kind: python, code: "result = {}" }
-  - step: create
-    tool: { kind: python, code: "result = {}" }
-"#;
-        let playbook = crate::playbook::parser::parse_playbook(yaml).unwrap();
-
-        let mut e_started = make_event("playbook_started", None);
-        e_started.event_id = 1;
-        e_started.context = Some(serde_json::json!({
-            "workload": { "request_id": "req-123" },
-            "path": "t"
-        }));
-        let mut e_issued = make_event("command.issued", Some("start"));
-        e_issued.event_id = 2;
-        let mut e_done = make_event("call.done", Some("start"));
-        e_done.event_id = 3;
-        e_done.result = Some(serde_json::json!({
-            "status": "COMPLETED",
-            "context": { "result": { "status": "success", "context": {
-                "data": { "error": "Invalid JWT format" }, "status": "success" } } }
-        }));
-        let mut e_completed = make_event("command.completed", Some("start"));
-        e_completed.event_id = 4;
-        e_completed.result = Some(serde_json::json!({
-            "status": "success", "context": { "status": "success", "command_id": "x" }
-        }));
-
-        let events = vec![e_started, e_issued, e_done, e_completed];
-        let orch = WorkflowOrchestrator::new();
-        let result = orch
-            .evaluate(&events, &playbook, Some("command.completed"))
-            .expect("evaluate ok");
-
-        let skipped: Vec<String> = result
-            .events_to_emit
-            .iter()
-            .filter(|e| e.event_type == "step.skipped")
-            .filter_map(|e| e.node_name.clone())
-            .collect();
-        let cmds: Vec<String> = result.commands.iter().map(|c| c.step_name.clone()).collect();
-        assert!(
-            !skipped.contains(&"err_cb".to_string()),
-            "err_cb arc must fire (start.error defined + request_id truthy), not skip. \
-             skipped={skipped:?} commands={cmds:?}"
-        );
-    }
 
     #[test]
     fn test_build_context_data_accessor_does_not_clobber_existing_data_field() {

--- a/src/db/models/event.rs
+++ b/src/db/models/event.rs
@@ -389,6 +389,7 @@ impl From<&Event> for noetl_orchestrate_core::event::Event {
         noetl_orchestrate_core::event::Event {
             event_id: e.event_id,
             execution_id: e.execution_id,
+            catalog_id: e.catalog_id,
             event_type: e.event_type.clone(),
             node_name: e.node_name.clone(),
             status: e.status.clone(),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,11 +10,10 @@
 // `commands` + `evaluator` moved into the pure `noetl-orchestrate-core` crate
 // (noetl/ai-meta#108); re-exported here so `crate::engine::commands` /
 // `super::commands` call sites (orchestrator, handlers) are unchanged.
-pub use noetl_orchestrate_core::{commands, evaluator};
+pub use noetl_orchestrate_core::{commands, evaluator, state};
 pub mod orchestrator;
-pub mod state;
 
 pub use noetl_orchestrate_core::commands::{Command, CommandBuilder};
 pub use noetl_orchestrate_core::evaluator::ConditionEvaluator;
+pub use noetl_orchestrate_core::state::{ExecutionState, StepState, WorkflowState};
 pub use orchestrator::WorkflowOrchestrator;
-pub use state::{ExecutionState, StepState, WorkflowState};

--- a/src/engine/orchestrator.rs
+++ b/src/engine/orchestrator.rs
@@ -299,8 +299,12 @@ impl WorkflowOrchestrator {
         trigger_event_type: Option<&str>,
     ) -> AppResult<OrchestrationResult> {
         // Reconstruct workflow state from events (full path — used by tests and
-        // by trigger_orchestrator on a cold cache).
-        let mut state = WorkflowState::from_events(events)
+        // by trigger_orchestrator on a cold cache).  `state` lives in
+        // noetl-orchestrate-core on the pure `core::event::Event`; convert the
+        // server's `db::Event` slice at this boundary (noetl/ai-meta#109).
+        let core_events: Vec<noetl_orchestrate_core::event::Event> =
+            events.iter().map(Into::into).collect();
+        let mut state = WorkflowState::from_events(&core_events)
             .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
         let latest_ts = events.last().map(|e| e.created_at);
         self.evaluate_state(&mut state, latest_ts, playbook, trigger_event_type)
@@ -1909,6 +1913,86 @@ mod tests {
         }
     }
 
+    // Moved from state.rs when state moved into noetl-orchestrate-core
+    // (noetl/ai-meta#109): this is a state+orchestrator integration test, so it
+    // lives with the orchestrator (a server type) until the orchestrator moves too.
+    #[test]
+    fn test_auth0_login_full_orchestrator_arc_routing_repro() {
+        use crate::engine::WorkflowOrchestrator;
+        let yaml = r#"
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: t
+  path: t
+workload:
+  request_id: "req-123"
+workflow:
+  - step: start
+    tool:
+      kind: python
+      code: |
+        result = {"error": "Invalid JWT format"}
+    next:
+      spec:
+        mode: exclusive
+      arcs:
+        - step: err_cb
+          when: "{{ (start.error is defined) and request_id }}"
+        - step: end_step
+          when: "{{ start.error is defined and not request_id }}"
+        - step: create
+          when: "{{ start.sub is defined }}"
+  - step: err_cb
+    tool: { kind: python, code: "result = {}" }
+  - step: end_step
+    tool: { kind: python, code: "result = {}" }
+  - step: create
+    tool: { kind: python, code: "result = {}" }
+"#;
+        let playbook = serde_yaml::from_str::<crate::playbook::Playbook>(yaml).unwrap();
+
+        let mut e_started = make_event("playbook_started", None);
+        e_started.event_id = 1;
+        e_started.context = Some(serde_json::json!({
+            "workload": { "request_id": "req-123" },
+            "path": "t"
+        }));
+        let mut e_issued = make_event("command.issued", Some("start"));
+        e_issued.event_id = 2;
+        let mut e_done = make_event("call.done", Some("start"));
+        e_done.event_id = 3;
+        e_done.result = Some(serde_json::json!({
+            "status": "COMPLETED",
+            "context": { "result": { "status": "success", "context": {
+                "data": { "error": "Invalid JWT format" }, "status": "success" } } }
+        }));
+        let mut e_completed = make_event("command.completed", Some("start"));
+        e_completed.event_id = 4;
+        e_completed.result = Some(serde_json::json!({
+            "status": "success", "context": { "status": "success", "command_id": "x" }
+        }));
+
+        let events = vec![e_started, e_issued, e_done, e_completed];
+        let orch = WorkflowOrchestrator::new();
+        let result = orch
+            .evaluate(&events, &playbook, Some("command.completed"))
+            .expect("evaluate ok");
+
+        let skipped: Vec<String> = result
+            .events_to_emit
+            .iter()
+            .filter(|e| e.event_type == "step.skipped")
+            .filter_map(|e| e.node_name.clone())
+            .collect();
+        let cmds: Vec<String> = result.commands.iter().map(|c| c.step_name.clone()).collect();
+        assert!(
+            !skipped.contains(&"err_cb".to_string()),
+            "err_cb arc must fire (start.error defined + request_id truthy), not skip. \
+             skipped={skipped:?} commands={cmds:?}"
+        );
+    }
+
     #[test]
     fn cursor_frame_tracking_via_apply_event() {
         // noetl/ai-meta#100: cursor frame progress is maintained INCREMENTALLY
@@ -1918,22 +2002,22 @@ mod tests {
         // step.enter carrying the __cursor_loop marker -> is_cursor.
         let mut enter = make_event("step.enter", Some("cur"));
         enter.result = Some(serde_json::json!({"context": {"__cursor_loop": true}}));
-        ws.apply_event(&enter);
+        ws.apply_event(&(&enter).into());
         assert!(ws.steps.get("cur").unwrap().is_cursor);
 
         let mut claim0 = make_event("command.issued", Some("cur"));
         claim0.meta =
             Some(serde_json::json!({"command_id": "c0", "cursor": {"phase": "claim", "frame": 0}}));
-        ws.apply_event(&claim0);
+        ws.apply_event(&(&claim0).into());
         // The claim's RETURNING rows arrive on call.done.
         let mut claim0_data = make_event("call.done", Some("cur"));
         claim0_data.result = Some(serde_json::json!({
             "context": {"command_id": "c0", "data": {"rows": [{"id": 1}, {"id": 2}]}}
         }));
-        ws.apply_event(&claim0_data);
+        ws.apply_event(&(&claim0_data).into());
         let mut claim0_done = make_event("command.completed", Some("cur"));
         claim0_done.meta = Some(serde_json::json!({"command_id": "c0"}));
-        ws.apply_event(&claim0_done);
+        ws.apply_event(&(&claim0_done).into());
 
         let f0 = ws.steps.get("cur").unwrap().cursor_frames[&0].clone();
         assert!(f0.claim_completed);
@@ -1945,16 +2029,16 @@ mod tests {
         let mut body0 = make_event("command.issued", Some("cur"));
         body0.meta =
             Some(serde_json::json!({"command_id": "b0", "cursor": {"phase": "body", "frame": 0}}));
-        ws.apply_event(&body0);
+        ws.apply_event(&(&body0).into());
         let mut body0_done = make_event("command.completed", Some("cur"));
         body0_done.meta = Some(serde_json::json!({"command_id": "b0"}));
-        ws.apply_event(&body0_done);
+        ws.apply_event(&(&body0_done).into());
         let f0 = ws.steps.get("cur").unwrap().cursor_frames[&0].clone();
         assert_eq!(f0.body_issued, 1);
         assert_eq!(f0.body_completed, 1);
 
         // Repeated completion events for the same command_id are deduped.
-        ws.apply_event(&body0_done);
+        ws.apply_event(&(&body0_done).into());
         assert_eq!(
             ws.steps.get("cur").unwrap().cursor_frames[&0].body_completed,
             1,
@@ -1965,19 +2049,19 @@ mod tests {
         let mut claim1 = make_event("command.issued", Some("cur"));
         claim1.meta =
             Some(serde_json::json!({"command_id": "c1", "cursor": {"phase": "claim", "frame": 1}}));
-        ws.apply_event(&claim1);
+        ws.apply_event(&(&claim1).into());
         let mut claim1_data = make_event("call.done", Some("cur"));
         claim1_data.result =
             Some(serde_json::json!({"context": {"command_id": "c1", "data": {"rows": []}}}));
-        ws.apply_event(&claim1_data);
+        ws.apply_event(&(&claim1_data).into());
         let mut claim1_done = make_event("command.completed", Some("cur"));
         claim1_done.meta = Some(serde_json::json!({"command_id": "c1"}));
-        ws.apply_event(&claim1_done);
+        ws.apply_event(&(&claim1_done).into());
         let f1 = ws.steps.get("cur").unwrap().cursor_frames[&1].clone();
         assert!(f1.claim_completed && f1.claim_rows.is_empty());
 
         // Re-entry (loop-back): a fresh step.enter resets frame tracking.
-        ws.apply_event(&enter);
+        ws.apply_event(&(&enter).into());
         assert!(ws.steps.get("cur").unwrap().cursor_frames.is_empty());
     }
 

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1631,7 +1631,7 @@ async fn rebuild_state(
             hydrate_result_references(&mut events_since, result_store, keep_refs).await;
             let mut ws = snap.state;
             for e in &events_since {
-                ws.apply_event(e);
+                ws.apply_event(&e.into());
             }
             // The window includes everything after the snapshot, so the highest
             // loaded id is the current head.
@@ -1657,7 +1657,7 @@ async fn rebuild_state(
                 .await?,
             );
             hydrate_result_references(&mut all_events, result_store, keep_refs).await;
-            let state = crate::engine::state::WorkflowState::from_events(&all_events)
+            let state = crate::engine::state::WorkflowState::from_events(&all_events.iter().map(Into::into).collect::<Vec<_>>())
                 .ok_or_else(|| AppError::Validation("No events found for execution".to_string()))?;
             let last_event_id = all_events.last().map(|e| e.event_id).unwrap_or(0);
             let routing_meta = all_events
@@ -1880,7 +1880,7 @@ async fn trigger_orchestrator_inner(
         hydrate_result_references(&mut strag, &result_store, state.config.refs_in_state).await;
         if let Some(ws) = cache.state.as_mut() {
             for e in &strag {
-                ws.apply_event(e);
+                ws.apply_event(&e.into());
             }
         }
         straggler_applied = !strag.is_empty();
@@ -1936,7 +1936,7 @@ async fn trigger_orchestrator_inner(
     } else if !new_events.is_empty() {
         let ws = cache.state.as_mut().unwrap();
         for e in &new_events {
-            ws.apply_event(e);
+            ws.apply_event(&e.into());
         }
         cache.applied_count += new_events.len() as i64;
         cache.last_event_id = new_events


### PR DESCRIPTION
**Slice 2** of the Event-ABI round ([noetl/ai-meta#109](https://github.com/noetl/ai-meta/issues/109)): `state.rs` — `WorkflowState` + the `from_events`/`apply_event` drive-state machine — moves into `noetl-orchestrate-core` on `core::event::Event`, so drive-state reconstruction is wasm-resident.

**Boundary:** the server converts `db::Event → core::event::Event` via `From<&db::Event>` at the drive entry — orchestrator's `evaluate` + the four `from_events`/`apply_event` sites in `events.rs` (cheap; refs-in-state keeps payloads small). `orchestrator` keeps its `db::Event` signature so its big fixture set is untouched; its 11 test `apply_event` calls convert at the call.

**wasm portability surfaced + handled:** `Instant` self-timing gated `#[cfg(not(target_arch = "wasm32"))]` (the plug-in host times the invoke); `tracing` added (wasm-safe); `catalog_id` added to the core event (`#[serde(default)]`, wire-tolerant). The one state+orchestrator integration test moved to `orchestrator.rs`'s tests.

**Verified:** 587 server + 86 core tests green; core compiles to `wasm32-unknown-unknown` (no WASI); clippy clean. Pure refactor.

**Last slice:** move `orchestrator`/`evaluate` — then the whole drive core is wasm-resident and the plug-in round begins.

Refs noetl/ai-meta#109

🤖 Generated with [Claude Code](https://claude.com/claude-code)