### PR TITLE
Surface _ref/_store on kept refs + default refs_in_state true (#115 Phase 1)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -43,17 +43,20 @@ pub struct AppConfig {
     #[serde(default)]
     pub disable_metrics: bool,
 
-    /// References-in-state (noetl/ai-meta#101 phase 2).  When true, the
+    /// References-in-state (noetl/ai-meta#101 → #115 Phase 1).  When true, the
     /// orchestrator stops resolving over-budget result references back to inline
-    /// data — it keeps `{reference, extracted}` on the event so the state +
-    /// command context carry references, not bulk payloads (a 1.7MB step output
-    /// no longer balloons every `command.issued`).  The orchestrator evaluates
-    /// `when:`/`set:` off the small `extracted` predicate block; the worker
-    /// resolves the full reference at render time.  Envy maps
-    /// `NOETL_REFS_IN_STATE`.  **Default false** — preserves block-b's
-    /// resolve-inline behavior exactly until the consume side (worker resolve +
-    /// cursor-claim handling) is in place.
-    #[serde(default)]
+    /// data — it keeps `{reference, extracted}` (+ the `_ref`/`_store` locator
+    /// accessors) on the event so the state + command context carry references,
+    /// not bulk payloads (a 1.7MB step output no longer balloons every
+    /// `command.issued`, and the drive state stays bounded).  The orchestrator
+    /// evaluates `when:`/`set:` off the small `extracted` predicate block; the
+    /// worker resolves the full reference at render time **only** for inputs that
+    /// bind the bulk (`resolve_context_references` selective consume side).  Envy
+    /// maps `NOETL_REFS_IN_STATE`.  **Default true** — the consume side (worker
+    /// selective resolve + `_ref`/`_store` surfacing) landed with #115 Phase 1,
+    /// so references stay out of state/commands by default.  Set
+    /// `NOETL_REFS_IN_STATE=false` to revert to the resolve-inline behavior.
+    #[serde(default = "default_true")]
     pub refs_in_state: bool,
 
     /// CQRS read-model ownership (noetl/ai-meta#103 phase 2b).  When true, the
@@ -242,7 +245,9 @@ impl Default for AppConfig {
             nats_url: None,
             enable_gcp_token_api: true,
             disable_metrics: false,
-            refs_in_state: false,
+            // noetl/ai-meta#115 Phase 1: references stay out of state/commands by
+            // default now that the worker selective-resolve consume side landed.
+            refs_in_state: true,
             projector_owns_snapshot: false,
             // noetl/ai-meta#108 (c): worker-driven drive is the default.
             orchestrate_plugin_drive: true,

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1545,6 +1545,30 @@ fn event_status_from_name(event_name: &str) -> &'static str {
 /// triggered this evaluation pass (usually the `command.completed`
 /// row).  It's used as the `parent_event_id` for newly-inserted
 /// events so the event log forms a proper causal chain.
+/// Merge the locator accessors (`_ref`, `_store`, `_uri`) from a kept
+/// `reference` block into the bounded `extracted` summary, so the flat step
+/// binding (`{{ step._ref }}`, `{{ step._store }}`) carries them without the
+/// bulk payload.  Only injects when `extracted` is a JSON object and the keys
+/// aren't already present (the worker's own inline `{data:{_ref}}` shape wins).
+/// A non-object `extracted` (scalar / array summary) is returned untouched.
+fn with_ref_accessors(
+    mut extracted: serde_json::Value,
+    ref_block: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let (Some(obj), Some(reference)) = (extracted.as_object_mut(), ref_block) else {
+        return extracted;
+    };
+    for (accessor, field) in [("_ref", "ref"), ("_store", "store"), ("_uri", "uri")] {
+        if obj.contains_key(accessor) {
+            continue;
+        }
+        if let Some(v) = reference.get(field) {
+            obj.insert(accessor.to_string(), v.clone());
+        }
+    }
+    extracted
+}
+
 /// Resolve any `{status, reference: {ref: "noetl://..."}}` results in `events`
 /// back to the inline `{status, context: <data>}` shape the orchestrator reads.
 ///
@@ -1620,14 +1644,28 @@ async fn hydrate_result_references(
         // resolves the bulk payload at render time.  No `extracted` (pre-phase-1
         // refs) falls through to the resolve path below for back-compat.
         if keep_refs {
-            let extracted = match shape {
-                Shape::Nested => result
-                    .pointer("/context/result/reference/extracted")
-                    .cloned(),
-                Shape::TopLevel => result.pointer("/reference/extracted").cloned(),
+            let (extracted, ref_block) = match shape {
+                Shape::Nested => (
+                    result
+                        .pointer("/context/result/reference/extracted")
+                        .cloned(),
+                    result.pointer("/context/result/reference").cloned(),
+                ),
+                Shape::TopLevel => (
+                    result.pointer("/reference/extracted").cloned(),
+                    result.pointer("/reference").cloned(),
+                ),
             };
             if let Some(extracted) = extracted {
-                let data = serde_json::json!({ "data": extracted });
+                // Surface the locator accessors (`_ref`, `_store`, `_uri`) on the
+                // kept summary so reference-only consumers — `{{ step._ref }}`
+                // (artifact.get lazy-load), `{{ step._ref is defined }}` /
+                // `{{ step._store }}` (storage-tier predicates) — resolve off the
+                // bounded block without pulling the bulk payload (the consume
+                // side of noetl/ai-meta#115 Phase 1). The bulk stays in the store
+                // behind `reference.ref`; the worker resolves it only for inputs
+                // that bind the bulk (see worker `resolve_context_references`).
+                let data = serde_json::json!({ "data": with_ref_accessors(extracted, ref_block.as_ref()) });
                 match shape {
                     Shape::Nested => {
                         if let Some(inner) = result
@@ -2784,6 +2822,37 @@ async fn emit_playbook_failed(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn with_ref_accessors_injects_locator_keys() {
+        // #115 Phase 1: keep_refs surfaces `_ref`/`_store`/`_uri` on the bounded
+        // summary so `{{ step._ref }}` / `{{ step._store }}` resolve without bulk.
+        let extracted = serde_json::json!({ "status": "ok", "count": 500 });
+        let reference = serde_json::json!({
+            "ref": "noetl://execution/1/result/start/9",
+            "store": "kv",
+            "uri": "noetl://t/p/results/1/start/0/0/1",
+            "extracted": {},
+        });
+        let out = with_ref_accessors(extracted, Some(&reference));
+        assert_eq!(out["_ref"], serde_json::json!("noetl://execution/1/result/start/9"));
+        assert_eq!(out["_store"], serde_json::json!("kv"));
+        assert_eq!(out["_uri"], serde_json::json!("noetl://t/p/results/1/start/0/0/1"));
+        // The summary scalars are preserved.
+        assert_eq!(out["status"], serde_json::json!("ok"));
+        assert_eq!(out["count"], serde_json::json!(500));
+    }
+
+    #[test]
+    fn with_ref_accessors_preserves_existing_and_skips_non_object() {
+        // A worker-provided inline `_ref` wins; a non-object summary is untouched.
+        let extracted = serde_json::json!({ "_ref": "worker-set", "x": 1 });
+        let reference = serde_json::json!({ "ref": "server-set" });
+        let out = with_ref_accessors(extracted, Some(&reference));
+        assert_eq!(out["_ref"], serde_json::json!("worker-set"));
+        let scalar = serde_json::json!("just-a-string");
+        assert_eq!(with_ref_accessors(scalar.clone(), Some(&reference)), scalar);
+    }
 
     fn test_request_skeleton() -> EventRequest {
         EventRequest {


### PR DESCRIPTION
## What

The server read-path half of references-in-state Phase 1 (noetl/ai-meta#115,
the reframed noetl/ai-meta#101 consume side). Two coordinated changes:

1. **`hydrate_result_references` keep_refs branch** now merges the `reference`
   block's `ref`/`store`/`uri` onto the bounded `extracted` summary it surfaces
   as `context.data` (new `with_ref_accessors`). The flat step binding then
   carries `_ref` / `_store` / `_uri`, so reference-only consumers —
   `{{ step._ref }}` (artifact.get lazy-load), `{{ step._ref is defined }}` /
   `{{ step._store }}` (storage-tier predicates) — resolve off the bounded block
   **without** pulling the bulk payload. The bulk stays in the store behind
   `reference.ref`; the worker resolves it only for inputs that bind the bulk
   (noetl/worker selective `resolve_context_references`). The inline splice on
   this branch was already removed (#101) — this completes it.

2. **`refs_in_state` now defaults `true`** (`config/app.rs`). The
   noetl/ai-meta#114 kind experiment proved flipping it **without** the consume
   side breaks bulk-consuming fixtures; the consume side (worker selective
   resolve + this `_ref`/`_store` surfacing) lands in the same change set, so the
   flip is now safe. Keeps the drive state + `command.issued` context bounded by
   default (no 17.4MB drive state, no 1.32MB next-command context).
   `NOETL_REFS_IN_STATE=false` reverts.

Builds on #113 (server#241, v3.29.4) + #114 (server#242, v3.29.5) — both in this
branch's base.

## Validation (kind gate-ON: PUBLISH_ONLY + off-server drive + materializer sole-writer)

- The 3 #114-stuck fixtures (`test_output_select`, `test_storage_tiers`,
  `kind_playbook_lease_expiry`) reach `playbook.completed` with bounded sizes
  (max command context 10KB / 36KB / 18KB) and **0** `__orchestrate__` event
  rows. `_ref is defined` / `_store` now resolve correctly.
- 565 lib tests pass (2 new) + clippy clean.

Refs noetl/ai-meta#115 noetl/ai-meta#101 noetl/ai-meta#113 noetl/ai-meta#114

🤖 Generated with [Claude Code](https://claude.com/claude-code)