### PR TITLE
feat(orchestrate-drive): zero noetl.event rows for the meta-command (#108)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -746,14 +746,22 @@ pub async fn get_command(
     // lookup.  Use the cross-shard resolver: probe every shard,
     // first hit wins.  In single-pool fallback mode this is a
     // single probe against the one pool.
+    // noetl.event is authoritative for normal commands; the event-free
+    // `system/orchestrate` meta-command (noetl/ai-meta#108) is served from
+    // noetl.command as a fallback (`pri` ordering keeps noetl.event first).
     let found = state
         .pools
         .find_first(|_shard_idx, pool| async move {
             sqlx::query_as::<_, (i64, String, String, serde_json::Value, serde_json::Value)>(
                 r#"
-                SELECT execution_id, node_name, node_type, context, meta
-                FROM noetl.event
-                WHERE event_id = $1 AND event_type = 'command.issued'
+                SELECT execution_id, node_name, node_type, context, meta FROM (
+                    SELECT execution_id, node_name, node_type, context, meta, 0 AS pri
+                    FROM noetl.event WHERE event_id = $1 AND event_type = 'command.issued'
+                    UNION ALL
+                    SELECT execution_id, step_name AS node_name, tool_kind AS node_type,
+                           context, meta, 1 AS pri
+                    FROM noetl.command WHERE event_id = $1
+                ) s ORDER BY pri LIMIT 1
                 "#,
             )
             .bind(event_id)
@@ -772,10 +780,7 @@ pub async fn get_command(
             context,
             meta,
         })),
-        None => Err(AppError::NotFound(format!(
-            "command.issued event not found: {}",
-            event_id
-        ))),
+        None => Err(AppError::NotFound(format!("command not found: {}", event_id))),
     }
 }
 
@@ -803,14 +808,24 @@ pub async fn claim_command(
     //
     // In single-pool fallback mode the resolver short-circuits
     // (one pool, one probe).
+    // Resolve event_id -> execution_id. Normal commands carry a `command.issued`
+    // event in noetl.event; the worker-driven `system/orchestrate` meta-command
+    // (noetl/ai-meta#108) deliberately writes NO event (it would burst Postgres
+    // at scale) — its command lives only in noetl.command. The `pri` ordering
+    // keeps noetl.event authoritative when present (normal commands: exact prior
+    // behavior); noetl.command is the fallback that only fires for the
+    // event-free meta-command.
     let resolved_execution_id: Option<i64> = state
         .pools
         .find_first(|_shard_idx, pool| async move {
             sqlx::query_scalar::<_, i64>(
                 r#"
-                SELECT execution_id
-                FROM noetl.event
-                WHERE event_id = $1 AND event_type = 'command.issued'
+                SELECT execution_id FROM (
+                    SELECT execution_id, 0 AS pri FROM noetl.event
+                    WHERE event_id = $1 AND event_type = 'command.issued'
+                    UNION ALL
+                    SELECT execution_id, 1 AS pri FROM noetl.command WHERE event_id = $1
+                ) s ORDER BY pri LIMIT 1
                 "#,
             )
             .bind(event_id)
@@ -820,17 +835,21 @@ pub async fn claim_command(
         .await?
         .map(|(_shard_idx, eid)| eid);
 
-    let resolved_execution_id = resolved_execution_id.ok_or_else(|| {
-        AppError::NotFound(format!("command.issued event not found: {}", event_id))
-    })?;
+    let resolved_execution_id = resolved_execution_id
+        .ok_or_else(|| AppError::NotFound(format!("command not found: {}", event_id)))?;
 
     let mut tx = state.pools.pool_for(resolved_execution_id).begin().await?;
 
     let cmd_row = sqlx::query(
         r#"
-        SELECT execution_id, catalog_id, node_name, node_type, context, meta
-        FROM noetl.event
-        WHERE event_id = $1 AND event_type = 'command.issued'
+        SELECT execution_id, catalog_id, node_name, node_type, context, meta FROM (
+            SELECT execution_id, catalog_id, node_name, node_type, context, meta, 0 AS pri
+            FROM noetl.event WHERE event_id = $1 AND event_type = 'command.issued'
+            UNION ALL
+            SELECT execution_id, catalog_id, step_name AS node_name, tool_kind AS node_type,
+                   context, meta, 1 AS pri
+            FROM noetl.command WHERE event_id = $1
+        ) s ORDER BY pri LIMIT 1
         "#,
     )
     .bind(event_id)
@@ -838,10 +857,7 @@ pub async fn claim_command(
     .await?;
 
     let Some(row) = cmd_row else {
-        return Err(AppError::NotFound(format!(
-            "command.issued event not found: {}",
-            event_id
-        )));
+        return Err(AppError::NotFound(format!("command not found: {}", event_id)));
     };
 
     let execution_id: i64 = row.try_get("execution_id")?;

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1035,7 +1035,6 @@ pub(crate) async fn dispatch_orchestrate_command(
     const STEP: &str = "__orchestrate__";
     let event_id = state.snowflake.generate()?;
     let command_id = format!("{execution_id}:{STEP}:{event_id}");
-    let now = chrono::Utc::now();
 
     // The worker reads `tool_config.plugin` + `tool_config.args` (its
     // `wasm_config_to_ref`); `args` carries the OrchestrateStateInput.
@@ -1059,30 +1058,16 @@ pub(crate) async fn dispatch_orchestrate_command(
         "actionable": true,
     });
 
+    // The meta-command writes NOTHING to noetl.event (noetl/ai-meta#108): it is
+    // infrastructure, not a workflow step, and at scale a `command.issued` row
+    // per drive would burst noetl.event + Postgres. Its delivery record lives
+    // only in noetl.command — the worker's claim/get path falls back to it when
+    // noetl.event has no `command.issued` for the event_id. So this row is the
+    // sole record the worker fetches: it is FATAL on error (no event-log
+    // fallback), unlike the best-effort mirror in `persist_engine_commands_batch`.
     let pool = state.pools.pool_for(execution_id);
-    sqlx::query(
-        "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
-         node_id, node_name, node_type, status, context, meta, parent_event_id, created_at) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
-    )
-    .bind(event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind("command.issued")
-    .bind(STEP)
-    .bind(STEP)
-    .bind("wasm")
-    .bind("PENDING")
-    .bind(&cmd_context)
-    .bind(&cmd_meta)
-    .bind(parent_event_id)
-    .bind(now)
-    .execute(pool)
-    .await?;
-
-    // noetl.command row — non-fatal (event log is the source of truth).
     let num_command_id = state.snowflake.generate()?;
-    if let Err(e) = sqlx::query(
+    sqlx::query(
         "INSERT INTO noetl.command (command_id, event_id, execution_id, catalog_id, \
          step_name, tool_kind, status, attempt, context, meta, latest_event_id) \
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
@@ -1099,10 +1084,7 @@ pub(crate) async fn dispatch_orchestrate_command(
     .bind(&cmd_meta)
     .bind(parent_event_id)
     .execute(pool)
-    .await
-    {
-        tracing::warn!(error = %e, execution_id, "orchestrate command row insert failed (non-fatal)");
-    }
+    .await?;
 
     // Route the drive to the dedicated `system` worker pool (noetl/ai-meta#108)
     // so it doesn't compete with user compute for slots — the system pool


### PR DESCRIPTION
Follow-up (a) of slice 4b ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)). Closes the directive that **system pool playbooks keep only their own state, not workflow events** — the worker-driven `__orchestrate__` meta-command now touches `noetl.event` **zero** times.

## What
- `dispatch_orchestrate_command` no longer writes a `command.issued` row to `noetl.event`; the command's delivery record lives **only in `noetl.command`** (its own state, updatable in place). That row is now the sole record the worker fetches, so it's **fatal on error** (no event-log fallback).
- `claim_command` + `get_command` resolve/read the command from `noetl.event` first — a `pri` ordering keeps it **authoritative**, so every normal command's claim path is byte-for-byte unchanged — and fall back to `noetl.command` **only on a miss**, which happens exclusively for the event-free meta-command.

Combined with slice 4b's lifecycle-event suppression, `__orchestrate__` now writes **0 of its former 5 `noetl.event` rows** per drive. At 10×1000 that removes thousands of pure-infrastructure rows from the burst.

## Validation (kind, drive on)
Small-workload cursor+fan-out `test_pft_flow_v2`:
- **`__orchestrate__` rows in `noetl.event`: 0** (target met) — the worker fetched the command from `noetl.command` via the claim fallback.
- **COMPLETED**, `playbook.completed` emitted, **0 errors**.
- **20 real workflow steps** drove normally — the shared claim path is unaffected for normal commands.

553 tests green; clippy clean. Default off; the in-process drive remains the fallback.

## Remaining for #108
- NATS stream/consumer affinity so the system pool actually claims the drive (ops/`noetl-ops`).
- The deliberate default-flip (staged rollout).

Refs [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)