### PR TITLE
feat(events): chain-walk state builder behind NOETL_STATE_BUILD_MODE (RFC #115 Phase 3)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -188,6 +188,54 @@ pub struct AppConfig {
     /// ordinary commands never offload (their context is a few KB).
     #[serde(default = "default_command_context_max_bytes")]
     pub command_context_max_bytes: usize,
+
+    /// How the orchestrator drive reconstructs `WorkflowState` for an execution
+    /// (RFC noetl/ai-meta#115 Phase 3).  Envy maps `NOETL_STATE_BUILD_MODE`.
+    ///
+    /// - **`event_scan`** (default) — the established path: bounded rebuild from
+    ///   the latest `projection_snapshot` + an `event_id`-range scan of
+    ///   `noetl.event`, or a full `WHERE execution_id = $1` scan when no snapshot
+    ///   exists.  Unchanged prod behavior.
+    /// - **`chain_walk`** — follow the one-level `prev_event_id` chain (Phase 2)
+    ///   from the in-memory chain head back to the genesis event, each hop a
+    ///   `(execution_id, event_id)` **PK lookup** — never a `WHERE execution_id`
+    ///   scan of `noetl.event`.  The collected events are fed to the SAME
+    ///   `WorkflowState::from_events`, so the built state is equivalent to the
+    ///   event-scan build (parity by construction).  When the chain head is cold
+    ///   (server restart / different replica), a walked node isn't yet
+    ///   materialized (materializer lag under the gate), or the walk's root is
+    ///   not a genesis event, the build **falls back to `event_scan`** for that
+    ///   trigger (counted via `noetl_state_build_total{outcome}`) — correctness
+    ///   is never sacrificed.  This is the in-process proof of tenet 3/4 before
+    ///   the off-server builder + cache (Phase 4).
+    ///
+    /// **Default `event_scan`** — prod/default behavior is unchanged; flipping to
+    /// `chain_walk` is opt-in.
+    #[serde(default)]
+    pub state_build_mode: StateBuildMode,
+
+    /// When true, the drive builds `WorkflowState` **both** ways (event-scan AND
+    /// chain-walk) on each cold/rebuild and asserts they are equal, recording a
+    /// mismatch via `noetl_state_build_parity_total{result}` — the drive still
+    /// **uses the configured `state_build_mode` result** for its decision (the
+    /// shadow build is observation-only, so a parity bug can't change behavior).
+    /// Envy maps `NOETL_STATE_BUILD_PARITY_CHECK`.  **Default false** — a
+    /// validation/diagnostic switch, off in prod.
+    #[serde(default)]
+    pub state_build_parity_check: bool,
+}
+
+/// Strategy for reconstructing orchestrator `WorkflowState` — see
+/// [`AppConfig::state_build_mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StateBuildMode {
+    /// Bounded snapshot + `event_id`-range / full scan of `noetl.event` (the
+    /// established path).  Default.
+    #[default]
+    EventScan,
+    /// Walk the `prev_event_id` chain head→root by PK lookup (RFC #115 Phase 3).
+    ChainWalk,
 }
 
 fn default_host() -> String {
@@ -261,6 +309,9 @@ impl Default for AppConfig {
             shard_index: None,
             shard_count: None,
             command_context_max_bytes: default_command_context_max_bytes(),
+            // noetl/ai-meta#115 Phase 3: event-scan is the default; chain_walk is opt-in.
+            state_build_mode: StateBuildMode::EventScan,
+            state_build_parity_check: false,
         }
     }
 }
@@ -298,5 +349,24 @@ mod tests {
         let cfg = AppConfig::default();
         assert_eq!(cfg.command_context_max_bytes, 512 * 1024);
         assert!(cfg.command_context_max_bytes < 1024 * 1024);
+    }
+
+    #[test]
+    fn test_state_build_mode_defaults_event_scan() {
+        // noetl/ai-meta#115 Phase 3: prod/default behavior is unchanged — the
+        // chain-walk builder is opt-in via NOETL_STATE_BUILD_MODE=chain_walk.
+        let cfg = AppConfig::default();
+        assert_eq!(cfg.state_build_mode, StateBuildMode::EventScan);
+        assert!(!cfg.state_build_parity_check);
+    }
+
+    #[test]
+    fn test_state_build_mode_deserializes_snake_case() {
+        // Envy parses NOETL_STATE_BUILD_MODE through serde; the variants are
+        // snake_case so `chain_walk` / `event_scan` map cleanly.
+        let cw: StateBuildMode = serde_json::from_str("\"chain_walk\"").unwrap();
+        assert_eq!(cw, StateBuildMode::ChainWalk);
+        let es: StateBuildMode = serde_json::from_str("\"event_scan\"").unwrap();
+        assert_eq!(es, StateBuildMode::EventScan);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,5 +6,5 @@
 mod app;
 pub mod database;
 
-pub use app::AppConfig;
+pub use app::{AppConfig, StateBuildMode};
 pub use database::{DatabaseConfig, ShardConnection, ShardConnectionError, ShardingConfig};

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1749,6 +1749,20 @@ const ORCH_EVENT_COLS: &str = r#"
                created_at
         FROM noetl.event "#;
 
+/// Same projection as [`ORCH_EVENT_COLS`] plus the `prev_event_id` chain link —
+/// the column the chain-walk state builder (RFC noetl/ai-meta#115 Phase 3) follows
+/// one level at a time.  Only used by [`fetch_chain_node`], which always pins
+/// `WHERE execution_id = $1 AND event_id = $2` (the `(execution_id, event_id)` PK),
+/// so this never drives a `WHERE execution_id`-only scan.
+const ORCH_EVENT_COLS_WITH_PREV: &str = r#"
+        SELECT event_id, execution_id, catalog_id,
+               parent_event_id, parent_execution_id,
+               event_type, node_id, node_name, node_type, status,
+               context, meta, result, worker_id,
+               NULLIF(meta->>'attempt', '')::int AS attempt,
+               created_at, prev_event_id
+        FROM noetl.event "#;
+
 /// Map rows selected via [`ORCH_EVENT_COLS`] into `Event`s.  `attempt` lives in
 /// `meta` JSONB (no dedicated column), sourced via the `NULLIF(...)::int` alias.
 fn parse_event_rows(rows: Vec<sqlx::postgres::PgRow>) -> Vec<crate::db::models::Event> {
@@ -1934,6 +1948,220 @@ async fn rebuild_state(
     }
 }
 
+// ── Chain-walk state builder (RFC noetl/ai-meta#115 Phase 3) ─────────────────
+//
+// Reconstructs `WorkflowState` by following the one-level `prev_event_id` chain
+// (Phase 2) from the in-memory chain head back to the genesis event, instead of
+// the `event_scan` `rebuild_state` path's `WHERE execution_id = $1 …` scans.
+// Each hop is a `(execution_id, event_id)` PK point-lookup (`fetch_chain_node`);
+// the collected events are sorted by `event_id` and fed to the SAME
+// `WorkflowState::from_events`, so the built state is equivalent to the
+// event-scan build (parity by construction).  The whole thing is gated behind
+// `NOETL_STATE_BUILD_MODE=chain_walk` and falls back to event-scan on any
+// completeness doubt (cold head, missing node under materializer lag, a chain
+// that doesn't reach the genesis), so correctness is never sacrificed.
+
+/// One node fetched during a chain walk: the parsed `Event` plus its
+/// `prev_event_id` link (the next hop backward; `None` at the chain root).
+struct ChainNode {
+    event: crate::db::models::Event,
+    prev_event_id: Option<i64>,
+}
+
+/// Fetch a single chain node by its `(execution_id, event_id)` primary key — the
+/// only query shape the walk issues.  This is a **point lookup on the PK**, never
+/// a `WHERE execution_id`-only scan.  Returns `None` when the row isn't present
+/// (e.g. the event was published but not yet materialized under the publish-only
+/// gate, or a dangling link) so the caller can fall back rather than build a
+/// partial state.
+async fn fetch_chain_node(
+    pool: &crate::db::DbPool,
+    execution_id: i64,
+    event_id: i64,
+) -> AppResult<Option<ChainNode>> {
+    use sqlx::Row;
+    let row = sqlx::query(&format!(
+        "{ORCH_EVENT_COLS_WITH_PREV} WHERE execution_id = $1 AND event_id = $2"
+    ))
+    .bind(execution_id)
+    .bind(event_id)
+    .fetch_optional(pool)
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    // Read the link before the row is consumed by `parse_event_rows`.
+    let prev_event_id: Option<i64> = row.try_get("prev_event_id").ok().flatten();
+    let event = parse_event_rows(vec![row])
+        .into_iter()
+        .next()
+        .expect("one row in, one event out");
+    Ok(Some(ChainNode {
+        event,
+        prev_event_id,
+    }))
+}
+
+/// The genesis (first) event type of an execution — the chain root for a
+/// complete chain.  `playbook_started` is emitted first by `execute` (before any
+/// `command.issued`), and the event-scan `rebuild_state` already keys
+/// `routing_meta` off it, so its presence in the collected set means the walk
+/// reached the true start (not just a post-restart tail).
+fn chain_has_genesis(events: &[crate::db::models::Event]) -> bool {
+    events.iter().any(|e| e.event_type == "playbook_started")
+}
+
+/// A successful chain-walk build: the same [`RebuildResult`] the event-scan path
+/// produces, plus the per-trigger drive inputs the caller would otherwise read
+/// off the event-scan window (`trigger_event_type`, `latest_ts`) and the count of
+/// events the walk collected.
+struct ChainWalkBuild {
+    result: RebuildResult,
+    collected: usize,
+    trigger_event_type: String,
+    latest_ts: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Build `WorkflowState` for `execution_id` by walking the `prev_event_id` chain
+/// head→root (RFC #115 Phase 3).  Returns `None` (caller falls back to
+/// event-scan) when the chain can't be trusted to be complete:
+/// - the chain head is unknown (cold cache / restart / handled on another
+///   replica) — `fallback_cold_head`;
+/// - a walked node isn't present yet (materializer lag under the gate, dangling
+///   link) — `fallback_node_missing`;
+/// - the collected chain doesn't contain the genesis `playbook_started`
+///   (restart-spanning tail) — `fallback_non_genesis`;
+/// - the walk collected nothing — `fallback_empty`.
+///
+/// On success the collected events are sorted by `event_id` (the same order the
+/// event-scan path applies them) and handed to the SAME `from_events`, so the
+/// built state matches the event-scan build for the same execution.
+async fn rebuild_state_chain_walk(
+    state: &AppState,
+    pool: &crate::db::DbPool,
+    result_store: &crate::services::result_store::ResultStoreService,
+    execution_id: i64,
+    trigger_event_id: i64,
+    keep_refs: bool,
+) -> AppResult<Option<ChainWalkBuild>> {
+    // Head from the in-memory watermark — no DB read.  Cold slot → fall back.
+    let Some(head) = state.chain_heads.head(execution_id) else {
+        crate::metrics::record_state_build("chain_walk", "fallback_cold_head");
+        debug!(execution_id, "chain walk: cold head, falling back to event scan");
+        return Ok(None);
+    };
+
+    // Walk backward head→root by PK lookup, collecting nodes.  Bounded so a
+    // corrupt cycle can't spin (real chains are at most a few thousand events).
+    const MAX_WALK: usize = 5_000_000;
+    let mut events: Vec<crate::db::models::Event> = Vec::new();
+    let mut cursor = Some(head);
+    let mut guard = 0usize;
+    while let Some(eid) = cursor {
+        guard += 1;
+        if guard > MAX_WALK {
+            warn!(
+                execution_id,
+                head, "chain walk exceeded bound; falling back to event scan"
+            );
+            crate::metrics::record_state_build("chain_walk", "fallback_node_missing");
+            return Ok(None);
+        }
+        let Some(node) = fetch_chain_node(pool, execution_id, eid).await? else {
+            // Not yet present (materializer lag) or a dangling link: can't build
+            // a complete state — fall back this trigger; the next trigger retries
+            // once the node materializes.
+            crate::metrics::record_state_build("chain_walk", "fallback_node_missing");
+            debug!(
+                execution_id,
+                missing_event_id = eid,
+                "chain walk: node not present (lag/dangling), falling back to event scan"
+            );
+            return Ok(None);
+        };
+        cursor = node.prev_event_id;
+        events.push(node.event);
+    }
+
+    if events.is_empty() {
+        crate::metrics::record_state_build("chain_walk", "fallback_empty");
+        return Ok(None);
+    }
+    // Completeness guard: the walk must have reached the genesis event.  Without
+    // it the in-memory head only covered a post-restart tail and the built state
+    // would miss earlier events.
+    if !chain_has_genesis(&events) {
+        crate::metrics::record_state_build("chain_walk", "fallback_non_genesis");
+        debug!(
+            execution_id,
+            collected = events.len(),
+            "chain walk: root is not the genesis (restart-spanning tail), falling back"
+        );
+        return Ok(None);
+    }
+
+    // Apply in the SAME order the event-scan path uses (`event_id ASC`): the walk
+    // collected head→root (descending), so sort ascending → from_events sees the
+    // identical sequence → identical state.
+    events.sort_by_key(|e| e.event_id);
+    crate::metrics::record_state_build_chain_hops(events.len());
+    hydrate_result_references(&mut events, result_store, keep_refs).await;
+
+    let ws = crate::engine::state::WorkflowState::from_events(
+        &events.iter().map(Into::into).collect::<Vec<_>>(),
+    )
+    .ok_or_else(|| AppError::Validation("chain walk: from_events produced no state".to_string()))?;
+    let last_event_id = events.iter().map(|e| e.event_id).max().unwrap_or(head);
+    let routing_meta = events
+        .iter()
+        .find(|e| e.event_type == "playbook_started")
+        .and_then(|e| e.meta.clone());
+    let trigger_event_type = events
+        .iter()
+        .find(|e| e.event_id == trigger_event_id)
+        .map(|e| e.event_type.clone())
+        .unwrap_or_else(|| "command.completed".to_string());
+    let latest_ts = events.iter().map(|e| e.created_at).max();
+
+    crate::metrics::record_state_build("chain_walk", "ok");
+    Ok(Some(ChainWalkBuild {
+        result: RebuildResult {
+            state: ws,
+            last_event_id,
+            snapshot_version: 0,
+            routing_meta,
+        },
+        collected: events.len(),
+        trigger_event_type,
+        latest_ts,
+    }))
+}
+
+/// Shadow parity check (RFC #115 Phase 3): compare an event-scan-built state with
+/// a chain-walk-built state for the same execution.  Equality is **structural**
+/// via `serde_json::Value` (order-insensitive for the state's maps).  Records
+/// `noetl_state_build_parity_total{match|mismatch}` and logs a WARN carrying
+/// `execution_id` on mismatch.  Observation-only — the drive uses the configured
+/// `state_build_mode` result, so a parity bug can never change drive behavior.
+fn parity_check_states(
+    execution_id: i64,
+    event_scan: &crate::engine::state::WorkflowState,
+    chain_walk: &crate::engine::state::WorkflowState,
+) {
+    let a = serde_json::to_value(event_scan).ok();
+    let b = serde_json::to_value(chain_walk).ok();
+    if a.is_some() && a == b {
+        crate::metrics::record_state_build_parity("match");
+        debug!(execution_id, "state-build parity OK (chain-walk == event-scan)");
+    } else {
+        crate::metrics::record_state_build_parity("mismatch");
+        warn!(
+            execution_id,
+            "state-build parity MISMATCH: chain-walk state != event-scan state"
+        );
+    }
+}
+
 /// Outcome of advancing one execution's projection snapshot.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SnapshotAdvance {
@@ -2079,6 +2307,94 @@ async fn trigger_orchestrator_inner(
     let cache_slot = state.orch_cache.entry(execution_id);
     let mut cache = cache_slot.lock().await;
 
+    // State-construction outputs shared by both build modes (event-scan and
+    // chain-walk).  Hoisted so the chain-walk branch and the event-scan block
+    // below assign the same locals the downstream drive reads.
+    let mut total: Option<i64> = None;
+    let mut did_rebuild = false;
+    let mut straggler_applied = false;
+    let mut new_events: Vec<crate::db::models::Event> = Vec::new();
+    let mut trigger_event_type = String::new();
+    let mut latest_ts: Option<chrono::DateTime<chrono::Utc>> = None;
+
+    // RFC noetl/ai-meta#115 Phase 3 — chain-walk state build (flagged).  When
+    // `NOETL_STATE_BUILD_MODE=chain_walk`, rebuild `WorkflowState` for this
+    // trigger by walking the `prev_event_id` chain head→root (PK lookups, no
+    // `noetl.event` scan) and skip the event-scan block entirely.  Any
+    // completeness doubt (cold head, missing node under materializer lag, a chain
+    // that doesn't reach the genesis) falls back to event-scan for this trigger —
+    // so correctness is never sacrificed.  The drive logic downstream is
+    // identical; only HOW `cache.state` is built changes.
+    let mut chain_built = false;
+    if matches!(
+        state.config.state_build_mode,
+        crate::config::StateBuildMode::ChainWalk
+    ) {
+        if let Some(cw) = rebuild_state_chain_walk(
+            state,
+            pool,
+            &result_store,
+            execution_id,
+            trigger_event_id,
+            state.config.refs_in_state,
+        )
+        .await?
+        {
+            cache.state = Some(cw.result.state);
+            cache.last_event_id = cw.result.last_event_id;
+            cache.applied_count = cw.collected as i64;
+            cache.snapshot_version = cw.result.snapshot_version;
+            cache.routing_meta = cw.result.routing_meta;
+            cache.last_count_check = Some(std::time::Instant::now());
+            // The full chain rebuild always reflects the latest state, so treat
+            // every chain-walk build like a rebuild: the drive evaluates this
+            // trigger (the drive is idempotent against the current state, gated by
+            // the `orchestrate_in_flight` flag + cursor id-sets).
+            did_rebuild = true;
+            trigger_event_type = cw.trigger_event_type;
+            latest_ts = cw.latest_ts;
+            // total stays None → the projection-snapshot persistence gate below
+            // (`total == Some(applied_count)`) is skipped; chain-walk doesn't
+            // depend on or maintain `projection_snapshot`.
+            chain_built = true;
+        }
+        // else: fell back (metric recorded inside the builder) → run event-scan.
+    }
+
+    // Parity proof (RFC #115 Phase 3): when `NOETL_STATE_BUILD_PARITY_CHECK` is
+    // on, shadow-build the state BOTH ways and assert they match — observation
+    // only (the drive keeps using whichever mode built `cache.state`).  Costs an
+    // extra event-scan rebuild, so it's a validation switch, off in prod.
+    if state.config.state_build_parity_check {
+        let es = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state)
+            .await
+            .ok();
+        let cw = rebuild_state_chain_walk(
+            state,
+            pool,
+            &result_store,
+            execution_id,
+            trigger_event_id,
+            state.config.refs_in_state,
+        )
+        .await
+        .ok()
+        .flatten();
+        if let (Some(es), Some(cw)) = (es, cw) {
+            parity_check_states(execution_id, &es.state, &cw.result.state);
+        }
+    }
+
+    if !chain_built {
+        // Event-scan path: this trigger uses the `noetl.event`-scanning state
+        // construction block.  RFC #115 tenet 3 no-scan proof — with chain_walk
+        // on and no fallback, this counter's delta over a run stays 0.
+        crate::metrics::record_state_build_event_scan();
+    }
+
+    // ===== event-scan state construction (skipped when the chain walk built) ===
+    if !chain_built {
+
     // The consistency `COUNT(*)` over this execution's event partition is
     // O(events) — ≈27ms at 60k events — and only detects a *non-triggering*
     // straggler (an event type that doesn't fire the orchestrator, inserted
@@ -2094,7 +2410,7 @@ async fn trigger_orchestrator_inner(
         || cache
             .last_count_check
             .is_none_or(|t| now.duration_since(t) >= COUNT_THROTTLE);
-    let total: Option<i64> = if do_count {
+    total = if do_count {
         cache.last_count_check = Some(now);
         Some(
             sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
@@ -2108,7 +2424,7 @@ async fn trigger_orchestrator_inner(
 
     // Warm a cold cache from the latest snapshot + events-since (bounded), or
     // the full (still-small) early log when no snapshot exists yet.
-    let mut did_rebuild = false;
+    did_rebuild = false;
     if cache.state.is_none() {
         let r = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await?;
         cache.state = Some(r.state);
@@ -2126,7 +2442,7 @@ async fn trigger_orchestrator_inner(
     // catches the cursor-relevant stragglers (body completions) with no COUNT
     // and no rebuild.  Idempotent: cursor counters are gated by the
     // `cursor_issued`/`cursor_completed` id-sets.
-    let mut straggler_applied = false;
+    straggler_applied = false;
     if !did_rebuild && trigger_event_id <= cache.last_event_id {
         let mut strag = parse_event_rows(
             sqlx::query(&format!(
@@ -2154,7 +2470,7 @@ async fn trigger_orchestrator_inner(
     }
 
     // Events newer than what's applied.
-    let mut new_events: Vec<crate::db::models::Event> = parse_event_rows(
+    new_events = parse_event_rows(
         sqlx::query(&format!(
             "{ORCH_EVENT_COLS} WHERE execution_id = $1 AND event_id > $2 ORDER BY event_id ASC"
         ))
@@ -2168,12 +2484,12 @@ async fn trigger_orchestrator_inner(
     // Trigger type + drain timestamp.  The trigger event is normally among the
     // new events; after a cold rebuild / straggler apply that already folded it
     // in, fall back to a default type (and a None drain timestamp).
-    let trigger_event_type = new_events
+    trigger_event_type = new_events
         .iter()
         .find(|e| e.event_id == trigger_event_id)
         .map(|e| e.event_type.clone())
         .unwrap_or_else(|| "command.completed".to_string());
-    let latest_ts = new_events.last().map(|e| e.created_at);
+    latest_ts = new_events.last().map(|e| e.created_at);
 
     // Consistency.  With a fresh `total`, applying the new events should account
     // for ALL events; a shortfall means a straggler is below the watermark — and
@@ -2204,6 +2520,8 @@ async fn trigger_orchestrator_inner(
             .map(|e| e.event_id)
             .unwrap_or(cache.last_event_id);
     }
+
+    } // end event-scan state construction (`if !chain_built`)
 
     // Terminal-state guard (noetl/ai-meta#113 facet 2).  A cancel
     // (`playbook_cancelled`) — or any terminal event — transitions the cached
@@ -2825,6 +3143,80 @@ async fn emit_playbook_failed(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── RFC #115 Phase 3 — chain-walk state builder ──────────────────────────
+
+    /// Minimal `Event` for the chain-walk ordering tests.
+    fn ev(event_id: i64, prev: Option<i64>, event_type: &str) -> crate::db::models::Event {
+        // `prev` mirrors the chain link a real walk follows; the builder doesn't
+        // store it on `Event` (it's read off the row in `fetch_chain_node`), so
+        // it's only used here to reconstruct the walk order.
+        let _ = prev;
+        crate::db::models::Event {
+            id: event_id,
+            execution_id: 42,
+            catalog_id: 7,
+            event_id,
+            parent_event_id: None,
+            parent_execution_id: None,
+            event_type: event_type.to_string(),
+            node_id: None,
+            node_name: Some("start".to_string()),
+            node_type: None,
+            status: "ok".to_string(),
+            context: None,
+            meta: None,
+            result: None,
+            worker_id: None,
+            attempt: None,
+            created_at: chrono::DateTime::from_timestamp(event_id, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn chain_has_genesis_detects_playbook_started() {
+        let with = vec![ev(1, None, "playbook_started"), ev(2, Some(1), "command.issued")];
+        assert!(chain_has_genesis(&with));
+        // A restart-spanning tail (no genesis) must be rejected so the builder
+        // falls back to event-scan rather than building a partial state.
+        let tail = vec![ev(5, None, "command.completed"), ev(6, Some(5), "command.issued")];
+        assert!(!chain_has_genesis(&tail));
+    }
+
+    #[test]
+    fn chain_walk_collection_matches_event_scan_order() {
+        // Parity by construction: the event-scan path loads events `ORDER BY
+        // event_id ASC`; the chain walk collects them head→root (descending) then
+        // sorts by `event_id` ASC.  Both must hand `from_events` the identical
+        // sequence → identical state.  Here we simulate both orderings and assert
+        // the sorted sequences are equal (the builder calls the SAME from_events).
+        let scan_order = [
+            ev(10, None, "playbook_started"),
+            ev(20, Some(10), "command.issued"),
+            ev(30, Some(20), "command.completed"),
+            ev(40, Some(30), "command.issued"),
+        ];
+        // The walk collects head(40)→root(10): reverse of scan order.
+        let mut walk_collected: Vec<_> = scan_order.iter().rev().cloned().collect();
+        walk_collected.sort_by_key(|e| e.event_id);
+        let scan_ids: Vec<i64> = scan_order.iter().map(|e| e.event_id).collect();
+        let walk_ids: Vec<i64> = walk_collected.iter().map(|e| e.event_id).collect();
+        assert_eq!(
+            scan_ids, walk_ids,
+            "chain-walk sorted order must equal event-scan ORDER BY event_id ASC"
+        );
+
+        // And the states `from_events` produces from each ordering are identical.
+        let scan_state =
+            crate::engine::state::WorkflowState::from_events(&scan_order.iter().map(Into::into).collect::<Vec<_>>());
+        let walk_state =
+            crate::engine::state::WorkflowState::from_events(&walk_collected.iter().map(Into::into).collect::<Vec<_>>());
+        assert_eq!(
+            serde_json::to_value(&scan_state).unwrap(),
+            serde_json::to_value(&walk_state).unwrap(),
+            "chain-walk state must equal event-scan state (parity by construction)"
+        );
+    }
 
     #[test]
     fn with_ref_accessors_injects_locator_keys() {

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2137,28 +2137,187 @@ async fn rebuild_state_chain_walk(
     }))
 }
 
+/// Run the shadow parity check inside ONE `REPEATABLE READ` transaction so both
+/// the chain walk and the bounded event scan observe a single consistent MVCC
+/// snapshot of `noetl.event` (RFC #115 Phase 3 parity proof).  This removes the
+/// race against concurrent materialization — under the publish-only gate the
+/// chain head runs ahead of the materialized table and worker/server `event_id`s
+/// interleave, so two un-isolated reads can legitimately see different sets even
+/// for an identical execution.  Inside one snapshot the two builds collect the
+/// SAME events; any remaining difference is a real builder bug (logged by
+/// [`parity_check_states`] with the differing state keys).
+///
+/// Falls through (records nothing) when the chain head is cold or a chain node
+/// isn't present in the snapshot — those are the same conditions the live builder
+/// falls back on, not parity failures.
+async fn run_parity_check(
+    state: &AppState,
+    pool: &crate::db::DbPool,
+    result_store: &crate::services::result_store::ResultStoreService,
+    execution_id: i64,
+    keep_refs: bool,
+) -> AppResult<()> {
+    use sqlx::Row;
+    let Some(head) = state.chain_heads.head(execution_id) else {
+        return Ok(());
+    };
+    let mut conn = pool.acquire().await?;
+    sqlx::query("BEGIN ISOLATION LEVEL REPEATABLE READ")
+        .execute(&mut *conn)
+        .await?;
+
+    // (1) Walk the chain head→root on the snapshot, collecting nodes by PK.
+    let mut walk_events: Vec<crate::db::models::Event> = Vec::new();
+    let mut cursor = Some(head);
+    let mut complete = true;
+    while let Some(eid) = cursor {
+        let row = sqlx::query(&format!(
+            "{ORCH_EVENT_COLS_WITH_PREV} WHERE execution_id = $1 AND event_id = $2"
+        ))
+        .bind(execution_id)
+        .bind(eid)
+        .fetch_optional(&mut *conn)
+        .await?;
+        let Some(row) = row else {
+            complete = false;
+            break;
+        };
+        let prev: Option<i64> = row.try_get("prev_event_id").ok().flatten();
+        let ev = parse_event_rows(vec![row]).into_iter().next().expect("one row");
+        cursor = prev;
+        walk_events.push(ev);
+    }
+
+    // (2) Bounded scan of the same snapshot up to the walk's head.
+    let max_id = walk_events.iter().map(|e| e.event_id).max();
+    let scan_rows = if let Some(max_id) = max_id {
+        sqlx::query(&format!(
+            "{ORCH_EVENT_COLS} WHERE execution_id = $1 AND event_id <= $2 ORDER BY event_id ASC"
+        ))
+        .bind(execution_id)
+        .bind(max_id)
+        .fetch_all(&mut *conn)
+        .await?
+    } else {
+        Vec::new()
+    };
+    // Read-only — end the snapshot.
+    let _ = sqlx::query("COMMIT").execute(&mut *conn).await;
+    drop(conn);
+
+    // Skip non-parity cases: cold/missing chain or no genesis (the live builder
+    // would fall back here too).
+    if !complete || walk_events.is_empty() || !chain_has_genesis(&walk_events) {
+        return Ok(());
+    }
+    let mut scan_events = parse_event_rows(scan_rows);
+    if scan_events.is_empty() {
+        return Ok(());
+    }
+
+    // Build both states off the consistent snapshot, applying in event_id order.
+    walk_events.sort_by_key(|e| e.event_id);
+    hydrate_result_references(&mut walk_events, result_store, keep_refs).await;
+    hydrate_result_references(&mut scan_events, result_store, keep_refs).await;
+    let cw = crate::engine::state::WorkflowState::from_events(
+        &walk_events.iter().map(Into::into).collect::<Vec<_>>(),
+    );
+    let es = crate::engine::state::WorkflowState::from_events(
+        &scan_events.iter().map(Into::into).collect::<Vec<_>>(),
+    );
+    if let (Some(es), Some(cw)) = (es, cw) {
+        parity_check_states(execution_id, &es, &cw);
+    }
+    Ok(())
+}
+
+/// Wall-clock fields on `WorkflowState` / `StepInfo` that are populated from the
+/// event's `created_at` — which `parse_event_rows` resolves to `Utc::now()`
+/// whenever the column can't be decoded (the deployed `noetl.event.created_at` is
+/// `timestamp without time zone`, which doesn't decode into `DateTime<Utc>`).  So
+/// these timestamps **vary across every reconstruction** in BOTH build paths
+/// (`orchestrate-core/src/state.rs` documents this: "the `Utc::now()` loader
+/// fallback … varies across reconstructions").  They are not part of the logical
+/// state that drives decisions, so the parity comparison excludes them — what's
+/// being proven is that the chain-walk and event-scan builds produce the same
+/// *decision-relevant* state, not the same build-time clock reads.
+const NONDETERMINISTIC_STATE_KEYS: &[&str] = &["started_at", "completed_at", "entered_at"];
+
+/// Canonicalize a JSON value for order-insensitive structural comparison: drop
+/// the non-deterministic wall-clock keys ([`NONDETERMINISTIC_STATE_KEYS`]),
+/// recurse into objects, and **sort every array** by its element's canonical
+/// string form.  `WorkflowState` carries `HashSet` fields (`cursor_completed`,
+/// `iteration_command_ids`) that serialize to JSON arrays in arbitrary order, so
+/// a raw `serde_json::Value` array comparison would flag two logically-identical
+/// states as different.  Sorting is sound for this parity check: both builds
+/// apply events in the same `event_id` order, so any genuinely-ordered array is
+/// already element-equal between them (sorting is a no-op); only the set-backed
+/// arrays need reordering.  A real difference (different elements / lengths /
+/// keys) still survives the sort.
+fn canonicalize_state_json(v: &serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Array(a) => {
+            let mut items: Vec<serde_json::Value> = a.iter().map(canonicalize_state_json).collect();
+            items.sort_by_key(|v| v.to_string());
+            serde_json::Value::Array(items)
+        }
+        serde_json::Value::Object(o) => serde_json::Value::Object(
+            o.iter()
+                .filter(|(k, _)| !NONDETERMINISTIC_STATE_KEYS.contains(&k.as_str()))
+                .map(|(k, val)| (k.clone(), canonicalize_state_json(val)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
 /// Shadow parity check (RFC #115 Phase 3): compare an event-scan-built state with
 /// a chain-walk-built state for the same execution.  Equality is **structural**
-/// via `serde_json::Value` (order-insensitive for the state's maps).  Records
-/// `noetl_state_build_parity_total{match|mismatch}` and logs a WARN carrying
-/// `execution_id` on mismatch.  Observation-only — the drive uses the configured
-/// `state_build_mode` result, so a parity bug can never change drive behavior.
+/// via canonicalized `serde_json::Value` (order-insensitive for the state's maps
+/// AND its `HashSet`-backed arrays).  Records
+/// `noetl_state_build_parity_total{match|mismatch}` and, on mismatch, logs a WARN
+/// naming the differing top-level state keys (with `execution_id`).
+/// Observation-only — the drive uses the configured `state_build_mode` result, so
+/// a parity bug can never change drive behavior.
 fn parity_check_states(
     execution_id: i64,
     event_scan: &crate::engine::state::WorkflowState,
     chain_walk: &crate::engine::state::WorkflowState,
 ) {
-    let a = serde_json::to_value(event_scan).ok();
-    let b = serde_json::to_value(chain_walk).ok();
-    if a.is_some() && a == b {
-        crate::metrics::record_state_build_parity("match");
-        debug!(execution_id, "state-build parity OK (chain-walk == event-scan)");
-    } else {
-        crate::metrics::record_state_build_parity("mismatch");
-        warn!(
-            execution_id,
-            "state-build parity MISMATCH: chain-walk state != event-scan state"
-        );
+    let a = serde_json::to_value(event_scan).map(|v| canonicalize_state_json(&v));
+    let b = serde_json::to_value(chain_walk).map(|v| canonicalize_state_json(&v));
+    match (a, b) {
+        (Ok(a), Ok(b)) if a == b => {
+            crate::metrics::record_state_build_parity("match");
+            debug!(execution_id, "state-build parity OK (chain-walk == event-scan)");
+        }
+        (Ok(a), Ok(b)) => {
+            crate::metrics::record_state_build_parity("mismatch");
+            // Name the differing top-level keys so a mismatch is actionable.
+            let diff_keys: Vec<String> = match (&a, &b) {
+                (serde_json::Value::Object(ma), serde_json::Value::Object(mb)) => {
+                    let mut keys: Vec<String> = ma
+                        .keys()
+                        .chain(mb.keys())
+                        .filter(|k| ma.get(*k) != mb.get(*k))
+                        .cloned()
+                        .collect();
+                    keys.sort();
+                    keys.dedup();
+                    keys
+                }
+                _ => vec!["<root>".to_string()],
+            };
+            warn!(
+                execution_id,
+                diff_keys = %diff_keys.join(","),
+                "state-build parity MISMATCH: chain-walk state != event-scan state"
+            );
+        }
+        _ => {
+            crate::metrics::record_state_build_parity("mismatch");
+            warn!(execution_id, "state-build parity: a state failed to serialize");
+        }
     }
 }
 
@@ -2362,26 +2521,24 @@ async fn trigger_orchestrator_inner(
     }
 
     // Parity proof (RFC #115 Phase 3): when `NOETL_STATE_BUILD_PARITY_CHECK` is
-    // on, shadow-build the state BOTH ways and assert they match — observation
-    // only (the drive keeps using whichever mode built `cache.state`).  Costs an
-    // extra event-scan rebuild, so it's a validation switch, off in prod.
+    // on, shadow-build the state BOTH ways from ONE consistent DB snapshot and
+    // assert they match — observation only (the drive keeps using whichever mode
+    // built `cache.state`).  Reading both representations inside a single
+    // `REPEATABLE READ` transaction removes the race against concurrent
+    // materialization (and the cross-machine `event_id` interleave), so a
+    // mismatch is a real builder bug, not a timing artifact.  Validation switch;
+    // off in prod.
     if state.config.state_build_parity_check {
-        let es = rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state)
-            .await
-            .ok();
-        let cw = rebuild_state_chain_walk(
+        if let Err(e) = run_parity_check(
             state,
             pool,
             &result_store,
             execution_id,
-            trigger_event_id,
             state.config.refs_in_state,
         )
         .await
-        .ok()
-        .flatten();
-        if let (Some(es), Some(cw)) = (es, cw) {
-            parity_check_states(execution_id, &es.state, &cw.result.state);
+        {
+            debug!(execution_id, %e, "parity check skipped (read error)");
         }
     }
 
@@ -3181,6 +3338,34 @@ mod tests {
         // falls back to event-scan rather than building a partial state.
         let tail = vec![ev(5, None, "command.completed"), ev(6, Some(5), "command.issued")];
         assert!(!chain_has_genesis(&tail));
+    }
+
+    #[test]
+    fn canonicalize_strips_timestamps_and_sorts_arrays() {
+        // Two logically-identical states that differ only in (a) the order of a
+        // HashSet-backed array and (b) the non-deterministic wall-clock fields
+        // must canonicalize equal — that's what makes the parity check robust to
+        // serialization order + the `Utc::now()` created_at fallback.
+        let a = serde_json::json!({
+            "state": "InProgress",
+            "started_at": "2026-06-19T22:56:40Z",
+            "steps": { "s1": { "status": "done", "completed_at": "2026-06-19T22:56:41Z",
+                               "cursor_completed": ["b", "a", "c"] } }
+        });
+        let b = serde_json::json!({
+            "state": "InProgress",
+            "started_at": "2026-06-19T23:03:43Z",   // different clock read
+            "steps": { "s1": { "status": "done", "completed_at": "2026-06-19T23:03:44Z",
+                               "cursor_completed": ["c", "b", "a"] } } // different set order
+        });
+        assert_eq!(
+            canonicalize_state_json(&a),
+            canonicalize_state_json(&b),
+            "states differing only in set order + wall-clock fields must canonicalize equal"
+        );
+        // A real logical difference still survives canonicalization.
+        let c = serde_json::json!({ "state": "Completed", "steps": {} });
+        assert_ne!(canonicalize_state_json(&a), canonicalize_state_json(&c));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -54,7 +54,7 @@
 use std::sync::OnceLock;
 
 use prometheus::{
-    HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder,
+    Histogram, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder,
 };
 
 /// Bucket boundaries for the event-ingest histogram (seconds).
@@ -147,6 +147,123 @@ pub fn orchestrate_drive_total() -> &'static IntCounterVec {
 /// `decode_error` / `skipped_in_flight`).
 pub fn record_orchestrate_drive(stage: &str) {
     orchestrate_drive_total().with_label_values(&[stage]).inc();
+}
+
+// ── State-build mode (RFC noetl/ai-meta#115 Phase 3) ─────────────────────────
+
+/// `noetl_state_build_total{mode, outcome}` — how the drive built `WorkflowState`
+/// for a trigger. `mode` = `chain_walk` | `event_scan`. `outcome` = `ok`
+/// (built via that mode) | `fallback_cold_head` / `fallback_node_missing` /
+/// `fallback_non_genesis` / `fallback_empty` (chain_walk asked for, but a guard
+/// sent it to the event-scan path — correctness preserved). Watching
+/// `chain_walk/ok` vs the `fallback_*` outcomes shows how often the in-memory
+/// chain head served the build without a scan.
+pub fn state_build_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_state_build_total",
+                "Orchestrator WorkflowState builds, by mode and outcome (RFC #115 Phase 3).",
+            ),
+            &["mode", "outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one state build (`mode` = `chain_walk`|`event_scan`; `outcome` = `ok`
+/// or a `fallback_*` reason).
+pub fn record_state_build(mode: &str, outcome: &str) {
+    state_build_total().with_label_values(&[mode, outcome]).inc();
+}
+
+/// `noetl_state_build_event_scans_total` — incremented once each time the drive
+/// path enters the **event-scan** state-construction block (the block that issues
+/// `WHERE execution_id = $1 …` scans of `noetl.event`: the consistency `COUNT`,
+/// the `event_id > $2` window, and the bounded `rebuild_state`). This is the
+/// no-scan proof counter for RFC #115 tenet 3: with `NOETL_STATE_BUILD_MODE=chain_walk`
+/// and no fallback, the drive never enters that block, so this counter's delta
+/// over a run is **0** while `noetl_state_build_chain_hops` shows the PK-only walk
+/// did the work.
+pub fn state_build_event_scans_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_state_build_event_scans_total",
+            "Times the drive entered the noetl.event-scanning state-build block (RFC #115 \
+             tenet 3 no-scan proof; chain_walk keeps this at 0).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record that the drive used the event-scanning state-build path for a trigger.
+pub fn record_state_build_event_scan() {
+    state_build_event_scans_total().inc();
+}
+
+/// `noetl_state_build_chain_hops` — distribution of chain-walk depth (number of
+/// `(execution_id, event_id)` PK lookups) per successful chain-walk build. Each
+/// observation == the events collected by following `prev_event_id` head→root.
+/// Non-zero observations are the positive evidence the PK-only walk is doing the
+/// state construction.
+pub fn state_build_chain_hops() -> &'static Histogram {
+    static M: OnceLock<Histogram> = OnceLock::new();
+    M.get_or_init(|| {
+        let hist = Histogram::with_opts(
+            HistogramOpts::new(
+                "noetl_state_build_chain_hops",
+                "Chain-walk depth (prev_event_id PK lookups) per state build (RFC #115 Phase 3).",
+            )
+            .buckets(vec![1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]),
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(hist.clone()))
+            .expect("histogram registration must succeed");
+        hist
+    })
+}
+
+/// Record the depth of one chain-walk build.
+pub fn record_state_build_chain_hops(hops: usize) {
+    state_build_chain_hops().observe(hops as f64);
+}
+
+/// `noetl_state_build_parity_total{result}` — when `NOETL_STATE_BUILD_PARITY_CHECK`
+/// is on, each shadow comparison of the event-scan vs chain-walk build records
+/// `match` or `mismatch`. A non-zero `mismatch` is a correctness alarm (the two
+/// builders disagree for an execution) and is the parity proof's failure signal.
+pub fn state_build_parity_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_state_build_parity_total",
+                "Shadow event-scan vs chain-walk state-build comparisons, by result (RFC #115).",
+            ),
+            &["result"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one parity-check result (`match` | `mismatch`).
+pub fn record_state_build_parity(result: &str) {
+    state_build_parity_total().with_label_values(&[result]).inc();
 }
 
 /// Histogram: wall-clock time spent inside the `POST /api/events` handler.


### PR DESCRIPTION
## Summary

RFC [noetl/ai-meta#115](https://github.com/noetl/ai-meta/issues/115) **Phase 3** — the chain-walk state builder. Reconstructs orchestrator `WorkflowState` by following the one-level `prev_event_id` chain (Phase 2) from the in-memory chain head back to the genesis event, instead of `rebuild_state`'s `WHERE execution_id = $1 …` scan of `noetl.event`. Server-side, **flagged**, conservative — the event-scan path stays the default and the fallback.

This proves tenets 3 (no `noetl.event` scan) and 4 (one-level chain walk) **in-process** before the off-server builder + cache (Phase 4).

## Design

- **`NOETL_STATE_BUILD_MODE=chain_walk|event_scan`** (default `event_scan` — **prod/default behavior unchanged**). In `chain_walk` mode the drive builds state for each trigger by walking the chain:
  - head from the in-memory `ChainHeads` watermark (**no DB read**);
  - `fetch_chain_node` PK lookups (`WHERE execution_id=$1 AND event_id=$2`) head→root — **never** a `WHERE execution_id` scan;
  - collected events sorted by `event_id` and fed to the SAME `WorkflowState::from_events` → the built state is equivalent to the event-scan build (**parity by construction**).
- **Conservative fallbacks** (correctness never sacrificed) — cold head, a node not yet materialized (publish-only-gate lag) / dangling link, or a chain that doesn't reach the `playbook_started` genesis all fall back to event-scan for that trigger, counted via `noetl_state_build_total{mode,outcome}`.
- **`orchestrate-core` unchanged** — `from_events` reused as-is. Server-only, no crate cascade.
- **`NOETL_STATE_BUILD_PARITY_CHECK`** (default false) — a validation switch that shadow-builds the state both ways inside one `REPEATABLE READ` transaction and asserts structural equality (`noetl_state_build_parity_total{match|mismatch}`); observation-only, the drive uses the configured mode.

### Observability
- `noetl_state_build_total{mode,outcome}` — builds by mode + outcome (`ok` / `fallback_*`).
- `noetl_state_build_event_scans_total` — incremented only when the drive enters the event-scan block; **the no-scan proof counter** (0 under chain_walk with no fallback).
- `noetl_state_build_chain_hops` — PK-walk depth per build.
- `noetl_state_build_parity_total{result}`.

## Validation (kind, gate-ON: `PUBLISH_ONLY` + off-server drive + materializer sole-writer)

Representative topologies: linear (`simple_python`), loop (`loop_test`, 62 ev), fan-out+reduce (`fanout_reduce_phase6`), + the Phase-1 fixtures `output_select` (31 ev) and `storage_tiers` (55 ev).

- **Parity — 41/41 MATCH, 0 mismatch.** With the transaction-isolated, normalized comparison the chain-walk state == event-scan state for every trigger. (The check surfaced a pre-existing non-determinism — `noetl.event.created_at` is `timestamp without time zone`, so `parse_event_rows` resolves it to `Utc::now()`, making `started_at`/`entered_at`/`completed_at` vary across *every* reconstruction in both build paths; these wall-clock fields are excluded from the decision-relevant comparison, as orchestrate-core already documents.)
- **Structural parity (SQL, quiescent):** recursive `prev_event_id` walk reconstructs the exact event set the scan reads — `walk_reached == total`, 1 root, 0 dup-prev across all topologies (13/62/25/31/55).
- **No-scan:** in `chain_walk` mode, `noetl_state_build_event_scans_total` stayed **0** across 40 drive builds (1064 PK hops, 0 fallbacks). The drive issued zero `noetl.event` scans.
- **Behavioral parity:** all fixtures COMPLETE in `chain_walk` mode (same decisions / completion as event_scan).
- **Sole-writer + gate:** per-exec `event_rows == distinct_ids`, `catalog_id=0` rows = 0, `__orchestrate__` event rows = 0, materializer lag = 0. The committed `kind_validate_orchestrate_gate.sh` rig **PASS** in chain_walk mode.
- **Regression:** 577 lib tests (+4: config default/parse, genesis guard, parity-by-construction ordering, canonicalize) + clippy green. PROD untouched; no gate / mode default changed.

## What Phase 4 builds on this
The off-server `system/state_builder` (WASM, system pool) reuses this walk over the WAL with a pool-side cache keyed by the immutable chain head — eliminating the materializer-lag fallback (it reads the WAL, not the materialized table) and the per-trigger full re-walk (it advances only the new tail).

Refs noetl/ai-meta#115