### PR TITLE
feat(orchestrate): atomic-working-item context — minimal per-step command slice (RFC #115 Phase 5)

### DIFF
--- a/orchestrate-core/src/commands.rs
+++ b/orchestrate-core/src/commands.rs
@@ -69,6 +69,12 @@ pub struct IteratorMetadata {
 /// Builder for creating commands.
 pub struct CommandBuilder {
     renderer: TemplateRenderer,
+    /// When true, the persisted (worker-bound) command context is narrowed to
+    /// the minimal working-item slice the step statically references — the
+    /// atomic-working-item context contract (RFC noetl/ai-meta#115 Phase 5 /
+    /// tenet 6).  Default false: the full accumulated context ships, exactly as
+    /// before.  Narrowing is conservative — see [`crate::input_binding`].
+    atomic_item_context: bool,
 }
 
 impl Default for CommandBuilder {
@@ -78,10 +84,21 @@ impl Default for CommandBuilder {
 }
 
 impl CommandBuilder {
-    /// Create a new command builder.
+    /// Create a new command builder (full-context dispatch; default behavior).
     pub fn new() -> Self {
         Self {
             renderer: TemplateRenderer::new(),
+            atomic_item_context: false,
+        }
+    }
+
+    /// Create a command builder that narrows each command's worker-bound context
+    /// to the minimal working-item slice (RFC noetl/ai-meta#115 Phase 5).
+    /// `enabled = false` is identical to [`Self::new`].
+    pub fn with_atomic_item_context(enabled: bool) -> Self {
+        Self {
+            renderer: TemplateRenderer::new(),
+            atomic_item_context: enabled,
         }
     }
 
@@ -125,7 +142,23 @@ impl CommandBuilder {
 
         // Build tool command using the shimmed render context so that
         // {{ ctx.foo }} and {{ workload.foo }} templates resolve correctly.
+        // NOTE: server-side rendering always runs against the FULL context — the
+        // narrowing below only trims the *persisted* context the worker receives.
         let tool_command = self.build_tool_from_definition(&step.tool, &render_ctx)?;
+
+        // Atomic-working-item context (RFC noetl/ai-meta#115 Phase 5 / tenet 6):
+        // when enabled, hand the worker only the minimal slice of base-context
+        // keys this step statically references — not the whole accumulated
+        // context.  Scoped to plain (non-loop) steps; loop bodies dispatch via
+        // `build_iteration_command` (their fan-out coordinate handling stays on
+        // the full-context path for now).  `project_context` returns `None` for
+        // any step it can't statically bound, so we fall back to the full
+        // context — narrowing never drops a key the worker might read.
+        let out_context = if self.atomic_item_context && step.r#loop.is_none() {
+            crate::input_binding::project_context(step, context).unwrap_or_else(|| context.clone())
+        } else {
+            context.clone()
+        };
 
         Ok(Command {
             command_id,
@@ -135,7 +168,7 @@ impl CommandBuilder {
             step_name: step.step.clone(),
             tool: tool_command,
             // FLAT context (no ctx/workload self-copies) — the worker re-shims.
-            context: Some(context.clone()),
+            context: Some(out_context),
             metadata: metadata.cloned(),
             iterator: None,
         })

--- a/orchestrate-core/src/input_binding.rs
+++ b/orchestrate-core/src/input_binding.rs
@@ -1,0 +1,344 @@
+//! Static input-binding analysis for the atomic-working-item context contract
+//! (RFC noetl/ai-meta#115 Phase 5 / tenet 6).
+//!
+//! Builds directly on the explicit input-binding work (noetl/ai-meta#77, shipped
+//! BREAKING as v3.0.0): a step declares what it consumes via `input:` / `args:`
+//! and the tool's own templates (`command:` / `query:` / `code:` / `url:` …).
+//! This module statically extracts the set of **base dispatch-context top-level
+//! keys** a step's tool definition references, so the drive can hand a worker a
+//! *minimal* working-item context — only the upstream step outputs / refs the
+//! step actually binds — instead of the whole accumulated context (§6.1).
+//!
+//! ## Conservative by construction
+//!
+//! Narrowing is a pure optimization that only ever drops keys a step provably
+//! never names. If *any* reference can't be statically bounded — a whole-context
+//! `{{ ctx }}` spread, an unparseable fragment — [`analyze`] reports
+//! `bounded = false` and [`project_context`] returns `None`, so the caller
+//! passes the **full** context unchanged (today's behavior). A narrowed context
+//! is therefore always a superset of what the worker needs to re-render any
+//! deferred template: the server still renders the tool against the full context
+//! server-side, and the worker rebuilds its `ctx` / `workload` shims from
+//! whatever flat context arrives, so every retained key resolves.
+//!
+//! ## Reference → base-key mapping
+//!
+//! The flat dispatch context carries each upstream step's output under its step
+//! name as a top-level key, plus the structured `workload` block (the `ctx`
+//! namespace is a worker-rebuilt alias of the same flat map — it is not itself a
+//! base key). So a template reference maps to a base key as:
+//!
+//! - `{{ ctx.foo }}` → base key `foo` (ctx aliases the flat map; the real key is
+//!   the segment after `ctx`). A bare `{{ ctx }}` spread is **unbounded**.
+//! - `{{ workload.x }}` → base key `workload` (the structured block).
+//! - `{{ generate_data.id }}` / `{{ generate_data }}` → base key `generate_data`.
+//! - `{{ iter.item }}`, `{{ _prev }}`, `{{ output.x }}` … → no base key (these
+//!   are injected at execution time, per loop iteration or per pipeline tool
+//!   item, not carried in the base dispatch context).
+
+use std::collections::{BTreeSet, HashMap};
+
+use minijinja::Environment;
+use serde_json::Value;
+
+use crate::playbook::Step;
+
+/// Roots injected into the render context at execution time (per loop iteration,
+/// per pipeline tool item, or as a tool-result namespace) rather than carried in
+/// the base dispatch context. Referencing one of these does **not** require
+/// keeping a base-context key.
+const INJECTED_ROOTS: &[&str] = &[
+    "iter",
+    "item",
+    "loop",
+    "_prev",
+    "_results",
+    "outcome",
+    "output",
+    "result",
+    "__cursor_frame",
+    "__cursor_row",
+];
+
+/// Result of statically analyzing a step's tool definition for the base-context
+/// keys it references.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DeclaredInputs {
+    /// Base dispatch-context top-level keys the step's tool templates reference.
+    pub needed_keys: BTreeSet<String>,
+    /// True when every reference resolved to a concrete base key (or an
+    /// injected/local root). False forces the full-context fallback —
+    /// [`project_context`] returns `None`.
+    pub bounded: bool,
+}
+
+/// Statically analyze a step's tool definition (+ step-level `input:`/`args:`)
+/// for the set of base-context keys it references. Pure; no rendering, no I/O.
+pub fn analyze(step: &Step) -> DeclaredInputs {
+    let mut templates: Vec<String> = Vec::new();
+
+    // The tool definition is what the drive renders into the worker command and
+    // ships; its templates (rendered server-side AND those deferred to the
+    // worker) bound the base keys the worker can possibly read.
+    if let Ok(tool_v) = serde_json::to_value(&step.tool) {
+        collect_templates(&tool_v, &mut templates);
+    }
+    // Step-level `input:`/`args:` (Step.args) feeds the step's context too.
+    if let Some(args) = &step.args {
+        if let Ok(args_v) = serde_json::to_value(args) {
+            collect_templates(&args_v, &mut templates);
+        }
+    }
+
+    let env = Environment::new();
+    let mut needed = BTreeSet::new();
+    let mut bounded = true;
+
+    for tmpl in &templates {
+        match env.template_from_str(tmpl) {
+            Ok(t) => {
+                for var in t.undeclared_variables(true) {
+                    if !classify(&var, &mut needed) {
+                        bounded = false;
+                    }
+                }
+            }
+            // A fragment that doesn't parse as a standalone template (odd /
+            // partial syntax) can't be bounded — fall back to full context.
+            Err(_) => bounded = false,
+        }
+    }
+
+    DeclaredInputs {
+        needed_keys: needed,
+        bounded,
+    }
+}
+
+/// Given the full flat dispatch context and a step, return a narrowed context
+/// holding only the base keys the step references — or `None` when the step
+/// can't be statically bounded (the caller then passes the full context
+/// unchanged). Keys named but absent from `full` are simply omitted (the worker
+/// resolves them to undefined exactly as it would under the full context).
+pub fn project_context(
+    step: &Step,
+    full: &HashMap<String, Value>,
+) -> Option<HashMap<String, Value>> {
+    let di = analyze(step);
+    if !di.bounded {
+        return None;
+    }
+    let mut out = HashMap::with_capacity(di.needed_keys.len());
+    for k in &di.needed_keys {
+        if let Some(v) = full.get(k) {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    Some(out)
+}
+
+/// Map one (possibly dotted) undeclared-variable path to the base context key it
+/// needs, inserting into `needed`. Returns `false` when the reference can't be
+/// bounded (a bare whole-context `ctx` spread).
+fn classify(path: &str, needed: &mut BTreeSet<String>) -> bool {
+    let mut segs = path.split('.');
+    let root = match segs.next() {
+        Some(r) if !r.is_empty() => r,
+        _ => return true,
+    };
+    if INJECTED_ROOTS.contains(&root) {
+        return true;
+    }
+    if root == "ctx" {
+        // `ctx` aliases the whole flat context; the real base key is the next
+        // segment. A bare `{{ ctx }}` (no segment) is a whole-context spread.
+        match segs.next() {
+            Some(k) if !k.is_empty() => {
+                needed.insert(k.to_string());
+                true
+            }
+            _ => false,
+        }
+    } else {
+        needed.insert(root.to_string());
+        true
+    }
+}
+
+/// Recursively collect every string value that carries a Jinja template marker.
+fn collect_templates(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::String(s) => {
+            if s.contains("{{") || s.contains("{%") {
+                out.push(s.clone());
+            }
+        }
+        Value::Array(a) => {
+            for x in a {
+                collect_templates(x, out);
+            }
+        }
+        Value::Object(m) => {
+            for x in m.values() {
+                collect_templates(x, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step_from_yaml(y: &str) -> Step {
+        serde_yaml::from_str(y).expect("parse step")
+    }
+
+    fn ctx(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn declared_input_binds_only_named_upstream_keys() {
+        // A step whose single tool binds exactly two upstream outputs.
+        let step = step_from_yaml(
+            r#"
+step: consume
+tool:
+  kind: python
+  input:
+    rec_id: "{{ generate_data.id }}"
+    stats: "{{ ctx.stats_ref }}"
+  code: "print(rec_id)"
+"#,
+        );
+        let di = analyze(&step);
+        assert!(di.bounded, "static references must bound");
+        let keys: Vec<&str> = di.needed_keys.iter().map(|s| s.as_str()).collect();
+        assert_eq!(keys, vec!["generate_data", "stats_ref"]);
+    }
+
+    #[test]
+    fn project_drops_unreferenced_upstream_outputs() {
+        let step = step_from_yaml(
+            r#"
+step: consume
+tool:
+  kind: shell
+  command: "echo {{ generate_data.id }}"
+"#,
+        );
+        let full = ctx(&[
+            ("generate_data", serde_json::json!({"id": 7})),
+            ("unrelated_big", serde_json::json!({"blob": "x".repeat(10_000)})),
+            ("another_step", serde_json::json!({"k": "v"})),
+        ]);
+        let narrowed = project_context(&step, &full).expect("bounded");
+        assert_eq!(narrowed.len(), 1);
+        assert!(narrowed.contains_key("generate_data"));
+        assert!(!narrowed.contains_key("unrelated_big"));
+        assert!(!narrowed.contains_key("another_step"));
+    }
+
+    #[test]
+    fn workload_reference_keeps_workload_block() {
+        let step = step_from_yaml(
+            r#"
+step: consume
+tool:
+  kind: http
+  url: "{{ workload.api_url }}/v1"
+"#,
+        );
+        let di = analyze(&step);
+        assert!(di.bounded);
+        assert!(di.needed_keys.contains("workload"));
+    }
+
+    #[test]
+    fn bare_ctx_spread_is_unbounded_fallback() {
+        let step = step_from_yaml(
+            r#"
+step: consume
+tool:
+  kind: python
+  input:
+    everything: "{{ ctx | tojson }}"
+  code: "pass"
+"#,
+        );
+        let di = analyze(&step);
+        assert!(!di.bounded, "a whole-context spread must force full context");
+        let full = ctx(&[("a", serde_json::json!(1)), ("b", serde_json::json!(2))]);
+        assert!(
+            project_context(&step, &full).is_none(),
+            "unbounded → caller passes full context"
+        );
+    }
+
+    #[test]
+    fn injected_roots_need_no_base_key() {
+        // iter / _prev / output are injected per-iteration or per-tool-item.
+        let step = step_from_yaml(
+            r#"
+step: body
+tool:
+  kind: python
+  input:
+    item: "{{ iter.item }}"
+    prev: "{{ _prev.value }}"
+  code: "print({{ output.x }})"
+"#,
+        );
+        let di = analyze(&step);
+        assert!(di.bounded);
+        assert!(
+            di.needed_keys.is_empty(),
+            "injected roots add no base keys, got {:?}",
+            di.needed_keys
+        );
+    }
+
+    #[test]
+    fn pipeline_items_are_walked() {
+        // Flat (name-as-field) pipeline form: each item's input is scanned.
+        let step = step_from_yaml(
+            r#"
+step: pipe
+tool:
+  - name: fetch
+    kind: http
+    input:
+      url: "{{ source_cfg.endpoint }}"
+  - name: store
+    kind: postgres
+    input:
+      payload: "{{ ctx.row_ref }}"
+    query: "INSERT INTO t VALUES ('{{ payload }}')"
+"#,
+        );
+        let di = analyze(&step);
+        assert!(di.bounded);
+        assert!(di.needed_keys.contains("source_cfg"));
+        assert!(di.needed_keys.contains("row_ref"));
+    }
+
+    #[test]
+    fn no_templates_yields_empty_bounded() {
+        let step = step_from_yaml(
+            r#"
+step: literal
+tool:
+  kind: shell
+  command: "echo hello"
+"#,
+        );
+        let di = analyze(&step);
+        assert!(di.bounded);
+        assert!(di.needed_keys.is_empty());
+    }
+}

--- a/orchestrate-core/src/lib.rs
+++ b/orchestrate-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod commands;
 pub mod error;
 pub mod event;
 pub mod evaluator;
+pub mod input_binding;
 pub mod orchestrator;
 pub mod playbook;
 pub mod state;

--- a/orchestrate-core/src/orchestrator.rs
+++ b/orchestrate-core/src/orchestrator.rs
@@ -278,11 +278,18 @@ impl Default for WorkflowOrchestrator {
 }
 
 impl WorkflowOrchestrator {
-    /// Create a new workflow orchestrator.
+    /// Create a new workflow orchestrator (full-context dispatch; default).
     pub fn new() -> Self {
+        Self::with_atomic_item_context(false)
+    }
+
+    /// Create an orchestrator whose command builder narrows each worker-bound
+    /// command context to the minimal working-item slice (RFC noetl/ai-meta#115
+    /// Phase 5 / tenet 6).  `enabled = false` is identical to [`Self::new`].
+    pub fn with_atomic_item_context(enabled: bool) -> Self {
         Self {
             evaluator: ConditionEvaluator::new(),
-            command_builder: CommandBuilder::new(),
+            command_builder: CommandBuilder::with_atomic_item_context(enabled),
             renderer: TemplateRenderer::new(),
         }
     }

--- a/plugins/orchestrate/src/lib.rs
+++ b/plugins/orchestrate/src/lib.rs
@@ -39,6 +39,12 @@ pub struct OrchestrateInput {
     /// The event type that triggered this evaluation (`None` on a cold start).
     #[serde(default)]
     pub trigger_event_type: Option<String>,
+    /// Narrow each worker-bound command context to the minimal working-item
+    /// slice (RFC noetl/ai-meta#115 Phase 5).  `#[serde(default)]` keeps the
+    /// wire shape back-compatible: an older host that omits the field drives
+    /// with full-context dispatch exactly as before.
+    #[serde(default)]
+    pub atomic_item_context: bool,
 }
 
 /// The plug-in's **state** input contract — an already-built `WorkflowState`
@@ -58,6 +64,10 @@ pub struct OrchestrateStateInput {
     pub playbook: Playbook,
     #[serde(default)]
     pub trigger_event_type: Option<String>,
+    /// Narrow each worker-bound command context to the minimal working-item
+    /// slice (RFC noetl/ai-meta#115 Phase 5).  Back-compatible default (false).
+    #[serde(default)]
+    pub atomic_item_context: bool,
 }
 
 /// The error envelope returned when evaluation fails, so the scheduler can tell
@@ -82,7 +92,7 @@ pub fn orchestrate(input: &[u8]) -> Vec<u8> {
 fn orchestrate_inner(input: &[u8]) -> Result<Vec<u8>, String> {
     let parsed: OrchestrateInput =
         serde_json::from_slice(input).map_err(|e| format!("decode OrchestrateInput: {e}"))?;
-    let orchestrator = WorkflowOrchestrator::new();
+    let orchestrator = WorkflowOrchestrator::with_atomic_item_context(parsed.atomic_item_context);
     let result: OrchestrationResult = orchestrator
         .evaluate(
             &parsed.events,
@@ -108,7 +118,7 @@ pub fn orchestrate_state(input: &[u8]) -> Vec<u8> {
 fn orchestrate_state_inner(input: &[u8]) -> Result<Vec<u8>, String> {
     let mut parsed: OrchestrateStateInput =
         serde_json::from_slice(input).map_err(|e| format!("decode OrchestrateStateInput: {e}"))?;
-    let orchestrator = WorkflowOrchestrator::new();
+    let orchestrator = WorkflowOrchestrator::with_atomic_item_context(parsed.atomic_item_context);
     let result: OrchestrationResult = orchestrator
         .evaluate_state(
             &mut parsed.state,

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -278,6 +278,23 @@ pub struct AppConfig {
     /// to `audit_only` is opt-in and staged.
     #[serde(default)]
     pub event_read_path: EventReadPath,
+
+    /// **Atomic-working-item context** (RFC noetl/ai-meta#115 Phase 5 / tenet 6).
+    /// Envy maps `NOETL_ATOMIC_ITEM_CONTEXT`.
+    ///
+    /// When **true**, each worker-bound command carries only the minimal slice of
+    /// base-context keys the step statically references (its declared `input:` +
+    /// the tool's own templates), instead of the whole accumulated context — the
+    /// worker becomes a true atomic compute block (run tool T on input I).
+    /// Builds on the explicit input-binding surface shipped under #77.  The
+    /// narrowing is conservative: any step that can't be statically bounded
+    /// (whole-context `{{ ctx }}` spread, unparseable fragment) keeps the full
+    /// context, so existing playbooks are unaffected.
+    ///
+    /// **Default false** — full-context dispatch, prod/default behavior
+    /// unchanged.  Flipping to true is opt-in and staged.
+    #[serde(default)]
+    pub atomic_item_context: bool,
 }
 
 /// How the execution-lifecycle hot path reads `noetl.event` — see
@@ -402,6 +419,9 @@ impl Default for AppConfig {
             // noetl/ai-meta#115 Phase 6: hot-path event-scan readers stay on the
             // event table by default; audit_only routes them to the descriptor.
             event_read_path: EventReadPath::EventScan,
+            // noetl/ai-meta#115 Phase 5: full-context dispatch by default; the
+            // atomic-working-item minimal-slice narrowing is opt-in (and staged).
+            atomic_item_context: false,
         }
     }
 }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -3020,6 +3020,11 @@ async fn trigger_orchestrator_inner(
             // state is never staler than the server's view, which prevents a
             // lag-induced re-issue of a fan-in barrier step (RFC #115 Phase 4).
             "expected_head": cache.last_event_id,
+            // RFC #115 Phase 5: carry the atomic-item-context flag so the
+            // off-server drive narrows worker-bound command contexts too.  The
+            // server-built `run_state` fallback reads it directly; the worker
+            // forwards it onto its from_events `OrchestrateInput` (Phase 5b).
+            "atomic_item_context": state.config.atomic_item_context,
         });
         crate::handlers::execute::dispatch_orchestrate_command(
             state,
@@ -3045,7 +3050,10 @@ async fn trigger_orchestrator_inner(
     }
 
     // In-process drive (the `NOETL_ORCHESTRATE_PLUGIN_DRIVE=false` fallback).
-    let orchestrator = WorkflowOrchestrator::new();
+    // RFC noetl/ai-meta#115 Phase 5: narrow each command's worker-bound context
+    // to the minimal working-item slice when the atomic-item-context flag is on.
+    let orchestrator =
+        WorkflowOrchestrator::with_atomic_item_context(state.config.atomic_item_context);
     let ws = cache.state.as_mut().unwrap();
     let result = match orchestrator.evaluate_state(
         ws,

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1318,7 +1318,11 @@ async fn generate_initial_commands(
         .ok_or_else(|| AppError::Validation("Start step 'start' not found".to_string()))?;
 
     // Build command context by merging playbook workload (defaults) with execution payload (overrides)
-    let command_builder = crate::engine::commands::CommandBuilder::new();
+    // RFC noetl/ai-meta#115 Phase 5: narrow the initial command's worker-bound
+    // context to its minimal slice when the atomic-item-context flag is on.
+    let command_builder = crate::engine::commands::CommandBuilder::with_atomic_item_context(
+        state.config.atomic_item_context,
+    );
     let mut context = HashMap::new();
 
     // First, add playbook workload defaults
@@ -1463,6 +1467,18 @@ async fn generate_initial_commands(
         }
 
         return Ok(total as i32);
+    }
+
+    // RFC #115 Phase 5 observability: classify how the start command was sized
+    // (the narrowing itself happens inside build_command).  Zero cost when off.
+    if state.config.atomic_item_context {
+        let narrowed = start_step.r#loop.is_none()
+            && noetl_orchestrate_core::input_binding::analyze(start_step).bounded;
+        crate::metrics::record_atomic_item_context(if narrowed {
+            "narrowed"
+        } else {
+            "full_fallback"
+        });
     }
 
     let command = command_builder.build_command(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -149,6 +149,38 @@ pub fn record_orchestrate_drive(stage: &str) {
     orchestrate_drive_total().with_label_values(&[stage]).inc();
 }
 
+// ── Atomic-working-item context (RFC noetl/ai-meta#115 Phase 5) ───────────────
+
+/// `noetl_atomic_item_context_total{outcome}` — how the in-process drive sized
+/// each worker-bound command context when the atomic-item-context flag is on.
+/// `outcome` = `narrowed` (a minimal slice replaced the full context) |
+/// `full_fallback` (the step couldn't be statically bounded, so the full
+/// context shipped — conservative). Zero increments while the flag is off.
+pub fn atomic_item_context_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_atomic_item_context_total",
+                "Worker-bound command context sizing under the atomic-item-context flag (RFC #115 Phase 5).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one atomic-item-context sizing decision (`narrowed` | `full_fallback`).
+pub fn record_atomic_item_context(outcome: &str) {
+    atomic_item_context_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
 // ── State-build mode (RFC noetl/ai-meta#115 Phase 3) ─────────────────────────
 
 /// `noetl_state_build_total{mode, outcome}` — how the drive built `WorkflowState`


### PR DESCRIPTION
## What

RFC noetl/ai-meta#115 **Phase 5 (tenet 6)** — the atomic-working-item context contract. A tool-running worker stops receiving the whole accumulated execution context and instead gets only the **minimal slice of base-context keys the step statically references** (its declared `input:`/`args:` + the tool's own templates).

Builds directly on the explicit input-binding surface shipped under **noetl/ai-meta#77** (BREAKING v3.0.0). #77 gave steps a way to *declare* what they consume; this phase adds the analysis + projection that turns those declarations into a bounded per-item context.

## How

**orchestrate-core**
- New `input_binding` module. `analyze(step)` statically extracts the base dispatch-context keys a step references — minijinja `undeclared_variables` over the serialized tool definition + step input, mapping `ctx.X`→`X`, `workload`→`workload`, bare step-name→key, and injected roots (`iter`/`_prev`/`output`/…) to none. **Conservative**: any reference it can't statically bound (a whole-context `{{ ctx }}` spread, an unparseable fragment) yields `bounded = false`. `project_context(step, ctx)` narrows the flat context to the referenced keys, or returns `None` (caller keeps the full context).
- `CommandBuilder::with_atomic_item_context` + `WorkflowOrchestrator::with_atomic_item_context`: `build_command` narrows the **persisted** (worker-bound) context for plain non-loop steps. Server-side rendering still runs against the **full** context, so narrowing only ever drops keys the step provably never names.

**plugin**: `OrchestrateInput` / `OrchestrateStateInput` gain a `#[serde(default)]` `atomic_item_context` bool; both wasm entries build the orchestrator with it. Back-compatible wire shape (older host omits it → full-context dispatch).

**server**: `NOETL_ATOMIC_ITEM_CONTEXT` (`AppConfig.atomic_item_context`, **default false**) threads to the in-process drive + the start-command builder + the off-server dispatch input. Metric `noetl_atomic_item_context_total{outcome}`.

## Safety

**Default false → prod/default behavior unchanged.** Narrowing is opt-in, scoped to plain non-loop steps, and falls back to the full context for any step it can't statically bound. Binding semantics of existing playbooks are untouched.

## Validation

- 7 new `input_binding` unit tests + 132 orchestrate-core tests + 584 server tests green; clippy clean (no new warnings).
- **Kind gate-ON** (server `p5-atomic`, `NOETL_ATOMIC_ITEM_CONTEXT=true`, `STATE_BUILDER=server` + `PLUGIN_DRIVE=true` + `PUBLISH_ONLY=true`), fixture `noetl/e2e` `atomic_item_context.yaml` (`consumer` binds only `{{ producer_a.tag }}`):
  - **flag ON**: consumer `render_context` = `[producer_a]` ONLY — `producer_b` + `start` + `steps` + `workload` + `execution_id` + `catalog_id` + `path` all dropped; execution **COMPLETED**; `noetl_atomic_item_context_total{narrowed}` +1.
  - **flag OFF**: consumer `render_context` = `[catalog_id, execution_id, path, producer_a, producer_b, start, steps, workload]` — full context, **COMPLETED**. Back-compat holds.
  - Offserver regression rig: all executions COMPLETED, `__orchestrate__` event rows = 0, dispatched/applied advance, system-pool isolation, lag-0 — at the default. (The rig's `#113/#114` offload-metric assertions are pre-existing-stale under the `refs_in_state=true` default; they fail identically with this flag off.)

Companion: `noetl/worker#NN` (off-server from_events forwarding), `noetl/e2e#NN` (fixture + rig).

Refs noetl/ai-meta#115
Refs noetl/ai-meta#107

🤖 Generated with [Claude Code](https://claude.com/claude-code)