### PR TITLE
fix(cqrs): route ExecutionService cancel/finalize through emit_event chokepoint (#103 2d-3)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -731,14 +731,15 @@ async fn main() -> anyhow::Result<()> {
     // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when
     // `NOETL_EVENT_INGEST_PUBLISH_ONLY` is on, server-originated events publish to
     // `noetl_events` instead of INSERTing — the materializer is the sole writer.
-    // Loud at startup because it changes the durability boundary; also flags the
-    // two paths still on the synchronous INSERT (ExecutionService cancel/finalize —
-    // they lack AppState; correct, no lost/double writes, staged for a follow-up).
+    // Loud at startup because it changes the durability boundary.  Every
+    // server-originated producer — including ExecutionService cancel/finalize —
+    // now routes through the chokepoint, so the server writes ZERO noetl.event
+    // rows under the gate (the materializer is the only writer).
     if app_config.event_ingest_publish_only {
         if state.nats.is_some() {
             tracing::warn!(
                 target: "noetl_server::startup",
-                "NOETL_EVENT_INGEST_PUBLISH_ONLY=ON — server-originated noetl.event writes PUBLISH to noetl_events (materializer is the sole writer); ExecutionService cancel/finalize remain synchronous (staged)"
+                "NOETL_EVENT_INGEST_PUBLISH_ONLY=ON — ALL server-originated noetl.event writes PUBLISH to noetl_events (materializer is the sole writer; the server writes zero event rows)"
             );
         } else {
             tracing::warn!(
@@ -802,7 +803,11 @@ async fn main() -> anyhow::Result<()> {
     // its per-execution methods route via pool_for(execution_id)
     // and `list()` fan-outs via for_each_shard.  In single-pool
     // fallback mode this is the same handle as db_pool.
-    let execution_service = ExecutionService::new(state.pools.clone(), state.snowflake.clone());
+    // Pass the full `state` so the service's cancel/finalize paths can
+    // route their noetl.event writes through the emit_event chokepoint
+    // (noetl/ai-meta#103 2d-3) — honouring NOETL_EVENT_INGEST_PUBLISH_ONLY.
+    let execution_service =
+        ExecutionService::new(state.pools.clone(), state.snowflake.clone(), state.clone());
     let runtime_service = RuntimeService::new(db_pool.clone(), state.snowflake.clone());
 
     // Phase D R5 Round 1 (noetl/ai-meta#49 → noetl/server#148).

--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::db::{DbPool, DbPoolMap};
 use crate::error::{AppError, AppResult};
+use crate::handlers::event_write::{emit_event, EventRow};
+use crate::state::AppState;
 
 /// Execution summary for listing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,6 +93,17 @@ pub struct ExecutionFilter {
 pub struct ExecutionService {
     pools: DbPoolMap,
     snowflake: std::sync::Arc<crate::snowflake::SnowflakeGenerator>,
+    /// Full application state.  Present in the production wiring
+    /// (`main.rs` builds the service from the constructed `AppState`)
+    /// and absent only in the pool-less unit-test shim
+    /// ([`Self::new_legacy`], which exercises the in-memory
+    /// `determine_status` path).  `cancel` / `finalize` route their
+    /// `noetl.event` writes through the `emit_event` chokepoint
+    /// (noetl/ai-meta#103 2d-3) so they honour
+    /// `NOETL_EVENT_INGEST_PUBLISH_ONLY` like the other producer sites —
+    /// that needs `&AppState` (the gate flag, the NATS publisher, the
+    /// catalog pool for the system-pool exemption).
+    state: Option<AppState>,
 }
 
 impl ExecutionService {
@@ -105,22 +118,38 @@ impl ExecutionService {
     /// with `AppState` and the other services.  Phase F R1.5 of
     /// noetl/ai-meta#49 moved id generation out of the DB-side
     /// `noetl.snowflake_id()` function.
+    /// `state` is the full [`AppState`]; `pools` + `snowflake` are
+    /// kept as direct fields (every other accessor reads them) and
+    /// the whole state is retained so `cancel` / `finalize` can reach
+    /// the `emit_event` chokepoint.
     pub fn new(
         pools: DbPoolMap,
         snowflake: std::sync::Arc<crate::snowflake::SnowflakeGenerator>,
+        state: AppState,
     ) -> Self {
-        Self { pools, snowflake }
+        Self {
+            pools,
+            snowflake,
+            state: Some(state),
+        }
     }
 
     /// Build an [`ExecutionService`] wrapping a single legacy
     /// pool — for test / example code paths that don't have a
     /// [`DbPoolMap`] in scope.  Internally wraps the pool via
     /// [`DbPoolMap::from_single_pool`].
+    /// `state` is `None`: this shim has no `AppState`, so it must not
+    /// be used for `cancel` / `finalize` (those require the chokepoint).
+    /// It exists only for the in-memory `determine_status` unit tests.
     pub fn new_legacy(
         db: DbPool,
         snowflake: std::sync::Arc<crate::snowflake::SnowflakeGenerator>,
     ) -> Self {
-        Self::new(DbPoolMap::from_single_pool(db), snowflake)
+        Self {
+            pools: DbPoolMap::from_single_pool(db),
+            snowflake,
+            state: None,
+        }
     }
 
     /// Borrow the per-execution pool for the given `execution_id`.
@@ -128,6 +157,54 @@ impl ExecutionService {
     #[inline]
     fn pool_for(&self, execution_id: i64) -> &DbPool {
         self.pools.pool_for(execution_id)
+    }
+
+    /// The `&AppState` the chokepoint needs.  Present in every
+    /// production path; `None` only in the pool-less `new_legacy`
+    /// test shim, which never calls `cancel` / `finalize`.  Returning
+    /// a clear error (rather than silently falling back to a raw
+    /// INSERT) keeps the gate contract intact — there is exactly one
+    /// `noetl.event` write path for these events.
+    fn require_state(&self) -> AppResult<&AppState> {
+        self.state.as_ref().ok_or_else(|| {
+            AppError::Internal(
+                "ExecutionService built without AppState (test shim); \
+                 cancel/finalize require the emit_event chokepoint"
+                    .to_string(),
+            )
+        })
+    }
+
+    /// Resolve the execution's `catalog_id`, reading `noetl.event`
+    /// first and falling back to `noetl.command`.  The fallback is
+    /// load-bearing under the CQRS write-path cutover
+    /// (noetl/ai-meta#103 2d-3): with `NOETL_EVENT_INGEST_PUBLISH_ONLY`
+    /// on, `noetl.event` may be empty (events are published to
+    /// `noetl_events` and not INSERTed until the materializer drains
+    /// them), so an event-only lookup would `NotFound` a still-running
+    /// execution.  `noetl.command` is written synchronously even under
+    /// the gate (it's the command queue the worker reads), so it
+    /// always carries the execution's `catalog_id`.  Mirrors
+    /// `handlers::events::get_catalog_id`.
+    async fn resolve_catalog_id(&self, execution_id: i64) -> AppResult<i64> {
+        let pool = self.pool_for(execution_id);
+        if let Some((id,)) = sqlx::query_as::<_, (i64,)>(
+            "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 LIMIT 1",
+        )
+        .bind(execution_id)
+        .fetch_optional(pool)
+        .await?
+        {
+            return Ok(id);
+        }
+        let row: Option<(i64,)> = sqlx::query_as::<_, (i64,)>(
+            "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
+        )
+        .bind(execution_id)
+        .fetch_optional(pool)
+        .await?;
+        row.map(|(id,)| id)
+            .ok_or_else(|| AppError::NotFound(format!("Execution not found: {}", execution_id)))
     }
 
     /// List executions with optional filters.
@@ -642,40 +719,36 @@ impl ExecutionService {
             )));
         }
 
-        // Get catalog_id for the event
-        let catalog_id: Option<(i64,)> =
-            sqlx::query_as("SELECT catalog_id FROM noetl.event WHERE execution_id = $1 LIMIT 1")
-                .bind(execution_id)
-                .fetch_optional(self.pool_for(execution_id))
-                .await?;
+        // The chokepoint needs the full state; fail fast if this is a
+        // pool-less test shim (which never reaches here in production).
+        let state = self.require_state()?;
 
-        let catalog_id = catalog_id
-            .ok_or_else(|| AppError::NotFound(format!("Execution not found: {}", execution_id)))?
-            .0;
+        // Get catalog_id for the event (event-log first, command-queue
+        // fallback under the gate — see `resolve_catalog_id`).
+        let catalog_id = self.resolve_catalog_id(execution_id).await?;
 
         // Generate event ID via the application-side snowflake
         // generator (Phase F R1.5 of noetl/ai-meta#49).
-        let event_id: (i64,) = (self.snowflake.generate()?,);
+        let event_id = self.snowflake.generate()?;
 
-        // Insert cancellation event
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            "#,
+        // Write the cancellation event through the CQRS write-path
+        // chokepoint (noetl/ai-meta#103 2d-3): gate-off INSERTs the row
+        // synchronously (byte-identical to the prior inline INSERT — the
+        // canonical INSERT binds the full column superset, the columns
+        // this site omits default to NULL); gate-on PUBLISHES it to
+        // `noetl_events` so the materializer is the sole writer.  The
+        // relocated trigger then drives the execution to its terminal
+        // CANCELLED state from the materialized row.
+        let row = EventRow::new(
+            event_id,
+            execution_id,
+            catalog_id,
+            "playbook_cancelled",
+            "CANCELLED",
+            Utc::now(),
         )
-        .bind(event_id.0)
-        .bind(execution_id)
-        .bind(catalog_id)
-        .bind("playbook_cancelled")
-        .bind("playbook")
-        .bind("playbook")
-        .bind("CANCELLED")
-        .bind(Utc::now())
-        .execute(self.pool_for(execution_id))
-        .await?;
+        .with_node("playbook");
+        emit_event(state, self.pool_for(execution_id), row).await?;
 
         Ok(())
     }
@@ -713,20 +786,17 @@ impl ExecutionService {
             )));
         }
 
-        // Get catalog_id
-        let catalog_id: Option<(i64,)> =
-            sqlx::query_as("SELECT catalog_id FROM noetl.event WHERE execution_id = $1 LIMIT 1")
-                .bind(execution_id)
-                .fetch_optional(self.pool_for(execution_id))
-                .await?;
+        // The chokepoint needs the full state; fail fast if this is a
+        // pool-less test shim (which never reaches here in production).
+        let state = self.require_state()?;
 
-        let catalog_id = catalog_id
-            .ok_or_else(|| AppError::NotFound(format!("Execution not found: {}", execution_id)))?
-            .0;
+        // Get catalog_id (event-log first, command-queue fallback under
+        // the gate — see `resolve_catalog_id`).
+        let catalog_id = self.resolve_catalog_id(execution_id).await?;
 
         // Generate event ID via the application-side snowflake
         // generator (Phase F R1.5 of noetl/ai-meta#49).
-        let event_id: (i64,) = (self.snowflake.generate()?,);
+        let event_id = self.snowflake.generate()?;
 
         let event_type = if status == "COMPLETED" {
             "playbook_completed"
@@ -734,26 +804,23 @@ impl ExecutionService {
             "playbook_failed"
         };
 
-        // Insert finalization event
-        sqlx::query(
-            r#"
-            INSERT INTO noetl.event (
-                event_id, execution_id, catalog_id, event_type,
-                node_id, node_name, status, error, created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            "#,
+        // Write the finalization event through the CQRS write-path
+        // chokepoint (noetl/ai-meta#103 2d-3): gate-off INSERTs the row
+        // synchronously (byte-identical to the prior inline INSERT,
+        // including the `error` column); gate-on PUBLISHES it to
+        // `noetl_events` so the materializer is the sole writer and the
+        // relocated trigger drives the execution to its terminal state.
+        let row = EventRow::new(
+            event_id,
+            execution_id,
+            catalog_id,
+            event_type,
+            status,
+            Utc::now(),
         )
-        .bind(event_id.0)
-        .bind(execution_id)
-        .bind(catalog_id)
-        .bind(event_type)
-        .bind("playbook")
-        .bind("playbook")
-        .bind(status)
-        .bind(error)
-        .bind(Utc::now())
-        .execute(self.pool_for(execution_id))
-        .await?;
+        .with_node("playbook")
+        .with_error(error.map(str::to_string));
+        emit_event(state, self.pool_for(execution_id), row).await?;
 
         Ok(())
     }
@@ -1033,5 +1100,27 @@ mod tests {
             make_event("playbook.completed", "COMPLETED"),
         ];
         assert_eq!(service.determine_status(&events), "COMPLETED");
+    }
+
+    // ===== noetl/ai-meta#103 2d-3 — cancel/finalize chokepoint =====
+
+    /// The pool-less unit-test shim (`new_legacy`) carries no
+    /// `AppState`, so `require_state` must reject it with a clear error
+    /// rather than silently falling back to a raw INSERT.  This pins the
+    /// contract: there is exactly one `noetl.event` write path for
+    /// cancel/finalize (the `emit_event` chokepoint), and it always runs
+    /// with a real `AppState` in production.  `cancel` / `finalize`
+    /// themselves can't be unit-tested without a live DB (the catalog
+    /// lookup + write are validated on kind), but this guards against a
+    /// future shim accidentally bypassing the gate.
+    #[tokio::test(flavor = "current_thread")]
+    async fn require_state_errors_without_app_state() {
+        let service = make_service();
+        let result = service.require_state();
+        assert!(result.is_err(), "test shim must not yield an AppState");
+        assert!(
+            matches!(result, Err(AppError::Internal(_))),
+            "expected an Internal error variant"
+        );
     }
 }


### PR DESCRIPTION
## What

Closes the **final** #103 2d-3 flip blocker: the two ExecutionService
terminal writers — `cancel` (`playbook_cancelled`) and `finalize`
(`playbook_completed` / `playbook_failed`) — now route their
`noetl.event` writes through the `emit_event` chokepoint, so they honour
`NOETL_EVENT_INGEST_PUBLISH_ONLY` like the other 13 producer sites
instead of writing `noetl.event` synchronously under the gate.

With this merged, **all three #103 flip blockers are closed** and the
server is a complete non-writer of the event log when `PUBLISH_ONLY` is
on — the materializer is the sole writer.

## How

- `ExecutionService` now carries the full `AppState` (cheap, all-`Arc`;
  `AppState` does not reference the service → no cycle). The pool-less
  `new_legacy` unit shim keeps `state: None`; `require_state` rejects it
  so there is **exactly one** event write path for cancel/finalize.
- Both sites build an `EventRow` and call `emit_event`:
  - **gate-off**: synchronous INSERT, **byte-identical** to the prior
    inline INSERT (canonical full-column superset; finalize `error`
    column preserved; `node_id`/`node_name` = `'playbook'`).
  - **gate-on**: PUBLISHES to `noetl_events`; the materializer
    materializes it; the relocated trigger drives the execution to its
    terminal state — no cancel/finalize event stranded.
- `resolve_catalog_id` falls back `noetl.event` → `noetl.command`
  (synchronous under the gate), mirroring #236's `get_catalog_id` fix —
  a fresh execution's `noetl.event` is empty under the gate.
- Startup gate log updated to state the server writes **zero**
  `noetl.event` rows under the gate.

## Test

- 558 lib tests + clippy green. New `require_state_errors_without_app_state`
  unit test pins the single-write-path contract.
- Kind-validated both modes with a dedicated e2e rig
  (`kind_validate_cancel_finalize_gate.sh`, noetl/e2e): gate-off
  cancel+finalize INSERT synchronously (published delta +0, byte-identical
  columns); gate-on cancel+finalize PUBLISHED (server writes 0 rows),
  materializer sole writer, terminal state reached, no loss / no dup,
  0 `catalog_id=0`. _(evidence in the PR thread / noetl/ai-meta#103.)_

No production default changed — `PUBLISH_ONLY` stays default-off.

Closes noetl/server#239
Refs noetl/ai-meta#103