### PR TITLE
fix(orchestrate): rebuild WorkflowState on cold-cache apply (off-server drive × gate crash-recovery)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2458,6 +2458,60 @@ async fn apply_worker_orchestration(
         return Ok(0);
     };
 
+    // Cold cache on apply (noetl/ai-meta#104 — off-server-drive × gate
+    // crash-recovery).  The orch_cache only evicts on terminal, so a cold slot
+    // here means the server restarted between dispatching this `__orchestrate__`
+    // command and receiving its `call.done` (the off-server round-trip — NATS →
+    // worker → drive → call.done — widens that window vs the in-process drive).
+    // Dropping the result would strand the execution: no next command is issued,
+    // no further real event fires a trigger, and the reconcile poller only
+    // re-drives executions still in `active_executions()` (empty after restart).
+    // Instead rebuild `WorkflowState` from the durable log — under PUBLISH_ONLY
+    // that log is the materializer's projection of the NATS WAL, the same source
+    // the warm trigger reads — so the drive result applies onto consistent
+    // committed state.  Idempotent: `apply_orchestration_result` issues commands
+    // keyed by deterministic `command_id`, and the cursor counters are gated by
+    // the `cursor_issued`/`cursor_completed` id-sets, so a re-applied result is a
+    // forward no-op rather than a double-issue.
+    if cache.state.is_none() {
+        let pool = state.pools.pool_for(execution_id);
+        let result_store = crate::services::result_store::ResultStoreService::new(
+            pool.clone(),
+            state.snowflake.clone(),
+        );
+        match rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await {
+            Ok(r) => {
+                let total: i64 =
+                    sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
+                        .bind(execution_id)
+                        .fetch_one(pool)
+                        .await
+                        .unwrap_or(0);
+                cache.last_event_id = r.last_event_id;
+                cache.applied_count = total;
+                cache.snapshot_version = r.snapshot_version;
+                cache.routing_meta = r.routing_meta;
+                cache.state = Some(r.state);
+                crate::metrics::record_orchestrate_drive("cold_rebuild");
+                info!(
+                    execution_id,
+                    "worker-driven: cold cache on apply — rebuilt WorkflowState from the durable \
+                     log before applying (crash-recovery, noetl/ai-meta#104)"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    execution_id,
+                    error = %e,
+                    "worker-driven: cold cache on apply and rebuild failed; cannot apply \
+                     orchestrate result this pass (reconcile will retry)"
+                );
+                crate::metrics::record_orchestrate_drive("cold_rebuild_failed");
+                return Ok(0);
+            }
+        }
+    }
+
     let catalog_id = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
     if catalog_id == 0 {
         warn!(


### PR DESCRIPTION
## What

When the worker-driven (off-server) orchestrate drive's `call.done` reaches `apply_worker_orchestration` with a **cold `orch_cache` slot**, the apply previously **dropped** the drive result (`cold cache (no catalog_id) … cannot apply`). The `orch_cache` only evicts on terminal (`state.rs`), so a cold slot at apply time means the **server restarted between dispatching the `__orchestrate__` command and receiving its `call.done`** — a window the off-server round-trip (NATS → worker → drive → call.done) widens versus the in-process drive. Dropping strands the execution until the background reconcile poller re-drives it (an extra wasted off-server round-trip + up to one reconcile interval of latency).

This PR rebuilds `WorkflowState` **from the durable log** before applying — the [noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) "rebuild from the WAL/projection" principle. Under `NOETL_EVENT_INGEST_PUBLISH_ONLY` the durable log is the materializer's projection of the NATS WAL (the same committed source the warm relocated trigger reads), so the in-flight result applies onto consistent state with read-your-writes. Idempotent: commands are keyed by deterministic `command_id` and cursor counters are gated by the `cursor_issued`/`cursor_completed` id-sets, so a re-applied result is a forward no-op.

Confined to the cold branch (`cache.state.is_none()`) the warm happy path never enters. Adds `noetl_orchestrate_drive_total{stage=cold_rebuild|cold_rebuild_failed}` for observability.

## Why now

This is the last blocker [noetl/ai-meta#103](https://github.com/noetl/ai-meta/issues/103) flagged before the `PUBLISH_ONLY` flip is operator-safe: gate-on was only ever validated with the **in-process** drive (`NOETL_ORCHESTRATE_PLUGIN_DRIVE=false`). This PR + the companion e2e rig prove the off-server drive composes with the gate.

## Kind validation (gate-on + off-server drive + materializer sole writer)

- **Happy path:** fresh execution + cursor fan-out → COMPLETED; server wrote **0** `noetl.event` rows (all PUBLISHED — `noetl_event_ingest_published_total` = 25); materializer materialized all 25 exactly once (25 rows == 25 distinct ids); 0 `catalog_id=0`; drive `dispatched=applied`, `decode_error=0`.
- **Crash-recovery:** server hard-killed mid-drive → the in-flight `call.done` lands on the cold new pod → `cold_rebuild` fires (metric + log) → that execution completes **COMPLETED** with full event integrity (25 rows == 25 distinct, correct fan-out, `playbook.completed`).
- **No regression:** gate-off + in-process drive (production default) → COMPLETED, synchronous INSERT, no published/drive metrics; gate-off + off-server drive (`kind_validate_orchestrate_offserver.sh`) → PASS.

Companion e2e rig: noetl/e2e#60 (`kind_validate_orchestrate_gate.sh`).

Closes noetl/server#237
Refs noetl/ai-meta#104, noetl/ai-meta#103, noetl/ai-meta#111