### PR TITLE
feat(orchestrate-drive): worker-driven orchestrator drive — runs off-server on the pool (#108)

### DIFF
--- a/orchestrate-core/src/state.rs
+++ b/orchestrate-core/src/state.rs
@@ -405,7 +405,22 @@ impl WorkflowState {
     }
 
     /// Apply a single event to update the workflow state.
+    /// The reserved step name of the worker-driven orchestrate "meta" command
+    /// (noetl/ai-meta#108). The server issues `system/orchestrate` as a command
+    /// under this step so the worker pool runs the drive; its lifecycle events
+    /// are infrastructure, NOT workflow steps, so they are ignored here (see
+    /// `apply_event`) — otherwise `steps.entry(name).or_insert_with(..)` below
+    /// would create a phantom step and corrupt the drive state.
+    pub const ORCHESTRATE_META_STEP: &'static str = "__orchestrate__";
+
     pub fn apply_event(&mut self, event: &Event) {
+        // Ignore the worker-driven orchestrate meta-command's own events: they
+        // drive the execution but are not workflow steps. Without this, a
+        // `command.issued`/`command.completed` for `__orchestrate__` would
+        // phantom-create a step in `self.steps` (noetl/ai-meta#108).
+        if event.node_name.as_deref() == Some(Self::ORCHESTRATE_META_STEP) {
+            return;
+        }
         match event.event_type.as_str() {
             "playbook_started" => {
                 self.state = ExecutionState::InProgress;
@@ -1884,6 +1899,32 @@ mod tests {
     // -----------------------------------------------------------------------
     // apply_set_mutations tests (arc-level `set:` DSL contract)
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn orchestrate_meta_command_events_do_not_pollute_state() {
+        // The worker-driven orchestrate meta-command (noetl/ai-meta#108) issues
+        // `command.issued`/`command.completed` under the reserved `__orchestrate__`
+        // step. Those must NOT create a phantom step — otherwise the drive would
+        // see a step that isn't in the playbook.
+        let mut ws = WorkflowState::new(12345, 67890);
+        ws.apply_event(&make_event(
+            "command.issued",
+            Some(WorkflowState::ORCHESTRATE_META_STEP),
+        ));
+        ws.apply_event(&make_event(
+            "command.completed",
+            Some(WorkflowState::ORCHESTRATE_META_STEP),
+        ));
+        assert!(
+            !ws.steps.contains_key(WorkflowState::ORCHESTRATE_META_STEP),
+            "the meta-command must not create a workflow step"
+        );
+        assert!(ws.steps.is_empty(), "no steps should exist, got {:?}", ws.steps.keys().collect::<Vec<_>>());
+
+        // A real step's command.issued still creates its step (guard is scoped).
+        ws.apply_event(&make_event("command.issued", Some("real_step")));
+        assert!(ws.steps.contains_key("real_step"));
+    }
 
     #[test]
     fn test_apply_set_mutations_strips_ctx_prefix() {

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -78,6 +78,18 @@ pub struct AppConfig {
     #[serde(default)]
     pub orchestrate_plugin_shadow: bool,
 
+    /// Worker-driven orchestrator drive (noetl/ai-meta#108 slice 3).  When true,
+    /// on a triggering event the server issues the `system/orchestrate` plug-in
+    /// as a command to the worker pool (step `__orchestrate__`, `entry:
+    /// run_state`) instead of driving in-process; the worker runs the drive and
+    /// its completion is applied via `apply_orchestration_result`.  Envy maps
+    /// `NOETL_ORCHESTRATE_PLUGIN_DRIVE`.  **Default false** — the in-process
+    /// drive stays the untouched fallback; flip on only after the shadow
+    /// (`orchestrate_plugin_shadow`) is clean and `system/orchestrate@1` is
+    /// registered.  Requires the worker pool to carry the `wasm-plugin` feature.
+    #[serde(default)]
+    pub orchestrate_plugin_drive: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -191,6 +203,7 @@ impl Default for AppConfig {
             refs_in_state: false,
             projector_owns_snapshot: false,
             orchestrate_plugin_shadow: false,
+            orchestrate_plugin_drive: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -676,9 +676,25 @@ async fn handle_event_inner(
     // `check_completion` sees end as done and emits
     // `playbook.completed`.  Without this trigger the playbook
     // stalled at `command.completed [end]` with no terminal event.
-    let should_trigger_orchestrator =
-        request.event_type == "command.completed" || request.event_type == "command.failed";
-    if should_trigger_orchestrator {
+    if request.step == noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP {
+        // Worker-driven drive (noetl/ai-meta#108 slice 3): the `system/orchestrate`
+        // plug-in's output (the OrchestrationResult) rides the `call.done` event
+        // — the lifecycle `command.completed`/`claimed`/`started` carry no output.
+        // Apply it (emit events + issue the real commands) instead of triggering
+        // the orchestrator. Those real commands' completions re-trigger the drive
+        // — the loop continues; the meta-command's own events never do.
+        if request.event_type == "call.done" {
+            match apply_worker_orchestration(&state, execution_id, event_id, &request.payload).await
+            {
+                Ok(cmds) => info!(
+                    execution_id,
+                    commands = cmds,
+                    "worker-driven: applied orchestrate result"
+                ),
+                Err(e) => warn!(execution_id, error = %e, "worker-driven: apply failed"),
+            }
+        }
+    } else if request.event_type == "command.completed" || request.event_type == "command.failed" {
         match trigger_orchestrator(&state, execution_id, event_id).await {
             Ok(cmds) => {
                 info!(
@@ -2013,15 +2029,59 @@ async fn trigger_orchestrator_inner(
             })?;
     let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
 
-    // 3. Evaluate against the cached state.
+    // 3. Resolve over-budget cursor claim references into inline rows before the
+    //    drive reads them (noetl/ai-meta#101 phase 2) — a referenced claim has
+    //    `claim_ref` set + empty `claim_rows`; without this the cursor sees 0
+    //    rows and wrongly DRAINs.  No-op unless the flag kept a claim reference.
+    //    Scoped so the `&mut` borrow ends before the drive branches read `cache`.
+    {
+        let ws = cache.state.as_mut().unwrap();
+        resolve_cursor_claim_refs(ws, &result_store).await;
+    }
+
+    // Worker-driven drive (noetl/ai-meta#108 slice 3): issue `system/orchestrate`
+    // to the worker pool instead of evaluating in-process.  The worker runs the
+    // drive on the bounded `WorkflowState`; `apply_worker_orchestration` applies
+    // its result on the command's completion.  Default off → the in-process path
+    // below runs unchanged.
+    if state.config.orchestrate_plugin_drive {
+        // Serialise drives per execution: if one is already dispatched, don't
+        // double-issue (two near-simultaneous triggers / the reconcile poller
+        // would otherwise produce two orchestrate commands → duplicate work).
+        if cache.orchestrate_in_flight {
+            crate::metrics::record_orchestrate_drive("skipped_in_flight");
+            debug!(execution_id, "worker-driven: orchestrate already in flight; skip");
+            return Ok(0);
+        }
+        let routing = cache
+            .routing_meta
+            .as_ref()
+            .map(crate::handlers::execute::CommandRouting::from_started_meta)
+            .unwrap_or_default();
+        let input = serde_json::json!({
+            "state": cache.state.as_ref().expect("state present after rebuild"),
+            "latest_ts": latest_ts,
+            "playbook": &playbook,
+            "trigger_event_type": trigger_event_type,
+        });
+        crate::handlers::execute::dispatch_orchestrate_command(
+            state,
+            execution_id,
+            catalog_id,
+            trigger_event_id,
+            input,
+            &playbook,
+            &routing,
+        )
+        .await?;
+        cache.orchestrate_in_flight = true;
+        debug!(execution_id, "worker-driven: dispatched system/orchestrate to the pool");
+        return Ok(0);
+    }
+
+    // In-process drive (the default, and the shadow's reference half).
     let orchestrator = WorkflowOrchestrator::new();
     let ws = cache.state.as_mut().unwrap();
-    // References-in-state (noetl/ai-meta#101 phase 2): resolve any over-budget
-    // cursor claim references into inline rows before the drive reads them — a
-    // referenced claim has `claim_ref` set + empty `claim_rows`, and without
-    // this the cursor would see 0 rows and wrongly DRAIN.  No-op unless the flag
-    // kept a claim reference (flag-off claims are resolved inline by hydrate).
-    resolve_cursor_claim_refs(ws, &result_store).await;
     // Orchestrate plug-in shadow (noetl/ai-meta#108 slice 4): snapshot the state
     // BEFORE `evaluate_state` mutates it, so the plug-in evaluates the identical
     // input. Cloned only when the shadow is loaded (default off → no cost).
@@ -2239,6 +2299,103 @@ async fn apply_orchestration_result(
         );
     }
 
+    Ok(commands_generated)
+}
+
+/// Recursively find the `output_b64` string a wasm plug-in's tool result carries
+/// (the worker base64-wraps the plug-in's output bytes; the exact nesting
+/// depends on the result-envelope shape, so search rather than assume a path).
+fn find_output_b64(v: &serde_json::Value) -> Option<&str> {
+    match v {
+        serde_json::Value::Object(m) => {
+            if let Some(serde_json::Value::String(s)) = m.get("output_b64") {
+                return Some(s);
+            }
+            m.values().find_map(find_output_b64)
+        }
+        serde_json::Value::Array(a) => a.iter().find_map(find_output_b64),
+        _ => None,
+    }
+}
+
+/// Apply the `OrchestrationResult` a worker computed for the worker-driven drive
+/// (noetl/ai-meta#108 slice 3): decode it from the `system/orchestrate`
+/// completion, then emit events + issue commands via `apply_orchestration_result`
+/// — the same emission the in-process drive uses. Always clears the per-execution
+/// in-flight guard so the next trigger can dispatch again.
+async fn apply_worker_orchestration(
+    state: &AppState,
+    execution_id: i64,
+    trigger_event_id: i64,
+    payload: &serde_json::Value,
+) -> AppResult<i32> {
+    use base64::Engine;
+
+    // Clear the in-flight guard first (the drive completed, success or not) so a
+    // decode failure doesn't wedge the execution — the reconcile can re-drive.
+    let cache_slot = state.orch_cache.entry(execution_id);
+    let mut cache = cache_slot.lock().await;
+    cache.orchestrate_in_flight = false;
+
+    let decoded = find_output_b64(payload)
+        .and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())
+        .and_then(|bytes| {
+            serde_json::from_slice::<noetl_orchestrate_core::orchestrator::OrchestrationResult>(
+                &bytes,
+            )
+            .ok()
+        });
+    let Some(result) = decoded else {
+        warn!(
+            execution_id,
+            "worker-driven: could not decode OrchestrationResult from orchestrate completion \
+             (missing output_b64, bad base64, or an error envelope)"
+        );
+        crate::metrics::record_orchestrate_drive("decode_error");
+        return Ok(0);
+    };
+
+    let catalog_id = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
+    if catalog_id == 0 {
+        warn!(
+            execution_id,
+            "worker-driven: cold cache (no catalog_id); cannot apply orchestrate result this pass"
+        );
+        return Ok(0);
+    }
+    let routing = cache
+        .routing_meta
+        .as_ref()
+        .map(crate::handlers::execute::CommandRouting::from_started_meta)
+        .unwrap_or_default();
+
+    // Phase F R4-3: noetl.catalog is a cluster-wide table.
+    let playbook_yaml: String =
+        sqlx::query_scalar("SELECT content FROM noetl.catalog WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .fetch_one(state.pools.cluster())
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!("worker-driven: load playbook {catalog_id}: {e}"))
+            })?;
+    let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
+
+    let commands_generated = apply_orchestration_result(
+        state,
+        execution_id,
+        catalog_id,
+        trigger_event_id,
+        &result,
+        &playbook,
+        &routing,
+    )
+    .await?;
+    crate::metrics::record_orchestrate_drive("applied");
+
+    if result.should_complete {
+        drop(cache);
+        state.orch_cache.evict(execution_id);
+    }
     Ok(commands_generated)
 }
 

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1012,6 +1012,113 @@ pub(crate) async fn persist_engine_commands_batch(
     Ok(prepared.len() as i32)
 }
 
+/// Dispatch the worker-driven orchestrate "meta" command (noetl/ai-meta#108
+/// slice 3): issue `system/orchestrate` (entry `run_state`) as a single wasm
+/// command under the reserved `__orchestrate__` step, carrying the serialized
+/// `OrchestrateStateInput` as its args. The worker runs the drive and reports
+/// the `OrchestrationResult`; the server applies it on the command's completion
+/// (`apply_worker_orchestration` in `handlers::events`).
+///
+/// Unlike `persist_engine_commands_batch` this does NOT require the step to
+/// exist in the playbook — `__orchestrate__` is infrastructure, not a workflow
+/// step, and its `command.*` events are ignored by `WorkflowState::apply_event`
+/// (the `ORCHESTRATE_META_STEP` guard) so it never pollutes the drive state.
+pub(crate) async fn dispatch_orchestrate_command(
+    state: &AppState,
+    execution_id: i64,
+    catalog_id: i64,
+    parent_event_id: i64,
+    input: serde_json::Value,
+    playbook: &crate::playbook::types::Playbook,
+    routing: &CommandRouting,
+) -> AppResult<()> {
+    const STEP: &str = "__orchestrate__";
+    let event_id = state.snowflake.generate()?;
+    let command_id = format!("{execution_id}:{STEP}:{event_id}");
+    let now = chrono::Utc::now();
+
+    // The worker reads `tool_config.plugin` + `tool_config.args` (its
+    // `wasm_config_to_ref`); `args` carries the OrchestrateStateInput.
+    let tool_config = serde_json::json!({
+        "plugin": { "path": "system/orchestrate", "version": 1, "entry": "run_state" },
+        "args": input,
+    });
+    let cmd_context = serde_json::json!({
+        "tool_config": tool_config,
+        "args": {},
+        "render_context": {},
+    });
+    let cmd_meta = serde_json::json!({
+        "command_id": command_id,
+        "step": STEP,
+        "tool_kind": "wasm",
+        "max_attempts": 1,
+        "attempt": 1,
+        "execution_id": execution_id.to_string(),
+        "catalog_id": catalog_id.to_string(),
+        "actionable": true,
+    });
+
+    let pool = state.pools.pool_for(execution_id);
+    sqlx::query(
+        "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
+         node_id, node_name, node_type, status, context, meta, parent_event_id, created_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+    )
+    .bind(event_id)
+    .bind(execution_id)
+    .bind(catalog_id)
+    .bind("command.issued")
+    .bind(STEP)
+    .bind(STEP)
+    .bind("wasm")
+    .bind("PENDING")
+    .bind(&cmd_context)
+    .bind(&cmd_meta)
+    .bind(parent_event_id)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    // noetl.command row — non-fatal (event log is the source of truth).
+    let num_command_id = state.snowflake.generate()?;
+    if let Err(e) = sqlx::query(
+        "INSERT INTO noetl.command (command_id, event_id, execution_id, catalog_id, \
+         step_name, tool_kind, status, attempt, context, meta, latest_event_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+    )
+    .bind(num_command_id)
+    .bind(event_id)
+    .bind(execution_id)
+    .bind(catalog_id)
+    .bind(STEP)
+    .bind("wasm")
+    .bind("PENDING")
+    .bind(1_i32)
+    .bind(&cmd_context)
+    .bind(&cmd_meta)
+    .bind(parent_event_id)
+    .execute(pool)
+    .await
+    {
+        tracing::warn!(error = %e, execution_id, "orchestrate command row insert failed (non-fatal)");
+    }
+
+    publish_command_notification(
+        state,
+        execution_id,
+        event_id,
+        &command_id,
+        STEP,
+        "wasm",
+        playbook,
+        routing,
+    )
+    .await?;
+    crate::metrics::record_orchestrate_drive("dispatched");
+    Ok(())
+}
+
 /// Generate initial commands for the start step.
 ///
 /// If the start step declares a `loop:` block, this function fans out

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -148,6 +148,35 @@ pub fn record_orchestrate_shadow(result: &str) {
         .inc();
 }
 
+/// Counter: worker-driven orchestrate drive events, by stage (`dispatched` —
+/// the server issued the orchestrate command to the pool; `applied` — its
+/// result was applied; `decode_error` — the worker's result couldn't be
+/// decoded; `skipped_in_flight` — a drive was already running). The drive loop's
+/// health at a glance (noetl/ai-meta#108).
+pub fn orchestrate_drive_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_orchestrate_drive_total",
+                "Worker-driven orchestrate drive events, by stage.",
+            ),
+            &["stage"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one worker-driven drive event (`dispatched` / `applied` /
+/// `decode_error` / `skipped_in_flight`).
+pub fn record_orchestrate_drive(stage: &str) {
+    orchestrate_drive_total().with_label_values(&[stage]).inc();
+}
+
 /// Histogram: wall-clock time spent inside the `POST /api/events` handler.
 pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
     static M: OnceLock<HistogramVec> = OnceLock::new();

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,6 +119,14 @@ pub struct ExecOrchState {
     /// immediate `trigger_event_id`-straggler handling carry correctness.  Not
     /// serialized (in-memory only).
     pub last_count_check: Option<std::time::Instant>,
+    /// Worker-driven drive (noetl/ai-meta#108 slice 3): true while an
+    /// `system/orchestrate` command is dispatched to the pool but its result
+    /// has not yet been applied.  Set when the scheduler dispatches, cleared
+    /// when the completion is applied.  Serialises drives per execution so two
+    /// near-simultaneous triggers (or the reconcile poller) don't dispatch two
+    /// orchestrate commands → double-issue the same next commands.  In-memory
+    /// only; a server restart re-derives the drive from the event log.
+    pub orchestrate_in_flight: bool,
 }
 
 


### PR DESCRIPTION
Slice 3 of the worker-driven cutover ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)) — **the dissolution milestone**: when `NOETL_ORCHESTRATE_PLUGIN_DRIVE=on`, the orchestrator drive runs **on the worker pool**, not in the server. Validated end-to-end on kind: a real execution drives start→end→completed entirely through the worker round-trip.

## How it works
1. **Scheduler** (`trigger_orchestrator_inner`): in drive mode, after resolving cursor refs, the server issues **one** `system/orchestrate` command (`entry: run_state`, `args:` the bounded `WorkflowState` + playbook + trigger) to the worker pool via `dispatch_orchestrate_command` — no in-process evaluate. An `orchestrate_in_flight` cache flag serialises drives per execution (no double-dispatch from concurrent triggers / the reconcile).
2. **Worker** runs the plug-in (`run_state`, [worker#113](https://github.com/noetl/worker/pull/113)) and returns the `OrchestrationResult` (base64 `output_b64` on the `call.done` event).
3. **Apply-on-callback** (`handle_event_inner`): a `call.done` for `__orchestrate__` routes to `apply_worker_orchestration` → decode → `apply_orchestration_result` (slice 2) emits events + issues the real commands. Their completions re-trigger the drive; the meta-command's own events never do — loop-safe.
4. **State guard** (`WorkflowState::apply_event`): events for the reserved `__orchestrate__` step are ignored, so the meta-command never phantom-creates a workflow step.

`dispatch_orchestrate_command` (execute.rs) issues the wasm command without the `playbook.get_step` requirement (the meta-command isn't a workflow step). Metric `noetl_orchestrate_drive_total{stage=dispatched|applied|decode_error|skipped_in_flight}`.

## Kind validation (server `oc-drive2` + worker `oc-drive`, `NOETL_ORCHESTRATE_PLUGIN_DRIVE=true`)
`test/simple_python` (start → end) drove to **COMPLETED** through the worker round-trip:
- `noetl_orchestrate_drive_total{stage="dispatched"} 2`, `{stage="applied"} 2`, **zero decode_error, zero skipped**.
- 2 `__orchestrate__` round-trips (each full lifecycle: issued→claimed→started→call.done→completed), real steps `start` + `end` executed, **`playbook.completed` emitted**.
- **`__orchestrate__` did NOT leak as a workflow step** (`step.enter` set = `['end']`) — the state guard holds.

A first-pass bug was caught + fixed here: `output_b64` rides the `call.done` event, not `command.completed` (which carries only `{command_id, status}`); the apply now hooks `call.done`.

## Safety
Default off — the in-process drive is the untouched fallback. Both build configs green (default + `--features orchestrate-shadow`); core 124 + server 553 tests green; clippy clean.

## Next (#108 slice 4)
Shadow→flip discipline at scale (the PFT under drive mode), then retire `trigger_orchestrator_inner` as the in-process drive once drive mode is the default; the in-server shadow + the `wasmtime` server dep come back out. Routing the orchestrate command to the dedicated system pool (it currently co-locates on the execution's segment) is a follow-up.

Refs [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)