### PR TITLE
fix(cqrs): get_catalog_id falls back to noetl.command under PUBLISH_ONLY (#103 2d-3)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1394,13 +1394,37 @@ fn build_result_object(request: &EventRequest, status: &str) -> serde_json::Valu
     serde_json::Value::Object(result)
 }
 
-/// Get catalog_id from existing events.
+/// Get catalog_id for an execution.
+///
+/// Reads `noetl.event` first (authoritative when present), then falls back to
+/// `noetl.command`.  The fallback is load-bearing under the CQRS write-path
+/// cutover (noetl/ai-meta#103 2d-3): with `NOETL_EVENT_INGEST_PUBLISH_ONLY` on,
+/// `noetl.event` is EMPTY (events are published to `noetl_events` and not
+/// INSERTed until the materializer drains them), so a worker-emitted event's
+/// `normalize_event_to_row` would resolve `catalog_id = None → 0` and the
+/// published row would carry `catalog_id = 0`, FK-violating
+/// `event_catalog_id_fkey` when the materializer INSERTs it (→ the whole batch
+/// fails + the events are lost).  `noetl.command` is written synchronously even
+/// under the gate (it's the command queue the worker reads), so it always
+/// carries the execution's `catalog_id`.
 async fn get_catalog_id(state: &AppState, execution_id: i64) -> AppResult<Option<i64>> {
-    let row: Option<(i64,)> = sqlx::query_as::<_, (i64,)>(
+    let pool = state.pools.pool_for(execution_id);
+    if let Some((id,)) = sqlx::query_as::<_, (i64,)>(
         "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 LIMIT 1",
     )
     .bind(execution_id)
-    .fetch_optional(state.pools.pool_for(execution_id))
+    .fetch_optional(pool)
+    .await?
+    {
+        return Ok(Some(id));
+    }
+
+    // Fallback: noetl.command (synchronous under PUBLISH_ONLY).
+    let row: Option<(i64,)> = sqlx::query_as::<_, (i64,)>(
+        "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
+    )
+    .bind(execution_id)
+    .fetch_optional(pool)
     .await?;
 
     Ok(row.map(|(id,)| id))


### PR DESCRIPTION
## The bug

Under `NOETL_EVENT_INGEST_PUBLISH_ONLY` (the 2d-3 sole-writer cutover,
[#235](https://github.com/noetl/server/pull/235)), a fresh execution's events
ended up **lost** — the materializer drained them but `noetl.event` stayed empty.

Root cause (found via a serial clean-cluster soak): `get_catalog_id` resolved
`catalog_id` by `SELECT catalog_id FROM noetl.event WHERE execution_id = $1`. But
under the gate **`noetl.event` is empty** (events are published, not INSERTed,
until the materializer drains them), so a worker-emitted event's
`normalize_event_to_row` got `catalog_id = None → 0`. The published row carried
`catalog_id = 0`, and when the materializer batch-INSERTed it, **`event_catalog_id_fkey`
FK-violated** (no catalog 0) → the whole `events/project` batch failed (HTTP 500)
→ and because the drain acks on poll-success, the events were already acked off
the stream → **lost**.

Live evidence: `build_envelopes` showed event catalog_ids
`[652264425491005680 ×3, 0, 0, 0]` — the 3 server-side events (execute.rs, which
has catalog_id directly) were fine; the 3 worker-emitted events (handle_event →
get_catalog_id) were `0`. `materialize` returned
`{"error":"... violates foreign key constraint event_catalog_id_fkey","status":500}`.

## The fix

`get_catalog_id` now falls back to `noetl.command` when `noetl.event` has no row.
`noetl.command` is written **synchronously even under the gate** (it's the command
queue the worker reads), so it always carries the execution's `catalog_id`.
One-function change; gate-off behavior unchanged (noetl.event has rows there, so
the fallback never fires).

## Validated on kind (image built from this branch)

**Gate-ON (`PUBLISH_ONLY=true`) — full end-to-end, zero loss:**
- A fresh execution ran all the way to **COMPLETED** via the materializer-as-sole-writer path.
- Server wrote **0 `noetl.event` rows**; the materializer inserted all 31 events
  (`projected` 6→12→12→1, **no duplicates, no FK errors**).
- **drained = materialized = 31** (stream pending=0, 31 rows in `noetl.event`) —
  no acked-but-unmaterialized loss.
- 31 events / 31 distinct ids (no double-write), strictly ordered, `playbook.completed=1`,
  **0 events with catalog_id=0**.

**Gate-OFF — no regression:** off-server orchestrate e2e **PASS** (COMPLETED,
dispatched+4/applied+4, 0 `__orchestrate__` in `noetl.event`); 557 lib tests pass.

## Note

The earlier-hypothesized materializer-playbook fixes (ack-after-materialize,
`drain_events.count` routing, serialize) were red herrings — the serial soak
showed routing resolved `count=6` correctly and serial driving didn't help; the
loss was this server-side catalog_id FK. A separate **durability hardening**
remains valid but is not the cause: the materializer acks on fetch, so a *future*
transient `events/project` failure could still lose events — true
ack-after-materialize needs a deferred-ack capability in the subscription tool
(at-least-once + the idempotent `events/project` is the current platform model).
Tracked on noetl/ai-meta#103 as the remaining item before the `PUBLISH_ONLY` flip
is operator-safe.

Refs noetl/ai-meta#103