### PR TITLE
feat(dispatch): stamp execution_pool on the command notification — pool affinity (#108)

### DIFF
--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1437,6 +1437,11 @@ async fn publish_command_notification(
         "command_id": command_id,
         "step": step,
         "server_url": server_url,
+        // Stamp the resolved pool segment on the dispatch so the worker can
+        // decline commands that aren't for its pool — defence-in-depth against a
+        // JetStream consumer whose filter_subject drifted broad and so receives
+        // another pool's commands (noetl/ai-meta#108).
+        "execution_pool": pool_segment,
     });
     // Carry the W3C trace context on the command notification so the worker
     // can attach it to its dispatch span (RFC §7.4).


### PR DESCRIPTION
Follow-up (b) of the worker-driven cutover ([noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)) — the **"update context for dispatch"** half.

`publish_command_notification` now stamps the resolved pool segment (`shared`/`system`/subscription override — the same segment that forms the NATS subject `noetl.commands.<segment>.<eid>`) onto the command notification as `execution_pool`.

The worker uses it ([worker#114](https://github.com/noetl/worker/pull/114)) to decline commands not for its pool, so pool isolation survives a JetStream consumer whose `filter_subject` drifted broad — the failure that let the default pool claim the `system/orchestrate` drive on kind.

Additive + backward compatible: a worker that ignores the field behaves exactly as before.

## Validation (kind, server + both worker pools on the new images, drive on)
`test/simple_python` drove to COMPLETED with the `__orchestrate__` commands claimed + executed **on the system pool** (3 executions), **zero** on the default pool. 553 tests green; clippy clean.

Refs [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)