### PR TITLE
feat(orchestrate-shadow): in-server live shadow of the system/orchestrate plug-in (#108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +47,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +89,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +118,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "memchr",
@@ -232,6 +268,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -288,6 +330,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -353,6 +397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,12 +447,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba4f80548f22dc9c43911907b5e322c5555544ee85f785115701e6a28c9abe1"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005884e3649c3e5ff2dc79e8a94b138f11569cc08a91244a292714d2a86e9156"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4036255ec33ce9a37495dfbcfc4e1118fd34e693eff9a1e106336b7cd16a9b"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ca74f4b68319da11d39e894437cb6e20ec7c2e11fbbda823c3bf207beedff7"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e54f433a0269c4187871aa06d452214d5515d228d5bdc22219585e9eef895"
+
+[[package]]
+name = "cranelift-control"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cb4018f5bf59fb53f515fa9d80e6f8c5ce19f198dc538984ebd23ecf8965ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305399fd781a2953ac78c1396f02ff53144f39c33eb7fc7789cf4e8936d13a96"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9230b460a128d53653456137751d27baf567947a3ab8c0c4d6e31fd08036d81e"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b961e24ae3ec9813a24a15ae64bbd2a42e4de4d79a7f3225a412e3b94e78d1c8"
+
+[[package]]
+name = "cranelift-native"
+version = "0.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5bd76df6c9151188dfa428c863b33da5b34561b67f43c0cf3f24a794f9fa1f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -416,6 +585,15 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -515,6 +693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +732,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -596,6 +804,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +870,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fiat-crypto"
@@ -783,6 +1018,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1098,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1125,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "serde",
 ]
 
 [[package]]
@@ -1013,7 +1291,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1137,6 +1415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1449,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1183,10 +1469,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1207,6 +1532,18 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1243,6 +1580,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1617,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1299,6 +1657,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memo-map"
@@ -1365,7 +1732,7 @@ dependencies = [
 name = "noetl-orchestrate-core"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "minijinja",
  "serde",
@@ -1385,7 +1752,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
- "base64",
+ "base64 0.22.1",
  "chacha20poly1305",
  "chrono",
  "ctor",
@@ -1422,6 +1789,7 @@ dependencies = [
  "tracing-subscriber",
  "twox-hash",
  "uuid",
+ "wasmtime",
  "x25519-dalek",
  "zeroize",
 ]
@@ -1506,6 +1874,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1946,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1662,6 +2057,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +2121,27 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b8d81cf799e20564931e9867ca32de545188c6ee4c2e0f6e41d32f0c7dc6fb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "sptr",
+]
 
 [[package]]
 name = "quinn"
@@ -1889,6 +2317,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+dependencies = [
+ "hashbrown 0.14.5",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,7 +2375,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1990,6 +2442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2460,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2153,6 +2637,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2226,6 +2714,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2354,6 +2851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,7 +2919,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -2487,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -2531,7 +3040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "chrono",
@@ -2661,6 +3170,21 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2846,7 +3370,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -2860,6 +3384,47 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3044,6 +3609,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3776,327 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa79bcd666a043b58f5fa62b221b0b914dd901e6f620e8ab7371057a797f3e1"
+dependencies = [
+ "leb128",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5220ee4c6ffcc0cb9d7c47398052203bc902c8ef3985b0c8134118440c0b2921"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68c93bcc5e934985afd8b65214bdd77abd3863b2e1855eae1b07a11c4ef30a8"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b79302e3e084713249cc5622e8608e7410afdeeea8c8026d04f491d1fab0b4b"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "ittapi",
+ "libc",
+ "libm",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.36.7",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 0.38.44",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "wasm-encoder 0.219.2",
+ "wasmparser 0.219.2",
+ "wasmtime-asm-macros",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "wat",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe53a24e7016a5222875d8ca3ad6024b464465985693c42098cd0bb710002c28"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0677a7e76c24746b68e3657f7cc50c0ff122ee7e97bbda6e710c1b790ebc93cb"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e118acbd2bc09b32ad8606bc7cef793bf5019c1b107772e64dc6c76b5055d40b"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6db4f3ee18c699629eabb9c64e77efe5a93a5137f098db7cab295037ba41c2"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b87e6c78f562b50aff1afd87ff32a57e241424c846c1c8f3c5fd352d2d62906"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object 0.36.7",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.219.2",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25bfeaa16432d59a0706e2463d315ef4c9ebcfaf5605670b99d46373bdf9f27"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap",
+ "log",
+ "object 0.36.7",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.219.2",
+ "wasmparser 0.219.2",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759ab0caa3821a6211743fe1eed448ab9df439e3af6c60dea15486c055611806"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2a056056e9ac6916c2b8e4743408560300c1355e078c344211f13210d449b3"
+dependencies = [
+ "object 0.36.7",
+ "rustix 0.38.44",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b218a92866f74f35162f5d03a4e0f62cd0e1cc624285b1014275e5d4575fad"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5f8acf677ee6b3b8ba400dd9753ea4769e56a95c4b30b045ac6d2d54b2f8ea"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d6b5297bea14d8387c3974b2b011de628cc9b188f135cec752b74fd368964b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object 0.36.7",
+ "target-lexicon",
+ "wasmparser 0.219.2",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "252.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.252.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+dependencies = [
+ "wast",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,10 +4161,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b42b678c8651ec4900d7600037d235429fc985c31cbc33515885ec0d2a9e158"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.219.2",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+]
 
 [[package]]
 name = "windows"
@@ -3394,6 +4318,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3603,10 +4536,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-parser"
+version = "0.219.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca004bb251010fe956f4a5b9d4bf86b4e415064160dd6669569939e8cbf2504f"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.219.2",
+]
 
 [[package]]
 name = "writeable"
@@ -3748,3 +4708,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,18 @@ members = ["orchestrate-core"]
 #     --manifest-path plugins/orchestrate/Cargo.toml
 exclude = ["plugins/orchestrate"]
 
+[features]
+# In-server shadow of the system/orchestrate plug-in (noetl/ai-meta#108 slice 4):
+# pulls in wasmtime so the server can run the plug-in alongside the in-process
+# drive and diff. Off by default — the production server stays lean; enable when
+# building a shadow-validation image.
+orchestrate-shadow = ["dep:wasmtime"]
+
 [dependencies]
 # Pure orchestrator drive core (one source → native + wasm32; noetl/ai-meta#108).
 noetl-orchestrate-core = { path = "orchestrate-core" }
+# wasmtime host for the orchestrate-shadow feature; pinned to the worker's major.
+wasmtime = { version = "27", optional = true }
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,14 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+# Build deps for the recipe + the orchestrate-shadow feature (wasmtime) so the
+# cook layer caches them (noetl/ai-meta#108 slice 4).
+RUN cargo chef cook --release --features orchestrate-shadow --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --bin noetl-control-plane
+# Built with the orchestrate-shadow feature so the image can run the in-server
+# plug-in shadow; the behaviour is still gated at runtime by
+# NOETL_ORCHESTRATE_PLUGIN_SHADOW (default off).
+RUN cargo build --release --features orchestrate-shadow --bin noetl-control-plane
 
 # Build the built-in system plug-ins to wasm32 (noetl/ai-meta#108 slice 3).
 # The `plugins/orchestrate` crate is excluded from the server workspace, so it is

--- a/plugins/orchestrate/Cargo.toml
+++ b/plugins/orchestrate/Cargo.toml
@@ -23,12 +23,13 @@ crate-type = ["cdylib", "rlib"]
 noetl-orchestrate-core = { path = "../../orchestrate-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# `OrchestrateStateInput.latest_ts` is a `DateTime<Utc>`; default-features off +
+# serde/std keeps it wasm32-safe (no clock/wasmbind), matching the core.
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 
 [dev-dependencies]
-# Native-only: the parity test builds the playbook from YAML and stamps fixed
-# event timestamps (chrono matches the core's `DateTime<Utc>`).
+# Native-only: the parity tests build the playbook from YAML.
 serde_yaml = "0.9"
-chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 # The shadow-diff integration test loads the built `.wasm` and runs it through a
 # wasmtime harness that mirrors the worker host's `invoke_bytes` ABI byte-for-byte.
 # Pinned to the worker's wasmtime major (`repos/worker/Cargo.toml`) so "runs in

--- a/plugins/orchestrate/src/lib.rs
+++ b/plugins/orchestrate/src/lib.rs
@@ -21,6 +21,7 @@
 use noetl_orchestrate_core::event::Event;
 use noetl_orchestrate_core::orchestrator::{OrchestrationResult, WorkflowOrchestrator};
 use noetl_orchestrate_core::playbook::Playbook;
+use noetl_orchestrate_core::state::WorkflowState;
 use serde::{Deserialize, Serialize};
 
 /// The plug-in's input contract — the drive read-set the scheduler hands in.
@@ -36,6 +37,25 @@ pub struct OrchestrateInput {
     /// The playbook (blueprint) for the execution, loaded from the catalog.
     pub playbook: Playbook,
     /// The event type that triggered this evaluation (`None` on a cold start).
+    #[serde(default)]
+    pub trigger_event_type: Option<String>,
+}
+
+/// The plug-in's **state** input contract — an already-built `WorkflowState`
+/// plus the playbook + trigger. This is what the in-server shadow uses: it hands
+/// the plug-in the same incrementally-maintained `WorkflowState` the in-process
+/// orchestrator drives, so the diff isolates the wasm runtime from any
+/// event-slice / snapshot reconstruction (noetl/ai-meta#108 slice 4). The
+/// kernel scheduler will later use the event-slice [`OrchestrateInput`] path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestrateStateInput {
+    /// The drive state (the projection-snapshot shape the server already
+    /// serializes). The plug-in mutates its own deserialized copy.
+    pub state: WorkflowState,
+    /// The most recent event's timestamp (stamps a cursor-drain completion).
+    #[serde(default)]
+    pub latest_ts: Option<chrono::DateTime<chrono::Utc>>,
+    pub playbook: Playbook,
     #[serde(default)]
     pub trigger_event_type: Option<String>,
 }
@@ -73,6 +93,33 @@ fn orchestrate_inner(input: &[u8]) -> Result<Vec<u8>, String> {
     serde_json::to_vec(&result).map_err(|e| format!("encode OrchestrationResult: {e}"))
 }
 
+/// State-input round-trip: decode an [`OrchestrateStateInput`] → run
+/// `evaluate_state` on its (owned) state → encode the `OrchestrationResult`.
+/// The in-server shadow's wasm entry point.
+pub fn orchestrate_state(input: &[u8]) -> Vec<u8> {
+    match orchestrate_state_inner(input) {
+        Ok(bytes) => bytes,
+        Err(msg) => serde_json::to_vec(&OrchestrateError { error: msg }).unwrap_or_else(|_| {
+            br#"{"error":"failed to serialize orchestrate error"}"#.to_vec()
+        }),
+    }
+}
+
+fn orchestrate_state_inner(input: &[u8]) -> Result<Vec<u8>, String> {
+    let mut parsed: OrchestrateStateInput =
+        serde_json::from_slice(input).map_err(|e| format!("decode OrchestrateStateInput: {e}"))?;
+    let orchestrator = WorkflowOrchestrator::new();
+    let result: OrchestrationResult = orchestrator
+        .evaluate_state(
+            &mut parsed.state,
+            parsed.latest_ts,
+            &parsed.playbook,
+            parsed.trigger_event_type.as_deref(),
+        )
+        .map_err(|e| format!("evaluate_state: {e}"))?;
+    serde_json::to_vec(&result).map_err(|e| format!("encode OrchestrationResult: {e}"))
+}
+
 // ---- wasm32 data-plane ABI -------------------------------------------------
 // The host's contract (worker `WasmPluginHost::invoke_bytes`): the guest exports
 // `memory` + `alloc(size) -> ptr` + `run(in_ptr, in_len) -> packed_i64` where
@@ -99,6 +146,19 @@ pub extern "C" fn alloc(size: usize) -> *mut u8 {
 pub extern "C" fn run(input_ptr: *const u8, input_len: usize) -> i64 {
     let input = unsafe { std::slice::from_raw_parts(input_ptr, input_len) };
     let output = orchestrate(input);
+    let out_ptr = output.as_ptr() as i64;
+    let out_len = output.len() as i64;
+    std::mem::forget(output);
+    (out_ptr << 32) | out_len
+}
+
+/// State-input entry point (same packed-`i64` data-plane ABI as `run`) — the
+/// in-server shadow invokes this with an [`OrchestrateStateInput`].
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn run_state(input_ptr: *const u8, input_len: usize) -> i64 {
+    let input = unsafe { std::slice::from_raw_parts(input_ptr, input_len) };
+    let output = orchestrate_state(input);
     let out_ptr = output.as_ptr() as i64;
     let out_len = output.len() as i64;
     std::mem::forget(output);
@@ -217,6 +277,67 @@ workflow:
         assert!(steps.contains(&"err_cb"), "expected err_cb command, got {steps:?}");
     }
 
+    /// The **state** path (used by the in-server shadow): `orchestrate_state`
+    /// reproduces native `evaluate_state` on the same `WorkflowState`.
+    #[test]
+    fn orchestrate_state_matches_native_evaluate_state() {
+        let yaml = r#"
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata: { name: test, path: test }
+workflow:
+  - step: start
+    tool: { kind: python, code: "result = {}" }
+    next:
+      arcs:
+        - step: end
+  - step: end
+    tool: { kind: python, code: "result = {}" }
+"#;
+        let playbook: Playbook = serde_yaml::from_str(yaml).unwrap();
+        let mut started = Event {
+            event_id: 1,
+            execution_id: 12345,
+            catalog_id: 67890,
+            event_type: "playbook_started".to_string(),
+            node_name: None,
+            status: String::new(),
+            context: Some(serde_json::json!({ "workload": {}, "path": "test" })),
+            result: None,
+            meta: None,
+            timestamp: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            parent_execution_id: None,
+            attempt: None,
+        };
+        started.event_id = 1;
+        let events = vec![started];
+        let state = WorkflowState::from_events(&events).expect("build state");
+        let latest_ts = events.last().map(|e| e.timestamp);
+
+        // Native evaluate_state on a clone (evaluate_state mutates its state).
+        let native = WorkflowOrchestrator::new()
+            .evaluate_state(&mut state.clone(), latest_ts, &playbook, None)
+            .expect("native evaluate_state");
+
+        // Plug-in state path — JSON in, JSON out.
+        let input = OrchestrateStateInput {
+            state,
+            latest_ts,
+            playbook,
+            trigger_event_type: None,
+        };
+        let out = orchestrate_state(&serde_json::to_vec(&input).unwrap());
+        let plugin: OrchestrationResult =
+            serde_json::from_slice(&out).expect("decode OrchestrationResult (not an error)");
+
+        assert_eq!(
+            serde_json::to_value(&native.commands).unwrap(),
+            serde_json::to_value(&plugin.commands).unwrap(),
+            "state-path commands diverge from native evaluate_state"
+        );
+        assert!(!plugin.commands.is_empty(), "expected a first command");
+    }
+
     /// A malformed input yields the error envelope, not a panic — the scheduler
     /// can always distinguish a drive failure from a result.
     #[test]
@@ -224,5 +345,9 @@ workflow:
         let out = orchestrate(b"not json");
         let err: OrchestrateError = serde_json::from_slice(&out).expect("error envelope");
         assert!(err.error.contains("decode OrchestrateInput"), "{}", err.error);
+
+        let out2 = orchestrate_state(b"not json");
+        let err2: OrchestrateError = serde_json::from_slice(&out2).expect("error envelope");
+        assert!(err2.error.contains("decode OrchestrateStateInput"), "{}", err2.error);
     }
 }

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -68,6 +68,16 @@ pub struct AppConfig {
     #[serde(default)]
     pub projector_owns_snapshot: bool,
 
+    /// In-server shadow of the `system/orchestrate` WASM plug-in
+    /// (noetl/ai-meta#108 slice 4).  When true (and the binary is built with
+    /// the `orchestrate-shadow` feature), every orchestrator evaluation also
+    /// runs the plug-in on the same `WorkflowState` and diffs the emitted
+    /// commands — the in-process result stays authoritative.  Envy maps
+    /// `NOETL_ORCHESTRATE_PLUGIN_SHADOW`.  **Default false** — a clean shadow
+    /// over the PFT (all `match`) is the gate before any worker-driven cutover.
+    #[serde(default)]
+    pub orchestrate_plugin_shadow: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -180,6 +190,7 @@ impl Default for AppConfig {
             disable_metrics: false,
             refs_in_state: false,
             projector_owns_snapshot: false,
+            orchestrate_plugin_shadow: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2022,6 +2022,16 @@ async fn trigger_orchestrator_inner(
     // this the cursor would see 0 rows and wrongly DRAIN.  No-op unless the flag
     // kept a claim reference (flag-off claims are resolved inline by hydrate).
     resolve_cursor_claim_refs(ws, &result_store).await;
+    // Orchestrate plug-in shadow (noetl/ai-meta#108 slice 4): snapshot the state
+    // BEFORE `evaluate_state` mutates it, so the plug-in evaluates the identical
+    // input. Cloned only when the shadow is loaded (default off → no cost).
+    let shadow_pre_state = if state.config.orchestrate_plugin_shadow
+        && crate::orchestrate_shadow::enabled()
+    {
+        Some(ws.clone())
+    } else {
+        None
+    };
     let result = match orchestrator.evaluate_state(
         ws,
         latest_ts,
@@ -2057,6 +2067,20 @@ async fn trigger_orchestrator_inner(
             return Ok(0);
         }
     };
+
+    // Orchestrate plug-in shadow (noetl/ai-meta#108 slice 4): run the plug-in on
+    // the pre-evaluate state and diff its commands against the in-process
+    // `result`. Observation only — the live result above is authoritative.
+    if let Some(pre_state) = shadow_pre_state {
+        crate::orchestrate_shadow::shadow_diff(
+            pre_state,
+            latest_ts,
+            &playbook,
+            trigger_event_type.as_str(),
+            &result,
+            execution_id,
+        );
+    }
 
     info!(
         execution_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod error;
 pub mod handlers;
 pub mod metrics;
 pub mod nats;
+pub mod orchestrate_shadow;
 pub mod playbook;
 pub mod result_ext;
 pub mod sanitize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -757,6 +757,21 @@ async fn main() -> anyhow::Result<()> {
         Ok(n) => tracing::info!(count = n, "seeded built-in system plug-ins"),
         Err(e) => tracing::warn!(error = %e, "failed to seed system plug-ins; continuing"),
     }
+    // Orchestrate plug-in shadow (noetl/ai-meta#108 slice 4) — load the just-seeded
+    // `system/orchestrate@1` into the in-server wasmtime host so every drive can
+    // be diffed against the plug-in. Gated by `NOETL_ORCHESTRATE_PLUGIN_SHADOW` +
+    // the `orchestrate-shadow` build feature; without the feature `init` is a
+    // no-op. Best-effort: a missing plug-in just leaves the shadow disabled.
+    if app_config.orchestrate_plugin_shadow {
+        match noetl_server::db::queries::plugin_module::get(&db_pool, "system/orchestrate", 1).await
+        {
+            Ok(Some(row)) => noetl_server::orchestrate_shadow::init(&row.bytes),
+            Ok(None) => {
+                tracing::warn!("orchestrate shadow on but system/orchestrate@1 not registered")
+            }
+            Err(e) => tracing::warn!(error = %e, "orchestrate shadow: failed to load plug-in"),
+        }
+    }
     // Object store (noetl/ai-meta#105 Round 5) — durable Feather tier backing a
     // plug-in's `noetl.object_put`. Same idempotent startup-DDL pattern.
     noetl_server::db::queries::object_store::ensure_table(&db_pool).await?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -120,6 +120,34 @@ pub fn record_cleanup_purged(table: &str, rows: u64) {
         .inc_by(rows);
 }
 
+/// Counter: in-server `system/orchestrate` plug-in shadow evaluations, bucketed
+/// by `result` (`match` / `mismatch` / `error`).  A clean shadow over the PFT —
+/// all `match`, zero `mismatch` — is the cutover gate (noetl/ai-meta#108).
+pub fn orchestrate_shadow_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_orchestrate_shadow_total",
+                "Orchestrate plug-in shadow evaluations vs the in-process drive, by result.",
+            ),
+            &["result"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one shadow evaluation outcome (`match` / `mismatch` / `error`).
+pub fn record_orchestrate_shadow(result: &str) {
+    orchestrate_shadow_total()
+        .with_label_values(&[result])
+        .inc();
+}
+
 /// Histogram: wall-clock time spent inside the `POST /api/events` handler.
 pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
     static M: OnceLock<HistogramVec> = OnceLock::new();

--- a/src/orchestrate_shadow.rs
+++ b/src/orchestrate_shadow.rs
@@ -1,0 +1,222 @@
+//! In-server **shadow** of the `system/orchestrate` WASM plug-in
+//! (noetl/ai-meta#108 slice 4).
+//!
+//! When `NOETL_ORCHESTRATE_PLUGIN_SHADOW=true` (and the binary is built with the
+//! `orchestrate-shadow` feature), the orchestrator runs the plug-in *alongside*
+//! the in-process drive on every evaluation: it hands the plug-in the **same**
+//! `WorkflowState` the in-process `evaluate_state` just consumed and diffs the
+//! emitted command sets. The in-process result stays authoritative — the shadow
+//! only observes — so the live platform is untouched while we build
+//! cutover confidence over the real workload.
+//!
+//! The diff is **command-set identity** (parsed `Value` equality), not raw
+//! bytes: the drive's `context` maps serialize in insertion order, which differs
+//! wasm32-vs-host (slice 2 finding). The scheduler deserializes commands anyway.
+//!
+//! Everything heavy is gated behind the `orchestrate-shadow` feature so the
+//! production server doesn't carry `wasmtime` unless the shadow is wanted. The
+//! public wrappers are always present and are cheap no-ops without the feature,
+//! so call sites (`trigger_orchestrator_inner`) need no `cfg`.
+
+use noetl_orchestrate_core::orchestrator::OrchestrationResult;
+use noetl_orchestrate_core::playbook::Playbook;
+use noetl_orchestrate_core::state::WorkflowState;
+
+/// True when a compiled shadow host is loaded and ready to evaluate.
+pub fn enabled() -> bool {
+    #[cfg(feature = "orchestrate-shadow")]
+    {
+        imp::host().is_some()
+    }
+    #[cfg(not(feature = "orchestrate-shadow"))]
+    {
+        false
+    }
+}
+
+/// Run the plug-in on `pre_state` (the state as it was **before** the in-process
+/// `evaluate_state` mutated it) and diff its commands against `native`. Records a
+/// `match`/`mismatch` metric and warns on divergence. Never panics, never
+/// affects the live result — best-effort observation.
+#[allow(unused_variables)]
+pub fn shadow_diff(
+    pre_state: WorkflowState,
+    latest_ts: Option<chrono::DateTime<chrono::Utc>>,
+    playbook: &Playbook,
+    trigger_event_type: &str,
+    native: &OrchestrationResult,
+    execution_id: i64,
+) {
+    #[cfg(feature = "orchestrate-shadow")]
+    imp::shadow_diff(
+        pre_state,
+        latest_ts,
+        playbook,
+        trigger_event_type,
+        native,
+        execution_id,
+    );
+}
+
+/// Compile + install the shadow host from the plug-in's wasm bytes (typically
+/// fetched from `noetl.plugin_module`). No-op without the feature.
+#[allow(unused_variables)]
+pub fn init(wasm: &[u8]) {
+    #[cfg(feature = "orchestrate-shadow")]
+    imp::init(wasm);
+}
+
+#[cfg(feature = "orchestrate-shadow")]
+mod imp {
+    use std::sync::OnceLock;
+
+    use noetl_orchestrate_core::orchestrator::OrchestrationResult;
+    use noetl_orchestrate_core::playbook::Playbook;
+    use noetl_orchestrate_core::state::WorkflowState;
+    use serde::Serialize;
+    use tracing::{debug, warn};
+    use wasmtime::{Engine, Instance, Module, Store};
+
+    /// The compiled plug-in, instantiated fresh per call (the worker host's
+    /// isolation model). `Engine`/`Module` are `Send + Sync`.
+    pub struct ShadowHost {
+        engine: Engine,
+        module: Module,
+    }
+
+    static HOST: OnceLock<ShadowHost> = OnceLock::new();
+
+    pub fn host() -> Option<&'static ShadowHost> {
+        HOST.get()
+    }
+
+    pub fn init(wasm: &[u8]) {
+        if HOST.get().is_some() {
+            return;
+        }
+        let engine = Engine::default();
+        match Module::new(&engine, wasm) {
+            Ok(module) => {
+                let _ = HOST.set(ShadowHost { engine, module });
+                tracing::info!(bytes = wasm.len(), "orchestrate shadow host loaded");
+            }
+            Err(e) => warn!(error = %e, "orchestrate shadow: failed to compile plug-in; disabled"),
+        }
+    }
+
+    /// The plug-in's `OrchestrateStateInput` JSON shape, built server-side (the
+    /// plug-in crate is not a dependency, so we mirror the contract here).
+    #[derive(Serialize)]
+    struct StateInput<'a> {
+        state: &'a WorkflowState,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        latest_ts: Option<chrono::DateTime<chrono::Utc>>,
+        playbook: &'a Playbook,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trigger_event_type: Option<&'a str>,
+    }
+
+    pub fn shadow_diff(
+        pre_state: WorkflowState,
+        latest_ts: Option<chrono::DateTime<chrono::Utc>>,
+        playbook: &Playbook,
+        trigger_event_type: &str,
+        native: &OrchestrationResult,
+        execution_id: i64,
+    ) {
+        let Some(host) = HOST.get() else { return };
+
+        let input = StateInput {
+            state: &pre_state,
+            latest_ts,
+            playbook,
+            trigger_event_type: Some(trigger_event_type),
+        };
+        let input_bytes = match serde_json::to_vec(&input) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(execution_id, error = %e, "orchestrate shadow: encode input failed");
+                return;
+            }
+        };
+
+        let plugin_bytes = match host.run_state(&input_bytes) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(execution_id, error = %e, "orchestrate shadow: plug-in invocation failed");
+                return;
+            }
+        };
+
+        // Semantic command-set identity (parsed Value eq tolerates non-canonical
+        // context-map key order — slice 2 finding).
+        let native_v = serde_json::to_value(&native.commands).unwrap_or(serde_json::Value::Null);
+        let plugin_v: serde_json::Value = match serde_json::from_slice(&plugin_bytes) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(execution_id, error = %e, "orchestrate shadow: decode plug-in output failed");
+                return;
+            }
+        };
+        if let Some(err) = plugin_v.get("error") {
+            warn!(execution_id, plugin_error = %err, "orchestrate shadow: plug-in returned an error envelope");
+            crate::metrics::record_orchestrate_shadow("error");
+            return;
+        }
+        let plugin_cmds = plugin_v.get("commands").cloned().unwrap_or(serde_json::Value::Null);
+
+        if native_v == plugin_cmds {
+            crate::metrics::record_orchestrate_shadow("match");
+            debug!(
+                execution_id,
+                commands = native.commands.len(),
+                "orchestrate shadow: match"
+            );
+        } else {
+            crate::metrics::record_orchestrate_shadow("mismatch");
+            warn!(
+                execution_id,
+                trigger = trigger_event_type,
+                native_commands = native.commands.len(),
+                "orchestrate shadow: MISMATCH — plug-in commands diverge from in-process drive"
+            );
+        }
+    }
+
+    impl ShadowHost {
+        /// Invoke the plug-in's `run_state` export over the worker host's
+        /// data-plane ABI: `alloc(len)` → write input → `run_state(ptr,len)` →
+        /// unpack `(out_ptr<<32)|out_len` → read output. Fresh `Store`/`Instance`
+        /// per call.
+        fn run_state(&self, input: &[u8]) -> Result<Vec<u8>, String> {
+            let mut store = Store::new(&self.engine, ());
+            let instance = Instance::new(&mut store, &self.module, &[])
+                .map_err(|e| format!("instantiate: {e}"))?;
+            let memory = instance
+                .get_memory(&mut store, "memory")
+                .ok_or("missing export: memory")?;
+            let alloc = instance
+                .get_typed_func::<i32, i32>(&mut store, "alloc")
+                .map_err(|_| "missing export: alloc".to_string())?;
+            let run_state = instance
+                .get_typed_func::<(i32, i32), i64>(&mut store, "run_state")
+                .map_err(|_| "missing export: run_state".to_string())?;
+
+            let len = i32::try_from(input.len()).map_err(|_| "input exceeds i32".to_string())?;
+            let in_ptr = alloc.call(&mut store, len).map_err(|e| format!("alloc: {e}"))?;
+            memory
+                .write(&mut store, in_ptr as usize, input)
+                .map_err(|e| format!("write: {e}"))?;
+            let packed = run_state
+                .call(&mut store, (in_ptr, len))
+                .map_err(|e| format!("run_state: {e}"))?;
+            let out_ptr = ((packed >> 32) & 0xffff_ffff) as usize;
+            let out_len = (packed & 0xffff_ffff) as usize;
+            let mut out = vec![0u8; out_len];
+            memory
+                .read(&store, out_ptr, &mut out)
+                .map_err(|e| format!("read: {e}"))?;
+            Ok(out)
+        }
+    }
+}


### PR DESCRIPTION
Slice 4 of the plug-in round ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)). The orchestrator can now run the `system/orchestrate` WASM plug-in **alongside** the in-process drive on every evaluation and diff the emitted commands — the cutover-confidence gate over the real workload. The in-process result stays authoritative (observation only) — **zero risk to the live platform**.

## Plug-in (`plugins/orchestrate`)
- New `OrchestrateStateInput { state, latest_ts, playbook, trigger }` + `orchestrate_state()` + a `run_state` wasm export — the **state-input** path the shadow uses, so the plug-in evaluates the *same* `WorkflowState` the in-process `evaluate_state` consumes (no event-slice/snapshot reconstruction to confound the diff). `chrono` promoted to a regular (wasm-safe) dep. Native parity test added.

## Server
- **`src/orchestrate_shadow.rs`** (feature `orchestrate-shadow`, optional `wasmtime`): a process-global wasmtime host (fresh `Store`/`Instance` per call, mirrors the worker's invoke ABI) loaded from `noetl.plugin_module` at boot. `shadow_diff` clones the pre-evaluate state, runs `run_state`, diffs commands as **command-set identity** (parsed `Value` eq — per the slice-2 key-order finding). Always-present no-op wrappers so call sites need no `cfg`.
- **`trigger_orchestrator_inner`**: clone the state before `evaluate_state` (only when the shadow is loaded) and diff after — gated by `NOETL_ORCHESTRATE_PLUGIN_SHADOW`.
- Metric `noetl_orchestrate_shadow_total{result=match|mismatch|error}`; config flag `orchestrate_plugin_shadow`; `main.rs` loads the host post-seed.
- Dockerfile builds with `--features orchestrate-shadow` (runtime-gated, default off).

## Validation (kind, image `oc-shadow`, `NOETL_ORCHESTRATE_PLUGIN_SHADOW=true`)
Over the **live 10×1000 PFT**:
- `noetl_orchestrate_shadow_total{result="match"} 529` — **the only label**. **Zero `mismatch`, zero `error`**, 0 divergence log lines.
- Server + workers stable (r=0).
- Boot log: `orchestrate shadow host loaded bytes=1603665`.

**The plug-in drives the real workload identically to the in-process orchestrator, live.** That's the cutover gate cleared.

Both build configs green: default (no `wasmtime`, shadow is a no-op) + `--features orchestrate-shadow`. 553 server + 3 plug-in tests green; clippy clean both.

## Wiki
Server `deployment-specification` gains `NOETL_ORCHESTRATE_PLUGIN_SHADOW` (Rule 2a).

## Next
With the shadow clean, the worker-driven cutover (the kernel scheduler dispatches `system/orchestrate` on a worker and publishes its commands, retiring `trigger_orchestrator_inner`) is the final step of the orchestrator-as-plug-in arc — and the in-server shadow + `wasmtime` dep come back out once the server no longer drives.

Refs [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)