### PR TITLE
feat(orchestrate-drive): default the worker-driven drive ON (#108 (c))

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -83,11 +83,18 @@ pub struct AppConfig {
     /// as a command to the worker pool (step `__orchestrate__`, `entry:
     /// run_state`) instead of driving in-process; the worker runs the drive and
     /// its completion is applied via `apply_orchestration_result`.  Envy maps
-    /// `NOETL_ORCHESTRATE_PLUGIN_DRIVE`.  **Default false** — the in-process
-    /// drive stays the untouched fallback; flip on only after the shadow
-    /// (`orchestrate_plugin_shadow`) is clean and `system/orchestrate@1` is
-    /// registered.  Requires the worker pool to carry the `wasm-plugin` feature.
-    #[serde(default)]
+    /// `NOETL_ORCHESTRATE_PLUGIN_DRIVE`.
+    ///
+    /// **Default true** (noetl/ai-meta#108 (c) — the deliberate default-flip,
+    /// after the scale soak proved the drive runs off-server with zero
+    /// `noetl.event` burst and full system-pool isolation).  The deployment must
+    /// carry a system worker pool with the `wasm-plugin` feature (on by default)
+    /// and the seeded `system/orchestrate@1` plug-in; the standard ops manifests
+    /// provide both.  **Revert:** set `NOETL_ORCHESTRATE_PLUGIN_DRIVE=false` to
+    /// fall back to the in-process drive (`trigger_orchestrator_inner`, kept as
+    /// the untouched fallback below) — no rebuild needed, per-deployment and
+    /// immediate.
+    #[serde(default = "default_true")]
     pub orchestrate_plugin_drive: bool,
 
     /// Auto recreate runtime if missing
@@ -203,7 +210,8 @@ impl Default for AppConfig {
             refs_in_state: false,
             projector_owns_snapshot: false,
             orchestrate_plugin_shadow: false,
-            orchestrate_plugin_drive: false,
+            // noetl/ai-meta#108 (c): worker-driven drive is the default.
+            orchestrate_plugin_drive: true,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),
@@ -231,5 +239,12 @@ mod tests {
     fn test_bind_address() {
         let config = AppConfig::default();
         assert_eq!(config.bind_address(), "0.0.0.0:8082");
+    }
+
+    #[test]
+    fn test_orchestrate_drive_defaults_on() {
+        // noetl/ai-meta#108 (c): the worker-driven orchestrator drive is the
+        // default.  Revert is `NOETL_ORCHESTRATE_PLUGIN_DRIVE=false`.
+        assert!(AppConfig::default().orchestrate_plugin_drive);
     }
 }


### PR DESCRIPTION
## What

Flip `NOETL_ORCHESTRATE_PLUGIN_DRIVE` to **default `true`** — the worker-driven
orchestrator drive (the dissolution / orchestrate-on-the-system-pool path) is now
on by default instead of opt-in. This is item **(c)** — the deliberate
default-flip — of [noetl/ai-meta#108](https://github.com/noetl/ai-meta/issues/108).

- `src/config/app.rs`: `orchestrate_plugin_drive` serde default `default` → `default_true`;
  `Default` impl `false` → `true`; doc comment records the flip + the revert.
- New test `test_orchestrate_drive_defaults_on` locks in the default.

The in-process drive (`trigger_orchestrator_inner`) is **kept** as the fallback —
the `if state.config.orchestrate_plugin_drive { … } else { …in-process… }` branch
at `src/handlers/events.rs` is unchanged, so the flip only changes which branch
runs when the env var is absent.

## Why this is safe now (the prerequisites all shipped)

The flip was deferred as a production-policy decision until the drive was proven
off-server, burst-free, and pool-isolated at scale. All of that landed:

- **Off-server drive** (slices 1–3, #229): the drive runs on the worker pool.
- **Zero `noetl.event` burst** (slice 4b #230 + follow-up (a) #231): the
  `__orchestrate__` meta-command touches `noetl.event` **zero** times.
- **System-pool isolation** (follow-up (b) #232 + worker#114 + ops#191): the
  drive routes to `noetl.commands.system.>`, claimed only by the system pool.

## Validation — scale soak with drive ON, then default-on re-validation (kind)

Images built from the released tips (server v3.27.0 / worker v5.33.0).

**Pre-flip soak (drive via env, code default still false):**
- Single cursor+fan-out `test_pft_flow_v2` (3 fac × 40 pat): **COMPLETED**, 511s.
  **694 drives** dispatched=applied, decode_error=0. **System pool +694** (= drive
  count), **shared pool +671** (real steps only) → full isolation. **`__orchestrate__`
  rows in `noetl.event` = 0**. 0 errors. 23 distinct workflow steps.
- 5× concurrent self-contained cursor: **5/5 COMPLETED**, 67 drives all on system
  pool, decode_error=0, 0 errors, 0 `__orchestrate__` rows.

**Post-flip (this PR's image, NO env override — drive via the new code default):**
- See the closing comment on #108 for the default-on == explicit-on numbers and
  the regression pass.

## Revert

`NOETL_ORCHESTRATE_PLUGIN_DRIVE=false` on the deployment → in-process drive
returns immediately, no rebuild. Or revert this commit.

## Wiki

`deployment-specification.md` env-var row updated to default `true` + revert note
(noetl/server wiki @ 0210012), in the same change set.

Closes noetl/ai-meta#108
