### PR TITLE
Route the off-server drive to the pool-side WAL builder (RFC #115 Phase 4 cutover)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2802,11 +2802,28 @@ async fn trigger_orchestrator_inner(
             .as_ref()
             .map(crate::handlers::execute::CommandRouting::from_started_meta)
             .unwrap_or_default();
+        // Off-server drive cutover (RFC #115 Phase 4): under
+        // `NOETL_STATE_BUILDER=offserver` the drive obtains its `WorkflowState`
+        // from the pool-side WAL builder (the worker walks the `prev_event_id`
+        // chain off the `noetl_events` WAL and feeds the spine to the wasm `run`
+        // / from_events entry — state CONSTRUCTION runs off the server).  We mark
+        // the command `__offserver_build__` + carry `execution_id` so the worker
+        // self-sources the spine; the server-built `state` rides along as the
+        // **fallback** the worker uses only when its WAL chain is incomplete
+        // (lag / cold) — so progress + correctness never regress below the
+        // server-built `run_state` path.  Default `server` → the state is the
+        // sole drive input exactly as today.
+        let offserver = matches!(
+            state.config.state_builder,
+            crate::config::StateBuilder::Offserver
+        );
         let input = serde_json::json!({
             "state": cache.state.as_ref().expect("state present after rebuild"),
             "latest_ts": latest_ts,
             "playbook": &playbook,
             "trigger_event_type": trigger_event_type,
+            "__offserver_build__": offserver,
+            "execution_id": execution_id,
         });
         crate::handlers::execute::dispatch_orchestrate_command(
             state,
@@ -2819,7 +2836,15 @@ async fn trigger_orchestrator_inner(
         )
         .await?;
         cache.orchestrate_in_flight = true;
-        debug!(execution_id, "worker-driven: dispatched system/orchestrate to the pool");
+        crate::metrics::record_orchestrate_drive(if offserver {
+            "dispatched_offserver"
+        } else {
+            "dispatched"
+        });
+        debug!(
+            execution_id,
+            offserver, "worker-driven: dispatched system/orchestrate to the pool"
+        );
         return Ok(0);
     }
 

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2824,6 +2824,12 @@ async fn trigger_orchestrator_inner(
             "trigger_event_type": trigger_event_type,
             "__offserver_build__": offserver,
             "execution_id": execution_id,
+            // The server's dispatch watermark (the highest event applied to the
+            // server-built state).  The worker's WAL build serves only once its
+            // pool-side index has caught up to this head — so the off-server
+            // state is never staler than the server's view, which prevents a
+            // lag-induced re-issue of a fan-in barrier step (RFC #115 Phase 4).
+            "expected_head": cache.last_event_id,
         });
         crate::handlers::execute::dispatch_orchestrate_command(
             state,


### PR DESCRIPTION
Under `NOETL_STATE_BUILDER=offserver`, the worker-driven orchestrate dispatch marks the `system/orchestrate` command `__offserver_build__` and carries `execution_id`, so the system worker pool builds the drive's `WorkflowState` from the `noetl_events` WAL spine (the wasm `run`/from_events entry) instead of the server building it and shipping it via `run_state`.

## What changed
- **`trigger_orchestrator_inner`** — adds the offserver markers to the orchestrate input; the server-built `state` still rides along as the worker's **fallback** for an incomplete WAL chain (lag/cold). Records `noetl_orchestrate_drive_total{stage="dispatched_offserver"}`.

## Conservatism
Default `StateBuilder::Server` unchanged — the server-built state stays the sole drive input exactly as today. The worker's fallback means the worst case (incomplete WAL) equals today's `run_state` path. The server retains its chain-walk/event-scan bookkeeping for terminal/cancel/`catalog_id`/routing correctness; eliminating that residual server-side rebuild (the full "zero server reads") is the **precisely-staged remainder** of Phase 4.

Pairs with noetl/worker#119 (the pool-side build) + noetl/ops (the `NOETL_STATE_BUILDER` knob) + noetl/e2e (the gate-ON parity rig). Validated on gate-ON kind.

Builds on the `NOETL_STATE_BUILDER` flag scaffold (server#246, v3.33.0).

See noetl/ai-meta#115