### PR TITLE
feat(events): one-level prev_event_id chain links (RFC #115 Phase 2)

### DIFF
--- a/src/db/queries/event_chain.rs
+++ b/src/db/queries/event_chain.rs
@@ -1,0 +1,77 @@
+//! `prev_event_id` chain columns — the one-level event chain (RFC #115 Phase 2,
+//! noetl/ai-meta#115 §4).
+//!
+//! Each `noetl.event` and `noetl.command` gains an additive `prev_event_id`
+//! pointer naming the immediately-previous node in the execution's causal
+//! order, so per-execution state can be followed **pointer-by-pointer, one
+//! level at a time** instead of scanning the whole event table (the chain-walk
+//! state builder lands in Phase 3 — this phase only *populates* the links;
+//! nothing reads them yet).
+//!
+//! The columns are owned by the platform schema (`schema_ddl.sql` in
+//! `noetl/noetl` carries the canonical definition for fresh installs), but the
+//! server **also** ensures them idempotently at startup — mirroring
+//! [`crate::db::queries::result_store::ensure_table`] — so a server image
+//! carrying the populate-on-emit code never writes a column the running
+//! database is missing (the gate-off INSERT binds an explicit column list; a
+//! missing column would fail every insert).  `ADD COLUMN IF NOT EXISTS` on the
+//! partitioned parents propagates to every partition.
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+
+/// Idempotently add `prev_event_id` to `noetl.event` + `noetl.command` and the
+/// chain-walk lookup index.
+///
+/// **Best-effort, never fatal.**  The platform schema is owned by the DB init
+/// role (the canonical definition is `schema_ddl.sql` in `noetl/noetl`); the
+/// server's connection role may not own `noetl.event` / `noetl.command` and so
+/// can't `ALTER` them (`must be owner of table …`).  In that deployment the
+/// columns are provisioned by the owner and this function's `ADD COLUMN IF NOT
+/// EXISTS` would be a no-op anyway — so a permission error (or any DDL error)
+/// is logged and swallowed rather than crashing startup.  The function still
+/// returns `Ok(())`; a genuinely-missing column surfaces later as a clear
+/// gate-off INSERT error, not a boot loop.
+pub async fn ensure_columns(pool: &DbPool) -> AppResult<()> {
+    // noetl.event — additive chain link.  Parent table; ADD COLUMN cascades to
+    // the range partitions.
+    try_ddl(
+        pool,
+        "ALTER TABLE noetl.event ADD COLUMN IF NOT EXISTS prev_event_id BIGINT",
+        "noetl.event.prev_event_id",
+    )
+    .await;
+    // noetl.command — the issuing-event pointer (the event whose application
+    // issued the command; RFC #115 §4.1).
+    try_ddl(
+        pool,
+        "ALTER TABLE noetl.command ADD COLUMN IF NOT EXISTS prev_event_id BIGINT",
+        "noetl.command.prev_event_id",
+    )
+    .await;
+    // Chain-walk integrity lookup: "who points AT this node" (forward replay /
+    // chain-integrity check).  The "give me node <head>" walk is served by the
+    // existing (execution_id, event_id) PK.  Partial — only linked rows.
+    try_ddl(
+        pool,
+        "CREATE INDEX IF NOT EXISTS idx_event_prev_event_id \
+         ON noetl.event (execution_id, prev_event_id) \
+         WHERE prev_event_id IS NOT NULL",
+        "idx_event_prev_event_id",
+    )
+    .await;
+    Ok(())
+}
+
+/// Run one idempotent DDL statement, logging-and-swallowing any error (the
+/// column is then expected to be owner-provisioned).  See [`ensure_columns`].
+async fn try_ddl(pool: &DbPool, sql: &str, what: &str) {
+    if let Err(e) = sqlx::query(sql).execute(pool).await {
+        tracing::warn!(
+            error = %e,
+            target = what,
+            "event-chain DDL skipped (server role likely not table owner; \
+             column expected to be provisioned by schema_ddl.sql)"
+        );
+    }
+}

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -5,6 +5,7 @@
 pub mod catalog;
 pub mod credential;
 pub mod event;
+pub mod event_chain;
 pub mod keychain;
 pub mod plugin_module;
 pub mod object_store;

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -45,6 +45,15 @@ pub struct EventRow {
     pub event_type: String,
     pub status: String,
     pub created_at: DateTime<Utc>,
+    /// One-level event-chain link (RFC #115 Phase 2, noetl/ai-meta#115 §4): the
+    /// immediately-previous event in this execution's causal order.  Normally
+    /// left `None` by the producer site and filled in by [`emit_events`] from
+    /// the per-execution chain head ([`crate::state::ChainHeads`]) so every
+    /// server-emitted row carries a link without each call site threading it.
+    /// A producer that already knows the precise predecessor may set it
+    /// explicitly; [`emit_events`] then respects it.  `None` after stamping
+    /// means this is the execution's root event.
+    pub prev_event_id: Option<i64>,
     pub node_id: Option<String>,
     pub node_name: Option<String>,
     pub node_type: Option<String>,
@@ -74,6 +83,7 @@ impl EventRow {
             event_type: event_type.into(),
             status: status.into(),
             created_at,
+            prev_event_id: None,
             node_id: None,
             node_name: None,
             node_type: None,
@@ -108,6 +118,13 @@ impl EventRow {
     }
     pub fn with_parent_event_id(mut self, id: i64) -> Self {
         self.parent_event_id = Some(id);
+        self
+    }
+    /// Explicitly set the chain link (RFC #115 §4).  Rarely needed — the
+    /// chokepoint fills it from the per-execution head — but available when a
+    /// producer knows the exact predecessor.
+    pub fn with_prev_event_id(mut self, id: Option<i64>) -> Self {
+        self.prev_event_id = id;
         self
     }
     pub fn with_parent_execution_id(mut self, id: Option<i64>) -> Self {
@@ -152,6 +169,7 @@ impl EventRow {
             "node_name": self.node_name,
             "node_type": self.node_type,
             "parent_event_id": self.parent_event_id,
+            "prev_event_id": self.prev_event_id,
             "parent_execution_id": self.parent_execution_id,
             "context": self.context,
             "result": self.result,
@@ -237,6 +255,37 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
         return Ok(());
     }
 
+    // One-level event chain (RFC #115 Phase 2, noetl/ai-meta#115 §4): stamp each
+    // row's `prev_event_id` from the per-execution chain head before it is
+    // written, so the per-execution events form a walkable singly-linked list
+    // (`prev_event_id` → predecessor) without a `noetl.event` scan.  This is the
+    // one server-side chokepoint every server-originated event passes through
+    // (drive events, command.issued, and worker-lifecycle events via
+    // `handle_event`), so stamping here covers the whole chain on both the
+    // gate-off INSERT and gate-on publish paths — the materializer then persists
+    // the link verbatim.  All rows in a batch share one execution (the batch is
+    // built per execution), so a single linkage call covers them in order.
+    let rows: Vec<EventRow> = {
+        let execution_id = rows[0].execution_id;
+        let ids: Vec<i64> = rows.iter().map(|r| r.event_id).collect();
+        let prevs = state.chain_heads.link_batch(execution_id, &ids);
+        rows.iter()
+            .zip(prevs)
+            .map(|(r, prev)| {
+                // Respect an explicit prev a producer already set; otherwise
+                // take the chain-head link.
+                if r.prev_event_id.is_some() {
+                    r.clone()
+                } else {
+                    let mut r = r.clone();
+                    r.prev_event_id = prev;
+                    r
+                }
+            })
+            .collect()
+    };
+    let rows = rows.as_slice();
+
     // All rows in a batch share the same execution + catalog, so one decision
     // covers the batch.
     if should_publish(state, rows[0].catalog_id).await {
@@ -264,7 +313,7 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
 async fn insert_rows(pool: &DbPool, rows: &[EventRow]) -> AppResult<()> {
     let mut qb = sqlx::QueryBuilder::new(
         "INSERT INTO noetl.event (event_id, execution_id, catalog_id, parent_event_id, \
-         parent_execution_id, event_type, node_id, node_name, node_type, status, \
+         prev_event_id, parent_execution_id, event_type, node_id, node_name, node_type, status, \
          context, result, meta, error, worker_id, created_at) ",
     );
     qb.push_values(rows.iter(), |mut b, r| {
@@ -272,6 +321,7 @@ async fn insert_rows(pool: &DbPool, rows: &[EventRow]) -> AppResult<()> {
             .push_bind(r.execution_id)
             .push_bind(r.catalog_id)
             .push_bind(r.parent_event_id)
+            .push_bind(r.prev_event_id)
             .push_bind(r.parent_execution_id)
             .push_bind(&r.event_type)
             .push_bind(&r.node_id)
@@ -341,6 +391,17 @@ mod tests {
         assert!(j["node_type"].is_null());
         assert!(j["parent_event_id"].is_null());
         assert!(j["worker_id"].is_null());
+        // RFC #115 §4: an unset chain link serializes as null (→ NULL / root).
+        assert!(j.get("prev_event_id").is_some(), "must carry prev_event_id key");
+        assert!(j["prev_event_id"].is_null());
+    }
+
+    #[test]
+    fn stream_json_carries_prev_event_id_when_set() {
+        // The chain link must ride the published stream shape so the gate-on
+        // materializer persists it verbatim (RFC #115 §4).
+        let j = sample_row().with_prev_event_id(Some(41)).to_stream_json();
+        assert_eq!(j["prev_event_id"], 41);
     }
 
     #[test]

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2221,6 +2221,7 @@ async fn trigger_orchestrator_inner(
         let st = cache.state.as_ref().map(|ws| ws.state);
         drop(cache);
         state.orch_cache.evict(execution_id);
+        state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
         debug!(
             execution_id,
             state = ?st,
@@ -2424,6 +2425,7 @@ async fn trigger_orchestrator_inner(
     if result.should_complete {
         drop(cache);
         state.orch_cache.evict(execution_id);
+        state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
     }
 
     Ok(commands_generated)
@@ -2771,6 +2773,7 @@ async fn apply_worker_orchestration(
     if result.should_complete {
         drop(cache);
         state.orch_cache.evict(execution_id);
+        state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
     }
     Ok(commands_generated)
 }

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -848,6 +848,12 @@ pub(crate) async fn persist_engine_command(
     // ROW below stays a synchronous INSERT — it's the command queue, not the
     // event log (#103 is event-log-scoped), and the worker fetches command
     // config from noetl.command, so it must be present read-your-writes.
+    // The real predecessor event (RFC #115 §4.1) — the chain head before this
+    // command.issued advances it (see persist_engine_commands_batch).
+    let issuing_event = state
+        .chain_heads
+        .head(execution_id)
+        .unwrap_or(parent_event_id);
     let ev = crate::handlers::event_write::EventRow::new(
         event_id,
         execution_id,
@@ -869,6 +875,7 @@ pub(crate) async fn persist_engine_command(
         event_id,
         catalog_id,
         parent_event_id,
+        issuing_event,
         &step.step,
         command.tool.kind.as_str(),
         &cmd_context,
@@ -1025,6 +1032,21 @@ pub(crate) async fn persist_engine_commands_batch(
     // Multi-row `command.issued` EVENTS through the CQRS chokepoint (#103 2d-3):
     // one multi-row INSERT (gate off) or one publish per row (gate on). The
     // noetl.command ROWS below stay synchronous (command queue, not event log).
+    // prev_event_id for the command rows (RFC #115 §4.1) is the **real** event
+    // whose application issued the command — the `step.enter` / unblocking
+    // completion that is the chain head right now, BEFORE the command.issued
+    // batch advances it.  This is exactly the predecessor the watermark stamps
+    // on each command.issued event.  Using it (not `parent_event_id`, which
+    // under the off-server drive is the suppressed `__orchestrate__` trigger)
+    // keeps the command pointer referencing a materialized event.  For a cursor
+    // fan-out the head is the claim/branch event, so every body command points
+    // back at its fan-out origin (§4.4).  Fallback to `parent_event_id` only if
+    // the chain head is somehow unset (no events yet — shouldn't happen after
+    // playbook_started).
+    let issuing_event = state
+        .chain_heads
+        .head(execution_id)
+        .unwrap_or(parent_event_id);
     let event_rows: Vec<crate::handlers::event_write::EventRow> = prepared
         .iter()
         .map(|p| {
@@ -1047,9 +1069,15 @@ pub(crate) async fn persist_engine_commands_batch(
 
     // Multi-row INSERT of all `noetl.command` rows (non-fatal — the event log is
     // the source of truth; mirror the single path's warn-on-failure).
+    // `prev_event_id` (RFC #115 Phase 2, noetl/ai-meta#115 §4.1): the event whose
+    // application issued this command — i.e. the drive trigger (`parent_event_id`).
+    // For a cursor fan-out that trigger is the claim/branch event, so every body
+    // command points back at its fan-out origin (§4.4).  `latest_event_id` keeps
+    // its existing meaning (most-recent lifecycle event); `prev_event_id` is the
+    // immutable issuing link.
     let mut cqb = sqlx::QueryBuilder::new(
         "INSERT INTO noetl.command (command_id, event_id, execution_id, catalog_id, \
-         step_name, tool_kind, status, attempt, context, meta, latest_event_id) ",
+         step_name, tool_kind, status, attempt, context, meta, latest_event_id, prev_event_id) ",
     );
     cqb.push_values(prepared.iter(), |mut b, p| {
         b.push_bind(p.num_command_id)
@@ -1062,7 +1090,8 @@ pub(crate) async fn persist_engine_commands_batch(
             .push_bind(1_i32)
             .push_bind(&p.cmd_context)
             .push_bind(&p.cmd_meta)
-            .push_bind(parent_event_id);
+            .push_bind(parent_event_id)
+            .push_bind(issuing_event);
     });
     if let Err(e) = cqb.build().execute(pool).await {
         tracing::warn!(
@@ -1148,8 +1177,8 @@ pub(crate) async fn dispatch_orchestrate_command(
     let num_command_id = state.snowflake.generate()?;
     sqlx::query(
         "INSERT INTO noetl.command (command_id, event_id, execution_id, catalog_id, \
-         step_name, tool_kind, status, attempt, context, meta, latest_event_id) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+         step_name, tool_kind, status, attempt, context, meta, latest_event_id, prev_event_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
     )
     .bind(num_command_id)
     .bind(event_id)
@@ -1161,6 +1190,10 @@ pub(crate) async fn dispatch_orchestrate_command(
     .bind(1_i32)
     .bind(&cmd_context)
     .bind(&cmd_meta)
+    .bind(parent_event_id)
+    // prev_event_id (RFC #115 §4.1): the drive trigger that issued this
+    // meta-command.  The `__orchestrate__` command is suppressed from the event
+    // chain (no command.issued row), but its issuing link is recorded uniformly.
     .bind(parent_event_id)
     .execute(pool)
     .await?;
@@ -1402,6 +1435,7 @@ async fn insert_command_row(
     event_id: i64,
     catalog_id: i64,
     parent_event_id: i64,
+    prev_event_id: i64,
     step_name: &str,
     tool_kind: &str,
     context: &serde_json::Value,
@@ -1421,9 +1455,9 @@ async fn insert_command_row(
         INSERT INTO noetl.command (
             command_id, event_id, execution_id, catalog_id,
             step_name, tool_kind, status, attempt,
-            context, meta, latest_event_id
+            context, meta, latest_event_id, prev_event_id
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
         )
         "#,
     )
@@ -1438,6 +1472,10 @@ async fn insert_command_row(
     .bind(context)
     .bind(meta)
     .bind(parent_event_id)
+    // prev_event_id (RFC #115 §4.1): the real predecessor (step.enter /
+    // unblocking completion) that issued this command — the chain head captured
+    // by the caller before the command.issued event advanced it.
+    .bind(prev_event_id)
     .execute(state.pools.pool_for(execution_id))
     .await?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,6 +789,12 @@ async fn main() -> anyhow::Result<()> {
     // (only /api/execute writes it) and bounded by age; dedup is opt-in per
     // subscription so the table stays empty unless a critical stream uses it.
     noetl_server::db::queries::subscription_dedup::ensure_table(&db_pool).await?;
+    // One-level event chain (RFC #115 Phase 2, noetl/ai-meta#115 §4) — add the
+    // additive `prev_event_id` link to noetl.event + noetl.command so the
+    // populate-on-emit code never writes a column the running DB is missing
+    // (the gate-off INSERT binds an explicit column list).  Idempotent; the
+    // canonical definition also lives in noetl/noetl's schema_ddl.sql.
+    noetl_server::db::queries::event_chain::ensure_columns(&db_pool).await?;
     // kind: Subscription (noetl/ai-meta#90 Phase 2) — seed the `subscription`
     // resource kind so a catalog register doesn't trip the
     // `noetl.catalog.kind -> noetl.resource(name)` FK.  Idempotent.

--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -460,6 +460,12 @@ pub struct EventEnvelope {
     pub execution_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_event_id: Option<i64>,
+    /// One-level event-chain link (RFC #115 Phase 2, noetl/ai-meta#115 §4): the
+    /// immediately-previous event in this execution's causal order, stamped by
+    /// the emit chokepoint and published in the stream shape; the materializer
+    /// persists it verbatim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prev_event_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -535,6 +541,7 @@ pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResul
             execution_id,
             catalog_id,
             parent_event_id,
+            prev_event_id,
             event_type,
             node_id,
             node_name,
@@ -555,6 +562,7 @@ pub async fn project_events(pool: &DbPool, events: &[EventEnvelope]) -> AppResul
             COALESCE(NULLIF(row->>'execution_id', '')::bigint, 0),
             COALESCE(NULLIF(row->>'catalog_id', '')::bigint, 0),
             NULLIF(row->>'parent_event_id', '')::bigint,
+            NULLIF(row->>'prev_event_id', '')::bigint,
             row->>'event_type',
             row->>'node_id',
             row->>'node_name',
@@ -622,6 +630,26 @@ mod tests {
         assert!(none.timestamp.is_none());
         let absent: EventEnvelope = serde_json::from_str(r#"{"event_id":4}"#).unwrap();
         assert!(absent.timestamp.is_none());
+    }
+
+    // RFC #115 §4: the chain link in the published stream shape must
+    // deserialize into the envelope (and survive a re-serialize, since
+    // `project_events` re-encodes the batch before the INSERT … SELECT).
+    #[test]
+    fn envelope_round_trips_prev_event_id() {
+        // Stream shape carries prev_event_id (set on a non-root event).
+        let env: EventEnvelope =
+            serde_json::from_str(r#"{"event_id":12,"prev_event_id":11}"#).unwrap();
+        assert_eq!(env.prev_event_id, Some(11));
+        // Re-serialize (what project_events does) keeps it for the SQL SELECT.
+        let reser = serde_json::to_value(&env).unwrap();
+        assert_eq!(reser["prev_event_id"], 11);
+        // A root event (null / absent) → None, omitted on re-serialize.
+        let root: EventEnvelope =
+            serde_json::from_str(r#"{"event_id":1,"prev_event_id":null}"#).unwrap();
+        assert_eq!(root.prev_event_id, None);
+        let reser_root = serde_json::to_value(&root).unwrap();
+        assert!(reser_root.get("prev_event_id").is_none());
     }
 
     // The full request shape the CQRS materializer POSTs — a batch of envelopes

--- a/src/state.rs
+++ b/src/state.rs
@@ -91,6 +91,12 @@ pub struct AppState {
     /// execution's concurrent completion triggers.
     pub orch_cache: Arc<OrchStateCache>,
 
+    /// Per-execution chain head for the one-level event chain (RFC #115 Phase
+    /// 2, noetl/ai-meta#115 §4).  The event-write chokepoint reads + advances it
+    /// to stamp each row's `prev_event_id`, so per-execution events form a
+    /// walkable singly-linked list.  See [`ChainHeads`].
+    pub chain_heads: Arc<ChainHeads>,
+
     /// CQRS write-path publisher (noetl/ai-meta#103 phase 2d-3).  Lazily built
     /// on first use from [`Self::nats`] so the `emit_event` chokepoint can
     /// publish to the `noetl_events` stream when
@@ -137,6 +143,62 @@ pub struct ExecOrchState {
     pub orchestrate_in_flight: bool,
 }
 
+
+/// Per-execution chain head for the one-level event chain (RFC #115 Phase 2,
+/// noetl/ai-meta#115 §4).  Maps `execution_id → event_id of the last event
+/// appended to the chain`.  The event-write chokepoint
+/// ([`crate::handlers::event_write::emit_events`]) reads the head as the next
+/// row's `prev_event_id`, then advances it — so the per-execution events form a
+/// singly-linked list walkable pointer-by-pointer, no `noetl.event` scan.
+///
+/// In-memory only and **no DB read on the hot path**: a cold slot (execution's
+/// first event, or an execution whose earlier events were handled by a
+/// different replica / before a restart) yields `None`, i.e. a chain root.
+/// This shares the locality assumption the existing [`OrchStateCache`] already
+/// relies on — an execution's drive is serialised on one replica — so the chain
+/// is continuous for the single-writer / single-replica topology the kind gate
+/// validates.  Restart-spanning repair is a Phase 3 builder concern (it
+/// re-walks from a durable head); nothing reads `prev_event_id` yet, so a chain
+/// restart here is additive metadata, never a regression.
+#[derive(Default)]
+pub struct ChainHeads {
+    map: std::sync::Mutex<std::collections::HashMap<i64, i64>>,
+}
+
+impl ChainHeads {
+    /// Stamp the chain link for a batch of event ids emitted (in order) for one
+    /// execution, advancing the head as it goes.  Returns, for each id, the
+    /// `prev_event_id` it should carry (`None` for a chain root).  One short
+    /// `std::Mutex` critical section, no `await` held — safe to call from any
+    /// chokepoint path without lock-ordering hazards against
+    /// [`OrchStateCache`]'s per-execution `tokio::Mutex`.
+    ///
+    /// An empty `event_ids` is a no-op returning an empty vec.
+    pub fn link_batch(&self, execution_id: i64, event_ids: &[i64]) -> Vec<Option<i64>> {
+        let mut map = self.map.lock().unwrap();
+        let mut head = map.get(&execution_id).copied();
+        let mut prevs = Vec::with_capacity(event_ids.len());
+        for &eid in event_ids {
+            prevs.push(head);
+            head = Some(eid);
+        }
+        if let Some(h) = head {
+            map.insert(execution_id, h);
+        }
+        prevs
+    }
+
+    /// Drop a terminal execution's head (frees memory).  Called alongside
+    /// [`OrchStateCache::evict`] on the terminal-event paths.
+    pub fn evict(&self, execution_id: i64) {
+        self.map.lock().unwrap().remove(&execution_id);
+    }
+
+    /// Current head for an execution, if any.  Test/diagnostic helper.
+    pub fn head(&self, execution_id: i64) -> Option<i64> {
+        self.map.lock().unwrap().get(&execution_id).copied()
+    }
+}
 
 /// Per-execution orchestrator state cache.  The outer `std::Mutex` guards a
 /// short get-or-insert; the inner per-execution `tokio::Mutex` is held across
@@ -262,6 +324,7 @@ impl AppState {
             shard: Arc::new(shard),
             start_time: std::time::Instant::now(),
             orch_cache: Arc::new(OrchStateCache::default()),
+            chain_heads: Arc::new(ChainHeads::default()),
             event_stream_publisher: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
@@ -298,6 +361,8 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
+    use super::ChainHeads;
+
     // Note: Full tests require a database connection
     // These are placeholder tests for documentation
 
@@ -305,5 +370,87 @@ mod tests {
     fn test_uptime() {
         // AppState::new requires a real DB pool, so we can't easily test here
         // This is a documentation placeholder
+    }
+
+    // RFC #115 §4: the per-execution chain head turns a stream of emitted event
+    // ids into a walkable singly-linked list.
+    #[test]
+    fn chain_head_links_first_event_is_root() {
+        let heads = ChainHeads::default();
+        // First batch: the execution's first event has no predecessor (root).
+        let prevs = heads.link_batch(7, &[100]);
+        assert_eq!(prevs, vec![None], "execution's first event is a chain root");
+        assert_eq!(heads.head(7), Some(100));
+    }
+
+    #[test]
+    fn chain_head_links_batch_in_order() {
+        let heads = ChainHeads::default();
+        // A multi-row batch (e.g. a cursor fan-out's N command.issued events)
+        // links each row to the previous one in order; the first to the head.
+        let prevs = heads.link_batch(7, &[10, 11, 12]);
+        assert_eq!(prevs, vec![None, Some(10), Some(11)]);
+        assert_eq!(heads.head(7), Some(12), "head advances to the last id");
+        // A following batch continues the chain from the advanced head.
+        let prevs = heads.link_batch(7, &[20, 21]);
+        assert_eq!(prevs, vec![Some(12), Some(20)]);
+        assert_eq!(heads.head(7), Some(21));
+    }
+
+    #[test]
+    fn chain_head_is_per_execution() {
+        let heads = ChainHeads::default();
+        heads.link_batch(1, &[10, 11]);
+        heads.link_batch(2, &[90]);
+        // Distinct executions never share a head.
+        assert_eq!(heads.head(1), Some(11));
+        assert_eq!(heads.head(2), Some(90));
+        let p1 = heads.link_batch(1, &[12]);
+        let p2 = heads.link_batch(2, &[91]);
+        assert_eq!(p1, vec![Some(11)]);
+        assert_eq!(p2, vec![Some(90)]);
+    }
+
+    #[test]
+    fn chain_head_walk_reconstructs_full_sequence_no_gaps() {
+        // Property the kind validation asserts in SQL: walking prev_event_id
+        // from the head reconstructs the full per-execution sequence with no
+        // gaps.  Model it over the in-memory linker.
+        let heads = ChainHeads::default();
+        let ids = [5_i64, 6, 7, 8, 9];
+        let prevs = heads.link_batch(42, &ids);
+        // Build the prev map the chain would persist.
+        let mut prev_of = std::collections::HashMap::new();
+        for (id, prev) in ids.iter().zip(&prevs) {
+            prev_of.insert(*id, *prev);
+        }
+        // Walk backward from the head.
+        let mut walked = Vec::new();
+        let mut cur = heads.head(42);
+        while let Some(id) = cur {
+            walked.push(id);
+            cur = prev_of.get(&id).copied().flatten();
+        }
+        walked.reverse();
+        assert_eq!(walked, ids, "pointer walk == full emit sequence, no gaps");
+    }
+
+    #[test]
+    fn chain_head_evict_drops_state() {
+        let heads = ChainHeads::default();
+        heads.link_batch(7, &[10]);
+        assert_eq!(heads.head(7), Some(10));
+        heads.evict(7);
+        assert_eq!(heads.head(7), None, "evicted execution starts a fresh chain");
+        // After eviction the next event is treated as a root again.
+        let prevs = heads.link_batch(7, &[20]);
+        assert_eq!(prevs, vec![None]);
+    }
+
+    #[test]
+    fn chain_head_empty_batch_is_noop() {
+        let heads = ChainHeads::default();
+        assert_eq!(heads.link_batch(7, &[]), Vec::<Option<i64>>::new());
+        assert_eq!(heads.head(7), None);
     }
 }


### PR DESCRIPTION
## What

Phase 2 of [RFC noetl/ai-meta#115](https://github.com/noetl/ai-meta/issues/115) — the **one-level event chain** (tenet 4). Adds the additive `prev_event_id` linkage so per-execution events form a walkable singly-linked list, followable **pointer-by-pointer without scanning `noetl.event`**. Pure population; **no reader consumes the link yet** (that is Phase 3). No behavior change, no prod gate change.

## How

- **Event chain.** `EventRow` gains `prev_event_id`; the emit chokepoint `emit_events` stamps it from a per-execution **chain-head watermark** (`ChainHeads` in `AppState`). This is the single server-side path every server-originated event passes through (drive events, `command.issued`, and worker-lifecycle events via `handle_event`), so the whole chain is covered on **both** the gate-off INSERT and the gate-on publish (`to_stream_json`) paths. The gate-on materializer persists the link verbatim (`EventEnvelope` + `project_events` SELECT).
- **Command → issuing event.** `noetl.command.prev_event_id` = the **real** event that issued the command (the `step.enter`/unblocking completion — the chain head captured *before* the `command.issued` batch advances it). For a cursor fan-out that head is the claim/branch event, so every body command points back at its fan-out origin (§4.4). Set on all command INSERT sites.
- **Self-ensuring, never fatal.** `db::queries::event_chain::ensure_columns` adds the columns + chain-walk index idempotently at startup, logging-and-continuing if the server role doesn't own the table (the column is then owner-provisioned via `schema_ddl.sql`). The canonical DDL lands in [noetl/noetl#…](https://github.com/noetl/noetl/pull/) (`schema_ddl.sql`).
- Chain heads evicted alongside `orch_cache` on terminal.

## Correctness preserved

Ordering, idempotency, sole-writer (#103), `__orchestrate__` suppression, fan-out/loop semantics, replay, and the Phase-1 bounded sizes — the link is additive metadata.

## Validation (local kind, gate-ON: PUBLISH_ONLY + off-server drive + materializer sole-writer)

Six executions across every topology — for each: exactly **1 root** (prev NULL), **0 dangling** event prev, **0 duplicate** prev (strict linked list), **1 head**, and a pointer-walk from the head reconstructs the **full sequence with no gaps** (`walked == total`, each hop a PK lookup — no full-table scan). Real-step command→issuing-event dangling **= 0**.

| Topology | events walked/total | fan-out branch link |
| :-- | :-- | :-- |
| linear (`simple_python`) | 13/13 | — |
| loop (`loop_test`) | 62/62 | — |
| fan-out (`fanout_reduce_phase6`) | 25/25 | 2 bodies share a **real** branch-origin event |
| sub-playbook (`playbook_composition`) | 46/46 | — |
| Phase-1 `output_select` | 31/31 (ctx 7.3KB, bounded) | — |
| Phase-1 `storage_tiers` | 55/55 (ctx 36KB, bounded) | — |

Regression: `kind_validate_orchestrate_gate.sh` **PASS** (sole-writer 25==25, 0 dup cycles, catalog0=0, `__orchestrate__` event=0/command=4); Phase-1 fixtures complete with bounded sizes; 573 lib tests + clippy green.

Refs noetl/ai-meta#115