### PR TITLE
feat(system-plugins): seed built-in system plug-ins into the registry on boot (#108)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 target
+# Nested Cargo target dirs (e.g. the excluded plugins/orchestrate crate) — the
+# top-level `target` glob does not match these, and shipping them in the build
+# context is huge + breaks the COPY. The wasm plug-in is rebuilt in its own
+# Docker stage, so the local artifact is never needed in the context.
+**/target
 .git
 .github
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,29 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin noetl-control-plane
 
+# Build the built-in system plug-ins to wasm32 (noetl/ai-meta#108 slice 3).
+# The `plugins/orchestrate` crate is excluded from the server workspace, so it is
+# built explicitly; the artifact is baked into the runtime image + seeded into
+# the plug-in registry on boot.
+FROM chef AS wasmbuilder
+RUN rustup target add wasm32-unknown-unknown
+COPY . .
+RUN cargo build --release --target wasm32-unknown-unknown \
+        --manifest-path plugins/orchestrate/Cargo.toml
+
 FROM alpine:3.22.2 AS runtime
 WORKDIR /app
 RUN apk add --no-cache libgcc libstdc++ ca-certificates openssl
 COPY --from=builder /app/target/release/noetl-control-plane ./noetl-control-plane
+# Built-in system plug-ins, seeded into noetl.plugin_module on boot. The file
+# stem becomes the catalog path: orchestrate.wasm -> system/orchestrate@1.
+COPY --from=wasmbuilder \
+    /app/plugins/orchestrate/target/wasm32-unknown-unknown/release/noetl_orchestrate_plugin.wasm \
+    /opt/noetl/plugins/orchestrate.wasm
 
 ENV NOETL_HOST=0.0.0.0 \
     NOETL_PORT=8082 \
+    NOETL_SYSTEM_PLUGIN_DIR=/opt/noetl/plugins \
     RUST_LOG=info,noetl_server=debug
 
 EXPOSE 8082

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod sanitize;
 pub mod secrets;
 pub mod services;
 pub mod sharding;
+pub mod system_plugins;
 pub mod tls;
 pub mod snowflake;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -747,6 +747,16 @@ async fn main() -> anyhow::Result<()> {
     // for the system worker pool's wasmtime PluginSource.  Same idempotent
     // startup-DDL pattern; server-owned end-to-end.
     noetl_server::db::queries::plugin_module::ensure_table(&db_pool).await?;
+    // Seed built-in system plug-ins (noetl/ai-meta#108 slice 3) — the
+    // server-owned `system/orchestrate` (+ future built-ins) compiled to wasm32
+    // and baked into the image are registered into noetl.plugin_module on boot,
+    // so the worker pool can fetch them without an out-of-band operator POST.
+    // Non-fatal: a seed failure must not block the server from starting.
+    match noetl_server::system_plugins::seed_system_plugins(&db_pool).await {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(count = n, "seeded built-in system plug-ins"),
+        Err(e) => tracing::warn!(error = %e, "failed to seed system plug-ins; continuing"),
+    }
     // Object store (noetl/ai-meta#105 Round 5) — durable Feather tier backing a
     // plug-in's `noetl.object_put`. Same idempotent startup-DDL pattern.
     noetl_server::db::queries::object_store::ensure_table(&db_pool).await?;

--- a/src/system_plugins.rs
+++ b/src/system_plugins.rs
@@ -1,0 +1,170 @@
+//! Seed built-in **system plug-ins** into the module registry on boot
+//! (noetl/ai-meta#108 slice 3).
+//!
+//! The `system/orchestrate` plug-in (and any future built-in system plug-in) is
+//! compiled from this repo's `plugins/` tree to `wasm32-unknown-unknown` and
+//! baked into the server image. On startup the server reads those `.wasm` files
+//! and upserts them into `noetl.plugin_module` so the worker pool's
+//! `HttpPluginSource` can fetch them by `(path, version)` + digest — without an
+//! out-of-band operator `POST`.
+//!
+//! **Hot-reload by re-seed.** Every boot re-seeds at version 1; the digest is
+//! recomputed from the current bytes, so a new image with new plug-in bytes
+//! publishes a new digest at `system/<name>@1`. The worker resolves the digest
+//! from the registry on every dispatch, so it reloads on the next claim — the
+//! same digest-keyed hot-replace path proven for the materialiser
+//! (noetl/ai-meta#105). Version bumps are reserved for deliberate ABI breaks.
+//!
+//! The server seeds its **own** built-ins by calling `plugin_module::upsert`
+//! directly (in-process, it holds the pool) — not through the token-gated
+//! `/api/internal/plugins` HTTP surface, which is for *external* registration.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::db::{queries::plugin_module, DbPool};
+use crate::error::AppResult;
+
+/// Env var naming the directory the server reads built-in system plug-in
+/// `.wasm` files from at boot. Defaults to the image's baked plug-in dir.
+pub const PLUGIN_DIR_ENV: &str = "NOETL_SYSTEM_PLUGIN_DIR";
+const DEFAULT_PLUGIN_DIR: &str = "/opt/noetl/plugins";
+/// Built-in system plug-ins seed at this version; digest-keyed hot-reload
+/// (re-seed with new bytes) makes a version bump unnecessary for updates.
+const SEED_VERSION: i32 = 1;
+
+/// One plug-in to register, resolved from a `.wasm` file. Pure data — the scan
+/// half is DB-free and unit-testable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeedEntry {
+    /// Catalog path, `system/<file-stem>` (e.g. `orchestrate.wasm` →
+    /// `system/orchestrate`).
+    pub path: String,
+    pub version: i32,
+    /// SHA-256 hex digest of `bytes` — must match the register endpoint's
+    /// `hex::encode(Sha256::digest(..))` so worker cache keys agree.
+    pub digest: String,
+    pub media_type: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Scan a directory for `*.wasm` files and resolve each into a [`SeedEntry`].
+/// Pure (no DB): reads files, derives `system/<stem>`, computes the digest.
+/// A missing directory yields an empty list (local dev without the baked image);
+/// an unreadable individual file is skipped with a warning, not fatal.
+pub fn scan_system_plugins(dir: &Path) -> Vec<SeedEntry> {
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(
+                dir = %dir.display(),
+                error = %e,
+                "no system plug-in dir; nothing to seed"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut entries: Vec<SeedEntry> = Vec::new();
+    for dirent in read.flatten() {
+        let file = dirent.path();
+        if file.extension().and_then(|e| e.to_str()) != Some("wasm") {
+            continue;
+        }
+        let Some(stem) = file.file_stem().and_then(|s| s.to_str()) else {
+            tracing::warn!(file = %file.display(), "skipping plug-in with non-UTF8 name");
+            continue;
+        };
+        let bytes = match std::fs::read(&file) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(file = %file.display(), error = %e, "skipping unreadable plug-in");
+                continue;
+            }
+        };
+        let digest = hex::encode(Sha256::digest(&bytes));
+        entries.push(SeedEntry {
+            path: format!("system/{stem}"),
+            version: SEED_VERSION,
+            digest,
+            media_type: "application/wasm".to_string(),
+            bytes,
+        });
+    }
+    // Deterministic order (directory iteration order is unspecified) so logs and
+    // any future digest-of-digests are stable.
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    entries
+}
+
+/// The directory the server seeds from: `$NOETL_SYSTEM_PLUGIN_DIR` or the
+/// image's baked default.
+pub fn plugin_dir() -> PathBuf {
+    std::env::var(PLUGIN_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_PLUGIN_DIR))
+}
+
+/// Seed every built-in system plug-in found under [`plugin_dir`] into
+/// `noetl.plugin_module`. Returns the number seeded. Idempotent (upsert);
+/// safe to run on every boot.
+pub async fn seed_system_plugins(pool: &DbPool) -> AppResult<usize> {
+    let dir = plugin_dir();
+    let entries = scan_system_plugins(&dir);
+    if entries.is_empty() {
+        tracing::debug!(dir = %dir.display(), "no system plug-ins to seed");
+        return Ok(0);
+    }
+    for e in &entries {
+        plugin_module::upsert(pool, &e.path, e.version, &e.digest, &e.media_type, &e.bytes).await?;
+        tracing::info!(
+            plugin_path = %e.path,
+            version = e.version,
+            digest = %e.digest,
+            bytes = e.bytes.len(),
+            "seeded system plug-in"
+        );
+    }
+    tracing::info!(count = entries.len(), dir = %dir.display(), "system plug-ins seeded");
+    Ok(entries.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scan half is pure: a tmp dir with two `.wasm` files plus noise yields
+    /// exactly the two entries, `system/<stem>` paths, correct digests, sorted.
+    #[test]
+    fn scan_resolves_wasm_files_only() {
+        let dir = std::env::temp_dir().join(format!("noetl-seed-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("orchestrate.wasm"), b"\x00asm-fake-orchestrate").unwrap();
+        std::fs::write(dir.join("materialiser.wasm"), b"\x00asm-fake-materialiser").unwrap();
+        std::fs::write(dir.join("README.md"), b"not a plug-in").unwrap();
+
+        let entries = scan_system_plugins(&dir);
+
+        assert_eq!(entries.len(), 2, "only the .wasm files seed");
+        // Sorted by path.
+        assert_eq!(entries[0].path, "system/materialiser");
+        assert_eq!(entries[1].path, "system/orchestrate");
+        assert!(entries.iter().all(|e| e.version == 1));
+        assert!(entries.iter().all(|e| e.media_type == "application/wasm"));
+
+        // Digest matches the register endpoint's computation exactly.
+        let expected = hex::encode(Sha256::digest(b"\x00asm-fake-orchestrate"));
+        assert_eq!(entries[1].digest, expected);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A missing directory is a no-op (local dev without the baked image),
+    /// not an error.
+    #[test]
+    fn scan_missing_dir_is_empty() {
+        let dir = std::env::temp_dir().join("noetl-seed-test-does-not-exist-xyz");
+        assert!(scan_system_plugins(&dir).is_empty());
+    }
+}


### PR DESCRIPTION
Slice 3 of the plug-in round ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)). Slices 1+2 built the `system/orchestrate` plug-in and proved it runs identically in wasmtime; this slice gets it **into the registry in a real deployment** so the worker pool can fetch it.

The register/serve infra (`noetl.plugin_module` + `/api/internal/plugins` + the worker's `HttpPluginSource`) already existed ([#105](https://github.com/noetl/ai-meta/issues/105) Round 4) but **nothing registered the orchestrate plug-in** — there was no bootstrap. This adds one.

## What
- **`src/system_plugins.rs`** — `scan_system_plugins(dir)` (pure: glob `*.wasm` → read → sha256 digest → path `system/<stem>` → version 1; unit-tested, no DB) + `seed_system_plugins(pool)` (upserts each via `plugin_module::upsert`, in-process — **not** the token-gated `/api/internal/plugins` surface, which is for *external* registration). Missing dir → no-op (local dev); failures logged, never fatal.
- **`main.rs`** — seed after `plugin_module::ensure_table`, non-fatal.
- **`Dockerfile`** — a `wasmbuilder` stage builds `plugins/orchestrate` to wasm32 and bakes `orchestrate.wasm` → `/opt/noetl/plugins/`; `NOETL_SYSTEM_PLUGIN_DIR` defaults there.
- **`.dockerignore`** — exclude nested `**/target` (the excluded plug-in crate's local target is 1.8 GB and broke the context `COPY`).
- **Digest-keyed hot-reload** — every boot re-seeds `@1` with current bytes, so a new image hot-reloads the pool (worker resolves the digest per dispatch) with no version bump.

## Validation (kind, image `localhost/noetl-server:oc-seed`)
- Boot log: `seeded system plug-in path=system/orchestrate version=1 digest=823dec… bytes=1559093` → `count=1`.
- `GET /api/internal/plugins/system/orchestrate?version=1` → **200**, `application/wasm`, **1559093 bytes**, magic `\0asm`, `ETag`=digest; correct digest → 200, **stale digest → 409**.
- **Baked-file sha256 == served digest** (`823dec…`) — byte-identical image → registry → API.
- 553 lib tests green (2 new seed-scan tests); clippy clean; plug-in stays `exclude`d from the workspace.

## Wiki
Server `deployment-specification` env-var catalogue gains `NOETL_SYSTEM_PLUGIN_DIR` (wiki-maintenance Rule 2a).

## Next (#108)
4. Kernel scheduler (`NOETL_ORCHESTRATE_PLUGIN`, default off) — dispatch the now-registered plug-in alongside the in-process orchestrator, live-shadow over the PFT, flip after green.

Refs [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)