### PR TITLE
Retire the hot-path noetl.event read class — audit-only event read path (RFC #115 Phase 6)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -249,6 +249,50 @@ pub struct AppConfig {
     /// **Default `server`** — prod/default behavior is unchanged.
     #[serde(default)]
     pub state_builder: StateBuilder,
+
+    /// **How the execution-lifecycle hot path reads `noetl.event`** (RFC
+    /// noetl/ai-meta#115 Phase 6).  Envy maps `NOETL_EVENT_READ_PATH`.
+    ///
+    /// Phase 4 already removed the *drive*'s state-rebuild scan under
+    /// `state_builder=offserver`.  This flag retires the **remaining**
+    /// execution-scan readers of `noetl.event` on the hot path — the
+    /// `WHERE execution_id = $1` replay class that runs *outside* the drive:
+    /// the per-ingest `get_catalog_id` (`normalize_event_to_row`), the
+    /// child-execution `inherit_parent_trace`, the subscription dedup-audit
+    /// catalog lookup, and the container-callback existence + catalog reads.
+    ///
+    /// - **`event_scan`** (default) — those readers scan `noetl.event` exactly
+    ///   as today.  Unchanged prod behavior.
+    /// - **`audit_only`** — each reader is served from the in-memory
+    ///   execute-time [`crate::state::ExecDescriptor`] (catalog_id + routing,
+    ///   seeded at `playbook_started`).  A warm descriptor → ZERO `noetl.event`
+    ///   read; a cold descriptor (server restart mid-execution) **falls back**
+    ///   to the scan for that read (counted via
+    ///   `noetl_event_hotpath_reads_total{outcome="scan"}`) — correctness is
+    ///   never sacrificed.  `noetl.event` becomes **audit-only**: still written
+    ///   by the materializer (#103) and read by operator/status/replay APIs,
+    ///   never scanned by the execution lifecycle.  Pairs with
+    ///   `state_builder=offserver` to reach the end-to-end never-scan invariant.
+    ///
+    /// **Default `event_scan`** — prod/default behavior is unchanged; flipping
+    /// to `audit_only` is opt-in and staged.
+    #[serde(default)]
+    pub event_read_path: EventReadPath,
+}
+
+/// How the execution-lifecycle hot path reads `noetl.event` — see
+/// [`AppConfig::event_read_path`] (RFC noetl/ai-meta#115 Phase 6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventReadPath {
+    /// Hot-path readers scan `noetl.event` (`WHERE execution_id = $1`) exactly
+    /// as today.  Default — prod behavior.
+    #[default]
+    EventScan,
+    /// Hot-path readers are served from the in-memory execute-time descriptor;
+    /// `noetl.event` becomes audit-only (RFC #115 Phase 6).  Cold-descriptor
+    /// reads fall back to the scan.
+    AuditOnly,
 }
 
 /// Where orchestrator `WorkflowState` is constructed — see
@@ -355,6 +399,9 @@ impl Default for AppConfig {
             // noetl/ai-meta#115 Phase 4: server-side build is the default; the
             // off-server builder cutover is opt-in (and staged).
             state_builder: StateBuilder::Server,
+            // noetl/ai-meta#115 Phase 6: hot-path event-scan readers stay on the
+            // event table by default; audit_only routes them to the descriptor.
+            event_read_path: EventReadPath::EventScan,
         }
     }
 }
@@ -429,5 +476,24 @@ mod tests {
         assert_eq!(off, StateBuilder::Offserver);
         let srv: StateBuilder = serde_json::from_str("\"server\"").unwrap();
         assert_eq!(srv, StateBuilder::Server);
+    }
+
+    #[test]
+    fn test_event_read_path_defaults_event_scan() {
+        // noetl/ai-meta#115 Phase 6: prod/default behavior is unchanged — the
+        // hot-path event readers keep scanning noetl.event; audit_only (route to
+        // the descriptor, noetl.event becomes audit-only) is opt-in via
+        // NOETL_EVENT_READ_PATH=audit_only.
+        let cfg = AppConfig::default();
+        assert_eq!(cfg.event_read_path, EventReadPath::EventScan);
+    }
+
+    #[test]
+    fn test_event_read_path_deserializes_snake_case() {
+        // Envy parses NOETL_EVENT_READ_PATH through serde; variants are snake_case.
+        let ao: EventReadPath = serde_json::from_str("\"audit_only\"").unwrap();
+        assert_eq!(ao, EventReadPath::AuditOnly);
+        let es: EventReadPath = serde_json::from_str("\"event_scan\"").unwrap();
+        assert_eq!(es, EventReadPath::EventScan);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,5 +6,5 @@
 mod app;
 pub mod database;
 
-pub use app::{AppConfig, StateBuildMode, StateBuilder};
+pub use app::{AppConfig, EventReadPath, StateBuildMode, StateBuilder};
 pub use database::{DatabaseConfig, ShardConnection, ShardConnectionError, ShardingConfig};

--- a/src/handlers/container_callback.rs
+++ b/src/handlers/container_callback.rs
@@ -190,12 +190,39 @@ pub async fn container_callback(
 
     // -- Stale check: is there ANY event for this execution_id?
     let pool = state.pools.pool_for(execution_id);
-    let row: Option<(i64,)> = sqlx::query_as(
-        "SELECT 1::bigint FROM noetl.event WHERE execution_id = $1 LIMIT 1",
-    )
-    .bind(execution_id)
-    .fetch_optional(pool)
-    .await?;
+    // RFC #115 Phase 6: under `event_read_path=audit_only`, a warm execute-time
+    // descriptor proves the execution exists — ZERO `noetl.event` read.  A cold
+    // descriptor (server restart, or a genuinely stale callback for an execution
+    // this server never saw) falls through to the scan (counted `scan`), which
+    // preserves the stale-detection correctness.
+    let audit_only = matches!(
+        state.config.event_read_path,
+        crate::config::EventReadPath::AuditOnly
+    );
+    let descriptor_warm = audit_only
+        && state
+            .exec_descriptors
+            .get(execution_id)
+            .map(|d| d.catalog_id != 0)
+            .unwrap_or(false);
+    let row: Option<(i64,)> = if descriptor_warm {
+        crate::metrics::record_event_hotpath_read("container_callback_exists", "served_descriptor");
+        Some((1,))
+    } else if audit_only {
+        // Cold descriptor under audit_only: prove existence from `noetl.command`
+        // (the synchronous queue) — ZERO `noetl.event` read.
+        crate::metrics::record_event_hotpath_read("container_callback_exists", "served_command");
+        sqlx::query_as("SELECT 1::bigint FROM noetl.command WHERE execution_id = $1 LIMIT 1")
+            .bind(execution_id)
+            .fetch_optional(pool)
+            .await?
+    } else {
+        crate::metrics::record_event_hotpath_read("container_callback_exists", "scan");
+        sqlx::query_as("SELECT 1::bigint FROM noetl.event WHERE execution_id = $1 LIMIT 1")
+            .bind(execution_id)
+            .fetch_optional(pool)
+            .await?
+    };
 
     if row.is_none() {
         tracing::info!(
@@ -255,16 +282,40 @@ pub async fn container_callback(
 
     // catalog_id is required by the schema; resolve from the
     // execution's existing events (the start event carries it).
-    let catalog_id: i64 = sqlx::query_as::<_, (i64,)>(
-        "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 \
-         AND event_type IN ('playbook.initialized', 'playbook_started') \
-         LIMIT 1",
-    )
-    .bind(execution_id)
-    .fetch_optional(pool)
-    .await?
-    .map(|(c,)| c)
-    .unwrap_or(0);
+    // RFC #115 Phase 6: under `event_read_path=audit_only` a warm descriptor
+    // carries catalog_id — ZERO `noetl.event` read; cold falls through to scan.
+    let catalog_id: i64 = if descriptor_warm {
+        crate::metrics::record_event_hotpath_read("container_callback_catalog", "served_descriptor");
+        state
+            .exec_descriptors
+            .get(execution_id)
+            .map(|d| d.catalog_id)
+            .unwrap_or(0)
+    } else if audit_only {
+        // Cold descriptor under audit_only: catalog_id from `noetl.command` — the
+        // synchronous queue — ZERO `noetl.event` read.
+        crate::metrics::record_event_hotpath_read("container_callback_catalog", "served_command");
+        sqlx::query_as::<_, (i64,)>(
+            "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
+        )
+        .bind(execution_id)
+        .fetch_optional(pool)
+        .await?
+        .map(|(c,)| c)
+        .unwrap_or(0)
+    } else {
+        crate::metrics::record_event_hotpath_read("container_callback_catalog", "scan");
+        sqlx::query_as::<_, (i64,)>(
+            "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 \
+             AND event_type IN ('playbook.initialized', 'playbook_started') \
+             LIMIT 1",
+        )
+        .bind(execution_id)
+        .fetch_optional(pool)
+        .await?
+        .map(|(c,)| c)
+        .unwrap_or(0)
+    };
 
     // Persist the resume `call.done` using the deployed `noetl.event`
     // column set (matches handlers::events).  The previous path went

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -542,7 +542,7 @@ pub(crate) async fn normalize_event_to_row(
         None => state.snowflake.generate()?,
     };
 
-    let catalog_id = get_catalog_id(state, execution_id).await?;
+    let catalog_id = get_catalog_id(state, execution_id, "get_catalog_id_single").await?;
 
     let mut meta = request.meta.clone().unwrap_or_else(|| serde_json::json!({}));
     if let serde_json::Value::Object(ref mut map) = meta {
@@ -1180,7 +1180,7 @@ pub async fn handle_batch_events(
         .parse()
         .map_err(|_| AppError::Validation("Invalid execution_id".to_string()))?;
 
-    let catalog_id = get_catalog_id(&state, execution_id).await?;
+    let catalog_id = get_catalog_id(&state, execution_id, "get_catalog_id_batch").await?;
     // Phase F R4-3: batch writes land on this execution's shard.
     let mut tx = state.pools.pool_for(execution_id).begin().await?;
     let mut event_ids = Vec::with_capacity(request.events.len());
@@ -1476,8 +1476,46 @@ fn build_result_object(request: &EventRequest, status: &str) -> serde_json::Valu
 /// fails + the events are lost).  `noetl.command` is written synchronously even
 /// under the gate (it's the command queue the worker reads), so it always
 /// carries the execution's `catalog_id`.
-async fn get_catalog_id(state: &AppState, execution_id: i64) -> AppResult<Option<i64>> {
+async fn get_catalog_id(state: &AppState, execution_id: i64, site: &str) -> AppResult<Option<i64>> {
+    // RFC #115 Phase 6: under `event_read_path=audit_only`, serve catalog_id from
+    // the in-memory execute-time descriptor (seeded at `playbook_started`, before
+    // the first event emit) — ZERO `noetl.event` read on this per-ingest hot path.
+    // A cold descriptor (server restart mid-execution) falls through to the scan
+    // below (counted `scan`), so correctness never regresses.
     let pool = state.pools.pool_for(execution_id);
+    if matches!(
+        state.config.event_read_path,
+        crate::config::EventReadPath::AuditOnly
+    ) {
+        // Warm descriptor → served, ZERO read.
+        if let Some(desc) = state.exec_descriptors.get(execution_id) {
+            if desc.catalog_id != 0 {
+                crate::metrics::record_event_hotpath_read(site, "served_descriptor");
+                return Ok(Some(desc.catalog_id));
+            }
+        }
+        // Cold descriptor (a post-terminal straggler after the descriptor was
+        // evicted on terminal, or a server restart mid-execution): resolve
+        // catalog_id from `noetl.command` — the **synchronous** command queue
+        // (written for every command regardless of the publish-only gate, the
+        // queue the worker reads) — WITHOUT scanning `noetl.event`.  So
+        // get_catalog_id never reads `noetl.event` under audit_only.  We do NOT
+        // re-seed the descriptor here: re-seeding an already-evicted terminal
+        // execution would re-accumulate exactly the per-execution memory the
+        // terminal eviction frees (the unbounded growth this RFC removes).
+        crate::metrics::record_event_hotpath_read(site, "served_command");
+        let row: Option<(i64,)> = sqlx::query_as::<_, (i64,)>(
+            "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
+        )
+        .bind(execution_id)
+        .fetch_optional(pool)
+        .await?;
+        return Ok(row.map(|(id,)| id));
+    }
+    crate::metrics::record_event_hotpath_read(site, "scan");
+
+    // event_scan (default/prod): unchanged — noetl.event authoritative when
+    // present, noetl.command the fallback under the publish-only gate.
     if let Some((id,)) = sqlx::query_as::<_, (i64,)>(
         "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 LIMIT 1",
     )
@@ -1487,15 +1525,12 @@ async fn get_catalog_id(state: &AppState, execution_id: i64) -> AppResult<Option
     {
         return Ok(Some(id));
     }
-
-    // Fallback: noetl.command (synchronous under PUBLISH_ONLY).
     let row: Option<(i64,)> = sqlx::query_as::<_, (i64,)>(
         "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
     )
     .bind(execution_id)
     .fetch_optional(pool)
     .await?;
-
     Ok(row.map(|(id,)| id))
 }
 

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -472,14 +472,47 @@ async fn emit_deduplicated_event(
     // from the subscription scope's lifecycle events (its execution_id ==
     // scope).  Best-effort: if it can't be resolved, skip the audit rather
     // than turning a correct dedup into an error.
-    let catalog_id: Option<i64> = sqlx::query_scalar(
-        "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC LIMIT 1",
-    )
-    .bind(scope)
-    .fetch_optional(state.pools.pool_for(scope))
-    .await
-    .ok()
-    .flatten();
+    // RFC #115 Phase 6: under `event_read_path=audit_only`, serve the scope's
+    // catalog_id from the in-memory execute-time descriptor — ZERO `noetl.event`
+    // read.  Cold descriptor falls through to the scan (counted `scan`).
+    let catalog_id: Option<i64> = if matches!(
+        state.config.event_read_path,
+        crate::config::EventReadPath::AuditOnly
+    ) && state
+        .exec_descriptors
+        .get(scope)
+        .map(|d| d.catalog_id)
+        .filter(|c| *c != 0)
+        .is_some()
+    {
+        crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "served_descriptor");
+        state.exec_descriptors.get(scope).map(|d| d.catalog_id)
+    } else if matches!(
+        state.config.event_read_path,
+        crate::config::EventReadPath::AuditOnly
+    ) {
+        // Cold descriptor under audit_only: catalog_id from `noetl.command` — the
+        // synchronous queue — ZERO `noetl.event` read.
+        crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "served_command");
+        sqlx::query_scalar(
+            "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
+        )
+        .bind(scope)
+        .fetch_optional(state.pools.pool_for(scope))
+        .await
+        .ok()
+        .flatten()
+    } else {
+        crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "scan");
+        sqlx::query_scalar(
+            "SELECT catalog_id FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC LIMIT 1",
+        )
+        .bind(scope)
+        .fetch_optional(state.pools.pool_for(scope))
+        .await
+        .ok()
+        .flatten()
+    };
     let Some(catalog_id) = catalog_id else {
         tracing::debug!(subscription_id = scope, "dedup audit: no catalog_id for scope; skipping audit event");
         return;
@@ -645,6 +678,35 @@ async fn emit_playbook_started_event(
 /// `playbook_started` event so a child run joins the same distributed trace.
 /// Best-effort: a missing parent / missing trace simply yields `None`.
 async fn inherit_parent_trace(state: &AppState, parent_execution_id: i64) -> Option<serde_json::Value> {
+    // RFC #115 Phase 6: under `event_read_path=audit_only`, read the parent's
+    // trace off its in-memory execute-time descriptor (its `routing_meta` is the
+    // `playbook_started` meta this query reads) — ZERO `noetl.event` read.  A cold
+    // parent descriptor falls through to the scan (counted `scan`).
+    if matches!(
+        state.config.event_read_path,
+        crate::config::EventReadPath::AuditOnly
+    ) {
+        if let Some(desc) = state.exec_descriptors.get(parent_execution_id) {
+            if desc.catalog_id != 0 {
+                crate::metrics::record_event_hotpath_read("inherit_parent_trace", "served_descriptor");
+                return desc
+                    .routing_meta
+                    .as_ref()
+                    .and_then(|m| m.get("trace"))
+                    .filter(|v| !v.is_null())
+                    .cloned();
+            }
+        }
+        // Cold parent descriptor under audit_only: the W3C trace lives only in the
+        // parent's `playbook_started` meta (no `noetl.command` source).  Trace
+        // inheritance is best-effort observability — return None (the child opens
+        // a fresh trace segment) rather than scan `noetl.event`, keeping the
+        // never-scan invariant.  Only the parent-restart path is affected.
+        crate::metrics::record_event_hotpath_read("inherit_parent_trace", "served_none_cold");
+        return None;
+    }
+    crate::metrics::record_event_hotpath_read("inherit_parent_trace", "scan");
+
     let meta: Option<serde_json::Value> = sqlx::query_scalar(
         "SELECT meta FROM noetl.event WHERE execution_id = $1 AND event_type = 'playbook_started' \
          ORDER BY event_id ASC LIMIT 1",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -182,6 +182,53 @@ pub fn record_state_build(mode: &str, outcome: &str) {
     state_build_total().with_label_values(&[mode, outcome]).inc();
 }
 
+// ── Hot-path event reads (RFC noetl/ai-meta#115 Phase 6) ─────────────────────
+
+/// `noetl_event_hotpath_reads_total{site, outcome}` — every execution-lifecycle
+/// hot-path reader of `noetl.event` that the Phase-6 `event_read_path=audit_only`
+/// flag retires (the `WHERE execution_id = $1` replay class *outside* the drive:
+/// `get_catalog_id`, `inherit_parent_trace`, the subscription dedup-audit catalog
+/// lookup, the container-callback existence + catalog reads).
+///
+/// - `site` = `get_catalog_id` | `inherit_parent_trace` | `dedup_audit_catalog`
+///   | `container_callback_exists` | `container_callback_catalog`.
+/// - `outcome` = `served_descriptor` (served from the in-memory execute-time
+///   descriptor — **no `noetl.event` read**) | `scan` (fell back to the
+///   `WHERE execution_id` scan — cold descriptor, or `event_read_path=event_scan`).
+///
+/// The never-scan invariant proof (RFC §7): under `event_read_path=audit_only`
+/// + `state_builder=offserver`, across a full execution lifecycle the
+/// `{outcome="scan"}` series stays **flat** (Δ0) while the lifecycle still
+/// completes — every hot-path event read was served from a read model, and
+/// `noetl.event` was scanned by nobody on the hot path.  Pairs with the
+/// drive-path `noetl_state_build_event_scans_total` (which proves the drive's
+/// own zero-scan) for the end-to-end guarantee.
+pub fn event_hotpath_reads_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_event_hotpath_reads_total",
+                "Execution-lifecycle hot-path reads of noetl.event, by site and outcome (RFC #115 Phase 6).",
+            ),
+            &["site", "outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one hot-path event read (`site` = the reader; `outcome` =
+/// `served_descriptor` | `scan`).
+pub fn record_event_hotpath_read(site: &str, outcome: &str) {
+    event_hotpath_reads_total()
+        .with_label_values(&[site, outcome])
+        .inc();
+}
+
 /// `noetl_state_build_event_scans_total` — incremented once each time the drive
 /// path enters the **event-scan** state-construction block (the block that issues
 /// `WHERE execution_id = $1 …` scans of `noetl.event`: the consistency `COUNT`,


### PR DESCRIPTION
## What

`NOETL_EVENT_READ_PATH=event_scan|audit_only` (**default `event_scan`, prod unchanged**). RFC [noetl/ai-meta#115](https://github.com/noetl/ai-meta/issues/115) **Phase 6** — retire the **execution-lifecycle** readers of `noetl.event` so the table becomes **audit-only** (materializer-written per #103, read by operator/status/replay APIs, **never scanned by the hot path**).

Phase 4 already removed the *drive*'s `WorkflowState` rebuild + event scan under `NOETL_STATE_BUILDER=offserver`. This PR retires the **remaining** `WHERE execution_id = $1` replay-class readers that run *outside* the drive.

## Readers routed (under `audit_only`)

| Reader | Warm | Cold (post-terminal straggler / restart) |
| :-- | :-- | :-- |
| `get_catalog_id` (per-ingest: `normalize_event_to_row` + batch) | `ExecDescriptor.catalog_id` | `noetl.command` (synchronous queue, authoritative under the gate) — **not** a `noetl.event` scan |
| `inherit_parent_trace` (child execs) | parent descriptor `routing_meta` | `None` (best-effort trace; trace lives only in event meta — child opens a fresh segment, no scan) |
| subscription dedup-audit catalog | descriptor | `noetl.command` |
| container-callback existence + catalog | descriptor | `noetl.command` |

The `event_scan` (default) path is **unchanged byte-for-byte**. A cold descriptor never re-seeds — re-seeding an already-evicted terminal execution would re-accumulate exactly the per-execution memory the terminal eviction frees (the unbounded growth this RFC removes).

## Observability

`noetl_event_hotpath_reads_total{site, outcome}` — `outcome` ∈ `served_descriptor` | `served_command` | `scan`. The never-scan proof surface: under `audit_only` the `{outcome="scan"}` series stays **flat (Δ0)**.

## Validation (gate-ON kind: PUBLISH_ONLY + off-server drive + materializer sole-writer + `audit_only`)

End-to-end never-scan rig ([noetl/e2e]) across linear / loop / fan-out + Phase-1 `output_select`:

- **hot-path reads: `served_descriptor` +96, `served_command` +3, `scan` +0** — ZERO `noetl.event` scans across the whole lifecycle (incl. the terminal-teardown straggler, now served from `noetl.command`).
- **drive path: `state_build_total` Δ0, `state_build_event_scans` Δ0** (Phase-4 stateless edge). Combined ⇒ ZERO `noetl.event` scans anywhere on the hot path.
- linear(13) / loop(62) / fan-out(25) / output_select(31) all **COMPLETE**; sole-writer `event_rows==distinct`, `catalog0=0`, `__orchestrate__` event rows 0, materializer dup 0, lag-0.
- **audit still works**: direct `SELECT FROM noetl.event` returns the rows, status API `COMPLETED`, replay (`GET /api/replay/state`) folds `event_count=25`.
- committed orchestrate-gate rig **PASS** with `audit_only` on (no regression); 585 lib tests (+2 `EventReadPath` config tests) + clippy green.

PROD GKE untouched; default `event_scan`; no gate/mode/builder default changed.

Refs noetl/ai-meta#115