### PR TITLE
feat(orchestrate-drive): suppress meta-command events from noetl.event + system-pool routing (#108)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -616,27 +616,42 @@ async fn handle_event_inner(
     let row = normalize_event_to_row(&state, &request).await?;
     let event_id = row.event_id;
 
-    // Persist the event
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            event_id, execution_id, catalog_id, event_type,
-            node_id, node_name, status, result, meta, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-        "#,
-    )
-    .bind(row.event_id)
-    .bind(row.execution_id)
-    .bind(row.catalog_id)
-    .bind(&row.event_type)
-    .bind(&row.node_name)
-    .bind(&row.node_name)
-    .bind(&row.status)
-    .bind(&row.result)
-    .bind(&row.meta)
-    .bind(row.created_at)
-    .execute(state.pools.pool_for(execution_id))
-    .await?;
+    // System meta-command events are NOT workflow events — they're the
+    // infrastructure of the worker-driven drive (noetl/ai-meta#108). A single
+    // drive emits command.claimed/started/call.done/command.completed for
+    // `__orchestrate__`; at scale (thousands of drives) persisting them would
+    // burst noetl.event + Postgres for no benefit — the drive state is a pure
+    // function of the *real* step events, and the result is applied from the
+    // in-memory `call.done` payload, not from a persisted row. So skip the
+    // write for the meta-step. (The `command.issued` that delivers the command
+    // is written separately by `dispatch_orchestrate_command`; eliminating that
+    // last row needs a noetl.event-free claim path — tracked as a follow-up.)
+    let is_meta_command =
+        request.step == noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP;
+    if !is_meta_command {
+        sqlx::query(
+            r#"
+            INSERT INTO noetl.event (
+                event_id, execution_id, catalog_id, event_type,
+                node_id, node_name, status, result, meta, created_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            "#,
+        )
+        .bind(row.event_id)
+        .bind(row.execution_id)
+        .bind(row.catalog_id)
+        .bind(&row.event_type)
+        .bind(&row.node_name)
+        .bind(&row.node_name)
+        .bind(&row.status)
+        .bind(&row.result)
+        .bind(&row.meta)
+        .bind(row.created_at)
+        .execute(state.pools.pool_for(execution_id))
+        .await?;
+    } else {
+        crate::metrics::record_orchestrate_drive("event_suppressed");
+    }
 
     info!(
         "Event persisted: event_id={}, execution_id={}, event_type={}",
@@ -973,30 +988,38 @@ pub async fn claim_command(
         "informative": true,
     });
 
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            event_id, execution_id, catalog_id, event_type,
-            node_id, node_name, status, result, meta, worker_id, created_at
-        ) VALUES (
-            $1, $2, $3, $4,
-            $5, $6, $7, $8, $9, $10, $11
+    // Suppress the `command.claimed` event for the worker-driven orchestrate
+    // meta-command (noetl/ai-meta#108): it's infrastructure, not a workflow step,
+    // so it must not write to noetl.event (the claim's own state lives in the tx
+    // below). One drive at a time per execution is already guaranteed by the
+    // `orchestrate_in_flight` guard + the single NATS dispatch, so skipping the
+    // claimed-event idempotency anchor is safe here.
+    if step != noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP {
+        sqlx::query(
+            r#"
+            INSERT INTO noetl.event (
+                event_id, execution_id, catalog_id, event_type,
+                node_id, node_name, status, result, meta, worker_id, created_at
+            ) VALUES (
+                $1, $2, $3, $4,
+                $5, $6, $7, $8, $9, $10, $11
+            )
+            "#,
         )
-        "#,
-    )
-    .bind(claim_event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind("command.claimed")
-    .bind(&step)
-    .bind(&step)
-    .bind("RUNNING")
-    .bind(claim_result)
-    .bind(claim_meta)
-    .bind(&request.worker_id)
-    .bind(chrono::Utc::now())
-    .execute(&mut *tx)
-    .await?;
+        .bind(claim_event_id)
+        .bind(execution_id)
+        .bind(catalog_id)
+        .bind("command.claimed")
+        .bind(&step)
+        .bind(&step)
+        .bind("RUNNING")
+        .bind(claim_result)
+        .bind(claim_meta)
+        .bind(&request.worker_id)
+        .bind(chrono::Utc::now())
+        .execute(&mut *tx)
+        .await?;
+    }
 
     tx.commit().await?;
 

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1104,6 +1104,15 @@ pub(crate) async fn dispatch_orchestrate_command(
         tracing::warn!(error = %e, execution_id, "orchestrate command row insert failed (non-fatal)");
     }
 
+    // Route the drive to the dedicated `system` worker pool (noetl/ai-meta#108)
+    // so it doesn't compete with user compute for slots — the system pool
+    // subscribes to `noetl.commands.system.>`. The user pool's segment is derived
+    // from the playbook path; override it to `system` here, preserving the
+    // execution's W3C trace so the drive stays on the same trace.
+    let system_routing = CommandRouting {
+        pool: Some("system".to_string()),
+        trace: routing.trace.clone(),
+    };
     publish_command_notification(
         state,
         execution_id,
@@ -1112,7 +1121,7 @@ pub(crate) async fn dispatch_orchestrate_command(
         STEP,
         "wasm",
         playbook,
-        routing,
+        &system_routing,
     )
     .await?;
     crate::metrics::record_orchestrate_drive("dispatched");


### PR DESCRIPTION
Slice 4b of the worker-driven cutover ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)) — two scale concerns now that the drive runs on the pool. System playbooks are part of the NoETL ecosystem itself; their lifecycle shouldn't flood the workflow event log.

## 1. Postgres burst fix (the headline)
The `__orchestrate__` meta-command is **infrastructure, not a workflow step** — yet each drive wrote **5 rows** to `noetl.event` (`command.issued`/`claimed`/`started`/`call.done`/`command.completed`). At scale (thousands of drives) that bursts `noetl.event` + Postgres for no benefit: the drive state is a pure function of the *real* step events, and the result is applied from the in-memory `call.done` payload, not a persisted row.

Now the server **skips persisting the meta-command's events**:
- `handle_event_inner` skips the INSERT for the worker-emitted `started`/`call.done`/`completed` (metric `noetl_orchestrate_drive_total{stage="event_suppressed"}`).
- `claim_command` skips the `command.claimed` INSERT for the meta-step.

**Validated on kind:** `__orchestrate__` now writes **only the lone `command.issued`** delivery row (1 of 5 — **80% fewer rows**); the execution still COMPLETED.

## 2. System-pool routing
`dispatch_orchestrate_command` routes the drive to the dedicated `system` segment (`noetl.commands.system.<eid>`) instead of the execution's user segment (W3C trace preserved). **Honest scope:** the server now publishes there, but **true pool isolation needs a NATS stream/consumer-affinity fix in ops** — on kind the message lands but the *default* pool claims it via the HTTP pending-poll (the system pool's NATS consumer doesn't receive it yet). The drive stays functional (resilient via the poll); the isolation is an ops follow-up.

## Validation (kind, drive on, system pool on the entry-aware image)
Small-workload `test_pft_flow_v2` (cursors + fan-out) → **COMPLETED**; `__orchestrate__` wrote only `command.issued`. 553 tests green; clippy clean.

## Follow-ups
- **(a)** Eliminate the last `command.issued` row via a `noetl.event`-free claim path (claim/get reading `noetl.command`, where the command already lands) → `__orchestrate__` touches `noetl.event` **zero** times.
- **(b)** NATS stream/consumer affinity so the system pool actually claims the drive (true isolation from user compute).

Refs [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)