### PR TITLE
Multi-replica coherence: NATS-KV-backed ChainHeads + ExecDescriptor (RFC #115 program-scale)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,7 @@ dependencies = [
  "axum",
  "axum-server",
  "base64",
+ "bytes",
  "chacha20poly1305",
  "chrono",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 
 # NATS messaging
 async-nats = "0.38"
+# Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
+# watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
+# async-nats already pulls in transitively.
+bytes = "1"
 
 # Build-fix pin (NOT used directly).  time 0.3.48 (2026-06-12) collides with
 # async-nats 0.38.0's blanket `From<Kind> for Error<Kind>` under rustc 1.91+

--- a/src/coherence.rs
+++ b/src/coherence.rs
@@ -1,0 +1,367 @@
+//! Multi-replica coherence for the off-server drive's per-execution state.
+//!
+//! RFC noetl/ai-meta#115 program-scale step (noetl/ai-meta#107).
+//!
+//! ## The problem
+//!
+//! The off-server drive edge keys two execution-scoped facts off in-memory
+//! [`AppState`](crate::state::AppState) maps:
+//!
+//! - [`ChainHeads`](crate::state::ChainHeads) — the `prev_event_id` watermark
+//!   the `emit_events` chokepoint stamps so per-execution events form a walkable
+//!   singly-linked chain.
+//! - [`ExecDescriptor`](crate::state::ExecDescriptor) — `catalog_id` + routing +
+//!   the terminal flag, seeded at `playbook_started`, read by the stateless
+//!   dispatch.
+//!
+//! Both carry a **single-replica locality assumption**: they live on whichever
+//! replica handled the execution's first event.  With one server replica that is
+//! always the same process.  With 2+ replicas behind a load balancer a later
+//! trigger (a worker's `command.completed` POST, the reconcile poller) can land
+//! on a *different* replica, which finds a **cold** slot and:
+//!
+//! - for the watermark: stamps the event as a chain root (`prev_event_id = NULL`)
+//!   even though it continues an existing chain → a forked chain the off-server
+//!   builder's walk can't reassemble; and
+//! - for the descriptor: falls back to the server-built path that **reads
+//!   `noetl.event`** to rebuild `WorkflowState` — correct, but neither scan-free
+//!   nor coherent.
+//!
+//! ## The mechanism
+//!
+//! Under `NOETL_REPLICA_COHERENCE=nats_kv` both maps are backed by two JetStream
+//! **KV buckets** (`noetl_chain_heads`, `noetl_exec_descriptors`) so any replica
+//! resolves the same value:
+//!
+//! - The **head advance** is a **compare-and-swap** (`Store::update` against the
+//!   read revision): two replicas emitting concurrently for one execution
+//!   serialise through the CAS, so a single per-execution chain is preserved.
+//! - The **descriptor** is a CAS read-modify-write so a `seed` (catalog_id +
+//!   routing) and a `mark_terminal` from different replicas **merge** rather than
+//!   clobber.
+//!
+//! The in-process maps stay as a **write-through cache** and a **degraded-mode
+//! fallback**: when KV is unreachable (or `replica_coherence=local`, the
+//! default), the methods behave exactly as the original in-memory implementation
+//! — `local` is bit-identical to today, so single-replica + prod are unchanged.
+//!
+//! Each KV access is labelled on `noetl_replica_coherence_total{structure, op,
+//! outcome}` (see [`crate::metrics::record_replica_coherence`]); the load-bearing
+//! proof series is `outcome="kv_remote_hit"` — a descriptor/head that missed the
+//! local map but hit KV, i.e. a cross-replica resolve that avoided a cold
+//! server-built fallback.
+
+use std::sync::Arc;
+
+use async_nats::jetstream::{
+    self,
+    kv::{Operation, Store},
+};
+use bytes::Bytes;
+
+use crate::config::ReplicaCoherence;
+use crate::state::ExecDescriptor;
+
+/// KV bucket holding `execution_id → chain-head event_id`.
+const HEADS_BUCKET: &str = "noetl_chain_heads";
+/// KV bucket holding `execution_id → ExecDescriptor` (JSON).
+const DESC_BUCKET: &str = "noetl_exec_descriptors";
+/// Bounded CAS retries before giving up and degrading to the in-process map.
+const CAS_RETRIES: usize = 6;
+
+/// Shared coherence backend injected into [`ChainHeads`](crate::state::ChainHeads)
+/// and [`ExecDescriptors`](crate::state::ExecDescriptors).  Built once in
+/// [`AppState::new`](crate::state::AppState::new); the KV buckets are created
+/// lazily on first use (the same lazy shape as the event-stream publisher) so the
+/// sync constructor stays sync and a NATS hiccup at startup doesn't wedge boot.
+pub struct CoherenceKv {
+    nats: Option<Arc<async_nats::Client>>,
+    mode: ReplicaCoherence,
+    /// Lazily-built KV handles.  `Mutex<Option<Store>>` (not a `OnceCell`) so a
+    /// transient build failure is retried on the next access rather than cached
+    /// as permanently-disabled.
+    heads: tokio::sync::Mutex<Option<Store>>,
+    desc: tokio::sync::Mutex<Option<Store>>,
+}
+
+impl Default for CoherenceKv {
+    /// A disabled (local-only) backend — every method returns "not handled by
+    /// KV", so the wrapping structs use their in-process map.  Used by
+    /// `ChainHeads::default()` / `ExecDescriptors::default()` (tests + the
+    /// single-pool legacy path).
+    fn default() -> Self {
+        Self {
+            nats: None,
+            mode: ReplicaCoherence::Local,
+            heads: tokio::sync::Mutex::new(None),
+            desc: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+/// Outcome of a KV read that may distinguish a value present from a definitive
+/// absence (cold) vs. KV being unavailable (degrade to local).
+pub enum KvRead<T> {
+    /// KV authoritatively returned this value.
+    Hit(T),
+    /// KV authoritatively has no entry (genuinely cold / evicted everywhere).
+    Miss,
+    /// KV is disabled / unreachable / errored → caller falls back to the
+    /// in-process map (degraded mode == `local`).
+    Unavailable,
+}
+
+impl CoherenceKv {
+    /// Build the backend.  `nats` is the (optional) connected client; `mode`
+    /// selects `local` (default) vs. `nats_kv`.  No I/O here — buckets are built
+    /// on first access.
+    pub fn new(nats: Option<Arc<async_nats::Client>>, mode: ReplicaCoherence) -> Self {
+        Self {
+            nats,
+            mode,
+            heads: tokio::sync::Mutex::new(None),
+            desc: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    /// Whether KV backing is on AND a NATS client is present.  When false the
+    /// wrapping structs skip KV entirely and behave as the original in-memory
+    /// maps (the default, prod-unchanged path).
+    pub fn enabled(&self) -> bool {
+        matches!(self.mode, ReplicaCoherence::NatsKv) && self.nats.is_some()
+    }
+
+    /// Lazily build + cache a KV store handle for `bucket`.  Returns a clone of
+    /// the [`Store`] (cheap — it's a handle) or `None` if unbuildable.
+    async fn store(&self, bucket: &str, slot: &tokio::sync::Mutex<Option<Store>>) -> Option<Store> {
+        if !self.enabled() {
+            return None;
+        }
+        let mut guard = slot.lock().await;
+        if let Some(s) = guard.as_ref() {
+            return Some(s.clone());
+        }
+        let client = self.nats.as_ref()?;
+        let js = jetstream::new((**client).clone());
+        // Create is idempotent enough for our use — on "already exists" we fetch
+        // the existing bucket.  Small values, history=1 (we only need latest),
+        // file storage so the watermark survives a full cluster restart.
+        let cfg = jetstream::kv::Config {
+            bucket: bucket.to_string(),
+            description: "NoETL multi-replica drive coherence (RFC #115)".to_string(),
+            history: 1,
+            ..Default::default()
+        };
+        let built = match js.create_key_value(cfg).await {
+            Ok(s) => Some(s),
+            Err(create_err) => match js.get_key_value(bucket).await {
+                Ok(s) => Some(s),
+                Err(get_err) => {
+                    tracing::warn!(
+                        bucket,
+                        create_error = %create_err,
+                        get_error = %get_err,
+                        "replica coherence: KV bucket unbuildable; degrading to in-process map"
+                    );
+                    None
+                }
+            },
+        };
+        *guard = built.clone();
+        built
+    }
+
+    async fn heads_store(&self) -> Option<Store> {
+        self.store(HEADS_BUCKET, &self.heads).await
+    }
+
+    async fn desc_store(&self) -> Option<Store> {
+        self.store(DESC_BUCKET, &self.desc).await
+    }
+
+    // ── chain head ──────────────────────────────────────────────────────────
+
+    /// CAS-advance the chain head for `execution_id` to `new_head`; return the
+    /// head **before** this advance (the `prev_event_id` for the first event of
+    /// the batch).  `Hit(prev)` = KV is now authoritative; `Unavailable` = caller
+    /// uses the in-process map.  `Miss` is never returned by an advance.
+    pub async fn advance_head(&self, execution_id: i64, new_head: i64) -> KvRead<Option<i64>> {
+        let Some(store) = self.heads_store().await else {
+            return KvRead::Unavailable;
+        };
+        let key = execution_id.to_string();
+        let val = Bytes::from(new_head.to_string());
+        for _ in 0..CAS_RETRIES {
+            let (cur, rev) = match store.entry(&key).await {
+                Ok(Some(e)) if e.operation == Operation::Put => {
+                    (parse_i64(&e.value), e.revision)
+                }
+                // Tombstone (Delete/Purge) — `update` at its revision revives it.
+                Ok(Some(e)) => (None, e.revision),
+                Ok(None) => (None, 0),
+                Err(_) => return KvRead::Unavailable,
+            };
+            // `update(key, val, 0)` is exactly "create if absent" in async-nats,
+            // so one path covers absent / live / tombstone.
+            match store.update(&key, val.clone(), rev).await {
+                Ok(_) => return KvRead::Hit(cur),
+                Err(_) => {
+                    crate::metrics::record_replica_coherence("chain_head", "advance", "cas_retry");
+                    continue;
+                }
+            }
+        }
+        crate::metrics::record_replica_coherence("chain_head", "advance", "cas_exhausted");
+        KvRead::Unavailable
+    }
+
+    /// Read the coherent chain head for `execution_id`.
+    pub async fn get_head(&self, execution_id: i64) -> KvRead<i64> {
+        let Some(store) = self.heads_store().await else {
+            return KvRead::Unavailable;
+        };
+        match store.get(execution_id.to_string()).await {
+            Ok(Some(b)) => match parse_i64(&b) {
+                Some(v) => KvRead::Hit(v),
+                None => KvRead::Miss,
+            },
+            Ok(None) => KvRead::Miss,
+            Err(_) => KvRead::Unavailable,
+        }
+    }
+
+    /// Delete the head entry (terminal eviction).  Best-effort.
+    pub async fn evict_head(&self, execution_id: i64) {
+        if let Some(store) = self.heads_store().await {
+            let _ = store.delete(execution_id.to_string()).await;
+        }
+    }
+
+    // ── descriptor ──────────────────────────────────────────────────────────
+
+    /// Read the coherent descriptor for `execution_id`.
+    pub async fn get_descriptor(&self, execution_id: i64) -> KvRead<ExecDescriptor> {
+        let Some(store) = self.desc_store().await else {
+            return KvRead::Unavailable;
+        };
+        match store.get(execution_id.to_string()).await {
+            Ok(Some(b)) => match serde_json::from_slice::<ExecDescriptor>(&b) {
+                Ok(d) => KvRead::Hit(d),
+                Err(_) => KvRead::Miss,
+            },
+            Ok(None) => KvRead::Miss,
+            Err(_) => KvRead::Unavailable,
+        }
+    }
+
+    /// Merge `catalog_id` + `routing_meta` into the KV descriptor without
+    /// clobbering a concurrently-stamped `terminal` flag (CAS read-modify-write).
+    pub async fn seed_descriptor(
+        &self,
+        execution_id: i64,
+        catalog_id: i64,
+        routing_meta: Option<serde_json::Value>,
+    ) {
+        self.modify_descriptor(execution_id, |d| {
+            if catalog_id != 0 {
+                d.catalog_id = catalog_id;
+            }
+            if routing_meta.is_some() {
+                d.routing_meta = routing_meta.clone();
+            }
+        })
+        .await;
+    }
+
+    /// CAS-stamp the terminal flag on the KV descriptor (preserving catalog_id +
+    /// routing).
+    pub async fn mark_terminal_descriptor(&self, execution_id: i64) {
+        self.modify_descriptor(execution_id, |d| d.terminal = true).await;
+    }
+
+    /// Delete the descriptor entry (terminal eviction).  Best-effort.
+    pub async fn evict_descriptor(&self, execution_id: i64) {
+        if let Some(store) = self.desc_store().await {
+            let _ = store.delete(execution_id.to_string()).await;
+        }
+    }
+
+    /// CAS read-modify-write of the KV descriptor.  Reads the current value (or
+    /// `default` when absent/tombstone), applies `f`, writes back at the read
+    /// revision; retries on contention.  Best-effort — a failure leaves the
+    /// in-process map (the wrapper already wrote) as the degraded-mode truth.
+    async fn modify_descriptor<F>(&self, execution_id: i64, mut f: F)
+    where
+        F: FnMut(&mut ExecDescriptor),
+    {
+        let Some(store) = self.desc_store().await else {
+            return;
+        };
+        let key = execution_id.to_string();
+        for _ in 0..CAS_RETRIES {
+            let (mut desc, rev) = match store.entry(&key).await {
+                Ok(Some(e)) if e.operation == Operation::Put => (
+                    serde_json::from_slice::<ExecDescriptor>(&e.value).unwrap_or_default(),
+                    e.revision,
+                ),
+                Ok(Some(e)) => (ExecDescriptor::default(), e.revision),
+                Ok(None) => (ExecDescriptor::default(), 0),
+                Err(_) => return,
+            };
+            f(&mut desc);
+            let Ok(bytes) = serde_json::to_vec(&desc) else {
+                return;
+            };
+            match store.update(&key, Bytes::from(bytes), rev).await {
+                Ok(_) => return,
+                Err(_) => {
+                    crate::metrics::record_replica_coherence("descriptor", "modify", "cas_retry");
+                    continue;
+                }
+            }
+        }
+        crate::metrics::record_replica_coherence("descriptor", "modify", "cas_exhausted");
+    }
+}
+
+/// Parse a decimal `i64` from a KV value (the head is stored as its decimal
+/// string for human-readable bucket dumps).
+fn parse_i64(b: &[u8]) -> Option<i64> {
+    std::str::from_utf8(b).ok()?.trim().parse::<i64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_i64_roundtrip() {
+        assert_eq!(parse_i64(b"42"), Some(42));
+        assert_eq!(parse_i64(b"-1"), Some(-1));
+        assert_eq!(parse_i64(b"  7 "), Some(7));
+        assert_eq!(parse_i64(b"not-a-number"), None);
+        assert_eq!(parse_i64(b""), None);
+    }
+
+    #[tokio::test]
+    async fn default_backend_is_disabled() {
+        let c = CoherenceKv::default();
+        assert!(!c.enabled());
+        // Every op degrades cleanly with no NATS.
+        assert!(matches!(c.advance_head(1, 10).await, KvRead::Unavailable));
+        assert!(matches!(c.get_head(1).await, KvRead::Unavailable));
+        assert!(matches!(c.get_descriptor(1).await, KvRead::Unavailable));
+        // Writes/evicts are no-ops, not panics.
+        c.seed_descriptor(1, 5, None).await;
+        c.mark_terminal_descriptor(1).await;
+        c.evict_head(1).await;
+        c.evict_descriptor(1).await;
+    }
+
+    #[tokio::test]
+    async fn local_mode_with_client_absent_is_disabled() {
+        // nats_kv requested but no client → still disabled (degrades to local).
+        let c = CoherenceKv::new(None, ReplicaCoherence::NatsKv);
+        assert!(!c.enabled());
+    }
+}

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -295,6 +295,38 @@ pub struct AppConfig {
     /// unchanged.  Flipping to true is opt-in and staged.
     #[serde(default)]
     pub atomic_item_context: bool,
+
+    /// **Where the per-execution drive watermark + descriptor live** (RFC
+    /// noetl/ai-meta#115 program-scale / noetl/ai-meta#107).  Envy maps
+    /// `NOETL_REPLICA_COHERENCE`.
+    ///
+    /// The off-server drive edge keys two execution-scoped facts off in-memory
+    /// `AppState` maps: the [`crate::state::ChainHeads`] watermark (the
+    /// `prev_event_id` the emit chokepoint stamps) and the
+    /// [`crate::state::ExecDescriptor`] (catalog_id + routing + terminal).  Both
+    /// carry a **single-replica locality assumption** — they are seeded on the
+    /// replica that handled `playbook_started` and read on whichever replica a
+    /// later trigger lands on.  With one replica that is always the same process;
+    /// with 2+ a trigger that lands on a different replica finds a cold slot and
+    /// falls back to the server-built (event-reading) path — correct, but not
+    /// scan-free and not coherent.
+    ///
+    /// - **`local`** (default) — the maps are pure in-process state, exactly as
+    ///   today.  Prod/default behavior; unchanged.  Correct for single-replica.
+    /// - **`nats_kv`** — the maps are backed by two JetStream **KV buckets**
+    ///   (`noetl_chain_heads`, `noetl_exec_descriptors`) so any replica resolves
+    ///   the same watermark/descriptor.  The head advance is a **compare-and-swap**
+    ///   so a single per-execution chain is preserved even when two replicas emit
+    ///   concurrently; the descriptor is a CAS read-modify-write so seed +
+    ///   terminal merge.  The in-process maps become a write-through cache /
+    ///   degraded-mode fallback (KV unreachable → behaves as `local`).  Requires a
+    ///   connected NATS (the gate-on publish path already does); with no NATS it
+    ///   transparently degrades to `local`.
+    ///
+    /// **Default `local`** — prod/default behavior is unchanged.  `nats_kv` is the
+    /// multi-replica coherence substrate; opt-in and staged.
+    #[serde(default)]
+    pub replica_coherence: ReplicaCoherence,
 }
 
 /// How the execution-lifecycle hot path reads `noetl.event` — see
@@ -324,6 +356,21 @@ pub enum StateBuilder {
     /// State construction runs off-server on the system worker pool, reading the
     /// `noetl_events` WAL with a pool-side cache (RFC #115 Phase 4).
     Offserver,
+}
+
+/// Where the per-execution drive watermark + descriptor live — see
+/// [`AppConfig::replica_coherence`] (RFC noetl/ai-meta#115 program-scale).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplicaCoherence {
+    /// `ChainHeads` + `ExecDescriptor` are pure in-process `AppState` maps.
+    /// Default — prod behavior; correct for a single replica.
+    #[default]
+    Local,
+    /// The maps are backed by JetStream KV buckets so 2+ replicas resolve the
+    /// same watermark/descriptor (CAS on the head advance + descriptor merge);
+    /// the in-process maps become a write-through cache (RFC #115 program-scale).
+    NatsKv,
 }
 
 /// Strategy for reconstructing orchestrator `WorkflowState` — see
@@ -422,6 +469,9 @@ impl Default for AppConfig {
             // noetl/ai-meta#115 Phase 5: full-context dispatch by default; the
             // atomic-working-item minimal-slice narrowing is opt-in (and staged).
             atomic_item_context: false,
+            // noetl/ai-meta#115 program-scale: in-process maps by default; the
+            // NATS-KV multi-replica coherence backing is opt-in (and staged).
+            replica_coherence: ReplicaCoherence::Local,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,5 +6,5 @@
 mod app;
 pub mod database;
 
-pub use app::{AppConfig, EventReadPath, StateBuildMode, StateBuilder};
+pub use app::{AppConfig, EventReadPath, ReplicaCoherence, StateBuildMode, StateBuilder};
 pub use database::{DatabaseConfig, ShardConnection, ShardConnectionError, ShardingConfig};

--- a/src/handlers/container_callback.rs
+++ b/src/handlers/container_callback.rs
@@ -203,6 +203,7 @@ pub async fn container_callback(
         && state
             .exec_descriptors
             .get(execution_id)
+            .await
             .map(|d| d.catalog_id != 0)
             .unwrap_or(false);
     let row: Option<(i64,)> = if descriptor_warm {
@@ -289,6 +290,7 @@ pub async fn container_callback(
         state
             .exec_descriptors
             .get(execution_id)
+            .await
             .map(|d| d.catalog_id)
             .unwrap_or(0)
     } else if audit_only {

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -292,10 +292,10 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
         // stateless drive reads this flag to stop re-dispatching a terminal
         // execution WITHOUT rebuilding `WorkflowState` to call `is_terminal()`.
         if rows.iter().any(|r| is_terminal_event_type(&r.event_type)) {
-            state.exec_descriptors.mark_terminal(execution_id);
+            state.exec_descriptors.mark_terminal(execution_id).await;
         }
         let ids: Vec<i64> = rows.iter().map(|r| r.event_id).collect();
-        let prevs = state.chain_heads.link_batch(execution_id, &ids);
+        let prevs = state.chain_heads.link_batch(execution_id, &ids).await;
         rows.iter()
             .zip(prevs)
             .map(|(r, prev)| {

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1488,7 +1488,7 @@ async fn get_catalog_id(state: &AppState, execution_id: i64, site: &str) -> AppR
         crate::config::EventReadPath::AuditOnly
     ) {
         // Warm descriptor → served, ZERO read.
-        if let Some(desc) = state.exec_descriptors.get(execution_id) {
+        if let Some(desc) = state.exec_descriptors.get(execution_id).await {
             if desc.catalog_id != 0 {
                 crate::metrics::record_event_hotpath_read(site, "served_descriptor");
                 return Ok(Some(desc.catalog_id));
@@ -2080,7 +2080,7 @@ async fn rebuild_state_chain_walk(
     keep_refs: bool,
 ) -> AppResult<Option<ChainWalkBuild>> {
     // Head from the in-memory watermark — no DB read.  Cold slot → fall back.
-    let Some(head) = state.chain_heads.head(execution_id) else {
+    let Some(head) = state.chain_heads.head(execution_id).await else {
         crate::metrics::record_state_build("chain_walk", "fallback_cold_head");
         debug!(execution_id, "chain walk: cold head, falling back to event scan");
         return Ok(None);
@@ -2193,7 +2193,7 @@ async fn run_parity_check(
     keep_refs: bool,
 ) -> AppResult<()> {
     use sqlx::Row;
-    let Some(head) = state.chain_heads.head(execution_id) else {
+    let Some(head) = state.chain_heads.head(execution_id).await else {
         return Ok(());
     };
     let mut conn = pool.acquire().await?;
@@ -2485,9 +2485,9 @@ async fn dispatch_offserver_stateless_drive(
     // Terminal guard — no event read.  A cancel/finalize/completion already
     // stamped the descriptor; stop re-dispatching and free the in-memory state.
     if desc.terminal {
-        state.exec_descriptors.evict(execution_id);
+        state.exec_descriptors.evict(execution_id).await;
         state.orch_cache.evict(execution_id);
-        state.chain_heads.evict(execution_id);
+        state.chain_heads.evict(execution_id).await;
         crate::metrics::record_orchestrate_drive("stateless_terminal_skip");
         debug!(
             execution_id,
@@ -2517,7 +2517,7 @@ async fn dispatch_offserver_stateless_drive(
     // Dispatch watermark from the in-memory chain head — NO DB read.  The worker
     // serves the WAL build only once its pool-side index has caught up to this,
     // so the off-server state is never staler than the server's view.
-    let expected_head = state.chain_heads.head(execution_id).unwrap_or(0);
+    let expected_head = state.chain_heads.head(execution_id).await.unwrap_or(0);
 
     // Playbook content — PK lookup on the cluster `noetl.catalog` table (not a
     // `noetl.event` read).
@@ -2605,7 +2605,7 @@ async fn trigger_orchestrator_inner(
             crate::config::StateBuilder::Offserver
         )
     {
-        if let Some(desc) = state.exec_descriptors.get(execution_id) {
+        if let Some(desc) = state.exec_descriptors.get(execution_id).await {
             if desc.catalog_id != 0 {
                 return dispatch_offserver_stateless_drive(
                     state,
@@ -2876,8 +2876,8 @@ async fn trigger_orchestrator_inner(
         let st = cache.state.as_ref().map(|ws| ws.state);
         drop(cache);
         state.orch_cache.evict(execution_id);
-        state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
-        state.exec_descriptors.evict(execution_id); // RFC #115 Phase 4 remainder
+        state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
+        state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
         debug!(
             execution_id,
             state = ?st,
@@ -2948,7 +2948,8 @@ async fn trigger_orchestrator_inner(
     // `noetl.event` only on this recovery pass, then goes scan-free.
     state
         .exec_descriptors
-        .seed(execution_id, catalog_id, cache.routing_meta.clone());
+        .seed(execution_id, catalog_id, cache.routing_meta.clone())
+        .await;
 
     // Phase F R4-3: noetl.catalog is a cluster-wide table.
     let playbook_yaml: String =
@@ -3129,8 +3130,8 @@ async fn trigger_orchestrator_inner(
     if result.should_complete {
         drop(cache);
         state.orch_cache.evict(execution_id);
-        state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
-        state.exec_descriptors.evict(execution_id); // RFC #115 Phase 4 remainder
+        state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
+        state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
     }
 
     Ok(commands_generated)
@@ -3424,13 +3425,18 @@ async fn apply_worker_orchestration(
     // `cache.state`.  So skip the cold-rebuild ENTIRELY (no `noetl.event` read on
     // the apply side of the drive path either).  A cold descriptor falls through
     // to the crash-recovery rebuild below.
-    let offserver_apply = matches!(
+    let offserver_apply = if matches!(
         state.config.state_builder,
         crate::config::StateBuilder::Offserver
-    )
-    .then(|| state.exec_descriptors.get(execution_id))
-    .flatten()
-    .filter(|d| d.catalog_id != 0);
+    ) {
+        state
+            .exec_descriptors
+            .get(execution_id)
+            .await
+            .filter(|d| d.catalog_id != 0)
+    } else {
+        None
+    };
 
     let (catalog_id, routing) = if let Some(desc) = offserver_apply {
         crate::metrics::record_orchestrate_drive("applied_stateless");
@@ -3505,7 +3511,8 @@ async fn apply_worker_orchestration(
                 let cid = cache.state.as_ref().map(|s| s.catalog_id).unwrap_or(0);
                 state
                     .exec_descriptors
-                    .seed(execution_id, cid, cache.routing_meta.clone());
+                    .seed(execution_id, cid, cache.routing_meta.clone())
+                    .await;
             }
         }
 
@@ -3557,8 +3564,8 @@ async fn apply_worker_orchestration(
     if result.should_complete || result.state.is_terminal() {
         drop(cache);
         state.orch_cache.evict(execution_id);
-        state.chain_heads.evict(execution_id); // RFC #115 §4: drop the chain head too
-        state.exec_descriptors.evict(execution_id); // RFC #115 Phase 4 remainder
+        state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
+        state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
     }
     Ok(commands_generated)
 }

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -475,22 +475,25 @@ async fn emit_deduplicated_event(
     // RFC #115 Phase 6: under `event_read_path=audit_only`, serve the scope's
     // catalog_id from the in-memory execute-time descriptor — ZERO `noetl.event`
     // read.  Cold descriptor falls through to the scan (counted `scan`).
-    let catalog_id: Option<i64> = if matches!(
+    let audit_only = matches!(
         state.config.event_read_path,
         crate::config::EventReadPath::AuditOnly
-    ) && state
-        .exec_descriptors
-        .get(scope)
-        .map(|d| d.catalog_id)
-        .filter(|c| *c != 0)
-        .is_some()
-    {
+    );
+    // Read the (possibly KV-coherent) descriptor once.
+    let desc_catalog: Option<i64> = if audit_only {
+        state
+            .exec_descriptors
+            .get(scope)
+            .await
+            .map(|d| d.catalog_id)
+            .filter(|c| *c != 0)
+    } else {
+        None
+    };
+    let catalog_id: Option<i64> = if let Some(cid) = desc_catalog {
         crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "served_descriptor");
-        state.exec_descriptors.get(scope).map(|d| d.catalog_id)
-    } else if matches!(
-        state.config.event_read_path,
-        crate::config::EventReadPath::AuditOnly
-    ) {
+        Some(cid)
+    } else if audit_only {
         // Cold descriptor under audit_only: catalog_id from `noetl.command` — the
         // synchronous queue — ZERO `noetl.event` read.
         crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "served_command");
@@ -653,7 +656,8 @@ async fn emit_playbook_started_event(
     // are known; read in `events::trigger_orchestrator_inner`'s stateless branch.
     state
         .exec_descriptors
-        .seed(execution_id, catalog_id, Some(meta.clone()));
+        .seed(execution_id, catalog_id, Some(meta.clone()))
+        .await;
 
     // CQRS write-path chokepoint (#103 2d-3): INSERT (gate off) or publish (on).
     let ev = crate::handlers::event_write::EventRow::new(
@@ -686,7 +690,7 @@ async fn inherit_parent_trace(state: &AppState, parent_execution_id: i64) -> Opt
         state.config.event_read_path,
         crate::config::EventReadPath::AuditOnly
     ) {
-        if let Some(desc) = state.exec_descriptors.get(parent_execution_id) {
+        if let Some(desc) = state.exec_descriptors.get(parent_execution_id).await {
             if desc.catalog_id != 0 {
                 crate::metrics::record_event_hotpath_read("inherit_parent_trace", "served_descriptor");
                 return desc
@@ -926,6 +930,7 @@ pub(crate) async fn persist_engine_command(
     let issuing_event = state
         .chain_heads
         .head(execution_id)
+        .await
         .unwrap_or(parent_event_id);
     let ev = crate::handlers::event_write::EventRow::new(
         event_id,
@@ -1119,6 +1124,7 @@ pub(crate) async fn persist_engine_commands_batch(
     let issuing_event = state
         .chain_heads
         .head(execution_id)
+        .await
         .unwrap_or(parent_event_id);
     let event_rows: Vec<crate::handlers::event_write::EventRow> = prepared
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! }
 //! ```
 
+pub mod coherence;
 pub mod config;
 pub mod crypto;
 pub mod db;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -345,6 +345,61 @@ pub fn record_state_build_parity(result: &str) {
     state_build_parity_total().with_label_values(&[result]).inc();
 }
 
+// ── Replica coherence (RFC noetl/ai-meta#115 program-scale / #107) ───────────
+
+/// `noetl_replica_coherence_total{structure, op, outcome}` — every access to the
+/// per-execution drive watermark ([`crate::state::ChainHeads`]) or descriptor
+/// ([`crate::state::ExecDescriptor`]) under `NOETL_REPLICA_COHERENCE=nats_kv`,
+/// labelled by which read model served it.  The proof series for multi-replica
+/// coherence:
+///
+/// - `structure` = `chain_head` | `descriptor`.
+/// - `op` = `link_batch` | `head` | `get` | `seed` | `mark_terminal` | `evict`.
+/// - `outcome`:
+///   - `kv_ok` — a KV write (head CAS / descriptor merge / evict) succeeded.
+///   - `kv_remote_hit` — a `descriptor get` (or `head`) **missed the local
+///     in-process map but hit the KV bucket** — i.e. another replica seeded it
+///     and this replica resolved it coherently.  **This is the load-bearing
+///     proof counter**: every increment is a server-built cold-fallback (an event
+///     read) that the KV backing avoided when the trigger landed on a different
+///     replica than the one that seeded the execution.
+///   - `kv_local_hit` — both the local map and KV had it (the common
+///     single-replica / same-replica case).
+///   - `kv_miss` — KV authoritatively had no entry (genuinely cold: never-seeded
+///     or evicted everywhere) → the caller takes the server-built fallback.
+///   - `kv_unavailable` — KV unreachable / disabled / a CAS exhausted its
+///     retries → degraded to the in-process map (behaves as `local`).
+///
+/// Under `nats_kv` with 2+ replicas and triggers landing across them, a coherent
+/// run shows `kv_remote_hit > 0` (cross-replica resolves happened) while the
+/// drive's `noetl_state_build_event_scans_total` and the hot-path
+/// `noetl_event_hotpath_reads_total{outcome="scan"}` stay flat — coherence
+/// without a single recovery scan attributable to the replica split.
+pub fn replica_coherence_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_replica_coherence_total",
+                "Per-execution drive watermark/descriptor accesses under NOETL_REPLICA_COHERENCE=nats_kv, by structure/op/outcome (RFC #115 program-scale).",
+            ),
+            &["structure", "op", "outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one replica-coherence access (`structure`/`op`/`outcome`).
+pub fn record_replica_coherence(structure: &str, op: &str, outcome: &str) {
+    replica_coherence_total()
+        .with_label_values(&[structure, op, outcome])
+        .inc();
+}
+
 /// Histogram: wall-clock time spent inside the `POST /api/events` handler.
 pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
     static M: OnceLock<HistogramVec> = OnceLock::new();

--- a/src/state.rs
+++ b/src/state.rs
@@ -173,49 +173,135 @@ pub struct ExecOrchState {
 /// validates.  Restart-spanning repair is a Phase 3 builder concern (it
 /// re-walks from a durable head); nothing reads `prev_event_id` yet, so a chain
 /// restart here is additive metadata, never a regression.
-#[derive(Default)]
 pub struct ChainHeads {
     map: std::sync::Mutex<std::collections::HashMap<i64, i64>>,
+    /// Multi-replica coherence backend (RFC #115 program-scale).  `local`
+    /// (default) → disabled, the `map` is the whole story (today's behavior).
+    /// `nats_kv` → the head is CAS-advanced in a shared KV bucket so 2+ replicas
+    /// agree, and `map` becomes a write-through cache / degraded-mode fallback.
+    coherence: Arc<crate::coherence::CoherenceKv>,
+}
+
+impl Default for ChainHeads {
+    fn default() -> Self {
+        Self {
+            map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            coherence: Arc::new(crate::coherence::CoherenceKv::default()),
+        }
+    }
 }
 
 impl ChainHeads {
+    /// Build with a shared coherence backend (used by [`AppState::new`]).
+    pub fn with_coherence(coherence: Arc<crate::coherence::CoherenceKv>) -> Self {
+        Self {
+            map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            coherence,
+        }
+    }
+
     /// Stamp the chain link for a batch of event ids emitted (in order) for one
     /// execution, advancing the head as it goes.  Returns, for each id, the
-    /// `prev_event_id` it should carry (`None` for a chain root).  One short
-    /// `std::Mutex` critical section, no `await` held — safe to call from any
-    /// chokepoint path without lock-ordering hazards against
-    /// [`OrchStateCache`]'s per-execution `tokio::Mutex`.
+    /// `prev_event_id` it should carry (`None` for a chain root).
+    ///
+    /// Under `local` this is one short `std::Mutex` critical section (no `await`
+    /// held).  Under `nats_kv` the head before the batch is obtained by a KV
+    /// **compare-and-swap** so concurrent emits on different replicas serialise
+    /// into a single per-execution chain; the `std::Mutex` is never held across
+    /// the KV `await`.
     ///
     /// An empty `event_ids` is a no-op returning an empty vec.
-    pub fn link_batch(&self, execution_id: i64, event_ids: &[i64]) -> Vec<Option<i64>> {
+    pub async fn link_batch(&self, execution_id: i64, event_ids: &[i64]) -> Vec<Option<i64>> {
+        if event_ids.is_empty() {
+            return Vec::new();
+        }
+        let new_head = *event_ids.last().expect("non-empty checked above");
+        if self.coherence.enabled() {
+            if let crate::coherence::KvRead::Hit(prev_head) =
+                self.coherence.advance_head(execution_id, new_head).await
+            {
+                // Write-through the local cache (best-effort; KV is the truth).
+                self.map.lock().unwrap().insert(execution_id, new_head);
+                crate::metrics::record_replica_coherence("chain_head", "link_batch", "kv_ok");
+                return Self::prevs_from(prev_head, event_ids);
+            }
+            crate::metrics::record_replica_coherence("chain_head", "link_batch", "kv_unavailable");
+            // Fall through to the in-process map (degraded mode == local).
+        }
         let mut map = self.map.lock().unwrap();
-        let mut head = map.get(&execution_id).copied();
+        let head = map.get(&execution_id).copied();
+        let prevs = Self::prevs_from(head, event_ids);
+        map.insert(execution_id, new_head);
+        prevs
+    }
+
+    /// Given the head *before* a batch + the batch's ids (in order), the
+    /// `prev_event_id` each id carries: the first points at the prior head, each
+    /// subsequent at its predecessor in the batch.
+    fn prevs_from(prev_head: Option<i64>, event_ids: &[i64]) -> Vec<Option<i64>> {
+        let mut head = prev_head;
         let mut prevs = Vec::with_capacity(event_ids.len());
         for &eid in event_ids {
             prevs.push(head);
             head = Some(eid);
         }
-        if let Some(h) = head {
-            map.insert(execution_id, h);
-        }
         prevs
     }
 
-    /// Drop a terminal execution's head (frees memory).  Called alongside
-    /// [`OrchStateCache::evict`] on the terminal-event paths.
-    pub fn evict(&self, execution_id: i64) {
+    /// Drop a terminal execution's head (frees memory + the KV entry).  Called
+    /// alongside [`OrchStateCache::evict`] on the terminal-event paths.
+    pub async fn evict(&self, execution_id: i64) {
         self.map.lock().unwrap().remove(&execution_id);
+        if self.coherence.enabled() {
+            self.coherence.evict_head(execution_id).await;
+        }
     }
 
-    /// Current head for an execution, if any.  Test/diagnostic helper.
-    pub fn head(&self, execution_id: i64) -> Option<i64> {
+    /// Current head for an execution, if any.  Under `nats_kv` the coherent KV
+    /// value is authoritative (any replica resolves the same head); a KV miss is
+    /// a genuine cold slot, KV-unavailable degrades to the in-process map.
+    pub async fn head(&self, execution_id: i64) -> Option<i64> {
+        if self.coherence.enabled() {
+            match self.coherence.get_head(execution_id).await {
+                crate::coherence::KvRead::Hit(v) => {
+                    let local_had = self
+                        .map
+                        .lock()
+                        .unwrap()
+                        .insert(execution_id, v)
+                        .is_some();
+                    crate::metrics::record_replica_coherence(
+                        "chain_head",
+                        "head",
+                        if local_had { "kv_local_hit" } else { "kv_remote_hit" },
+                    );
+                    return Some(v);
+                }
+                crate::coherence::KvRead::Miss => {
+                    crate::metrics::record_replica_coherence("chain_head", "head", "kv_miss");
+                    return None;
+                }
+                crate::coherence::KvRead::Unavailable => {
+                    crate::metrics::record_replica_coherence(
+                        "chain_head",
+                        "head",
+                        "kv_unavailable",
+                    );
+                    // Fall through to local.
+                }
+            }
+        }
         self.map.lock().unwrap().get(&execution_id).copied()
     }
 }
 
 /// Execute-time descriptor for the stateless off-server drive edge (RFC #115
 /// Phase 4 remainder).  See the [`AppState::exec_descriptors`] field doc.
-#[derive(Clone, Debug, Default)]
+///
+/// `Serialize`/`Deserialize` so the multi-replica coherence backend
+/// ([`crate::coherence::CoherenceKv`]) can store it in a JetStream KV bucket
+/// under `NOETL_REPLICA_COHERENCE=nats_kv`.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ExecDescriptor {
     /// The execution's catalog id (immutable for the run).  Sourced from the
     /// `playbook_started` event at execute-time instead of from a rebuilt
@@ -240,42 +326,121 @@ pub struct ExecDescriptor {
 /// mid-execution) yields `None`, and the drive falls back to the server-built
 /// state path for that trigger — which re-seeds the descriptor — so correctness
 /// never regresses below the server-built drive.
-#[derive(Default)]
 pub struct ExecDescriptors {
     map: std::sync::Mutex<std::collections::HashMap<i64, ExecDescriptor>>,
+    /// Multi-replica coherence backend (RFC #115 program-scale).  `local`
+    /// (default) → disabled (today's behavior).  `nats_kv` → the descriptor is a
+    /// shared KV entry so a trigger landing on a replica that didn't seed the
+    /// execution resolves it (and the terminal flag) coherently instead of
+    /// taking a server-built cold fallback.
+    coherence: Arc<crate::coherence::CoherenceKv>,
+}
+
+impl Default for ExecDescriptors {
+    fn default() -> Self {
+        Self {
+            map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            coherence: Arc::new(crate::coherence::CoherenceKv::default()),
+        }
+    }
 }
 
 impl ExecDescriptors {
-    /// Seed `catalog_id` + `routing_meta` at execute-time (or re-seed from the
-    /// server-built fallback path after a cold-descriptor drive).  Fills the
-    /// load-bearing fields without clobbering a `terminal` flag a concurrent
-    /// cancel may already have stamped.
-    pub fn seed(&self, execution_id: i64, catalog_id: i64, routing_meta: Option<serde_json::Value>) {
-        let mut map = self.map.lock().unwrap();
-        let e = map.entry(execution_id).or_default();
-        if catalog_id != 0 {
-            e.catalog_id = catalog_id;
-        }
-        if routing_meta.is_some() {
-            e.routing_meta = routing_meta;
+    /// Build with a shared coherence backend (used by [`AppState::new`]).
+    pub fn with_coherence(coherence: Arc<crate::coherence::CoherenceKv>) -> Self {
+        Self {
+            map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            coherence,
         }
     }
 
-    /// Current descriptor snapshot for an execution, if seeded.
-    pub fn get(&self, execution_id: i64) -> Option<ExecDescriptor> {
-        self.map.lock().unwrap().get(&execution_id).cloned()
+    /// Seed `catalog_id` + `routing_meta` at execute-time (or re-seed from the
+    /// server-built fallback path after a cold-descriptor drive).  Fills the
+    /// load-bearing fields without clobbering a `terminal` flag a concurrent
+    /// cancel may already have stamped.  Under `nats_kv` the merge also rides a
+    /// KV CAS so a seed + a terminal-stamp from different replicas converge.
+    pub async fn seed(
+        &self,
+        execution_id: i64,
+        catalog_id: i64,
+        routing_meta: Option<serde_json::Value>,
+    ) {
+        {
+            let mut map = self.map.lock().unwrap();
+            let e = map.entry(execution_id).or_default();
+            if catalog_id != 0 {
+                e.catalog_id = catalog_id;
+            }
+            if routing_meta.is_some() {
+                e.routing_meta = routing_meta.clone();
+            }
+        }
+        if self.coherence.enabled() {
+            self.coherence
+                .seed_descriptor(execution_id, catalog_id, routing_meta)
+                .await;
+            crate::metrics::record_replica_coherence("descriptor", "seed", "kv_ok");
+        }
+    }
+
+    /// Current descriptor snapshot for an execution, if seeded.  Under `nats_kv`
+    /// the coherent KV value is authoritative: a KV hit that the local map
+    /// missed is a **cross-replica resolve** (`kv_remote_hit`) — the descriptor
+    /// another replica seeded, found without a server-built cold fallback.  A KV
+    /// miss is a genuine cold slot (never-seeded or evicted everywhere); KV
+    /// unavailable degrades to the in-process map.
+    pub async fn get(&self, execution_id: i64) -> Option<ExecDescriptor> {
+        let local = self.map.lock().unwrap().get(&execution_id).cloned();
+        if self.coherence.enabled() {
+            match self.coherence.get_descriptor(execution_id).await {
+                crate::coherence::KvRead::Hit(desc) => {
+                    crate::metrics::record_replica_coherence(
+                        "descriptor",
+                        "get",
+                        if local.is_some() { "kv_local_hit" } else { "kv_remote_hit" },
+                    );
+                    self.map.lock().unwrap().insert(execution_id, desc.clone());
+                    return Some(desc);
+                }
+                crate::coherence::KvRead::Miss => {
+                    crate::metrics::record_replica_coherence("descriptor", "get", "kv_miss");
+                    return None;
+                }
+                crate::coherence::KvRead::Unavailable => {
+                    crate::metrics::record_replica_coherence(
+                        "descriptor",
+                        "get",
+                        "kv_unavailable",
+                    );
+                    return local;
+                }
+            }
+        }
+        local
     }
 
     /// Stamp the terminal flag (emit chokepoint).  Creates the slot if cold so a
     /// cancel that lands before any drive still records the stop signal.
-    pub fn mark_terminal(&self, execution_id: i64) {
-        self.map.lock().unwrap().entry(execution_id).or_default().terminal = true;
+    pub async fn mark_terminal(&self, execution_id: i64) {
+        self.map
+            .lock()
+            .unwrap()
+            .entry(execution_id)
+            .or_default()
+            .terminal = true;
+        if self.coherence.enabled() {
+            self.coherence.mark_terminal_descriptor(execution_id).await;
+            crate::metrics::record_replica_coherence("descriptor", "mark_terminal", "kv_ok");
+        }
     }
 
-    /// Drop a terminal execution's descriptor (frees memory).  Called alongside
-    /// [`OrchStateCache::evict`] on the terminal paths.
-    pub fn evict(&self, execution_id: i64) {
+    /// Drop a terminal execution's descriptor (frees memory + the KV entry).
+    /// Called alongside [`OrchStateCache::evict`] on the terminal paths.
+    pub async fn evict(&self, execution_id: i64) {
         self.map.lock().unwrap().remove(&execution_id);
+        if self.coherence.enabled() {
+            self.coherence.evict_descriptor(execution_id).await;
+        }
     }
 }
 
@@ -394,17 +559,33 @@ impl AppState {
             "Shard configuration initialized"
         );
 
+        // Multi-replica coherence backend (RFC #115 program-scale,
+        // noetl/ai-meta#107).  `local` (default) → disabled, so `ChainHeads` +
+        // `ExecDescriptors` are the in-process maps (prod-unchanged).  `nats_kv`
+        // → both are backed by shared JetStream KV buckets so 2+ replicas resolve
+        // the same watermark/descriptor.  One backend shared by both structures.
+        let nats = nats.map(Arc::new);
+        let coherence = Arc::new(crate::coherence::CoherenceKv::new(
+            nats.clone(),
+            config.replica_coherence,
+        ));
+        tracing::info!(
+            replica_coherence = ?config.replica_coherence,
+            coherence_enabled = coherence.enabled(),
+            "Replica coherence backend initialized"
+        );
+
         Self {
             db,
             pools,
             config: Arc::new(config),
-            nats: nats.map(Arc::new),
+            nats,
             snowflake: Arc::new(snowflake),
             shard: Arc::new(shard),
             start_time: std::time::Instant::now(),
             orch_cache: Arc::new(OrchStateCache::default()),
-            chain_heads: Arc::new(ChainHeads::default()),
-            exec_descriptors: Arc::new(ExecDescriptors::default()),
+            chain_heads: Arc::new(ChainHeads::with_coherence(coherence.clone())),
+            exec_descriptors: Arc::new(ExecDescriptors::with_coherence(coherence)),
             event_stream_publisher: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
@@ -454,93 +635,97 @@ mod tests {
 
     // RFC #115 Phase 4 remainder: the execute-time descriptor carries catalog_id
     // + routing so the off-server drive routes without rebuilding state.
-    #[test]
-    fn exec_descriptor_seed_get_and_terminal() {
+    // `ChainHeads::default()` / `ExecDescriptors::default()` are
+    // coherence-disabled (local), so these tests assert the in-process
+    // behavior — the prod/default path the `nats_kv` backing must stay
+    // bit-compatible with.
+    #[tokio::test]
+    async fn exec_descriptor_seed_get_and_terminal() {
         let d = ExecDescriptors::default();
-        assert!(d.get(7).is_none(), "cold execution has no descriptor");
+        assert!(d.get(7).await.is_none(), "cold execution has no descriptor");
 
-        d.seed(7, 42, Some(serde_json::json!({"execution_pool": "default"})));
-        let got = d.get(7).expect("seeded");
+        d.seed(7, 42, Some(serde_json::json!({"execution_pool": "default"}))).await;
+        let got = d.get(7).await.expect("seeded");
         assert_eq!(got.catalog_id, 42);
         assert_eq!(got.routing_meta.unwrap()["execution_pool"], "default");
         assert!(!got.terminal, "freshly seeded is not terminal");
 
         // A terminal stamp (emit chokepoint) flips the flag without clobbering
         // the seeded facts.
-        d.mark_terminal(7);
-        let got = d.get(7).expect("still present");
+        d.mark_terminal(7).await;
+        let got = d.get(7).await.expect("still present");
         assert!(got.terminal, "terminal flag set");
         assert_eq!(got.catalog_id, 42, "catalog_id preserved across terminal stamp");
 
-        d.evict(7);
-        assert!(d.get(7).is_none(), "evicted");
+        d.evict(7).await;
+        assert!(d.get(7).await.is_none(), "evicted");
     }
 
-    #[test]
-    fn exec_descriptor_seed_preserves_terminal_and_does_not_zero_catalog() {
+    #[tokio::test]
+    async fn exec_descriptor_seed_preserves_terminal_and_does_not_zero_catalog() {
         let d = ExecDescriptors::default();
         // A cancel can stamp terminal before any drive seeded catalog_id.
-        d.mark_terminal(9);
+        d.mark_terminal(9).await;
         // A late seed (e.g. the recovery rebuild) must keep the terminal flag and
         // must not zero catalog_id when passed 0.
-        d.seed(9, 0, None);
-        let got = d.get(9).expect("present");
+        d.seed(9, 0, None).await;
+        let got = d.get(9).await.expect("present");
         assert!(got.terminal, "terminal flag survives a seed");
         assert_eq!(got.catalog_id, 0, "catalog_id stays 0 (nothing real to seed yet)");
         // A real seed fills catalog_id, still keeping terminal.
-        d.seed(9, 55, Some(serde_json::json!({"x": 1})));
-        let got = d.get(9).expect("present");
+        d.seed(9, 55, Some(serde_json::json!({"x": 1}))).await;
+        let got = d.get(9).await.expect("present");
         assert_eq!(got.catalog_id, 55);
         assert!(got.terminal);
     }
 
     // RFC #115 §4: the per-execution chain head turns a stream of emitted event
     // ids into a walkable singly-linked list.
-    #[test]
-    fn chain_head_links_first_event_is_root() {
+    #[tokio::test]
+    async fn chain_head_links_first_event_is_root() {
         let heads = ChainHeads::default();
         // First batch: the execution's first event has no predecessor (root).
-        let prevs = heads.link_batch(7, &[100]);
+        let prevs = heads.link_batch(7, &[100]).await;
         assert_eq!(prevs, vec![None], "execution's first event is a chain root");
-        assert_eq!(heads.head(7), Some(100));
+        assert_eq!(heads.head(7).await, Some(100));
     }
 
-    #[test]
-    fn chain_head_links_batch_in_order() {
+    #[tokio::test]
+    async fn chain_head_links_batch_in_order() {
         let heads = ChainHeads::default();
         // A multi-row batch (e.g. a cursor fan-out's N command.issued events)
         // links each row to the previous one in order; the first to the head.
-        let prevs = heads.link_batch(7, &[10, 11, 12]);
+        let prevs = heads.link_batch(7, &[10, 11, 12]).await;
         assert_eq!(prevs, vec![None, Some(10), Some(11)]);
-        assert_eq!(heads.head(7), Some(12), "head advances to the last id");
+        assert_eq!(heads.head(7).await, Some(12), "head advances to the last id");
         // A following batch continues the chain from the advanced head.
-        let prevs = heads.link_batch(7, &[20, 21]);
+        let prevs = heads.link_batch(7, &[20, 21]).await;
         assert_eq!(prevs, vec![Some(12), Some(20)]);
-        assert_eq!(heads.head(7), Some(21));
+        assert_eq!(heads.head(7).await, Some(21));
     }
 
-    #[test]
-    fn chain_head_is_per_execution() {
+    #[tokio::test]
+    async fn chain_head_is_per_execution() {
         let heads = ChainHeads::default();
-        heads.link_batch(1, &[10, 11]);
-        heads.link_batch(2, &[90]);
+        heads.link_batch(1, &[10, 11]).await;
+        heads.link_batch(2, &[90]).await;
         // Distinct executions never share a head.
-        assert_eq!(heads.head(1), Some(11));
-        assert_eq!(heads.head(2), Some(90));
-        let p1 = heads.link_batch(1, &[12]);
-        let p2 = heads.link_batch(2, &[91]);
+        assert_eq!(heads.head(1).await, Some(11));
+        assert_eq!(heads.head(2).await, Some(90));
+        let p1 = heads.link_batch(1, &[12]).await;
+        let p2 = heads.link_batch(2, &[91]).await;
         assert_eq!(p1, vec![Some(11)]);
         assert_eq!(p2, vec![Some(90)]);
     }
 
-    #[test]
-    fn chain_head_walk_reconstructs_full_sequence_no_gaps() {
+    #[tokio::test]
+    async fn chain_head_walk_reconstructs_full_sequence_no_gaps() {
         // Property the kind validation asserts in SQL: walking prev_event_id
         // from the head reconstructs the full per-execution sequence with no
         // gaps.  Model it over the in-memory linker.
         let heads = ChainHeads::default();
         let ids = [5_i64, 6, 7, 8, 9];
-        let prevs = heads.link_batch(42, &ids);
+        let prevs = heads.link_batch(42, &ids).await;
         // Build the prev map the chain would persist.
         let mut prev_of = std::collections::HashMap::new();
         for (id, prev) in ids.iter().zip(&prevs) {
@@ -548,7 +733,7 @@ mod tests {
         }
         // Walk backward from the head.
         let mut walked = Vec::new();
-        let mut cur = heads.head(42);
+        let mut cur = heads.head(42).await;
         while let Some(id) = cur {
             walked.push(id);
             cur = prev_of.get(&id).copied().flatten();
@@ -557,22 +742,22 @@ mod tests {
         assert_eq!(walked, ids, "pointer walk == full emit sequence, no gaps");
     }
 
-    #[test]
-    fn chain_head_evict_drops_state() {
+    #[tokio::test]
+    async fn chain_head_evict_drops_state() {
         let heads = ChainHeads::default();
-        heads.link_batch(7, &[10]);
-        assert_eq!(heads.head(7), Some(10));
-        heads.evict(7);
-        assert_eq!(heads.head(7), None, "evicted execution starts a fresh chain");
+        heads.link_batch(7, &[10]).await;
+        assert_eq!(heads.head(7).await, Some(10));
+        heads.evict(7).await;
+        assert_eq!(heads.head(7).await, None, "evicted execution starts a fresh chain");
         // After eviction the next event is treated as a root again.
-        let prevs = heads.link_batch(7, &[20]);
+        let prevs = heads.link_batch(7, &[20]).await;
         assert_eq!(prevs, vec![None]);
     }
 
-    #[test]
-    fn chain_head_empty_batch_is_noop() {
+    #[tokio::test]
+    async fn chain_head_empty_batch_is_noop() {
         let heads = ChainHeads::default();
-        assert_eq!(heads.link_batch(7, &[]), Vec::<Option<i64>>::new());
-        assert_eq!(heads.head(7), None);
+        assert_eq!(heads.link_batch(7, &[]).await, Vec::<Option<i64>>::new());
+        assert_eq!(heads.head(7).await, None);
     }
 }


### PR DESCRIPTION
## What

The off-server drive edge keys two execution-scoped facts off in-memory
`AppState` maps:

- **`ChainHeads`** — the `prev_event_id` watermark the `emit_events` chokepoint
  stamps so per-execution events form a walkable single-linked chain.
- **`ExecDescriptor`** — `catalog_id` + routing + the terminal flag, seeded at
  `playbook_started`, read by the stateless dispatch.

Both carry a **single-replica locality assumption** (documented at
`state.rs` `ChainHeads`): they live on whichever replica handled the execution's
first event. With 2+ replicas a later trigger that lands on a different replica
finds a cold slot and (a) for the watermark, stamps a continuation event as a
chain root → a forked chain the off-server builder can't reassemble; (b) for the
descriptor, falls back to the server-built path that **reads `noetl.event`** —
correct, but neither scan-free nor coherent.

Behind **`NOETL_REPLICA_COHERENCE=nats_kv`** (default `local`, **prod
unchanged**) both maps are backed by two JetStream **KV buckets**
(`noetl_chain_heads`, `noetl_exec_descriptors`) so any replica resolves the same
value:

- The **head advance** is a **compare-and-swap** (`Store::update` at the read
  revision), so concurrent emits for one execution serialise into a single chain.
- The **descriptor** is a CAS read-modify-write so a `seed` (catalog_id +
  routing) and a `mark_terminal` from different replicas **merge** rather than
  clobber.

The in-process maps stay as a **write-through cache + degraded-mode fallback**:
KV unreachable / `mode=local` → bit-identical to today (single-replica + prod
unchanged). Buckets are built lazily (same shape as the event-stream publisher)
so the sync `AppState` constructor stays sync.

## Why this is the right shape (and what it is NOT)

This is option (i) from the design space — back the watermark/descriptor with a
shared store the pool already uses (the RFC's "the watermark is a chain
pointer"). It reuses the NATS client already in `AppState` + the JetStream
context the publisher builds; no new deployment, no routing change.

**Kind validation on a 2-replica cluster proved this layer is necessary but not
sufficient.** The cross-replica resolves provably happen
(`noetl_replica_coherence_total{outcome="kv_remote_hit"}` advances for both head
and descriptor; no `kv_unavailable`), and it is **bit-for-bit single-replica
parity** with `local` (all topologies COMPLETE, clean chains). But on 2+
replicas, concurrent cross-replica emits still fork the chain because the
**write ordering** (which replica owns an execution's drive + chain write) is not
yet single-owner — so executions don't reliably COMPLETE on 2+ replicas yet. The
remaining piece is **execution-affinity** (option ii), staged as the next
program-scale step (see `noetl/ai-meta#107`). This PR is the data-coherence
substrate that affinity builds on.

## Observability

`noetl_replica_coherence_total{structure, op, outcome}` — the load-bearing proof
series is `outcome="kv_remote_hit"` (a head/descriptor that missed the local map
but hit KV = a cross-replica resolve that avoided a server-built cold fallback).

## Tests / validation

- 588 lib tests (585 + 3 new coherence) + clippy green. `ExecDescriptor` gains
  serde derives for KV storage; `ChainHeads`/`ExecDescriptors` methods are now
  `async` (all call sites are already in async fns).
- **kind single-replica `nats_kv`**: linear/loop/fan-out ×2 all COMPLETE, chain
  integrity perfect (roots=1, dangling=0, head-walk==total), `state_build_event_scans`
  +0, hotpath scan +0, sole-writer intact, `__orchestrate__` event rows = 0.
- **kind 2-replica `nats_kv`**: coherence resolves proven
  (`kv_remote_hit` advanced for head + descriptor, no `kv_unavailable`); full
  completion staged on execution-affinity.
- Rig: `noetl/e2e` `kind_validate_replica_coherence.sh`.

## Defaults / prod

`NOETL_REPLICA_COHERENCE` defaults `local`; no other default changed; prod GKE
untouched; the kind gate state was restored after validation.

Refs noetl/ai-meta#115
Refs noetl/ai-meta#107
Refs noetl/ai-meta#111

🤖 Generated with [Claude Code](https://claude.com/claude-code)