### PR TITLE
fix(orchestrate): recover offloaded drive result + stop drive on cancel (#113)

### DIFF
--- a/orchestrate-core/src/state.rs
+++ b/orchestrate-core/src/state.rs
@@ -55,6 +55,18 @@ impl From<&str> for ExecutionState {
     }
 }
 
+impl ExecutionState {
+    /// True once the execution has reached a terminal state — completed,
+    /// failed, or cancelled.  Past this point no further orchestration must
+    /// be driven (noetl/ai-meta#113 facet 2): a cancel (or any terminal
+    /// event) must stop the worker-driven drive from re-issuing
+    /// `__orchestrate__`, which otherwise re-loops forever (only a server
+    /// restart cleared it before the terminal guard was added).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
 /// State of a single workflow step.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -448,7 +460,12 @@ impl WorkflowState {
                 self.state = ExecutionState::Failed;
                 self.completed_at = Some(event.timestamp);
             }
-            "playbook.cancelled" => {
+            "playbook.cancelled" | "playbook_cancelled" => {
+                // The ExecutionService cancel chokepoint emits the underscore
+                // form `playbook_cancelled` (services/execution.rs); without
+                // matching it here the cached WorkflowState never transitioned
+                // to Cancelled and the drive kept re-issuing `__orchestrate__`
+                // (noetl/ai-meta#113 facet 2).
                 self.state = ExecutionState::Cancelled;
                 self.completed_at = Some(event.timestamp);
             }
@@ -1222,6 +1239,37 @@ mod tests {
         assert_eq!(ExecutionState::from("RUNNING"), ExecutionState::InProgress);
         assert_eq!(ExecutionState::from("completed"), ExecutionState::Completed);
         assert_eq!(ExecutionState::from("FAILED"), ExecutionState::Failed);
+    }
+
+    #[test]
+    fn test_execution_state_is_terminal() {
+        // noetl/ai-meta#113 facet 2 — the drive guard keys off this.
+        assert!(!ExecutionState::Initial.is_terminal());
+        assert!(!ExecutionState::InProgress.is_terminal());
+        assert!(ExecutionState::Completed.is_terminal());
+        assert!(ExecutionState::Failed.is_terminal());
+        assert!(ExecutionState::Cancelled.is_terminal());
+    }
+
+    #[test]
+    fn test_apply_event_cancels_on_both_event_spellings() {
+        // The cancel chokepoint emits the underscore form `playbook_cancelled`
+        // (services/execution.rs); the dotted `playbook.cancelled` also exists
+        // on legacy paths.  Both must drive the state to Cancelled / terminal so
+        // the off-server drive stops re-issuing `__orchestrate__`
+        // (noetl/ai-meta#113 facet 2).
+        for spelling in ["playbook_cancelled", "playbook.cancelled"] {
+            let mut state = WorkflowState::new(1, 2);
+            state.apply_event(&make_event("playbook_started", None));
+            assert_eq!(state.state, ExecutionState::InProgress);
+            state.apply_event(&make_event(spelling, None));
+            assert_eq!(
+                state.state,
+                ExecutionState::Cancelled,
+                "{spelling} should transition to Cancelled"
+            );
+            assert!(state.state.is_terminal(), "{spelling} state must be terminal");
+        }
     }
 
     #[test]

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2098,6 +2098,30 @@ async fn trigger_orchestrator_inner(
             .unwrap_or(cache.last_event_id);
     }
 
+    // Terminal-state guard (noetl/ai-meta#113 facet 2).  A cancel
+    // (`playbook_cancelled`) — or any terminal event — transitions the cached
+    // `WorkflowState` to a terminal `ExecutionState` via `apply_event`.  Once
+    // terminal, no further `__orchestrate__` must be dispatched: a straggler
+    // `command.completed` from an in-flight command, or the background reconcile
+    // poller (which forces a re-trigger on every still-cached execution), would
+    // otherwise keep re-issuing the drive for a cancelled execution forever —
+    // before this guard only a `rollout restart` of the server cleared the
+    // in-memory loop.  Evicting the slot also drops it from
+    // `active_executions()`, so the reconcile poller stops re-visiting it.  This
+    // runs ahead of the early-exit below so the forced-reconcile path is caught
+    // even when no new events arrived this pass.
+    if cache.state.as_ref().is_some_and(|ws| ws.state.is_terminal()) {
+        let st = cache.state.as_ref().map(|ws| ws.state);
+        drop(cache);
+        state.orch_cache.evict(execution_id);
+        debug!(
+            execution_id,
+            state = ?st,
+            "drive: execution is terminal; evicted orch cache, no further orchestrate dispatch"
+        );
+        return Ok(0);
+    }
+
     // Nothing changed and this is not a forced reconcile → exit early.  A forced
     // reconcile still evaluates (to drive a cursor that may now advance).
     if new_events.is_empty() && !did_rebuild && !straggler_applied && !force_count {
@@ -2421,6 +2445,42 @@ fn find_output_b64(v: &serde_json::Value) -> Option<&str> {
     }
 }
 
+/// Find the first durable result-store URI (`noetl://…`) carried by a `ref`
+/// field anywhere in the value.  The worker stamps it on the `reference` block
+/// of an over-budget `call.done` result (`build_call_done_result`'s durable
+/// path).  Used to recover an offloaded `OrchestrationResult` whose
+/// `output_b64` was staged to the result store instead of inlined — see
+/// [`apply_worker_orchestration`] and noetl/ai-meta#113.  Matches the exact key
+/// `"ref"` (the durable reference URI), not `"_ref"` (the inline navigation
+/// hint) — both point at the same row, but `"ref"` is the durable contract.
+fn find_noetl_ref(v: &serde_json::Value) -> Option<&str> {
+    match v {
+        serde_json::Value::Object(m) => {
+            if let Some(serde_json::Value::String(s)) = m.get("ref") {
+                if s.starts_with("noetl://") {
+                    return Some(s);
+                }
+            }
+            m.values().find_map(find_noetl_ref)
+        }
+        serde_json::Value::Array(a) => a.iter().find_map(find_noetl_ref),
+        _ => None,
+    }
+}
+
+/// Decode a base64-wrapped `OrchestrationResult` (the worker base64-wraps the
+/// `system/orchestrate` plug-in's output bytes).  Returns `None` on a missing
+/// input, a base64 error, or a JSON error (an error envelope rather than a
+/// result).  Shared by the inline and offloaded decode paths in
+/// [`apply_worker_orchestration`].
+fn decode_orchestration_result(
+    b64: Option<&str>,
+) -> Option<noetl_orchestrate_core::orchestrator::OrchestrationResult> {
+    use base64::Engine;
+    b64.and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+}
+
 /// Apply the `OrchestrationResult` a worker computed for the worker-driven drive
 /// (noetl/ai-meta#108 slice 3): decode it from the `system/orchestrate`
 /// completion, then emit events + issue commands via `apply_orchestration_result`
@@ -2432,22 +2492,74 @@ async fn apply_worker_orchestration(
     trigger_event_id: i64,
     payload: &serde_json::Value,
 ) -> AppResult<i32> {
-    use base64::Engine;
-
     // Clear the in-flight guard first (the drive completed, success or not) so a
     // decode failure doesn't wedge the execution — the reconcile can re-drive.
     let cache_slot = state.orch_cache.entry(execution_id);
     let mut cache = cache_slot.lock().await;
     cache.orchestrate_in_flight = false;
 
-    let decoded = find_output_b64(payload)
-        .and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())
-        .and_then(|bytes| {
-            serde_json::from_slice::<noetl_orchestrate_core::orchestrator::OrchestrationResult>(
-                &bytes,
-            )
-            .ok()
-        });
+    // Inline path: the drive result fit the worker's inline budget
+    // (`NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES`, default 100KB) and rides the
+    // `call.done` payload as an `output_b64` string.
+    let mut decoded = decode_orchestration_result(find_output_b64(payload));
+
+    // Offloaded path (noetl/ai-meta#113): a large drive result (≈ the full
+    // execution context — e.g. http_to_postgres, save_edge_cases) exceeds the
+    // inline budget, so the worker stages the whole tool result (which carries
+    // the `output_b64`) to the durable result store and emits only a
+    // `reference.ref` (`noetl://…`) — no inline `output_b64`.  Before this
+    // fallback the server dropped the drive decision, re-issued `__orchestrate__`,
+    // re-evaluated the same large state, re-offloaded, and never converged
+    // (a runaway PENDING-orchestrate loop, no terminal event).  Resolve the ref
+    // from the store (the same `result_store.resolve` the cursor/reference paths
+    // already use) and decode `output_b64` from the stored result instead.
+    if decoded.is_none() {
+        if let Some(ref_uri) = find_noetl_ref(payload) {
+            let pool = state.pools.pool_for(execution_id);
+            let result_store = crate::services::result_store::ResultStoreService::new(
+                pool.clone(),
+                state.snowflake.clone(),
+            );
+            match crate::services::result_store::parse_noetl_ref(ref_uri) {
+                Ok(parsed) => match result_store.resolve(&parsed).await {
+                    Ok(Some(stored)) => {
+                        decoded = decode_orchestration_result(find_output_b64(&stored));
+                        if decoded.is_some() {
+                            crate::metrics::record_orchestrate_drive("ref_resolved");
+                            info!(
+                                execution_id,
+                                ref_uri,
+                                "worker-driven: decoded offloaded OrchestrationResult from the \
+                                 durable result store (over-budget drive result, noetl/ai-meta#113)"
+                            );
+                        } else {
+                            warn!(
+                                execution_id,
+                                ref_uri,
+                                "worker-driven: resolved orchestrate result ref but it carried no \
+                                 decodable output_b64"
+                            );
+                        }
+                    }
+                    Ok(None) => warn!(
+                        execution_id,
+                        ref_uri, "worker-driven: orchestrate result ref not found in store"
+                    ),
+                    Err(e) => warn!(
+                        execution_id,
+                        ref_uri, %e,
+                        "worker-driven: orchestrate result ref resolution failed"
+                    ),
+                },
+                Err(e) => warn!(
+                    execution_id,
+                    ref_uri, %e,
+                    "worker-driven: unparseable orchestrate result ref"
+                ),
+            }
+        }
+    }
+
     let Some(result) = decoded else {
         warn!(
             execution_id,
@@ -3072,5 +3184,84 @@ mod tests {
             err.to_string().contains("execution_id"),
             "error should mention the field name: {err}"
         );
+    }
+
+    // --- noetl/ai-meta#113: offloaded OrchestrationResult recovery ---
+
+    #[test]
+    fn find_output_b64_walks_nested_inline_payload() {
+        // Inline (under-budget) drive: `output_b64` nests inside the
+        // call.done result envelope.
+        let payload = serde_json::json!({
+            "command_id": "c1",
+            "result": { "status": "COMPLETED", "context": { "data": {
+                "output_b64": "aGVsbG8=", "flush": { "errors": [] }
+            }}}
+        });
+        assert_eq!(find_output_b64(&payload), Some("aGVsbG8="));
+    }
+
+    #[test]
+    fn find_noetl_ref_finds_durable_ref_when_inline_absent() {
+        // Offloaded (over-budget) drive: no `output_b64`, only the durable
+        // `reference.ref` URI — exactly the noetl/ai-meta#113 shape the worker
+        // emits from `build_call_done_result`'s durable path.
+        let payload = serde_json::json!({
+            "command_id": "c1",
+            "result": {
+                "status": "COMPLETED",
+                "context": { "data": { "_ref": "noetl://execution/9/result/__orchestrate__/1" } },
+                "reference": {
+                    "kind": "result_ref",
+                    "ref": "noetl://execution/9/result/__orchestrate__/2",
+                    "store": "db"
+                }
+            }
+        });
+        assert_eq!(find_output_b64(&payload), None);
+        // Matches the durable `ref` (not the `_ref` navigation hint).
+        assert_eq!(
+            find_noetl_ref(&payload),
+            Some("noetl://execution/9/result/__orchestrate__/2")
+        );
+    }
+
+    #[test]
+    fn find_noetl_ref_ignores_non_noetl_and_shm_only_reference() {
+        // Degraded shm-only path carries an `arrow_ipc` hint with no resolvable
+        // `noetl://` ref — the server can't read another node's shm, so it must
+        // not mistake a non-URI string for a durable ref.
+        let payload = serde_json::json!({
+            "result": { "status": "COMPLETED", "reference": {
+                "kind": "arrow_ipc", "shm_name": "noetl-shm-abc", "byte_length": 42
+            }}
+        });
+        assert_eq!(find_noetl_ref(&payload), None);
+    }
+
+    #[test]
+    fn decode_orchestration_result_round_trips_b64_json() {
+        use base64::Engine;
+        // A minimal OrchestrationResult JSON, base64-wrapped exactly as the
+        // worker wraps the plug-in's output bytes.
+        let or_json = serde_json::json!({
+            "state": "completed",
+            "commands": [],
+            "should_complete": true,
+            "events_to_emit": []
+        });
+        let b64 = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&or_json).unwrap());
+        let decoded = decode_orchestration_result(Some(&b64))
+            .expect("valid base64 + JSON decodes to an OrchestrationResult");
+        assert!(decoded.should_complete);
+        assert!(decoded.commands.is_empty());
+
+        // None / garbage / non-result JSON → None (the error-envelope path).
+        assert!(decode_orchestration_result(None).is_none());
+        assert!(decode_orchestration_result(Some("not base64!!!")).is_none());
+        let not_a_result =
+            base64::engine::general_purpose::STANDARD.encode(b"{\"unexpected\":true}");
+        assert!(decode_orchestration_result(Some(&not_a_result)).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Fixes two server-side defects in the off-server orchestrate drive
(`NOETL_ORCHESTRATE_PLUGIN_DRIVE=true`, default-on since #108 / v3.28.0) that
stall large-context executions. Both are orthogonal to the CQRS gate (the
materializer sole-writer path is unaffected) and **do not affect prod** — prod
GKE runs the pre-#108 `batch-dispatch-v1` in-server drive.

Tracks noetl/ai-meta#113.

### Facet 1 — large drive result dropped (primary)

When an `__orchestrate__` drive result (≈ the full execution context) exceeds
the worker's 100KB inline budget (`NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES`), the
worker stages the whole tool result to the durable result store + shm and emits
only a `reference.ref` (`noetl://…`) — **no inline `output_b64`**. The server's
`apply_worker_orchestration` decoded only the inline form, so it dropped the
drive decision, re-issued `__orchestrate__`, re-evaluated the same large state,
re-offloaded → a non-convergent loop (200+ PENDING orchestrate commands on one
execution, no terminal event, repeating `could not decode OrchestrationResult`
WARN).

Fix: when no inline `output_b64` is present, resolve the offloaded
`reference.ref` from the result store (`result_store.resolve` + `parse_noetl_ref`
— the same path the cursor/reference hydration already uses) and decode
`output_b64` from the stored result. New drive-stage metric `ref_resolved`. The
small-inline path is unchanged (`find_output_b64` still hits first); idempotency,
`__orchestrate__` suppression, and sole-writer behaviour are preserved.

### Facet 2 — cancel did not stop the drive

`ExecutionService` cancel emits the underscore event `playbook_cancelled`, but
`WorkflowState::apply_event` matched only the dotted `playbook.cancelled`, so the
cached state never went terminal — the reconcile poller + straggler completions
kept re-issuing `__orchestrate__` for a cancelled execution (only a `rollout
restart` cleared it). Fix: match both spellings, add `ExecutionState::is_terminal()`,
and guard `trigger_orchestrator_inner` — once the cached state is terminal, evict
the orch-cache slot (drops it from `active_executions()`) and skip dispatch.

## Files

- `orchestrate-core/src/state.rs` — `is_terminal()`; match `playbook_cancelled`; tests.
- `src/handlers/events.rs` — offloaded-ref decode fallback (`find_noetl_ref`,
  `decode_orchestration_result`, `ref_resolved` metric); terminal-state drive guard; tests.

## Validation (kind gate-ON: PUBLISH_ONLY=true + PLUGIN_DRIVE=true + materializer sole-writer)

- **Facet 1**: `test_large_result_extraction` drove a **785KB** `__orchestrate__`
  result → worker offloaded to durable store → server logged *"decoded offloaded
  OrchestrationResult from the durable result store (#113)"*, `ref_resolved=1`,
  reached **COMPLETED**, 0 `__orchestrate__` event rows, **no decode WARN**.
- **The previously-stalled fixtures reach COMPLETED** with bounded, low
  orchestrate-command counts (e.g. http_to_postgres_direct/simple/bulk_python,
  save_edge_cases, large_result_extraction all 2–8 cycles) — no runaway PENDING
  loop. (lease_expiry / pipeline_heavy are slow-by-design loops, progressing
  past their old stall point with 0 orch event rows.)
- **Facet 2**: a drive-looping execution cancelled mid-flight froze its
  `__orchestrate__` command count the instant `playbook_cancelled` landed (0 new
  commands across 26s), status CANCELLED, terminal-guard evict fired once — **no
  server restart**.
- **Sole-writer / lag**: `noetl_worker_nats_consumer_pending{consumer="noetl_materializer"}`
  = 0 throughout; 0 `__orchestrate__` rows in `noetl.event`.
- `cargo test` (orchestrate-core + server lib) green; `cargo clippy` clean.

## Rollout safety

No env/default changes. `NOETL_ORCHESTRATE_PLUGIN_DRIVE` default and the in-process
drive (`=false`) fallback are untouched. Gates the off-server-drive prod cutover
(noetl/ai-meta#107 / #111) per #113 acceptance.

Refs noetl/ai-meta#113