### PR TITLE
Stateless off-server drive edge — zero state rebuild + zero noetl.event reads under offserver (RFC #115 Phase 4 remainder)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -237,14 +237,16 @@ pub struct AppConfig {
     ///   builder (which walks the `prev_event_id` chain from the `noetl_events`
     ///   **WAL** stream and caches the built spine keyed by the immutable chain
     ///   head — `noetl-worker`'s `state_builder`), so the server stops building
-    ///   state on the hot path.  The server chain-walk + event-scan stay as the
-    ///   fallbacks.
+    ///   state on the hot path.  Phase 4 remainder (noetl/ai-meta#107 step 2):
+    ///   the server edge is now **stateless** on the drive path — with a warm
+    ///   execute-time descriptor (catalog_id + routing seeded at
+    ///   `playbook_started`, terminal stamped at the emit chokepoint, the
+    ///   dispatch watermark read from the in-memory `ChainHeads`) the drive
+    ///   routes the command performing ZERO `noetl.event` reads + ZERO state
+    ///   rebuild; the worker self-sources the spine.  The server chain-walk +
+    ///   event-scan stay as the fallbacks (cold descriptor after a restart).
     ///
-    /// **Default `server`** — prod/default behavior is unchanged.  The
-    /// `offserver` drive-cutover wiring is staged behind this flag (the
-    /// pool-side builder + its WAL shadow loop land first — `noetl-worker`
-    /// `state_builder` + `NOETL_STATE_BUILDER_SHADOW`); flipping this to
-    /// `offserver` before that wiring lands is a no-op on the build path.
+    /// **Default `server`** — prod/default behavior is unchanged.
     #[serde(default)]
     pub state_builder: StateBuilder,
 }

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -219,6 +219,24 @@ pub async fn should_publish(state: &AppState, catalog_id: i64) -> bool {
         && !is_system_execution(state, catalog_id).await
 }
 
+/// Is this a terminal execution event?  Both the dotted (`playbook.completed`)
+/// and underscore (`playbook_completed`) spellings exist in the codebase — the
+/// cancel/finalize chokepoint emits the underscore form, the orchestrator emits
+/// the dotted form — so match both.  Mirror of `ExecutionState`'s terminal
+/// detection in `orchestrate-core::state` (`from_str` + `apply_event`).  Used to
+/// stamp the stateless-drive terminal flag at the [`emit_events`] chokepoint.
+fn is_terminal_event_type(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "playbook.completed"
+            | "playbook_completed"
+            | "playbook.failed"
+            | "playbook_failed"
+            | "playbook.cancelled"
+            | "playbook_cancelled"
+    )
+}
+
 /// Lazily build (once) + return the `noetl_events` publisher.  Returns `None`
 /// only if NATS is absent or the stream can't be ensured — callers then fall
 /// back to the synchronous INSERT.
@@ -267,6 +285,15 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     // built per execution), so a single linkage call covers them in order.
     let rows: Vec<EventRow> = {
         let execution_id = rows[0].execution_id;
+        // Stateless off-server drive edge (RFC #115 Phase 4 remainder): stamp the
+        // execute-time descriptor's terminal flag when a terminal event passes
+        // through this chokepoint (cancel via `services::execution::cancel`,
+        // finalize, the orchestrator's own `playbook.completed`/`.failed`).  The
+        // stateless drive reads this flag to stop re-dispatching a terminal
+        // execution WITHOUT rebuilding `WorkflowState` to call `is_terminal()`.
+        if rows.iter().any(|r| is_terminal_event_type(&r.event_type)) {
+            state.exec_descriptors.mark_terminal(execution_id);
+        }
         let ids: Vec<i64> = rows.iter().map(|r| r.event_id).collect();
         let prevs = state.chain_heads.link_batch(execution_id, &ids);
         rows.iter()
@@ -356,6 +383,27 @@ mod tests {
         )
         .with_node("step1")
         .with_result(json!({"status": "success"}))
+    }
+
+    #[test]
+    fn terminal_event_types_cover_both_spellings() {
+        // RFC #115 Phase 4 remainder — the stateless drive's terminal flag is
+        // stamped from this predicate.  The cancel/finalize chokepoint emits the
+        // underscore form; the orchestrator emits the dotted form.  Both must be
+        // recognized, and non-terminal types must not stamp.
+        for t in [
+            "playbook.completed",
+            "playbook_completed",
+            "playbook.failed",
+            "playbook_failed",
+            "playbook.cancelled",
+            "playbook_cancelled",
+        ] {
+            assert!(is_terminal_event_type(t), "{t} must be terminal");
+        }
+        for t in ["command.completed", "command.failed", "step.enter", "playbook_started"] {
+            assert!(!is_terminal_event_type(t), "{t} must NOT be terminal");
+        }
     }
 
     #[test]

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2420,6 +2420,118 @@ pub fn spawn_orchestrator_reconciler(state: AppState) {
     });
 }
 
+/// Stateless off-server drive dispatch (RFC #115 Phase 4 remainder,
+/// noetl/ai-meta#107 step 2).  Routes a `system/orchestrate` command to the
+/// worker pool WITHOUT the server building `WorkflowState` — the worker
+/// constructs state from the `noetl_events` WAL spine (the wasm `run` /
+/// from_events entry).  The server performs ZERO `noetl.event` reads here:
+///
+/// - `catalog_id` + `routing` come from the execute-time descriptor.
+/// - `expected_head` (the staleness-guard watermark) comes from the in-memory
+///   [`crate::state::ChainHeads`] — the highest event the server has emitted for
+///   this execution — not from a counted/scanned state.
+/// - terminal detection comes from the descriptor's `terminal` flag, stamped at
+///   the emit chokepoint (cancel / finalize / playbook completed|failed).
+/// - the worker resolves `trigger_event_type` off its WAL index from
+///   `trigger_event_id` (no server-side event read to classify the trigger).
+///
+/// No server-built `state` rides the command (the warm path ships none); an
+/// incomplete WAL chain on the worker after its bounded retry is a benign no-op
+/// that the reconcile poller re-drives once the drain catches up — so progress is
+/// guaranteed and no partial state is ever built.  Loading the playbook YAML by
+/// `catalog_id` from `noetl.catalog` is a PK lookup on the cluster catalog table,
+/// NOT a `noetl.event` read.
+async fn dispatch_offserver_stateless_drive(
+    state: &AppState,
+    execution_id: i64,
+    trigger_event_id: i64,
+    desc: &crate::state::ExecDescriptor,
+) -> AppResult<i32> {
+    // Terminal guard — no event read.  A cancel/finalize/completion already
+    // stamped the descriptor; stop re-dispatching and free the in-memory state.
+    if desc.terminal {
+        state.exec_descriptors.evict(execution_id);
+        state.orch_cache.evict(execution_id);
+        state.chain_heads.evict(execution_id);
+        crate::metrics::record_orchestrate_drive("stateless_terminal_skip");
+        debug!(
+            execution_id,
+            "stateless drive: execution terminal (descriptor flag); evicted, no dispatch"
+        );
+        return Ok(0);
+    }
+
+    // Per-execution serialise: reuse the orch_cache slot purely as the in-flight
+    // lock (we never build `cache.state` on this path).  Two near-simultaneous
+    // triggers / the reconcile poller must not double-issue the drive.
+    let cache_slot = state.orch_cache.entry(execution_id);
+    let mut cache = cache_slot.lock().await;
+    if cache.orchestrate_in_flight {
+        crate::metrics::record_orchestrate_drive("skipped_in_flight");
+        debug!(execution_id, "stateless drive: orchestrate already in flight; skip");
+        return Ok(0);
+    }
+
+    let catalog_id = desc.catalog_id;
+    let routing = desc
+        .routing_meta
+        .as_ref()
+        .map(crate::handlers::execute::CommandRouting::from_started_meta)
+        .unwrap_or_default();
+
+    // Dispatch watermark from the in-memory chain head — NO DB read.  The worker
+    // serves the WAL build only once its pool-side index has caught up to this,
+    // so the off-server state is never staler than the server's view.
+    let expected_head = state.chain_heads.head(execution_id).unwrap_or(0);
+
+    // Playbook content — PK lookup on the cluster `noetl.catalog` table (not a
+    // `noetl.event` read).
+    let playbook_yaml: String =
+        sqlx::query_scalar("SELECT content FROM noetl.catalog WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .fetch_one(state.pools.cluster())
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!(
+                    "stateless drive: load playbook for catalog_id {catalog_id}: {e}"
+                ))
+            })?;
+    let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
+
+    let input = serde_json::json!({
+        "__offserver_build__": true,
+        // No server-built `state` fallback rides the stateless command; the
+        // worker self-sources the spine from the WAL.  The marker tells the
+        // worker that an incomplete chain is a no-op (reconcile re-drives),
+        // not a fall-through to a (now absent) server-built state.
+        "__stateless__": true,
+        "execution_id": execution_id,
+        // The worker resolves `trigger_event_type` off its WAL index from this
+        // id (no server event read to classify the trigger).
+        "trigger_event_id": trigger_event_id,
+        "playbook": &playbook,
+        "expected_head": expected_head,
+    });
+
+    crate::handlers::execute::dispatch_orchestrate_command(
+        state,
+        execution_id,
+        catalog_id,
+        trigger_event_id,
+        input,
+        &playbook,
+        &routing,
+    )
+    .await?;
+    cache.orchestrate_in_flight = true;
+    crate::metrics::record_orchestrate_drive("dispatched_offserver_stateless");
+    debug!(
+        execution_id,
+        expected_head, "stateless drive: dispatched system/orchestrate (no server state build)"
+    );
+    Ok(0)
+}
+
 /// Orchestrator trigger.  `force_count` is set by the background reconcile
 /// poller ([`spawn_orchestrator_reconciler`]): it forces a fresh consistency
 /// `COUNT` (bypassing the throttle) and proceeds to evaluate even when no new
@@ -2439,6 +2551,39 @@ async fn trigger_orchestrator_inner(
         execution_id,
         trigger_event_id, force_count, "trigger_orchestrator: loading events"
     );
+
+    // Stateless off-server drive edge (RFC #115 Phase 4 remainder,
+    // noetl/ai-meta#107 step 2).  Under `NOETL_STATE_BUILDER=offserver` +
+    // worker-driven drive, when we hold a warm execute-time descriptor (catalog_id
+    // + routing seeded at `playbook_started`), route the drive WITHOUT building
+    // `WorkflowState` on the server — state CONSTRUCTION runs on the worker pool
+    // from the WAL spine.  The server reads ZERO `noetl.event` rows on this path:
+    // catalog_id + routing come from the descriptor, the dispatch watermark
+    // (`expected_head`) from the in-memory `ChainHeads`, terminal detection from
+    // the descriptor's emit-stamped flag.  A cold descriptor (server restart) or
+    // the in-process drive falls through to the server-built path below — which
+    // re-seeds the descriptor and ships the built state as the worker's
+    // incomplete-WAL fallback — so correctness never regresses below today.
+    if state.config.orchestrate_plugin_drive
+        && matches!(
+            state.config.state_builder,
+            crate::config::StateBuilder::Offserver
+        )
+    {
+        if let Some(desc) = state.exec_descriptors.get(execution_id) {
+            if desc.catalog_id != 0 {
+                return dispatch_offserver_stateless_drive(
+                    state,
+                    execution_id,
+                    trigger_event_id,
+                    &desc,
+                )
+                .await;
+            }
+        }
+        // Cold/incomplete descriptor → fall through to the server-built path,
+        // which re-seeds the descriptor so subsequent drives go stateless.
+    }
 
     // 1. Incremental state with bounded rebuild (noetl/ai-meta#100, #101 block b).
     //
@@ -2697,6 +2842,7 @@ async fn trigger_orchestrator_inner(
         drop(cache);
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
+        state.exec_descriptors.evict(execution_id); // RFC #115 Phase 4 remainder
         debug!(
             execution_id,
             state = ?st,
@@ -2759,6 +2905,15 @@ async fn trigger_orchestrator_inner(
             "No catalog_id found for execution {execution_id}"
         )));
     }
+
+    // Re-seed the execute-time descriptor from this server-built pass (RFC #115
+    // Phase 4 remainder).  This path runs when the descriptor was cold (a server
+    // restart mid-execution), so seeding catalog_id + the cached routing meta
+    // here lets the NEXT trigger take the stateless branch — the server reads
+    // `noetl.event` only on this recovery pass, then goes scan-free.
+    state
+        .exec_descriptors
+        .seed(execution_id, catalog_id, cache.routing_meta.clone());
 
     // Phase F R4-3: noetl.catalog is a cluster-wide table.
     let playbook_yaml: String =
@@ -2932,6 +3087,7 @@ async fn trigger_orchestrator_inner(
         drop(cache);
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
+        state.exec_descriptors.evict(execution_id); // RFC #115 Phase 4 remainder
     }
 
     Ok(commands_generated)
@@ -3047,6 +3203,23 @@ async fn apply_orchestration_result(
 /// Recursively find the `output_b64` string a wasm plug-in's tool result carries
 /// (the worker base64-wraps the plug-in's output bytes; the exact nesting
 /// depends on the result-envelope shape, so search rather than assume a path).
+/// Find a `true` boolean flag by key anywhere in the value (the worker's
+/// `call.done` result nests its data under tool-result envelopes).  Used to
+/// detect the stateless-drive `__offserver_retry__` no-op marker (RFC #115
+/// Phase 4 remainder).
+fn find_bool_flag(v: &serde_json::Value, key: &str) -> bool {
+    match v {
+        serde_json::Value::Object(m) => {
+            if m.get(key).and_then(|x| x.as_bool()) == Some(true) {
+                return true;
+            }
+            m.values().any(|x| find_bool_flag(x, key))
+        }
+        serde_json::Value::Array(a) => a.iter().any(|x| find_bool_flag(x, key)),
+        _ => false,
+    }
+}
+
 fn find_output_b64(v: &serde_json::Value) -> Option<&str> {
     match v {
         serde_json::Value::Object(m) => {
@@ -3112,6 +3285,21 @@ async fn apply_worker_orchestration(
     let cache_slot = state.orch_cache.entry(execution_id);
     let mut cache = cache_slot.lock().await;
     cache.orchestrate_in_flight = false;
+
+    // Stateless off-server retry (RFC #115 Phase 4 remainder): a stateless drive
+    // whose WAL chain was still incomplete after the worker's bounded retry
+    // returns a benign no-op marker instead of a built result (no server-built
+    // state fallback rides the stateless command).  This is NOT a decode error —
+    // clear in-flight (already done) and let the reconcile poller re-drive once
+    // the pool-side drain catches up.  No state read, no command issued.
+    if find_bool_flag(payload, "__offserver_retry__") {
+        crate::metrics::record_orchestrate_drive("offserver_retry");
+        debug!(
+            execution_id,
+            "stateless drive: worker WAL incomplete; benign no-op, reconcile will re-drive"
+        );
+        return Ok(0);
+    }
 
     // Inline path: the drive result fit the worker's inline budget
     // (`NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES`, default 100KB) and rides the
@@ -3185,73 +3373,114 @@ async fn apply_worker_orchestration(
         return Ok(0);
     };
 
-    // Cold cache on apply (noetl/ai-meta#104 — off-server-drive × gate
-    // crash-recovery).  The orch_cache only evicts on terminal, so a cold slot
-    // here means the server restarted between dispatching this `__orchestrate__`
-    // command and receiving its `call.done` (the off-server round-trip — NATS →
-    // worker → drive → call.done — widens that window vs the in-process drive).
-    // Dropping the result would strand the execution: no next command is issued,
-    // no further real event fires a trigger, and the reconcile poller only
-    // re-drives executions still in `active_executions()` (empty after restart).
-    // Instead rebuild `WorkflowState` from the durable log — under PUBLISH_ONLY
-    // that log is the materializer's projection of the NATS WAL, the same source
-    // the warm trigger reads — so the drive result applies onto consistent
-    // committed state.  Idempotent: `apply_orchestration_result` issues commands
-    // keyed by deterministic `command_id`, and the cursor counters are gated by
-    // the `cursor_issued`/`cursor_completed` id-sets, so a re-applied result is a
-    // forward no-op rather than a double-issue.
-    if cache.state.is_none() {
-        let pool = state.pools.pool_for(execution_id);
-        let result_store = crate::services::result_store::ResultStoreService::new(
-            pool.clone(),
-            state.snowflake.clone(),
-        );
-        match rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await {
-            Ok(r) => {
-                let total: i64 =
-                    sqlx::query_scalar("SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1")
-                        .bind(execution_id)
-                        .fetch_one(pool)
-                        .await
-                        .unwrap_or(0);
-                cache.last_event_id = r.last_event_id;
-                cache.applied_count = total;
-                cache.snapshot_version = r.snapshot_version;
-                cache.routing_meta = r.routing_meta;
-                cache.state = Some(r.state);
-                crate::metrics::record_orchestrate_drive("cold_rebuild");
-                info!(
-                    execution_id,
-                    "worker-driven: cold cache on apply — rebuilt WorkflowState from the durable \
-                     log before applying (crash-recovery, noetl/ai-meta#104)"
-                );
+    // Stateless off-server apply (RFC #115 Phase 4 remainder): under
+    // `NOETL_STATE_BUILDER=offserver` with a warm execute-time descriptor, the
+    // worker built + drove the state from the WAL; applying its result needs only
+    // `catalog_id` + `routing` (both from the descriptor) + the playbook —
+    // `apply_orchestration_result` issues `result.commands`, it does not read
+    // `cache.state`.  So skip the cold-rebuild ENTIRELY (no `noetl.event` read on
+    // the apply side of the drive path either).  A cold descriptor falls through
+    // to the crash-recovery rebuild below.
+    let offserver_apply = matches!(
+        state.config.state_builder,
+        crate::config::StateBuilder::Offserver
+    )
+    .then(|| state.exec_descriptors.get(execution_id))
+    .flatten()
+    .filter(|d| d.catalog_id != 0);
+
+    let (catalog_id, routing) = if let Some(desc) = offserver_apply {
+        crate::metrics::record_orchestrate_drive("applied_stateless");
+        (
+            desc.catalog_id,
+            desc.routing_meta
+                .as_ref()
+                .map(crate::handlers::execute::CommandRouting::from_started_meta)
+                .unwrap_or_default(),
+        )
+    } else {
+        // Cold cache on apply (noetl/ai-meta#104 — off-server-drive × gate
+        // crash-recovery).  The orch_cache only evicts on terminal, so a cold slot
+        // here means the server restarted between dispatching this `__orchestrate__`
+        // command and receiving its `call.done` (the off-server round-trip — NATS →
+        // worker → drive → call.done — widens that window vs the in-process drive).
+        // Dropping the result would strand the execution: no next command is issued,
+        // no further real event fires a trigger, and the reconcile poller only
+        // re-drives executions still in `active_executions()` (empty after restart).
+        // Instead rebuild `WorkflowState` from the durable log — under PUBLISH_ONLY
+        // that log is the materializer's projection of the NATS WAL, the same source
+        // the warm trigger reads — so the drive result applies onto consistent
+        // committed state.  Idempotent: `apply_orchestration_result` issues commands
+        // keyed by deterministic `command_id`, and the cursor counters are gated by
+        // the `cursor_issued`/`cursor_completed` id-sets, so a re-applied result is a
+        // forward no-op rather than a double-issue.
+        if cache.state.is_none() {
+            let pool = state.pools.pool_for(execution_id);
+            let result_store = crate::services::result_store::ResultStoreService::new(
+                pool.clone(),
+                state.snowflake.clone(),
+            );
+            match rebuild_state(pool, &result_store, execution_id, state.config.refs_in_state).await
+            {
+                Ok(r) => {
+                    let total: i64 = sqlx::query_scalar(
+                        "SELECT COUNT(*) FROM noetl.event WHERE execution_id = $1",
+                    )
+                    .bind(execution_id)
+                    .fetch_one(pool)
+                    .await
+                    .unwrap_or(0);
+                    cache.last_event_id = r.last_event_id;
+                    cache.applied_count = total;
+                    cache.snapshot_version = r.snapshot_version;
+                    cache.routing_meta = r.routing_meta;
+                    cache.state = Some(r.state);
+                    crate::metrics::record_orchestrate_drive("cold_rebuild");
+                    info!(
+                        execution_id,
+                        "worker-driven: cold cache on apply — rebuilt WorkflowState from the durable \
+                         log before applying (crash-recovery, noetl/ai-meta#104)"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        execution_id,
+                        error = %e,
+                        "worker-driven: cold cache on apply and rebuild failed; cannot apply \
+                         orchestrate result this pass (reconcile will retry)"
+                    );
+                    crate::metrics::record_orchestrate_drive("cold_rebuild_failed");
+                    return Ok(0);
+                }
             }
-            Err(e) => {
-                warn!(
-                    execution_id,
-                    error = %e,
-                    "worker-driven: cold cache on apply and rebuild failed; cannot apply \
-                     orchestrate result this pass (reconcile will retry)"
-                );
-                crate::metrics::record_orchestrate_drive("cold_rebuild_failed");
-                return Ok(0);
+            // A cold descriptor under offserver → re-seed from this recovery
+            // rebuild so the next trigger goes stateless again.
+            if matches!(
+                state.config.state_builder,
+                crate::config::StateBuilder::Offserver
+            ) {
+                let cid = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
+                state
+                    .exec_descriptors
+                    .seed(execution_id, cid, cache.routing_meta.clone());
             }
         }
-    }
 
-    let catalog_id = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
-    if catalog_id == 0 {
-        warn!(
-            execution_id,
-            "worker-driven: cold cache (no catalog_id); cannot apply orchestrate result this pass"
-        );
-        return Ok(0);
-    }
-    let routing = cache
-        .routing_meta
-        .as_ref()
-        .map(crate::handlers::execute::CommandRouting::from_started_meta)
-        .unwrap_or_default();
+        let catalog_id = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
+        if catalog_id == 0 {
+            warn!(
+                execution_id,
+                "worker-driven: cold cache (no catalog_id); cannot apply orchestrate result this pass"
+            );
+            return Ok(0);
+        }
+        let routing = cache
+            .routing_meta
+            .as_ref()
+            .map(crate::handlers::execute::CommandRouting::from_started_meta)
+            .unwrap_or_default();
+        (catalog_id, routing)
+    };
 
     // Phase F R4-3: noetl.catalog is a cluster-wide table.
     let playbook_yaml: String =
@@ -3276,10 +3505,17 @@ async fn apply_worker_orchestration(
     .await?;
     crate::metrics::record_orchestrate_drive("applied");
 
-    if result.should_complete {
+    // Evict on a terminal outcome.  `should_complete` covers the normal
+    // completion path (the drive emits the terminal event).  `result.state` being
+    // terminal also covers a drive that ran on already-terminal worker-built
+    // state (RFC #115 Phase 4 remainder: a straggler that triggered a drive after
+    // a cancel — the worker's WAL-built state is `Cancelled`, evaluate returns a
+    // no-op with `state: Cancelled`) so the slot is freed and not re-driven.
+    if result.should_complete || result.state.is_terminal() {
         drop(cache);
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
+        state.exec_descriptors.evict(execution_id); // RFC #115 Phase 4 remainder
     }
     Ok(commands_generated)
 }

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -611,6 +611,17 @@ async fn emit_playbook_started_event(
         }
     }
 
+    // Stateless off-server drive edge (RFC #115 Phase 4 remainder,
+    // noetl/ai-meta#107 step 2): seed the execute-time descriptor with the two
+    // execution-scoped, immutable facts the drive dispatch needs — catalog_id +
+    // the routing meta — so under `NOETL_STATE_BUILDER=offserver` the drive can
+    // route the orchestrate command WITHOUT rebuilding `WorkflowState` (ZERO
+    // `noetl.event` reads on the drive path).  Seeded here, the first place both
+    // are known; read in `events::trigger_orchestrator_inner`'s stateless branch.
+    state
+        .exec_descriptors
+        .seed(execution_id, catalog_id, Some(meta.clone()));
+
     // CQRS write-path chokepoint (#103 2d-3): INSERT (gate off) or publish (on).
     let ev = crate::handlers::event_write::EventRow::new(
         event_id,

--- a/src/state.rs
+++ b/src/state.rs
@@ -97,6 +97,19 @@ pub struct AppState {
     /// walkable singly-linked list.  See [`ChainHeads`].
     pub chain_heads: Arc<ChainHeads>,
 
+    /// Execute-time descriptors for the stateless off-server drive edge (RFC
+    /// #115 Phase 4 remainder, noetl/ai-meta#107 step 2).  Carries the
+    /// execution-scoped, immutable facts the drive dispatch needs —
+    /// `catalog_id` + `routing_meta` — seeded once when the execution starts, so
+    /// under `NOETL_STATE_BUILDER=offserver` the drive routes the command
+    /// WITHOUT rebuilding `WorkflowState` (ZERO `noetl.event` reads on the drive
+    /// path; state CONSTRUCTION runs on the worker pool from the WAL).  Plus a
+    /// `terminal` flag stamped by the [`crate::handlers::event_write::emit_events`]
+    /// chokepoint when a terminal event (cancel / finalize / playbook
+    /// completed|failed) is written, so the drive stops re-dispatching a terminal
+    /// execution without reading state.  See [`ExecDescriptors`].
+    pub exec_descriptors: Arc<ExecDescriptors>,
+
     /// CQRS write-path publisher (noetl/ai-meta#103 phase 2d-3).  Lazily built
     /// on first use from [`Self::nats`] so the `emit_event` chokepoint can
     /// publish to the `noetl_events` stream when
@@ -197,6 +210,72 @@ impl ChainHeads {
     /// Current head for an execution, if any.  Test/diagnostic helper.
     pub fn head(&self, execution_id: i64) -> Option<i64> {
         self.map.lock().unwrap().get(&execution_id).copied()
+    }
+}
+
+/// Execute-time descriptor for the stateless off-server drive edge (RFC #115
+/// Phase 4 remainder).  See the [`AppState::exec_descriptors`] field doc.
+#[derive(Clone, Debug, Default)]
+pub struct ExecDescriptor {
+    /// The execution's catalog id (immutable for the run).  Sourced from the
+    /// `playbook_started` event at execute-time instead of from a rebuilt
+    /// `WorkflowState`, so the drive needn't scan `noetl.event` for it.
+    pub catalog_id: i64,
+    /// The `playbook_started` event's `meta` (pool segment + W3C trace) — the
+    /// same shape [`crate::handlers::execute::CommandRouting::from_started_meta`]
+    /// reads, cached so follow-up command dispatch needn't reload the first
+    /// event.
+    pub routing_meta: Option<serde_json::Value>,
+    /// Set once a terminal event (cancel / finalize / playbook completed|failed)
+    /// is emitted for this execution.  The stateless drive checks this first and
+    /// stops re-dispatching a terminal execution — replacing the
+    /// `WorkflowState::is_terminal()` guard that needed a rebuilt state.
+    pub terminal: bool,
+}
+
+/// Per-execution execute-time descriptor cache for the stateless off-server
+/// drive edge (RFC #115 Phase 4 remainder, noetl/ai-meta#107 step 2).  In-memory
+/// only and no DB read on the hot path: seeded at execute, read by the drive,
+/// terminal-stamped at the emit chokepoint.  A cold slot (e.g. a server restart
+/// mid-execution) yields `None`, and the drive falls back to the server-built
+/// state path for that trigger — which re-seeds the descriptor — so correctness
+/// never regresses below the server-built drive.
+#[derive(Default)]
+pub struct ExecDescriptors {
+    map: std::sync::Mutex<std::collections::HashMap<i64, ExecDescriptor>>,
+}
+
+impl ExecDescriptors {
+    /// Seed `catalog_id` + `routing_meta` at execute-time (or re-seed from the
+    /// server-built fallback path after a cold-descriptor drive).  Fills the
+    /// load-bearing fields without clobbering a `terminal` flag a concurrent
+    /// cancel may already have stamped.
+    pub fn seed(&self, execution_id: i64, catalog_id: i64, routing_meta: Option<serde_json::Value>) {
+        let mut map = self.map.lock().unwrap();
+        let e = map.entry(execution_id).or_default();
+        if catalog_id != 0 {
+            e.catalog_id = catalog_id;
+        }
+        if routing_meta.is_some() {
+            e.routing_meta = routing_meta;
+        }
+    }
+
+    /// Current descriptor snapshot for an execution, if seeded.
+    pub fn get(&self, execution_id: i64) -> Option<ExecDescriptor> {
+        self.map.lock().unwrap().get(&execution_id).cloned()
+    }
+
+    /// Stamp the terminal flag (emit chokepoint).  Creates the slot if cold so a
+    /// cancel that lands before any drive still records the stop signal.
+    pub fn mark_terminal(&self, execution_id: i64) {
+        self.map.lock().unwrap().entry(execution_id).or_default().terminal = true;
+    }
+
+    /// Drop a terminal execution's descriptor (frees memory).  Called alongside
+    /// [`OrchStateCache::evict`] on the terminal paths.
+    pub fn evict(&self, execution_id: i64) {
+        self.map.lock().unwrap().remove(&execution_id);
     }
 }
 
@@ -325,6 +404,7 @@ impl AppState {
             start_time: std::time::Instant::now(),
             orch_cache: Arc::new(OrchStateCache::default()),
             chain_heads: Arc::new(ChainHeads::default()),
+            exec_descriptors: Arc::new(ExecDescriptors::default()),
             event_stream_publisher: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
@@ -361,7 +441,7 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::ChainHeads;
+    use super::{ChainHeads, ExecDescriptors};
 
     // Note: Full tests require a database connection
     // These are placeholder tests for documentation
@@ -370,6 +450,48 @@ mod tests {
     fn test_uptime() {
         // AppState::new requires a real DB pool, so we can't easily test here
         // This is a documentation placeholder
+    }
+
+    // RFC #115 Phase 4 remainder: the execute-time descriptor carries catalog_id
+    // + routing so the off-server drive routes without rebuilding state.
+    #[test]
+    fn exec_descriptor_seed_get_and_terminal() {
+        let d = ExecDescriptors::default();
+        assert!(d.get(7).is_none(), "cold execution has no descriptor");
+
+        d.seed(7, 42, Some(serde_json::json!({"execution_pool": "default"})));
+        let got = d.get(7).expect("seeded");
+        assert_eq!(got.catalog_id, 42);
+        assert_eq!(got.routing_meta.unwrap()["execution_pool"], "default");
+        assert!(!got.terminal, "freshly seeded is not terminal");
+
+        // A terminal stamp (emit chokepoint) flips the flag without clobbering
+        // the seeded facts.
+        d.mark_terminal(7);
+        let got = d.get(7).expect("still present");
+        assert!(got.terminal, "terminal flag set");
+        assert_eq!(got.catalog_id, 42, "catalog_id preserved across terminal stamp");
+
+        d.evict(7);
+        assert!(d.get(7).is_none(), "evicted");
+    }
+
+    #[test]
+    fn exec_descriptor_seed_preserves_terminal_and_does_not_zero_catalog() {
+        let d = ExecDescriptors::default();
+        // A cancel can stamp terminal before any drive seeded catalog_id.
+        d.mark_terminal(9);
+        // A late seed (e.g. the recovery rebuild) must keep the terminal flag and
+        // must not zero catalog_id when passed 0.
+        d.seed(9, 0, None);
+        let got = d.get(9).expect("present");
+        assert!(got.terminal, "terminal flag survives a seed");
+        assert_eq!(got.catalog_id, 0, "catalog_id stays 0 (nothing real to seed yet)");
+        // A real seed fills catalog_id, still keeping terminal.
+        d.seed(9, 55, Some(serde_json::json!({"x": 1})));
+        let got = d.get(9).expect("present");
+        assert_eq!(got.catalog_id, 55);
+        assert!(got.terminal);
     }
 
     // RFC #115 §4: the per-execution chain head turns a stream of emitted event


### PR DESCRIPTION
## Summary

The Phase-4 drive cutover (#247, v3.34.0) moved `WorkflowState`
**construction** off the server onto the system worker pool's WAL
builder. But the server still did **residual chain-walk bookkeeping** on
the drive path — it rebuilt state to read terminal/cancel, `catalog_id`,
routing, and the `expected_head` watermark, and shipped that built state
as the worker's incomplete-WAL fallback. The cutover report called
removing it the precisely-staged Phase-4 remainder.

This PR removes that residual rebuild. Under `NOETL_STATE_BUILDER=offserver`
the server edge is **stateless** on the drive path: **ZERO `noetl.event`
reads + ZERO state rebuild** — the server just routes commands and
persists events through the sole-writer gate.

## Design

- **`ExecDescriptors`** (`state.rs`) — a per-execution in-memory descriptor
  carrying the execution-scoped, immutable facts the drive needs:
  `catalog_id` + `routing_meta`, **seeded at execute-time** (the
  `playbook_started` emit). Plus a `terminal` flag **stamped at the
  `emit_events` chokepoint** when a terminal event (cancel / finalize /
  playbook completed|failed) is written.
- **`dispatch_offserver_stateless_drive`** (`events.rs`) — under offserver +
  a warm descriptor, routes the `system/orchestrate` command **without
  building state**:
  - `catalog_id` + `routing` from the descriptor.
  - `expected_head` (the staleness-guard watermark) from the in-memory
    `ChainHeads` — the highest event the server emitted — no DB read.
  - terminal detection from the descriptor flag.
  - `trigger_event_id` passed so the **worker resolves `trigger_event_type`
    off its WAL index** (no server read to classify the trigger).
  - **no server-built `state`** rides the command (`__stateless__`); an
    incomplete WAL chain on the worker is a benign no-op
    (`__offserver_retry__`) the reconcile poller re-drives once the drain
    catches up — never a partial state, never a wedge.
- **`apply_worker_orchestration`** — under offserver + warm descriptor,
  sources `catalog_id` + routing from the descriptor and **skips the
  cold-rebuild** (zero reads on the apply side too); evicts on a terminal
  worker-built `result.state` as well as `should_complete`.
- **Fallbacks preserved** — a cold descriptor (server restart
  mid-execution) falls through to the server-built path, which re-seeds the
  descriptor and ships the built state as the worker fallback. `chain_walk`
  + `event_scan` stay as the fallbacks. Correctness never regresses below
  the proven server-built drive.

`Default = server` — **prod/default behavior unchanged.**

## Observability

`noetl_orchestrate_drive_total{stage="dispatched_offserver_stateless"}` +
`{stage="applied_stateless"}` advance, while `noetl_state_build_total`
stays flat (neither `event_scan` nor `chain_walk` built state) — the
zero-rebuild proof. `state_builder_drive{stateless_retry}` records the
incomplete-WAL no-op.

## Validation (gate-ON kind — PUBLISH_ONLY + off-server drive + materializer sole-writer)

- **Stateless-edge proof** (extended `kind_validate_state_builder_offserver.sh`):
  server `noetl_state_build_total` delta **0** (zero rebuild),
  `noetl_state_build_event_scans_total` delta **0**,
  `dispatched_offserver_stateless` **+3**, `applied_stateless` **+3**.
- **Live parity** — `fanout_reduce_phase6` offserver vs server: identical
  fingerprint `[enrich_customer:1,normalize_customer:1,reduce_customer:1,start:1]`,
  both COMPLETED, fan-in barrier fires once. Plus linear (`simple_python`
  13 rows), loop (`loop_test` 62 rows), Phase-1 (`output_select` 31 rows)
  all COMPLETE off-server with `state_build_total` delta 0 across the batch.
- **WAL-build authoritative + scan-free** — worker drive served +3
  (fallback 0), worker `event_scans` 0, `wal_events` +25; cache cold +1 /
  incremental +2.
- **Sole-writer + lag-0** — per-exec `event_rows==distinct`, `catalog0=0`,
  `__orchestrate__` event rows 0, materializer duplicates 0; committed gate
  rig PASS.
- 583 lib tests + clippy green.

## Scope

Completes **#107 step 2** server-side: state rebuild + event reads are
fully removed from the drive path under the flag. Phase 5 (atomic-item
context, needs #77) + Phase 6 (retire the event read path entirely) remain.

Refs noetl/ai-meta#115
Refs noetl/ai-meta#107