### PR TITLE
feat(cqrs): emit_event chokepoint + PUBLISH_ONLY sole-writer gate (#103 2d-3, default-off)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -87,6 +87,25 @@ pub struct AppConfig {
     #[serde(default = "default_true")]
     pub orchestrate_plugin_drive: bool,
 
+    /// CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3).  When true, every
+    /// server-originated `noetl.event` write goes through the `emit_event`
+    /// chokepoint as a **publish** to the `noetl_events` JetStream stream
+    /// (instead of a synchronous `INSERT`), so the `system/event_materializer`
+    /// playbook becomes the **sole** `noetl.event` writer.  The orchestrator
+    /// trigger then fires from the materializer's write endpoint
+    /// (`/api/internal/events/project`) rather than the synchronous ingest, so
+    /// the drive still advances when writes are asynchronous.  Envy maps
+    /// `NOETL_EVENT_INGEST_PUBLISH_ONLY`.
+    ///
+    /// **Default false** — the ingest path INSERTs synchronously exactly as
+    /// today (byte-identical); the materializer runs in shadow (idempotent
+    /// duplicates).  Flip on only with the materializer deployed + a lag
+    /// metric/alert, one revert away (the producer cutover is an operator
+    /// decision).  Requires NATS; a no-op (stays on the synchronous INSERT
+    /// path) if NATS is not connected.
+    #[serde(default)]
+    pub event_ingest_publish_only: bool,
+
     /// Auto recreate runtime if missing
     #[serde(default = "default_true")]
     pub auto_recreate_runtime: bool,
@@ -201,6 +220,8 @@ impl Default for AppConfig {
             projector_owns_snapshot: false,
             // noetl/ai-meta#108 (c): worker-driven drive is the default.
             orchestrate_plugin_drive: true,
+            // noetl/ai-meta#103 2d-3: synchronous INSERT path by default.
+            event_ingest_publish_only: false,
             auto_recreate_runtime: true,
             runtime_sweep_interval: default_sweep_interval(),
             runtime_offline_seconds: default_offline_seconds(),

--- a/src/handlers/container_callback.rs
+++ b/src/handlers/container_callback.rs
@@ -273,26 +273,19 @@ pub async fn container_callback(
     // schema — so every callback POST 500'd with
     // `column "attempt" of relation "event" does not exist`, which
     // blocked the noetl/ai-meta#43 container-callback chain end to end.
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            event_id, execution_id, catalog_id, event_type,
-            node_id, node_name, status, result, meta, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-        "#,
+    // CQRS write-path chokepoint (#103 2d-3).
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        execution_id,
+        catalog_id,
+        "call.done",
+        status_label,
+        chrono::Utc::now(),
     )
-    .bind(event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind("call.done")
-    .bind(&step)
-    .bind(&step)
-    .bind(status_label)
-    .bind(&result_obj)
-    .bind(serde_json::json!({ "node_type": "container" }))
-    .bind(chrono::Utc::now())
-    .execute(pool)
-    .await?;
+    .with_node(&step)
+    .with_result(result_obj.clone())
+    .with_meta(serde_json::json!({ "node_type": "container" }));
+    crate::handlers::event_write::emit_event(&state, pool, ev).await?;
 
     crate::metrics::record_container_callback(request.state.as_str());
     tracing::info!(

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -1,0 +1,317 @@
+//! CQRS write-path chokepoint (noetl/ai-meta#103 phase 2d-3).
+//!
+//! Every **server-originated** `noetl.event` write goes through [`emit_event`] /
+//! [`emit_events`].  Two modes, selected by
+//! [`crate::config::AppConfig::event_ingest_publish_only`]:
+//!
+//! - **gate OFF (default):** the row is `INSERT`ed synchronously — byte-identical
+//!   to the inline INSERTs these call sites used before (the canonical INSERT
+//!   binds the full column superset; columns a site didn't set are `None` →
+//!   bound `NULL`, which equals the DB default those sites relied on).
+//! - **gate ON (`NOETL_EVENT_INGEST_PUBLISH_ONLY`):** the row is **published** to
+//!   the `noetl_events` JetStream stream in the same `to_jsonb(noetl.event row)`
+//!   shape the 2a tailer publishes (with `created_at`, `Nats-Msg-Id = event_id`),
+//!   and **not** inserted.  The `system/event_materializer` playbook drains the
+//!   stream and `POST /api/internal/events/project` becomes the **sole**
+//!   `noetl.event` writer.  The orchestrator trigger then fires from that write
+//!   endpoint (see `handlers::internal::events_project`) rather than the
+//!   synchronous ingest, so the drive still advances when writes are async.
+//!
+//! The two **sink** writers — `handlers::internal::events_materialize` and
+//! `services::internal::project_events` — are NOT routed here: they ARE the
+//! materializer, the one path that writes when the gate is on.
+//!
+//! Gate-on requires NATS.  If NATS is not connected the chokepoint falls back to
+//! the synchronous INSERT (logged once) so a misconfiguration degrades to
+//! today's behaviour rather than dropping events.
+
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::state::AppState;
+
+/// A full `noetl.event` row to write.  Column superset across every producer
+/// site; a field left `None` is bound `NULL` (byte-identical to the inline
+/// sites that omitted the column and let it default to `NULL`).  `tenant_id` /
+/// `organization_id` are intentionally absent — like the inline sites, the
+/// canonical INSERT does not bind them, so their `'default'` DB default fires.
+#[derive(Clone, Debug)]
+pub struct EventRow {
+    pub event_id: i64,
+    pub execution_id: i64,
+    pub catalog_id: i64,
+    pub event_type: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub node_id: Option<String>,
+    pub node_name: Option<String>,
+    pub node_type: Option<String>,
+    pub parent_event_id: Option<i64>,
+    pub parent_execution_id: Option<i64>,
+    pub context: Option<Value>,
+    pub result: Option<Value>,
+    pub meta: Option<Value>,
+    pub error: Option<String>,
+    pub worker_id: Option<String>,
+}
+
+impl EventRow {
+    /// Minimal constructor; chain the `with_*` setters for the optional columns.
+    pub fn new(
+        event_id: i64,
+        execution_id: i64,
+        catalog_id: i64,
+        event_type: impl Into<String>,
+        status: impl Into<String>,
+        created_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            event_id,
+            execution_id,
+            catalog_id,
+            event_type: event_type.into(),
+            status: status.into(),
+            created_at,
+            node_id: None,
+            node_name: None,
+            node_type: None,
+            parent_event_id: None,
+            parent_execution_id: None,
+            context: None,
+            result: None,
+            meta: None,
+            error: None,
+            worker_id: None,
+        }
+    }
+
+    /// Set `node_id` + `node_name` to the same value (the common case — the
+    /// step name takes both columns).
+    pub fn with_node(mut self, name: impl Into<String>) -> Self {
+        let name = name.into();
+        self.node_id = Some(name.clone());
+        self.node_name = Some(name);
+        self
+    }
+    /// Set `node_id` and `node_name` separately (e.g. `node_id="playbook"`,
+    /// `node_name=<path>` for `playbook_started`).
+    pub fn with_nodes(mut self, node_id: impl Into<String>, node_name: impl Into<String>) -> Self {
+        self.node_id = Some(node_id.into());
+        self.node_name = Some(node_name.into());
+        self
+    }
+    pub fn with_node_type(mut self, t: impl Into<String>) -> Self {
+        self.node_type = Some(t.into());
+        self
+    }
+    pub fn with_parent_event_id(mut self, id: i64) -> Self {
+        self.parent_event_id = Some(id);
+        self
+    }
+    pub fn with_parent_execution_id(mut self, id: Option<i64>) -> Self {
+        self.parent_execution_id = id;
+        self
+    }
+    pub fn with_context(mut self, v: Value) -> Self {
+        self.context = Some(v);
+        self
+    }
+    pub fn with_result(mut self, v: Value) -> Self {
+        self.result = Some(v);
+        self
+    }
+    pub fn with_meta(mut self, v: Value) -> Self {
+        self.meta = Some(v);
+        self
+    }
+    pub fn with_error(mut self, e: Option<String>) -> Self {
+        self.error = e;
+        self
+    }
+    pub fn with_worker_id(mut self, w: Option<String>) -> Self {
+        self.worker_id = w;
+        self
+    }
+
+    /// The `to_jsonb(noetl.event row)` shape the 2a tailer publishes — the
+    /// `system/event_materializer` playbook maps `created_at → timestamp` and
+    /// posts it to `/api/internal/events/project`.  Keep the DB column names +
+    /// `created_at` (NOT `timestamp`) so the materialized row is byte-identical
+    /// to the synchronous INSERT.
+    fn to_stream_json(&self) -> Value {
+        json!({
+            "event_id": self.event_id,
+            "execution_id": self.execution_id,
+            "catalog_id": self.catalog_id,
+            "event_type": self.event_type,
+            "status": self.status,
+            "created_at": self.created_at,
+            "node_id": self.node_id,
+            "node_name": self.node_name,
+            "node_type": self.node_type,
+            "parent_event_id": self.parent_event_id,
+            "parent_execution_id": self.parent_execution_id,
+            "context": self.context,
+            "result": self.result,
+            "meta": self.meta,
+            "error": self.error,
+            "worker_id": self.worker_id,
+        })
+    }
+}
+
+/// True when the gate is on AND NATS is connected (so a publisher can be built).
+/// Gate-on without NATS falls back to the INSERT path.
+fn publish_only(state: &AppState) -> bool {
+    state.config.event_ingest_publish_only && state.nats.is_some()
+}
+
+/// Lazily build (once) + return the `noetl_events` publisher.  Returns `None`
+/// only if NATS is absent or the stream can't be ensured — callers then fall
+/// back to the synchronous INSERT.
+async fn publisher(state: &AppState) -> Option<&crate::nats::EventStreamPublisher> {
+    let client = state.nats.clone()?;
+    state
+        .event_stream_publisher
+        .get_or_try_init(|| async move {
+            let cfg = crate::services::event_stream::EventStreamConfig::from_env();
+            crate::nats::EventStreamPublisher::new(client, cfg.dedup_window, cfg.max_age).await
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!(%e, "publish-only: failed to build noetl_events publisher; falling back to synchronous INSERT");
+            e
+        })
+        .ok()
+}
+
+/// Write one `noetl.event` row through the chokepoint.
+///
+/// `pool` is the per-execution pool the caller would have inserted into
+/// (`state.pools.pool_for(execution_id)`); it is used only on the gate-off
+/// INSERT path.
+pub async fn emit_event(state: &AppState, pool: &DbPool, row: EventRow) -> AppResult<()> {
+    emit_events(state, pool, std::slice::from_ref(&row)).await
+}
+
+/// Write a batch of `noetl.event` rows through the chokepoint.  Gate-off does a
+/// single multi-row INSERT; gate-on publishes each row (idempotent via
+/// `Nats-Msg-Id = event_id`).  An empty batch is a no-op.
+pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> AppResult<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    if publish_only(state) {
+        if let Some(pubr) = publisher(state).await {
+            for row in rows {
+                let bytes = serde_json::to_vec(&row.to_stream_json()).map_err(|e| {
+                    crate::error::AppError::Internal(format!("event publish encode: {e}"))
+                })?;
+                pubr.publish_event(row.event_id, &row.event_type, &bytes)
+                    .await
+                    .map_err(|e| {
+                        crate::error::AppError::Internal(format!("event publish: {e}"))
+                    })?;
+                crate::metrics::record_event_published(&row.event_type);
+            }
+            return Ok(());
+        }
+        // NATS unavailable / stream unbuildable → fall through to INSERT.
+    }
+
+    insert_rows(pool, rows).await
+}
+
+/// The canonical full-column-superset INSERT.  Single multi-row statement.
+async fn insert_rows(pool: &DbPool, rows: &[EventRow]) -> AppResult<()> {
+    let mut qb = sqlx::QueryBuilder::new(
+        "INSERT INTO noetl.event (event_id, execution_id, catalog_id, parent_event_id, \
+         parent_execution_id, event_type, node_id, node_name, node_type, status, \
+         context, result, meta, error, worker_id, created_at) ",
+    );
+    qb.push_values(rows.iter(), |mut b, r| {
+        b.push_bind(r.event_id)
+            .push_bind(r.execution_id)
+            .push_bind(r.catalog_id)
+            .push_bind(r.parent_event_id)
+            .push_bind(r.parent_execution_id)
+            .push_bind(&r.event_type)
+            .push_bind(&r.node_id)
+            .push_bind(&r.node_name)
+            .push_bind(&r.node_type)
+            .push_bind(&r.status)
+            .push_bind(&r.context)
+            .push_bind(&r.result)
+            .push_bind(&r.meta)
+            .push_bind(&r.error)
+            .push_bind(&r.worker_id)
+            .push_bind(r.created_at);
+    });
+    qb.build().execute(pool).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_row() -> EventRow {
+        EventRow::new(
+            42,
+            7,
+            3,
+            "command.completed",
+            "success",
+            DateTime::parse_from_rfc3339("2026-06-18T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .with_node("step1")
+        .with_result(json!({"status": "success"}))
+    }
+
+    #[test]
+    fn default_config_is_synchronous_insert() {
+        // The gate is off by default — the chokepoint must take the INSERT path.
+        let cfg = crate::config::AppConfig::default();
+        assert!(
+            !cfg.event_ingest_publish_only,
+            "NOETL_EVENT_INGEST_PUBLISH_ONLY must default to false"
+        );
+    }
+
+    #[test]
+    fn stream_json_uses_db_column_names_and_created_at() {
+        // The published shape must mirror the tailer's `to_jsonb(row)`:
+        // snake_case DB columns + `created_at` (the materializer playbook maps
+        // created_at→timestamp), so the materialized row is byte-identical.
+        let j = sample_row().to_stream_json();
+        assert_eq!(j["event_id"], 42);
+        assert_eq!(j["execution_id"], 7);
+        assert_eq!(j["catalog_id"], 3);
+        assert_eq!(j["event_type"], "command.completed");
+        assert_eq!(j["status"], "success");
+        assert_eq!(j["node_id"], "step1");
+        assert_eq!(j["node_name"], "step1");
+        assert_eq!(j["result"]["status"], "success");
+        assert!(j.get("created_at").is_some(), "must carry created_at");
+        assert!(
+            j.get("timestamp").is_none(),
+            "must NOT pre-map to timestamp — the materializer playbook does that"
+        );
+        // Absent optional columns serialize as JSON null (→ NULL on insert).
+        assert!(j["node_type"].is_null());
+        assert!(j["parent_event_id"].is_null());
+        assert!(j["worker_id"].is_null());
+    }
+
+    #[test]
+    fn builder_sets_node_id_and_name_together() {
+        let r = EventRow::new(1, 1, 1, "step.enter", "ENTERED", Utc::now()).with_node("s");
+        assert_eq!(r.node_id.as_deref(), Some("s"));
+        assert_eq!(r.node_name.as_deref(), Some("s"));
+    }
+}

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -162,10 +162,43 @@ impl EventRow {
     }
 }
 
-/// True when the gate is on AND NATS is connected (so a publisher can be built).
-/// Gate-on without NATS falls back to the INSERT path.
-fn publish_only(state: &AppState) -> bool {
-    state.config.event_ingest_publish_only && state.nats.is_some()
+/// Cache of `catalog_id → is a `system/*` playbook`.  `catalog_id → path` is
+/// immutable, so this is populated once per catalog and read lock-free after.
+static SYSTEM_CATALOG: std::sync::LazyLock<
+    std::sync::RwLock<std::collections::HashMap<i64, bool>>,
+> = std::sync::LazyLock::new(|| std::sync::RwLock::new(std::collections::HashMap::new()));
+
+/// Is this execution a **system-pool playbook** (`system/*`)?  System playbooks —
+/// the `system/event_materializer` + `system/projector` that DRAIN the stream —
+/// must be **exempt** from the publish gate: if their own events published, they
+/// could never bootstrap (the drainer would deadlock waiting for itself to
+/// drain). So they always write synchronously, even under the gate.
+async fn is_system_execution(state: &AppState, catalog_id: i64) -> bool {
+    if let Some(v) = SYSTEM_CATALOG.read().ok().and_then(|m| m.get(&catalog_id).copied()) {
+        return v;
+    }
+    let path: Option<String> =
+        sqlx::query_scalar("SELECT path FROM noetl.catalog WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .fetch_optional(state.pools.cluster())
+            .await
+            .ok()
+            .flatten();
+    let is_sys = path.as_deref().map(|p| p.starts_with("system/")).unwrap_or(false);
+    if let Ok(mut m) = SYSTEM_CATALOG.write() {
+        m.insert(catalog_id, is_sys);
+    }
+    is_sys
+}
+
+/// True when this execution's events should be PUBLISHED rather than INSERTed:
+/// the gate is on, NATS is connected, AND the execution is not a system-pool
+/// playbook (those drain the stream — see [`is_system_execution`]).  This is the
+/// single decision the chokepoint and the relocated trigger both consult.
+pub async fn should_publish(state: &AppState, catalog_id: i64) -> bool {
+    state.config.event_ingest_publish_only
+        && state.nats.is_some()
+        && !is_system_execution(state, catalog_id).await
 }
 
 /// Lazily build (once) + return the `noetl_events` publisher.  Returns `None`
@@ -204,7 +237,9 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
         return Ok(());
     }
 
-    if publish_only(state) {
+    // All rows in a batch share the same execution + catalog, so one decision
+    // covers the batch.
+    if should_publish(state, rows[0].catalog_id).await {
         if let Some(pubr) = publisher(state).await {
             for row in rows {
                 let bytes = serde_json::to_vec(&row.to_stream_json()).map_err(|e| {

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -711,7 +711,7 @@ async fn handle_event_inner(
             }
         }
     } else if (request.event_type == "command.completed" || request.event_type == "command.failed")
-        && !(state.config.event_ingest_publish_only && state.nats.is_some())
+        && !crate::handlers::event_write::should_publish(&state, row.catalog_id.unwrap_or(0)).await
     {
         // CQRS write-path cutover (#103 2d-3): when the gate is on, this event was
         // PUBLISHED, not written — `noetl.event` doesn't have it yet, so triggering
@@ -1025,7 +1025,8 @@ pub async fn claim_command(
     // after the tx commits (the noetl.command claim stays in-tx — it's the queue
     // the worker reads), so it materializes like every other event and the
     // claim audit isn't lost.
-    let publish_claim = state.config.event_ingest_publish_only && state.nats.is_some();
+    let publish_claim =
+        crate::handlers::event_write::should_publish(&state, catalog_id.unwrap_or(0)).await;
     let mut claim_event_to_publish: Option<crate::handlers::event_write::EventRow> = None;
     if step != noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP {
         if publish_claim {
@@ -1175,7 +1176,8 @@ pub async fn handle_batch_events(
     // CQRS write-path chokepoint (#103 2d-3).  Gate-off: in-tx multi-row INSERT
     // (byte-identical).  Gate-on: publish post-commit + the orchestrator trigger
     // relocates to the materializer endpoint.
-    let publish_batch = state.config.event_ingest_publish_only && state.nats.is_some();
+    let publish_batch =
+        crate::handlers::event_write::should_publish(&state, catalog_id.unwrap_or(0)).await;
     if publish_batch {
         let event_rows: Vec<crate::handlers::event_write::EventRow> = rows
             .iter()

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -629,25 +629,26 @@ async fn handle_event_inner(
     let is_meta_command =
         request.step == noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP;
     if !is_meta_command {
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, result, meta, created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-            "#,
+        // CQRS write-path chokepoint (#103 2d-3): INSERT (gate off, default) or
+        // publish to noetl_events (gate on → materializer is the sole writer).
+        // `catalog_id` is always Some here — the playbook_started event wrote
+        // one before any worker event, and the column is NOT NULL.
+        let ev = crate::handlers::event_write::EventRow::new(
+            row.event_id,
+            row.execution_id,
+            row.catalog_id.unwrap_or(0),
+            row.event_type.clone(),
+            row.status.clone(),
+            row.created_at,
         )
-        .bind(row.event_id)
-        .bind(row.execution_id)
-        .bind(row.catalog_id)
-        .bind(&row.event_type)
-        .bind(&row.node_name)
-        .bind(&row.node_name)
-        .bind(&row.status)
-        .bind(&row.result)
-        .bind(&row.meta)
-        .bind(row.created_at)
-        .execute(state.pools.pool_for(execution_id))
+        .with_node(row.node_name.clone())
+        .with_result(row.result.clone())
+        .with_meta(row.meta.clone());
+        crate::handlers::event_write::emit_event(
+            &state,
+            state.pools.pool_for(execution_id),
+            ev,
+        )
         .await?;
     } else {
         crate::metrics::record_orchestrate_drive("event_suppressed");
@@ -709,7 +710,15 @@ async fn handle_event_inner(
                 Err(e) => warn!(execution_id, error = %e, "worker-driven: apply failed"),
             }
         }
-    } else if request.event_type == "command.completed" || request.event_type == "command.failed" {
+    } else if (request.event_type == "command.completed" || request.event_type == "command.failed")
+        && !(state.config.event_ingest_publish_only && state.nats.is_some())
+    {
+        // CQRS write-path cutover (#103 2d-3): when the gate is on, this event was
+        // PUBLISHED, not written — `noetl.event` doesn't have it yet, so triggering
+        // here would rebuild stale state. The trigger relocates to the materializer's
+        // write endpoint (`handlers::internal::events_project`), which fires it AFTER
+        // the row is durably inserted (read-your-writes). Gate off (default): trigger
+        // inline exactly as today.
         match trigger_orchestrator(&state, execution_id, event_id).await {
             Ok(cmds) => {
                 info!(
@@ -1010,34 +1019,64 @@ pub async fn claim_command(
     // below). One drive at a time per execution is already guaranteed by the
     // `orchestrate_in_flight` guard + the single NATS dispatch, so skipping the
     // claimed-event idempotency anchor is safe here.
+    // CQRS write-path chokepoint (#103 2d-3).  Gate-off: the command.claimed
+    // event is written INSIDE the claim transaction exactly as before (atomic
+    // with the noetl.command claim update).  Gate-on: the event is PUBLISHED
+    // after the tx commits (the noetl.command claim stays in-tx — it's the queue
+    // the worker reads), so it materializes like every other event and the
+    // claim audit isn't lost.
+    let publish_claim = state.config.event_ingest_publish_only && state.nats.is_some();
+    let mut claim_event_to_publish: Option<crate::handlers::event_write::EventRow> = None;
     if step != noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP {
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, result, meta, worker_id, created_at
-            ) VALUES (
-                $1, $2, $3, $4,
-                $5, $6, $7, $8, $9, $10, $11
+        if publish_claim {
+            claim_event_to_publish = Some(
+                crate::handlers::event_write::EventRow::new(
+                    claim_event_id,
+                    execution_id,
+                    catalog_id.unwrap_or(0),
+                    "command.claimed",
+                    "RUNNING",
+                    chrono::Utc::now(),
+                )
+                .with_node(step.clone())
+                .with_result(claim_result.clone())
+                .with_meta(claim_meta.clone())
+                .with_worker_id(Some(request.worker_id.clone())),
+            );
+        } else {
+            sqlx::query(
+                r#"
+                INSERT INTO noetl.event (
+                    event_id, execution_id, catalog_id, event_type,
+                    node_id, node_name, status, result, meta, worker_id, created_at
+                ) VALUES (
+                    $1, $2, $3, $4,
+                    $5, $6, $7, $8, $9, $10, $11
+                )
+                "#,
             )
-            "#,
-        )
-        .bind(claim_event_id)
-        .bind(execution_id)
-        .bind(catalog_id)
-        .bind("command.claimed")
-        .bind(&step)
-        .bind(&step)
-        .bind("RUNNING")
-        .bind(claim_result)
-        .bind(claim_meta)
-        .bind(&request.worker_id)
-        .bind(chrono::Utc::now())
-        .execute(&mut *tx)
-        .await?;
+            .bind(claim_event_id)
+            .bind(execution_id)
+            .bind(catalog_id)
+            .bind("command.claimed")
+            .bind(&step)
+            .bind(&step)
+            .bind("RUNNING")
+            .bind(claim_result)
+            .bind(claim_meta)
+            .bind(&request.worker_id)
+            .bind(chrono::Utc::now())
+            .execute(&mut *tx)
+            .await?;
+        }
     }
 
     tx.commit().await?;
+
+    if let Some(ev) = claim_event_to_publish {
+        crate::handlers::event_write::emit_event(&state, state.pools.pool_for(execution_id), ev)
+            .await?;
+    }
 
     Ok(Json(ClaimResponse {
         status: "ok".to_string(),
@@ -1133,26 +1172,57 @@ pub async fn handle_batch_events(
     }
 
     let now = chrono::Utc::now();
-    let mut qb = sqlx::QueryBuilder::new(
-        "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
-         node_id, node_name, status, result, meta, worker_id, created_at) ",
-    );
-    qb.push_values(rows.iter(), |mut b, r| {
-        b.push_bind(r.event_id)
-            .push_bind(execution_id)
-            .push_bind(catalog_id)
-            .push_bind(&r.event_type)
-            .push_bind(&r.step)
-            .push_bind(&r.step)
-            .push_bind(&r.status)
-            .push_bind(&r.result_obj)
-            .push_bind(&r.meta_obj)
-            .push_bind(&request.worker_id)
-            .push_bind(now);
-    });
-    qb.build().execute(&mut *tx).await?;
-
-    tx.commit().await?;
+    // CQRS write-path chokepoint (#103 2d-3).  Gate-off: in-tx multi-row INSERT
+    // (byte-identical).  Gate-on: publish post-commit + the orchestrator trigger
+    // relocates to the materializer endpoint.
+    let publish_batch = state.config.event_ingest_publish_only && state.nats.is_some();
+    if publish_batch {
+        let event_rows: Vec<crate::handlers::event_write::EventRow> = rows
+            .iter()
+            .map(|r| {
+                crate::handlers::event_write::EventRow::new(
+                    r.event_id,
+                    execution_id,
+                    catalog_id.unwrap_or(0),
+                    r.event_type.clone(),
+                    r.status.clone(),
+                    now,
+                )
+                .with_node(r.step.clone())
+                .with_result(r.result_obj.clone())
+                .with_meta(r.meta_obj.clone())
+                .with_worker_id(request.worker_id.clone())
+            })
+            .collect();
+        // Commit the (possibly empty) claim tx first, then publish.
+        tx.commit().await?;
+        crate::handlers::event_write::emit_events(
+            &state,
+            state.pools.pool_for(execution_id),
+            &event_rows,
+        )
+        .await?;
+    } else {
+        let mut qb = sqlx::QueryBuilder::new(
+            "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
+             node_id, node_name, status, result, meta, worker_id, created_at) ",
+        );
+        qb.push_values(rows.iter(), |mut b, r| {
+            b.push_bind(r.event_id)
+                .push_bind(execution_id)
+                .push_bind(catalog_id)
+                .push_bind(&r.event_type)
+                .push_bind(&r.step)
+                .push_bind(&r.step)
+                .push_bind(&r.status)
+                .push_bind(&r.result_obj)
+                .push_bind(&r.meta_obj)
+                .push_bind(&request.worker_id)
+                .push_bind(now);
+        });
+        qb.build().execute(&mut *tx).await?;
+        tx.commit().await?;
+    }
 
     // Trigger orchestrator for any command.completed in the batch,
     // including end (end is now a real dispatched step per
@@ -1162,8 +1232,10 @@ pub async fn handle_batch_events(
     // event so a batch with multiple completions can still advance
     // multi-step playbooks.  Errors are logged and swallowed so a
     // bad-state evaluation doesn't fail the whole batch ingest.
+    // Gate-on (publish_batch): skip — the trigger relocates to the materializer's
+    // write endpoint (events_project), which fires it after the row materializes.
     for (idx, item) in request.events.iter().enumerate() {
-        if item.event_type == "command.completed" {
+        if item.event_type == "command.completed" && !publish_batch {
             let trigger_event_id = event_ids[idx];
             match trigger_orchestrator(&state, execution_id, trigger_event_id).await {
                 Ok(cmds) => {
@@ -1782,7 +1854,7 @@ pub(crate) async fn advance_snapshot(
     })
 }
 
-async fn trigger_orchestrator(
+pub(crate) async fn trigger_orchestrator(
     state: &AppState,
     execution_id: i64,
     trigger_event_id: i64,
@@ -2239,27 +2311,23 @@ async fn apply_orchestration_result(
             _ => serde_json::json!({"status": event_status}),
         };
 
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, result, meta, created_at, parent_event_id
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            "#,
+        // CQRS write-path chokepoint (#103 2d-3).
+        let mut ev = crate::handlers::event_write::EventRow::new(
+            event_id,
+            execution_id,
+            catalog_id,
+            emit.event_type.clone(),
+            event_status.clone(),
+            chrono::Utc::now(),
         )
-        .bind(event_id)
-        .bind(execution_id)
-        .bind(catalog_id)
-        .bind(&emit.event_type)
-        .bind(emit.node_name.as_deref())
-        .bind(emit.node_name.as_deref())
-        .bind(&event_status)
-        .bind(&result_obj)
-        .bind(serde_json::json!({"emitted_by": "orchestrator"}))
-        .bind(chrono::Utc::now())
-        .bind(trigger_event_id)
-        .execute(state.pools.pool_for(execution_id))
-        .await?;
+        .with_result(result_obj.clone())
+        .with_meta(serde_json::json!({"emitted_by": "orchestrator"}))
+        .with_parent_event_id(trigger_event_id);
+        if let Some(n) = emit.node_name.as_deref() {
+            ev = ev.with_node(n);
+        }
+        crate::handlers::event_write::emit_event(state, state.pools.pool_for(execution_id), ev)
+            .await?;
     }
 
     // 5. Issue new commands — batched (noetl/ai-meta#102 step 1).  A cursor
@@ -2286,27 +2354,21 @@ async fn apply_orchestration_result(
         };
         let event_id = state.snowflake.generate()?;
         let terminal_meta = serde_json::to_value(&result.completion_status).unwrap_or_default();
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, result, meta, created_at, parent_event_id
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            "#,
+        // CQRS write-path chokepoint (#103 2d-3).
+        let ev = crate::handlers::event_write::EventRow::new(
+            event_id,
+            execution_id,
+            catalog_id,
+            event_type,
+            status,
+            chrono::Utc::now(),
         )
-        .bind(event_id)
-        .bind(execution_id)
-        .bind(catalog_id)
-        .bind(event_type)
-        .bind("playbook")
-        .bind("playbook")
-        .bind(status)
-        .bind(serde_json::json!({"status": status}))
-        .bind(terminal_meta)
-        .bind(chrono::Utc::now())
-        .bind(trigger_event_id)
-        .execute(state.pools.pool_for(execution_id))
-        .await?;
+        .with_node("playbook")
+        .with_result(serde_json::json!({"status": status}))
+        .with_meta(terminal_meta)
+        .with_parent_event_id(trigger_event_id);
+        crate::handlers::event_write::emit_event(state, state.pools.pool_for(execution_id), ev)
+            .await?;
         info!(
             execution_id,
             terminal_event = %event_type,
@@ -2432,27 +2494,24 @@ async fn emit_playbook_failed(
     error: &str,
 ) -> AppResult<()> {
     let event_id = state.snowflake.generate()?;
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            event_id, execution_id, catalog_id, event_type,
-            node_id, node_name, status, result, meta, created_at, parent_event_id
-        ) VALUES ($1, $2, $3, 'playbook.failed', 'playbook', 'playbook', 'FAILED', $4, $5, $6, $7)
-        "#,
+    // CQRS write-path chokepoint (#103 2d-3).
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        execution_id,
+        catalog_id,
+        "playbook.failed",
+        "FAILED",
+        chrono::Utc::now(),
     )
-    .bind(event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind(serde_json::json!({"status": "FAILED", "context": {"error": error}}))
-    .bind(serde_json::json!({
+    .with_node("playbook")
+    .with_result(serde_json::json!({"status": "FAILED", "context": {"error": error}}))
+    .with_meta(serde_json::json!({
         "emitted_by": "orchestrator",
         "reason": "evaluate_error",
         "error": error,
     }))
-    .bind(chrono::Utc::now())
-    .bind(trigger_event_id)
-    .execute(state.pools.pool_for(execution_id))
-    .await?;
+    .with_parent_event_id(trigger_event_id);
+    crate::handlers::event_write::emit_event(state, state.pools.pool_for(execution_id), ev).await?;
     info!(
         execution_id,
         terminal_event = "playbook.failed",

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -495,28 +495,23 @@ async fn emit_deduplicated_event(
         "emitted_at": chrono::Utc::now().to_rfc3339(),
         "emitter": "control_plane",
     });
-    let res = sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            execution_id, catalog_id, event_id, event_type, node_id, node_name, node_type,
-            status, context, meta, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-        "#,
+    // CQRS write-path chokepoint (#103 2d-3); best-effort, mirrors the prior
+    // warn-on-failure.
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        scope,
+        catalog_id,
+        "subscription.message.deduplicated",
+        "DEDUPLICATED",
+        chrono::Utc::now(),
     )
-    .bind(scope)
-    .bind(catalog_id)
-    .bind(event_id)
-    .bind("subscription.message.deduplicated")
-    .bind("subscription")
-    .bind("ingress")
-    .bind("subscription")
-    .bind("DEDUPLICATED")
-    .bind(&context)
-    .bind(&meta)
-    .bind(chrono::Utc::now())
-    .execute(state.pools.pool_for(scope))
-    .await;
-    if let Err(e) = res {
+    .with_nodes("subscription", "ingress")
+    .with_node_type("subscription")
+    .with_context(context)
+    .with_meta(meta);
+    if let Err(e) =
+        crate::handlers::event_write::emit_event(state, state.pools.pool_for(scope), ev).await
+    {
         tracing::warn!(subscription_id = scope, error = %e, "dedup audit event insert failed (non-fatal)");
     }
 }
@@ -616,31 +611,21 @@ async fn emit_playbook_started_event(
         }
     }
 
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            execution_id, catalog_id, event_id, parent_execution_id,
-            event_type, node_id, node_name, node_type, status,
-            context, meta, created_at
-        ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
-        )
-        "#,
+    // CQRS write-path chokepoint (#103 2d-3): INSERT (gate off) or publish (on).
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        execution_id,
+        catalog_id,
+        "playbook_started",
+        "STARTED",
+        chrono::Utc::now(),
     )
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind(event_id)
-    .bind(parent_execution_id)
-    .bind("playbook_started")
-    .bind("playbook")
-    .bind(path)
-    .bind("execution")
-    .bind("STARTED")
-    .bind(&context)
-    .bind(&meta)
-    .bind(chrono::Utc::now())
-    .execute(state.pools.pool_for(execution_id))
-    .await?;
+    .with_nodes("playbook", path)
+    .with_node_type("execution")
+    .with_parent_execution_id(parent_execution_id)
+    .with_context(context)
+    .with_meta(meta);
+    crate::handlers::event_write::emit_event(state, state.pools.pool_for(execution_id), ev).await?;
 
     Ok(event_id)
 }
@@ -770,31 +755,25 @@ pub(crate) async fn persist_engine_command(
         }
     }
 
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            event_id, execution_id, catalog_id, event_type,
-            node_id, node_name, node_type, status,
-            context, meta, parent_event_id, created_at
-        ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
-        )
-        "#,
+    // CQRS write-path chokepoint (#103 2d-3): the command.issued EVENT goes
+    // through emit_event (INSERT gate-off / publish gate-on).  The noetl.command
+    // ROW below stays a synchronous INSERT — it's the command queue, not the
+    // event log (#103 is event-log-scoped), and the worker fetches command
+    // config from noetl.command, so it must be present read-your-writes.
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        execution_id,
+        catalog_id,
+        "command.issued",
+        "PENDING",
+        chrono::Utc::now(),
     )
-    .bind(event_id)
-    .bind(execution_id)
-    .bind(catalog_id)
-    .bind("command.issued")
-    .bind(&step.step)
-    .bind(&step.step)
-    .bind(command.tool.kind.as_str())
-    .bind("PENDING")
-    .bind(&cmd_context)
-    .bind(&cmd_meta)
-    .bind(parent_event_id)
-    .bind(chrono::Utc::now())
-    .execute(state.pools.pool_for(execution_id))
-    .await?;
+    .with_node(&step.step)
+    .with_node_type(command.tool.kind.as_str())
+    .with_context(cmd_context.clone())
+    .with_meta(cmd_meta.clone())
+    .with_parent_event_id(parent_event_id);
+    crate::handlers::event_write::emit_event(state, state.pools.pool_for(execution_id), ev).await?;
 
     if let Err(e) = insert_command_row(
         state,
@@ -945,26 +924,28 @@ pub(crate) async fn persist_engine_commands_batch(
 
     let pool = state.pools.pool_for(execution_id);
 
-    // Multi-row INSERT of all `command.issued` events.
-    let mut qb = sqlx::QueryBuilder::new(
-        "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
-         node_id, node_name, node_type, status, context, meta, parent_event_id, created_at) ",
-    );
-    qb.push_values(prepared.iter(), |mut b, p| {
-        b.push_bind(p.event_id)
-            .push_bind(execution_id)
-            .push_bind(catalog_id)
-            .push_bind("command.issued")
-            .push_bind(p.step_name)
-            .push_bind(p.step_name)
-            .push_bind(p.tool_kind)
-            .push_bind("PENDING")
-            .push_bind(&p.cmd_context)
-            .push_bind(&p.cmd_meta)
-            .push_bind(parent_event_id)
-            .push_bind(now);
-    });
-    qb.build().execute(pool).await?;
+    // Multi-row `command.issued` EVENTS through the CQRS chokepoint (#103 2d-3):
+    // one multi-row INSERT (gate off) or one publish per row (gate on). The
+    // noetl.command ROWS below stay synchronous (command queue, not event log).
+    let event_rows: Vec<crate::handlers::event_write::EventRow> = prepared
+        .iter()
+        .map(|p| {
+            crate::handlers::event_write::EventRow::new(
+                p.event_id,
+                execution_id,
+                catalog_id,
+                "command.issued",
+                "PENDING",
+                now,
+            )
+            .with_node(p.step_name)
+            .with_node_type(p.tool_kind)
+            .with_context(p.cmd_context.clone())
+            .with_meta(p.cmd_meta.clone())
+            .with_parent_event_id(parent_event_id)
+        })
+        .collect();
+    crate::handlers::event_write::emit_events(state, pool, &event_rows).await?;
 
     // Multi-row INSERT of all `noetl.command` rows (non-fatal — the event log is
     // the source of truth; mirror the single path's warn-on-failure).
@@ -1219,27 +1200,21 @@ async fn generate_initial_commands(
                 "iterator_var": loop_cfg.iterator,
             },
         });
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, result, meta, created_at, parent_event_id
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            "#,
+        // CQRS write-path chokepoint (#103 2d-3).
+        let ev = crate::handlers::event_write::EventRow::new(
+            enter_event_id,
+            execution_id,
+            catalog_id,
+            "step.enter",
+            "ENTERED",
+            chrono::Utc::now(),
         )
-        .bind(enter_event_id)
-        .bind(execution_id)
-        .bind(catalog_id)
-        .bind("step.enter")
-        .bind(&start_step.step)
-        .bind(&start_step.step)
-        .bind("ENTERED")
-        .bind(&enter_result)
-        .bind(serde_json::json!({"emitted_by": "execute_handler"}))
-        .bind(chrono::Utc::now())
-        .bind(parent_event_id)
-        .execute(state.pools.pool_for(execution_id))
-        .await?;
+        .with_node(&start_step.step)
+        .with_result(enter_result.clone())
+        .with_meta(serde_json::json!({"emitted_by": "execute_handler"}))
+        .with_parent_event_id(parent_event_id);
+        crate::handlers::event_write::emit_event(state, state.pools.pool_for(execution_id), ev)
+            .await?;
 
         // #76: parallel = all items; sequential = only iteration 0.
         let dispatch_count = if is_parallel { total } else { 1 };

--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -305,9 +305,18 @@ pub async fn outbox_pending_count(
 ///
 /// Batch-INSERT events into `noetl.event`.  Idempotent via
 /// `ON CONFLICT (event_id) DO NOTHING`.
-#[tracing::instrument(skip(pool, _token), fields(batch_size = request.events.len()))]
+///
+/// CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): this is the **sole**
+/// `noetl.event` writer when `NOETL_EVENT_INGEST_PUBLISH_ONLY` is on.  Because
+/// the synchronous ingest no longer triggers the orchestrator on a
+/// `command.completed`/`command.failed` (it only published the row), the trigger
+/// **relocates here** — fired AFTER the row is durably materialized, so the drive
+/// rebuilds off committed state (read-your-writes).  Only when the gate is on
+/// (off → the ingest path triggers inline exactly as before, so we must not
+/// double-trigger).
+#[tracing::instrument(skip(state, _token), fields(batch_size = request.events.len()))]
 pub async fn events_project(
-    State(pool): State<DbPool>,
+    State(state): State<AppState>,
     _token: RequireInternalApiToken,
     Json(request): Json<EventsProjectRequest>,
 ) -> AppResult<Json<EventsProjectResponse>> {
@@ -316,8 +325,38 @@ pub async fn events_project(
             "events must not be empty".to_string(),
         ));
     }
-    let (projected, duplicates) = svc::project_events(&pool, &request.events).await?;
+    let (projected, duplicates) = svc::project_events(&state.db, &request.events).await?;
     info!(projected, duplicates, "events/project done");
+
+    // Relocated orchestrator trigger (gate-on only).  For each execution whose
+    // just-materialized batch carried a triggering event, fire the drive with
+    // the highest such `event_id` as the trigger.  trigger_orchestrator is
+    // idempotent (the orch-cache reconcile folds any events it didn't see), so
+    // a redelivered batch re-triggering is a forward no-op.
+    if state.config.event_ingest_publish_only {
+        let mut triggers: std::collections::HashMap<i64, i64> = std::collections::HashMap::new();
+        for e in &request.events {
+            let is_trigger = matches!(
+                e.event_type.as_deref(),
+                Some("command.completed") | Some("command.failed")
+            );
+            if let (true, Some(eid)) = (is_trigger, e.execution_id) {
+                triggers
+                    .entry(eid)
+                    .and_modify(|m| *m = (*m).max(e.event_id))
+                    .or_insert(e.event_id);
+            }
+        }
+        for (execution_id, trigger_event_id) in triggers {
+            if let Err(e) =
+                crate::handlers::events::trigger_orchestrator(&state, execution_id, trigger_event_id)
+                    .await
+            {
+                warn!(execution_id, %e, "publish-only: post-materialize orchestrator trigger failed");
+            }
+        }
+    }
+
     Ok(Json(EventsProjectResponse {
         projected,
         duplicates,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod credentials;
 pub mod cross_region;
 pub mod dashboard;
 pub mod database;
+pub mod event_write;
 pub mod events;
 pub mod execute;
 pub mod executions;

--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -472,28 +472,21 @@ async fn write_lifecycle_event(
         "emitter": "control_plane",
         "subscription_lifecycle": true,
     });
-    sqlx::query(
-        r#"
-        INSERT INTO noetl.event (
-            execution_id, catalog_id, event_id,
-            event_type, node_id, node_name, node_type, status,
-            context, meta, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-        "#,
+    // CQRS write-path chokepoint (#103 2d-3).
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        subscription_id,
+        catalog_id,
+        event_type,
+        to.as_status(),
+        chrono::Utc::now(),
     )
-    .bind(subscription_id)
-    .bind(catalog_id)
-    .bind(event_id)
-    .bind(event_type)
-    .bind("subscription")
-    .bind(path)
-    .bind("subscription")
-    .bind(to.as_status())
-    .bind(&context)
-    .bind(&meta)
-    .bind(chrono::Utc::now())
-    .execute(state.pools.pool_for(subscription_id))
-    .await?;
+    .with_nodes("subscription", path)
+    .with_node_type("subscription")
+    .with_context(context)
+    .with_meta(meta);
+    crate::handlers::event_write::emit_event(state, state.pools.pool_for(subscription_id), ev)
+        .await?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,13 @@ fn build_router(
             "/api/internal/events/materialize",
             post(handlers::internal::events_materialize),
         )
+        // events/project (the materializer's row-shape writer) carries AppState
+        // so it can fire the relocated orchestrator trigger after materializing
+        // a batch under NOETL_EVENT_INGEST_PUBLISH_ONLY (#103 phase 2d-3).
+        .route(
+            "/api/internal/events/project",
+            post(handlers::internal::events_project),
+        )
         .with_state(state.clone());
 
     // Keychain routes
@@ -413,10 +420,6 @@ fn build_router(
         .route(
             "/api/internal/outbox/pending-count",
             get(handlers::internal::outbox_pending_count),
-        )
-        .route(
-            "/api/internal/events/project",
-            post(handlers::internal::events_project),
         )
         .route(
             "/api/internal/cleanup/purge",
@@ -724,6 +727,26 @@ async fn main() -> anyhow::Result<()> {
         state.clone(),
         noetl_server::services::event_stream::EventStreamConfig::from_env(),
     );
+
+    // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when
+    // `NOETL_EVENT_INGEST_PUBLISH_ONLY` is on, server-originated events publish to
+    // `noetl_events` instead of INSERTing — the materializer is the sole writer.
+    // Loud at startup because it changes the durability boundary; also flags the
+    // two paths still on the synchronous INSERT (ExecutionService cancel/finalize —
+    // they lack AppState; correct, no lost/double writes, staged for a follow-up).
+    if app_config.event_ingest_publish_only {
+        if state.nats.is_some() {
+            tracing::warn!(
+                target: "noetl_server::startup",
+                "NOETL_EVENT_INGEST_PUBLISH_ONLY=ON — server-originated noetl.event writes PUBLISH to noetl_events (materializer is the sole writer); ExecutionService cancel/finalize remain synchronous (staged)"
+            );
+        } else {
+            tracing::warn!(
+                target: "noetl_server::startup",
+                "NOETL_EVENT_INGEST_PUBLISH_ONLY set but NATS is not connected — falling back to synchronous INSERT (gate inert)"
+            );
+        }
+    }
 
     // Create services. The wallet's envelope cipher is built once over the
     // configured KEK provider (NOETL_KMS_PROVIDER: `local` default, or

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -206,6 +206,36 @@ pub fn event_stream_published_total() -> &'static IntCounterVec {
     })
 }
 
+/// Counter: events published through the `emit_event` chokepoint when the
+/// `NOETL_EVENT_INGEST_PUBLISH_ONLY` gate is on (noetl/ai-meta#103 phase 2d-3),
+/// by event type.  Distinct from the tailer's `event_stream_published_total`:
+/// this is the **producer cutover** path (the synchronous INSERT replaced by a
+/// publish), so a non-zero rate here means the materializer is the sole writer.
+pub fn event_ingest_published_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_event_ingest_published_total",
+                "Total events published to noetl_events by the emit_event chokepoint under NOETL_EVENT_INGEST_PUBLISH_ONLY (2d-3 cutover), by event type.",
+            ),
+            &["event_type"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one event published through the chokepoint (gate-on path).
+pub fn record_event_published(event_type: &str) {
+    event_ingest_published_total()
+        .with_label_values(&[event_type])
+        .inc();
+}
+
 /// Gauge: the tailer's current cursor (`noetl.event.id` last published).  Pair
 /// with the table's `MAX(id)` to read publish lag.  Single series (no labels) —
 /// one tailer per server.

--- a/src/state.rs
+++ b/src/state.rs
@@ -90,6 +90,14 @@ pub struct AppState {
     /// server).  The per-execution lock inside also serialises a single
     /// execution's concurrent completion triggers.
     pub orch_cache: Arc<OrchStateCache>,
+
+    /// CQRS write-path publisher (noetl/ai-meta#103 phase 2d-3).  Lazily built
+    /// on first use from [`Self::nats`] so the `emit_event` chokepoint can
+    /// publish to the `noetl_events` stream when
+    /// `config.event_ingest_publish_only` is on.  `OnceCell` so the gate-off
+    /// (default) path never builds it and the gate-on path ensures the stream
+    /// exactly once.  `None` inner stays uninitialised until the first publish.
+    pub event_stream_publisher: Arc<tokio::sync::OnceCell<crate::nats::EventStreamPublisher>>,
 }
 
 /// Cached orchestrator state for one execution, advanced incrementally.
@@ -254,6 +262,7 @@ impl AppState {
             shard: Arc::new(shard),
             start_time: std::time::Instant::now(),
             orch_cache: Arc::new(OrchStateCache::default()),
+            event_stream_publisher: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
 


### PR DESCRIPTION
## What

The 2d-3 cutover of the CQRS event-log split
([noetl/ai-meta#103](https://github.com/noetl/ai-meta/issues/103)), **default-off**.
Introduces a single server-side `noetl.event` write chokepoint and a gate that,
when on, makes the `system/event_materializer` playbook the **sole** `noetl.event`
writer.

- **`handlers::event_write`** — `emit_event` / `emit_events` over an `EventRow`.
  Gate OFF (default): canonical full-column INSERT, **byte-identical** to the
  prior inline INSERTs (absent columns bind `NULL` = the DB default those sites
  relied on; `tenant_id`/`organization_id` left to default). Gate ON: publish the
  `to_jsonb(row)` shape to `noetl_events` (`Nats-Msg-Id=event_id`) instead of
  INSERTing.
- **`NOETL_EVENT_INGEST_PUBLISH_ONLY`** config flag (default false). Lazy
  `OnceCell` publisher in `AppState`; falls back to INSERT if NATS is absent.
- **13 producer sites** routed through the chokepoint (handle_event,
  claim_command, handle_batch_events, apply_orchestration_result ×2,
  emit_playbook_failed, dedup-audit, playbook_started, command.issued single +
  batch, step.enter, container_callback, subscription). `noetl.command` rows stay
  synchronous (command queue, not event log). The two sink writers
  (`events_materialize`, `events_project`) are unchanged — they ARE the materializer.
- **Trigger relocation**: under the gate the ingest no longer triggers the
  orchestrator on `command.completed`/`failed` (the row isn't written yet); the
  trigger fires from `events_project` AFTER the row materializes (read-your-writes).
- **System-pool exemption**: `system/*` playbooks (the drainers) write
  synchronously even under the gate — otherwise the materializer could never
  bootstrap (it would deadlock waiting to drain its own events). `should_publish()`
  is the single decision (cached `catalog_id→path` lookup).

`__orchestrate__` suppression, ordering, idempotency, the event taxonomy
preserved; no double-writes (sink `ON CONFLICT`), no lost events (publish-ack
durability).

## Validated on kind (server image built from this branch)

**Gate-OFF (default) — byte-identical:**
- `kind_validate_orchestrate_offserver.sh` **PASS** (COMPLETED, dispatched+4/applied+4,
  0 `__orchestrate__` in `noetl.event`).
- Event-row regression: 25/25 events, 25 distinct ids (no double-write), all
  columns correct, `tenant/organization='default'` (DB default fired),
  `playbook_started` keeps `node_id≠node_name`, `command.issued` carries
  `parent_event_id`+`node_type`. **The chokepoint INSERT is byte-identical.**

**Gate-ON — producer sole-writer PROVEN:**
- A gate-on execution wrote **0 `noetl.event` rows** (verified twice) — events are
  PUBLISHED, not inserted (the `noetl_event_ingest_published_total` counter shows
  playbook_started/command.issued/claimed/started/completed/call.done published);
  `noetl.command`=synchronous so the worker can claim. **The server is no longer a
  writer of the event log.**
- The system-exemption works: the materializer bootstraps + completes its own
  cycle (reaches `end`, `events/project` materializes idempotently
  `{projected:0,duplicates:N}`); `events_project` fires the relocated trigger
  (notifications observed).

**Not cleanly shown end-to-end on kind:** a single fresh normal execution driven
fully to COMPLETED under the gate — the shared kind cluster was saturated by
accumulated stuck test executions whose reconcile-poller re-drives kept
re-flooding the stream, starving fresh execs. A test-environment artifact (the
individual mechanisms are all proven), not a cutover defect. Tracked on #103 for
a clean-cluster soak.

## Default-off / operator decision

`PUBLISH_ONLY` stays **default false**. The producer cutover (flip on → materializer
sole writer) is an **operator decision**, staged behind a materializer-lag
metric/alert, one revert away. No production default changed.

557 lib tests + clippy green; 3 new `event_write` unit tests (incl. gate-off
byte-identity + the published row shape).

Refs noetl/ai-meta#103