### PR TITLE
fix(orchestrate): offload oversized command context to result store (#114)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -165,6 +165,26 @@ pub struct AppConfig {
     /// for the layout.
     #[serde(default)]
     pub shard_count: Option<u32>,
+
+    /// Maximum serialised size (bytes) of a `command.issued` event's `context`
+    /// before it is offloaded to the result store (noetl/ai-meta#114).  When the
+    /// off-server orchestrate drive (`orchestrate_plugin_drive`) builds the next
+    /// step's command with `refs_in_state` **false**, the full resolved upstream
+    /// context is embedded inline in `render_context` — a large-context fixture
+    /// (e.g. `test_output_select`) produced a 1.32MB `command.issued` event that
+    /// exceeds NATS `max_payload` (1MB) under the publish-only gate, so the
+    /// publish never acks and the execution wedges.  When the serialised
+    /// `{tool_config, args, render_context}` exceeds this threshold,
+    /// `persist_engine_command(s)` offloads the whole context to
+    /// `noetl.result_store` and writes a tiny `{ "__context_ref__": "noetl://…" }`
+    /// marker onto the event + command row instead; `get_command` / `claim_command`
+    /// resolve the ref before handing the command to the worker (same
+    /// result-store pattern as the #113 drive-result fix).  Envy maps
+    /// `NOETL_COMMAND_CONTEXT_MAX_BYTES`.  **Default 524288 (512KB)** — comfortably
+    /// under the 1MB NATS ceiling with event/meta overhead, and large enough that
+    /// ordinary commands never offload (their context is a few KB).
+    #[serde(default = "default_command_context_max_bytes")]
+    pub command_context_max_bytes: usize,
 }
 
 fn default_host() -> String {
@@ -189,6 +209,12 @@ fn default_sweep_interval() -> u64 {
 
 fn default_offline_seconds() -> u64 {
     60
+}
+
+fn default_command_context_max_bytes() -> usize {
+    // 512KB — half the NATS 1MB max_payload, leaving headroom for the event's
+    // meta/envelope overhead while never tripping on ordinary (few-KB) commands.
+    512 * 1024
 }
 
 impl AppConfig {
@@ -229,6 +255,7 @@ impl Default for AppConfig {
             server_machine_id: None,
             shard_index: None,
             shard_count: None,
+            command_context_max_bytes: default_command_context_max_bytes(),
         }
     }
 }
@@ -256,5 +283,15 @@ mod tests {
         // noetl/ai-meta#108 (c): the worker-driven orchestrator drive is the
         // default.  Revert is `NOETL_ORCHESTRATE_PLUGIN_DRIVE=false`.
         assert!(AppConfig::default().orchestrate_plugin_drive);
+    }
+
+    #[test]
+    fn test_command_context_max_bytes_default_under_nats_ceiling() {
+        // noetl/ai-meta#114: the offload threshold must sit safely below the
+        // NATS 1MB max_payload so an offloaded `command.issued` event always
+        // fits, with headroom for the meta/envelope overhead.
+        let cfg = AppConfig::default();
+        assert_eq!(cfg.command_context_max_bytes, 512 * 1024);
+        assert!(cfg.command_context_max_bytes < 1024 * 1024);
     }
 }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -739,6 +739,65 @@ async fn handle_event_inner(
     }))
 }
 
+/// Resolve an offloaded command context back to its full `{tool_config, args,
+/// render_context}` (noetl/ai-meta#114).
+///
+/// When a `command.issued` context exceeded the budget, `persist_engine_command`
+/// stashed it in `noetl.result_store` and left a tiny
+/// `{ "__context_ref__": "noetl://…" }` marker on the event + command row so the
+/// published event stayed under the NATS `max_payload`.  Both `get_command` and
+/// `claim_command` call this before handing the command to the worker, so the
+/// worker is oblivious to the offload — it always receives the full context.
+///
+/// A within-budget (un-offloaded) context has no marker and is returned
+/// unchanged.  On any resolution failure the marker is returned as-is and a WARN
+/// is logged with `execution_id`; the worker then surfaces a missing-config
+/// error rather than the server silently substituting empty data.
+async fn resolve_command_context_ref(
+    state: &AppState,
+    context: serde_json::Value,
+) -> serde_json::Value {
+    use crate::handlers::execute::COMMAND_CONTEXT_REF_KEY;
+    use crate::services::result_store::{parse_noetl_ref, ResultStoreService};
+
+    let Some(ref_uri) = context
+        .get(COMMAND_CONTEXT_REF_KEY)
+        .and_then(|v| v.as_str())
+    else {
+        return context;
+    };
+
+    let parsed = match parse_noetl_ref(ref_uri) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(ref_uri, %e, "command context reference unparseable; left as-is (noetl/ai-meta#114)");
+            return context;
+        }
+    };
+    let result_store =
+        ResultStoreService::new(state.pools.pool_for(parsed.execution_id).clone(), state.snowflake.clone());
+    match result_store.resolve(&parsed).await {
+        Ok(Some(data)) => {
+            crate::metrics::record_orchestrate_drive("context_ref_resolved");
+            data
+        }
+        Ok(None) => {
+            warn!(
+                execution_id = parsed.execution_id,
+                ref_uri, "command context reference not found in store; left as-is (noetl/ai-meta#114)"
+            );
+            context
+        }
+        Err(e) => {
+            warn!(
+                execution_id = parsed.execution_id,
+                ref_uri, %e, "command context reference resolution failed; left as-is (noetl/ai-meta#114)"
+            );
+            context
+        }
+    }
+}
+
 /// Get command details from command.issued event.
 ///
 /// GET /api/commands/{event_id}
@@ -781,14 +840,20 @@ pub async fn get_command(
     let row = found.map(|(_shard_idx, r)| r);
 
     match row {
-        Some((execution_id, node_name, node_type, context, meta)) => Ok(Json(CommandResponse {
-            execution_id,
-            node_id: node_name.clone(),
-            node_name,
-            action: node_type,
-            context,
-            meta,
-        })),
+        Some((execution_id, node_name, node_type, context, meta)) => {
+            // Resolve an offloaded context back to the full payload before the
+            // worker sees it (noetl/ai-meta#114).  No-op for within-budget
+            // commands.
+            let context = resolve_command_context_ref(&state, context).await;
+            Ok(Json(CommandResponse {
+                execution_id,
+                node_id: node_name.clone(),
+                node_name,
+                action: node_type,
+                context,
+                meta,
+            }))
+        }
         None => Err(AppError::NotFound(format!("command not found: {}", event_id))),
     }
 }
@@ -876,6 +941,10 @@ pub async fn claim_command(
     let context: serde_json::Value = row
         .try_get("context")
         .unwrap_or_else(|_| serde_json::json!({}));
+    // Resolve an offloaded context back to the full payload before the worker
+    // sees it (noetl/ai-meta#114).  No-op for within-budget commands.  Both the
+    // idempotent-reclaim and the fresh-claim return paths below use this value.
+    let context = resolve_command_context_ref(&state, context).await;
     let meta: serde_json::Value = row
         .try_get("meta")
         .unwrap_or_else(|_| serde_json::json!({}));

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -646,6 +646,86 @@ async fn inherit_parent_trace(state: &AppState, parent_execution_id: i64) -> Opt
     meta.and_then(|m| m.get("trace").filter(|v| !v.is_null()).cloned())
 }
 
+/// Marker key for an offloaded command context (noetl/ai-meta#114).  When a
+/// `command.issued` event's `{tool_config, args, render_context}` exceeds
+/// [`AppConfig::command_context_max_bytes`](crate::config::AppConfig), the full
+/// context is stashed in `noetl.result_store` and the event + command row carry
+/// only `{ "__context_ref__": "noetl://…" }` so the published event stays under
+/// the NATS `max_payload`.  `get_command` / `claim_command` resolve it back
+/// before the worker sees the command.
+pub(crate) const COMMAND_CONTEXT_REF_KEY: &str = "__context_ref__";
+
+/// Logical `name` segment used for offloaded command contexts in the result
+/// store.  A constant (not the step name) keeps the `noetl://` URI parseable
+/// regardless of step-name characters and unambiguous to spot in the store.
+const COMMAND_CONTEXT_RESULT_NAME: &str = "__command_context__";
+
+/// Offload an over-budget command context to the result store, returning a tiny
+/// `{ "__context_ref__": "noetl://…", "__context_bytes__": N }` marker in its
+/// place (noetl/ai-meta#114).
+///
+/// The off-server orchestrate drive embeds the full resolved upstream context
+/// into the next step's `render_context` when `refs_in_state` is false; for a
+/// large-context fixture this balloons the `command.issued` event past the NATS
+/// `max_payload`, so the publish-only gate can't ack it and the execution
+/// wedges.  This keeps the published event small while the full context lives
+/// durably in `noetl.result_store`, resolved on the read side exactly like the
+/// #113 drive-result offload.
+///
+/// Returns the original `cmd_context` untouched when it is within budget (the
+/// common case — ordinary commands are a few KB), so the hot path is a single
+/// `serde_json::to_vec` length check with no extra DB round-trip.
+async fn maybe_offload_command_context(
+    state: &AppState,
+    execution_id: i64,
+    cmd_context: serde_json::Value,
+) -> AppResult<serde_json::Value> {
+    let max_bytes = state.config.command_context_max_bytes;
+    let bytes = match serde_json::to_vec(&cmd_context) {
+        Ok(v) => v.len(),
+        // If it can't even be serialised, hand it back unchanged — emit_event
+        // will surface the real encode error at the publish boundary.
+        Err(_) => return Ok(cmd_context),
+    };
+    if bytes <= max_bytes {
+        return Ok(cmd_context);
+    }
+
+    let result_store = crate::services::result_store::ResultStoreService::new(
+        state.pools.pool_for(execution_id).clone(),
+        state.snowflake.clone(),
+    );
+    let put = result_store
+        .put(
+            execution_id,
+            &crate::services::result_store::PutResultBody {
+                name: COMMAND_CONTEXT_RESULT_NAME.to_string(),
+                data: cmd_context,
+                scope: "execution".to_string(),
+                source_step: None,
+                store: None,
+                ttl: None,
+                correlation: None,
+                compress: false,
+            },
+        )
+        .await?;
+
+    crate::metrics::record_orchestrate_drive("context_offloaded");
+    debug!(
+        execution_id,
+        bytes,
+        max_bytes,
+        noetl_ref = %put.r#ref,
+        "command context exceeded budget — offloaded to result store (noetl/ai-meta#114)"
+    );
+
+    Ok(serde_json::json!({
+        COMMAND_CONTEXT_REF_KEY: put.r#ref,
+        "__context_bytes__": bytes,
+    }))
+}
+
 /// Persist one engine-generated command + its `command.issued`
 /// event + its NATS notification.
 ///
@@ -700,11 +780,19 @@ pub(crate) async fn persist_engine_command(
         Some(map) => serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})),
         None => serde_json::json!({}),
     };
-    let cmd_context = serde_json::json!({
-        "tool_config": command.tool.config,
-        "args": cmd_args,
-        "render_context": render_context,
-    });
+    // Offload an over-budget context to the result store + ref marker so the
+    // published `command.issued` event stays under the NATS max_payload
+    // (noetl/ai-meta#114).  Within-budget contexts pass through unchanged.
+    let cmd_context = maybe_offload_command_context(
+        state,
+        execution_id,
+        serde_json::json!({
+            "tool_config": command.tool.config,
+            "args": cmd_args,
+            "render_context": render_context,
+        }),
+    )
+    .await?;
 
     // Base meta — extended below with iteration_index/_total for
     // iterator commands so `state.apply_event` (Phase D R3b state
@@ -871,11 +959,21 @@ pub(crate) async fn persist_engine_commands_batch(
             Some(map) => serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})),
             None => serde_json::json!({}),
         };
-        let cmd_context = serde_json::json!({
-            "tool_config": command.tool.config,
-            "args": cmd_args,
-            "render_context": render_context,
-        });
+        // Offload an over-budget context to the result store + ref marker so the
+        // published `command.issued` event stays under the NATS max_payload
+        // (noetl/ai-meta#114).  This is the hot drive path — the next-step
+        // command a large-context fixture produces is exactly the one that
+        // blows the 1MB ceiling.  Within-budget contexts pass through unchanged.
+        let cmd_context = maybe_offload_command_context(
+            state,
+            execution_id,
+            serde_json::json!({
+                "tool_config": command.tool.config,
+                "args": cmd_args,
+                "render_context": render_context,
+            }),
+        )
+        .await?;
 
         let mut cmd_meta = serde_json::json!({
             "command_id": command_id,


### PR DESCRIPTION
## What

Removes the oversized `command.issued` event wedge in the off-server orchestrate
drive (noetl/ai-meta#114) — under the publish-only gate a `command.issued` event
carrying the full upstream context (~1.32MB observed) exceeded the NATS
`max_payload` (1MB), the publish never acked, and the execution wedged.

## Root cause

With `refs_in_state` **false** (the default), the off-server drive
(`NOETL_ORCHESTRATE_PLUGIN_DRIVE`) builds the next step's command with the full
resolved upstream context embedded inline in `render_context`. For a
large-context fixture the `command.issued` event reached ~1.32MB — past the NATS
`max_payload`. Under the publish-only gate the publish never acked (`didn't
receive ack in time`), so `step.enter` was persisted but the command was never
issued → a permanent wedge that only a cancel could clear.

## Fix

When a `command.issued` context's serialised `{tool_config, args,
render_context}` exceeds `NOETL_COMMAND_CONTEXT_MAX_BYTES` (**default 512KB**,
half the NATS ceiling), `persist_engine_command` / `persist_engine_commands_batch`
offload the whole context to `noetl.result_store` and write a tiny
`{ "__context_ref__": "noetl://…" }` marker onto the event + command row instead,
so the published event stays small. `get_command` and `claim_command` resolve the
ref back to the full context before the worker sees it — the same result-store
pattern the #113 drive-result fix added on the read side.

Within-budget commands (the common case, a few KB) pass through unchanged: the
hot path is one `serde_json::to_vec` length check, no extra DB round-trip.

### Why ref-on-oversize, not refs_in_state=true

The prompt offered two candidates: a ref-on-oversize threshold (this PR) vs.
flipping `refs_in_state` default to true. A kind experiment under the gate
settled it: `refs_in_state=true` keeps the state small (no inline bloat) **but**
breaks fixtures that consume the bulk upstream payload (`test_storage_tiers`,
`test_output_select` fail at the bulk-consuming step) because the worker
render-time ref-resolution (the consume side) is **not yet implemented** — exactly
the caveat in `AppConfig::refs_in_state`. So flipping the default is unsafe today;
the conservative ref-on-oversize offload is correct and orthogonal to the future
refs_in_state consume-side work (noetl/ai-meta#101).

## Correctness preserved

- `apply_event` reads only `command.issued` **meta** (cursor phase/frame,
  command_id), never the context — state rebuild / replay is unaffected.
- `__orchestrate__` suppression, sole-writer, idempotency, ordering unchanged.
- The NATS command **notification** never carried context (just IDs +
  server_url); only the event publish did.

## Observability

New drive-metric stages `noetl_orchestrate_drive_total{stage="context_offloaded"}`
and `{stage="context_ref_resolved"}`.

## Validation (kind gate-ON: PUBLISH_ONLY=true + PLUGIN_DRIVE=true + materializer sole-writer)

- Every `command.issued` event across all tested fixtures is now < 1MB (max 165KB
  on http_* fixtures; offloaded ones → 135–635B markers). Zero resolve-failure
  WARNs, zero `didn't receive ack`, zero `apply failed`.
- Off-server rig (noetl/e2e `kind_validate_orchestrate_offserver.sh`) **PASS**:
  fan-out (#108) + #113 large-context + a new #114 fixture
  (`test_oversize_command_context`, ~900KB next-command context) all COMPLETED;
  the #114 fixture offloaded (event 585B) and resolved; 0 `__orchestrate__` rows
  in `noetl.event` (sole-writer intact); materializer lag 0.
- 6 of #113's stalled fixtures now COMPLETE. The remaining 3
  (`test_output_select`, `test_storage_tiers`, `kind_playbook_lease_expiry`)
  progress past the oversized-event wedge but hit **deeper refs_in_state=false
  off-server-drive issues** — `__orchestrate__` drive-state bloat (up to 17MB) and
  the `_ref`/bulk-resolve lazy-load gap — that are the refs_in_state consume-side
  (noetl/ai-meta#101), distinct from the oversized-`command.issued`-event bug this
  PR fixes.

Refs noetl/ai-meta#114
