### PR TITLE
feat(affinity): execution-affinity single-owner write ordering for the off-server drive

### DIFF
--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -1,0 +1,319 @@
+//! Execution-affinity routing — single-owner write ordering for the off-server
+//! drive (RFC noetl/ai-meta#116, the multi-replica half of #115 program-scale /
+//! #107 step 3).
+//!
+//! ## The problem affinity closes
+//!
+//! The multi-replica coherence DATA layer ([`crate::coherence`],
+//! `NOETL_REPLICA_COHERENCE=nats_kv`) makes any replica resolve the **same**
+//! chain-head watermark + execution descriptor from shared JetStream KV. That is
+//! *necessary but not sufficient* for multi-replica off-server execution. The
+//! `command.issued` predecessor is read from the chain head in
+//! [`crate::handlers::execute`] and the head is CAS-advanced in
+//! [`crate::handlers::event_write::emit_events`] as **two non-atomic steps**;
+//! across two replicas a lifecycle emit for the same execution can advance the
+//! head between the read and the advance, so a `command.issued` carries a stale
+//! prev while the chain threads through a newer event → a forked chain the
+//! off-server WAL builder cannot reassemble (it perpetually reports "worker WAL
+//! incomplete" and the execution sticks RUNNING). The per-execution drive
+//! serialisation (`OrchStateCache::orchestrate_in_flight`) is *also* per-replica,
+//! so two replicas can drive the same execution concurrently — a second source of
+//! the same fork, plus a double-issue of the next commands.
+//!
+//! ## The mechanism — one replica owns an execution
+//!
+//! Affinity makes the read-then-advance atomic **by construction**: every trigger
+//! for an execution (`POST /api/events`, which carries both the worker-lifecycle
+//! events AND synchronously fires the drive) is routed to the single replica that
+//! [`crate::sharding::ShardConfig::owns`] it — `shard_for(execution_id)` over the
+//! stable XxHash64 already used for the sharded data layout. On the owner:
+//!
+//! - only one process ever drives + emits for the execution, so the existing
+//!   per-execution `orchestrate_in_flight` lock + the single-process in-memory
+//!   [`ChainHeads`](crate::state::ChainHeads) serialise the read→advance with no
+//!   distributed lock on the hot path; and
+//! - the double-drive disappears too — only the owner's reconcile poller and only
+//!   the owner's ingest path drive the execution.
+//!
+//! A non-owning replica that receives a trigger **forwards** it (a transparent
+//! server-side reverse-proxy POST) to the owner and returns the owner's response.
+//! KV coherence ([`crate::coherence`]) composes with affinity rather than being
+//! replaced: it covers the *genesis-on-a-different-replica* case (an execution
+//! whose `playbook_started` landed on a non-owner before any forwarding) and
+//! ownership *handoff* (a replica restart / shard-map change) — the new owner
+//! reads the coherent head/descriptor from KV instead of a cold local slot.
+//!
+//! ## Why forwarding, not a distributed drive lock
+//!
+//! Option (ii) from the #116 design space — a NATS-KV lease per drive plus a
+//! CAS-time issuing-event derivation — adds lease-acquire latency to *every*
+//! drive and carries lease-expiry edge cases (a slow owner whose lease lapses
+//! mid-drive lets a second replica in). Affinity solves the chain fork AND the
+//! double-drive with one mechanism (one owner for the whole execution) and reuses
+//! the `src/sharding.rs` substrate verbatim — no new hash, no new lock on the hot
+//! path.
+//!
+//! ## Default-safe
+//!
+//! - `NOETL_EXECUTION_AFFINITY` defaults **off** → no forwarding, prod unchanged.
+//! - With one replica `ShardConfig::owns` is always `true` (shard_count<=1), so
+//!   even with the flag on a single replica forwards nothing — bit-for-bit the
+//!   current behavior.
+//! - Forwarding requires a peer-URL template; absent it, affinity is inert.
+//! - A forward that fails (owner unreachable) **degrades to local processing** —
+//!   the worst case is the pre-affinity behavior (which under `nats_kv` is still
+//!   coherent), never a dropped event.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::http::HeaderMap;
+
+use crate::sharding::ShardConfig;
+
+/// Header marking a `/api/events` POST that this replica already forwarded once.
+/// The owner that receives it processes locally regardless of its own `owns()`
+/// verdict — a single forwarding hop, never a loop.
+pub const AFFINITY_FORWARDED_HEADER: &str = "x-noetl-affinity-forwarded";
+
+/// Placeholder in [`AppConfig::peer_url_template`](crate::config::AppConfig)
+/// replaced by the owner shard index when building the forward target.
+const SHARD_PLACEHOLDER: &str = "{shard}";
+
+/// Execution-affinity router. Built once in
+/// [`AppState::new`](crate::state::AppState::new); cloned cheaply (everything is
+/// behind an `Arc` / `Copy`).
+pub struct ExecutionAffinity {
+    /// `NOETL_EXECUTION_AFFINITY` — master switch. Off (default) → inert.
+    enabled: bool,
+    /// `NOETL_PEER_URL_TEMPLATE`, e.g.
+    /// `http://noetl-server-rust-{shard}.noetl-server-rust-headless:8082`. The
+    /// `{shard}` token is replaced by the owner's shard index. `None` → inert.
+    peer_url_template: Option<String>,
+    /// The cluster shard map (same `Arc` `AppState` holds).
+    shard: Arc<ShardConfig>,
+    /// Shared HTTP client for the reverse-proxy hop. Short timeout — the owner is
+    /// an in-cluster peer; a slow forward should degrade to local, not hang the
+    /// worker's POST.
+    client: reqwest::Client,
+}
+
+impl ExecutionAffinity {
+    /// Construct the router from config + the shared shard map.
+    pub fn new(
+        enabled: bool,
+        peer_url_template: Option<String>,
+        shard: Arc<ShardConfig>,
+    ) -> Self {
+        // 4s connect+request budget: forwarding to an in-cluster pod is sub-ms in
+        // the happy path; a longer hang means the owner is unhealthy and we'd
+        // rather degrade to local than block the worker.
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(4))
+            .build()
+            .unwrap_or_default();
+        Self {
+            enabled,
+            peer_url_template: peer_url_template.filter(|t| !t.trim().is_empty()),
+            shard,
+            client,
+        }
+    }
+
+    /// Is affinity routing actually in force? Requires the flag on, more than one
+    /// shard (single replica is a no-op), and a peer-URL template. When false
+    /// every helper short-circuits and the caller behaves exactly as today.
+    pub fn active(&self) -> bool {
+        self.enabled && self.shard.shard_count > 1 && self.peer_url_template.is_some()
+    }
+
+    /// Does this replica own `execution_id`'s drive + chain writes?
+    pub fn owns(&self, execution_id: i64) -> bool {
+        self.shard.owns(execution_id)
+    }
+
+    /// Build the owner replica's base URL for `execution_id` from the template,
+    /// substituting `{shard}` with `shard_for(execution_id)`. `None` if no
+    /// template is configured.
+    pub fn owner_base_url(&self, execution_id: i64) -> Option<String> {
+        let template = self.peer_url_template.as_ref()?;
+        let owner = crate::sharding::shard_for(execution_id, self.shard.shard_count);
+        Some(template.replace(SHARD_PLACEHOLDER, &owner.to_string()))
+    }
+
+    /// Decide + perform forwarding for an incoming `/api/events` POST.
+    ///
+    /// Returns:
+    /// - `Forwarded(resp)` — the owner handled it; `resp` is the owner's response
+    ///   to return to the caller verbatim.
+    /// - `ProcessLocally` — this replica is the owner (or affinity is inert, the
+    ///   request was already forwarded once, the id is unparseable, or the
+    ///   forward failed and we degrade) → run the normal handler body.
+    pub async fn route_event(
+        &self,
+        headers: &HeaderMap,
+        request: &crate::handlers::events::EventRequest,
+    ) -> AffinityRoute {
+        if !self.active() {
+            return AffinityRoute::ProcessLocally;
+        }
+        // Loop guard: a request we already forwarded lands on the owner with this
+        // header. Process it here even if owns() somehow disagrees (shard-map
+        // skew) — one hop, never a loop.
+        if headers.contains_key(AFFINITY_FORWARDED_HEADER) {
+            crate::metrics::record_execution_affinity("forwarded_terminus");
+            return AffinityRoute::ProcessLocally;
+        }
+        let Ok(execution_id) = request.execution_id.parse::<i64>() else {
+            // Malformed id — let the normal handler reject it with its own error.
+            return AffinityRoute::ProcessLocally;
+        };
+        if self.owns(execution_id) {
+            crate::metrics::record_execution_affinity("owned_local");
+            return AffinityRoute::ProcessLocally;
+        }
+        let Some(base) = self.owner_base_url(execution_id) else {
+            return AffinityRoute::ProcessLocally;
+        };
+        let url = format!("{}/api/events", base.trim_end_matches('/'));
+        match self
+            .client
+            .post(&url)
+            .header(AFFINITY_FORWARDED_HEADER, "1")
+            .json(request)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                match resp.json::<crate::handlers::events::EventResponse>().await {
+                    Ok(body) => {
+                        crate::metrics::record_execution_affinity("forwarded_ok");
+                        AffinityRoute::Forwarded(body)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            execution_id,
+                            owner = %url,
+                            error = %e,
+                            "execution-affinity: owner response undecodable; degrading to local processing"
+                        );
+                        crate::metrics::record_execution_affinity("forward_decode_err");
+                        AffinityRoute::ProcessLocally
+                    }
+                }
+            }
+            Ok(resp) => {
+                tracing::warn!(
+                    execution_id,
+                    owner = %url,
+                    status = %resp.status(),
+                    "execution-affinity: owner returned non-success; degrading to local processing"
+                );
+                crate::metrics::record_execution_affinity("forward_http_err");
+                AffinityRoute::ProcessLocally
+            }
+            Err(e) => {
+                tracing::warn!(
+                    execution_id,
+                    owner = %url,
+                    error = %e,
+                    "execution-affinity: owner unreachable; degrading to local processing"
+                );
+                crate::metrics::record_execution_affinity("forward_unavailable");
+                AffinityRoute::ProcessLocally
+            }
+        }
+    }
+}
+
+/// Outcome of [`ExecutionAffinity::route_event`].
+pub enum AffinityRoute {
+    /// The owner replica handled the event; return this response verbatim.
+    Forwarded(crate::handlers::events::EventResponse),
+    /// Run the normal handler body on this replica.
+    ProcessLocally,
+}
+
+/// Parse a StatefulSet pod ordinal from a hostname (`name-N` → `N`).
+///
+/// `NOETL_SHARD_INDEX_FROM_HOSTNAME=true` lets a single StatefulSet manifest give
+/// each pod a distinct shard index from identical env — the pod's stable ordinal
+/// hostname is the shard index. Returns `None` when the hostname has no trailing
+/// `-<digits>` segment (so a plain Deployment pod falls back to the explicit
+/// `NOETL_SHARD_INDEX` / single-shard default).
+pub fn shard_index_from_hostname(hostname: &str) -> Option<u32> {
+    let (_, ordinal) = hostname.rsplit_once('-')?;
+    ordinal.parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn affinity(enabled: bool, template: Option<&str>, index: u32, count: u32) -> ExecutionAffinity {
+        ExecutionAffinity::new(
+            enabled,
+            template.map(|s| s.to_string()),
+            Arc::new(ShardConfig::new(index, count).unwrap()),
+        )
+    }
+
+    #[test]
+    fn inert_when_disabled() {
+        let a = affinity(false, Some("http://peer-{shard}:8082"), 0, 2);
+        assert!(!a.active());
+    }
+
+    #[test]
+    fn inert_on_single_shard() {
+        // Flag on, but one shard → owns() is always true, nothing to forward.
+        let a = affinity(true, Some("http://peer-{shard}:8082"), 0, 1);
+        assert!(!a.active());
+        assert!(a.owns(12345));
+    }
+
+    #[test]
+    fn inert_without_template() {
+        let a = affinity(true, None, 0, 2);
+        assert!(!a.active());
+        let a = affinity(true, Some("   "), 0, 2);
+        assert!(!a.active(), "blank template is treated as unset");
+    }
+
+    #[test]
+    fn active_when_configured() {
+        let a = affinity(true, Some("http://peer-{shard}:8082"), 0, 2);
+        assert!(a.active());
+    }
+
+    #[test]
+    fn owner_url_substitutes_shard() {
+        let a = affinity(true, Some("http://noetl-server-rust-{shard}.hl:8082"), 0, 4);
+        for eid in [1_i64, 42, 320_816_801_799_737_344, i64::MAX, -7] {
+            let owner = crate::sharding::shard_for(eid, 4);
+            let url = a.owner_base_url(eid).unwrap();
+            assert_eq!(url, format!("http://noetl-server-rust-{owner}.hl:8082"));
+        }
+    }
+
+    #[test]
+    fn owns_partitions_with_shard_for() {
+        // Replica index 1 of 3 owns exactly the executions shard_for maps to 1.
+        let a = affinity(true, Some("http://peer-{shard}:8082"), 1, 3);
+        for eid in 0..500_i64 {
+            let owns = a.owns(eid);
+            assert_eq!(owns, crate::sharding::shard_for(eid, 3) == 1);
+        }
+    }
+
+    #[test]
+    fn hostname_ordinal_parsing() {
+        assert_eq!(shard_index_from_hostname("noetl-server-rust-0"), Some(0));
+        assert_eq!(shard_index_from_hostname("noetl-server-rust-1"), Some(1));
+        assert_eq!(shard_index_from_hostname("noetl-server-rust-13"), Some(13));
+        // No trailing ordinal (Deployment-style random suffix) → None.
+        assert_eq!(shard_index_from_hostname("noetl-server-rust-6cdb8b7b6"), None);
+        assert_eq!(shard_index_from_hostname("plainhost"), None);
+        assert_eq!(shard_index_from_hostname(""), None);
+    }
+}

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -327,6 +327,48 @@ pub struct AppConfig {
     /// multi-replica coherence substrate; opt-in and staged.
     #[serde(default)]
     pub replica_coherence: ReplicaCoherence,
+
+    /// **Execution-affinity routing** (RFC noetl/ai-meta#116, the multi-replica
+    /// half of #115 / #107 step 3).  Envy maps `NOETL_EXECUTION_AFFINITY`.
+    ///
+    /// The KV coherence layer (`replica_coherence=nats_kv`) makes replicas resolve
+    /// the same watermark/descriptor, but the `command.issued` prev read in
+    /// [`crate::handlers::execute`] and the head CAS-advance in
+    /// [`crate::handlers::event_write::emit_events`] are two non-atomic steps —
+    /// concurrent cross-replica emits for one execution fork the chain.  Affinity
+    /// closes the race by routing every trigger (`POST /api/events`, which also
+    /// fires the drive) to the single replica that
+    /// [`crate::sharding::ShardConfig::owns`] the execution; a non-owner forwards
+    /// the request to the owner.  The owner's single-process drive lock + chain
+    /// head then make the read→advance atomic with no distributed lock.
+    ///
+    /// - **false** (default) — no forwarding; prod/default behavior unchanged.
+    /// - **true** — non-owner replicas forward `/api/events` to the owner.  Inert
+    ///   unless `shard_count > 1` AND [`Self::peer_url_template`] is set, so a
+    ///   single replica with the flag on still forwards nothing.
+    #[serde(default)]
+    pub execution_affinity: bool,
+
+    /// **Owner-replica URL template** for execution-affinity forwarding (RFC
+    /// noetl/ai-meta#116).  Envy maps `NOETL_PEER_URL_TEMPLATE`.  The `{shard}`
+    /// token is replaced by the owner's shard index, e.g.
+    /// `http://noetl-server-rust-{shard}.noetl-server-rust-headless:8082` against
+    /// a StatefulSet + headless service.  `None` (default) → affinity is inert
+    /// even when [`Self::execution_affinity`] is true.
+    #[serde(default)]
+    pub peer_url_template: Option<String>,
+
+    /// **Derive [`Self::shard_index`] from the pod's hostname ordinal** (RFC
+    /// noetl/ai-meta#116).  Envy maps `NOETL_SHARD_INDEX_FROM_HOSTNAME`.  When
+    /// true and `NOETL_SHARD_INDEX` is unset, the trailing `-<N>` of the hostname
+    /// (a StatefulSet pod's stable ordinal) becomes the shard index — so one
+    /// StatefulSet manifest with identical env gives each pod a distinct shard.
+    /// An explicit `NOETL_SHARD_INDEX` always wins; a hostname with no trailing
+    /// ordinal (a Deployment pod) falls back to the single-shard default.
+    ///
+    /// **Default false** — prod/default behavior unchanged.
+    #[serde(default)]
+    pub shard_index_from_hostname: bool,
 }
 
 /// How the execution-lifecycle hot path reads `noetl.event` — see
@@ -472,6 +514,12 @@ impl Default for AppConfig {
             // noetl/ai-meta#115 program-scale: in-process maps by default; the
             // NATS-KV multi-replica coherence backing is opt-in (and staged).
             replica_coherence: ReplicaCoherence::Local,
+            // noetl/ai-meta#116: execution-affinity routing off by default; a
+            // non-owner replica forwards /api/events to the owner only when this
+            // is on AND shard_count > 1 AND a peer template is set.
+            execution_affinity: false,
+            peer_url_template: None,
+            shard_index_from_hostname: false,
         }
     }
 }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -468,8 +468,21 @@ pub struct CommandResponse {
 /// of the handler.
 pub async fn handle_event(
     state: State<AppState>,
+    headers: axum::http::HeaderMap,
     request: Json<EventRequest>,
 ) -> Result<Json<EventResponse>, AppError> {
+    // Execution-affinity (RFC noetl/ai-meta#116): single-owner write ordering.
+    // When affinity is active and this replica does not own the execution, the
+    // trigger (and the drive it would fire) is forwarded to the owner so the
+    // off-server chain head's read→advance stays atomic per execution and never
+    // forks across replicas.  Inert / owned executions fall through to local
+    // processing; a failed forward degrades to local (no event dropped).
+    if let crate::affinity::AffinityRoute::Forwarded(resp) =
+        state.0.affinity.route_event(&headers, &request.0).await
+    {
+        return Ok(Json(resp));
+    }
+
     let event_type_for_metrics = request.0.event_type.clone();
     let started_at = std::time::Instant::now();
 
@@ -2439,6 +2452,15 @@ pub fn spawn_orchestrator_reconciler(state: AppState) {
         loop {
             tokio::time::sleep(RECONCILE_INTERVAL).await;
             for execution_id in state.orch_cache.active_executions() {
+                // Execution-affinity (RFC noetl/ai-meta#116): only the owner
+                // replica drives an execution.  Under affinity the orch_cache on a
+                // replica holds only owned executions anyway (events are forwarded
+                // to the owner), but guard explicitly so a transiently-cached
+                // non-owned execution (e.g. one seeded here before forwarding) is
+                // never driven from two replicas' pollers.
+                if state.affinity.active() && !state.affinity.owns(execution_id) {
+                    continue;
+                }
                 // `i64::MAX` as the trigger id keeps the immediate-straggler
                 // shortcut from firing on an already-applied event.
                 match trigger_orchestrator_inner(&state, execution_id, i64::MAX, true).await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! }
 //! ```
 
+pub mod affinity;
 pub mod coherence;
 pub mod config;
 pub mod crypto;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -400,6 +400,48 @@ pub fn record_replica_coherence(structure: &str, op: &str, outcome: &str) {
         .inc();
 }
 
+// ── Execution affinity (RFC noetl/ai-meta#116) ───────────────────────────────
+
+/// `noetl_execution_affinity_total{outcome}` — every `POST /api/events` routing
+/// decision under `NOETL_EXECUTION_AFFINITY=true`.  The single-owner write-
+/// ordering proof for multi-replica off-server execution.
+///
+/// - `owned_local` — this replica owns the execution; processed locally (the
+///   common case on the owner).
+/// - `forwarded_ok` — a non-owner forwarded the event to the owner and got a
+///   success back.  **The load-bearing proof**: every increment is a trigger that
+///   would otherwise have driven/emitted on the wrong replica (a chain-fork
+///   source) and was instead funnelled to the single owner.
+/// - `forwarded_terminus` — a request the peer already forwarded once landed here
+///   (this replica is the owner); processed locally (loop guard).
+/// - `forward_unavailable` / `forward_http_err` / `forward_decode_err` — the
+///   forward failed; degraded to local processing (no event dropped). Should stay
+///   0 in a healthy cluster.
+pub fn execution_affinity_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_execution_affinity_total",
+                "POST /api/events affinity routing decisions under NOETL_EXECUTION_AFFINITY, by outcome (RFC noetl/ai-meta#116).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one execution-affinity routing decision.
+pub fn record_execution_affinity(outcome: &str) {
+    execution_affinity_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
 /// Histogram: wall-clock time spent inside the `POST /api/events` handler.
 pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
     static M: OnceLock<HistogramVec> = OnceLock::new();

--- a/src/state.rs
+++ b/src/state.rs
@@ -79,6 +79,15 @@ pub struct AppState {
     /// the [noetl/server wiki sharding-design page](https://github.com/noetl/server/wiki/sharding-design).
     pub shard: Arc<ShardConfig>,
 
+    /// Execution-affinity router (RFC noetl/ai-meta#116).  Routes every trigger
+    /// for an execution (`POST /api/events`) to the single replica that
+    /// [`ShardConfig::owns`] it, so the off-server drive's chain-head read +
+    /// advance are atomic per execution and never fork across replicas.  Inert
+    /// (no forwarding) unless `NOETL_EXECUTION_AFFINITY=true` AND `shard_count >
+    /// 1` AND `NOETL_PEER_URL_TEMPLATE` is set — so single-replica / prod are
+    /// unchanged.  See [`crate::affinity`].
+    pub affinity: Arc<crate::affinity::ExecutionAffinity>,
+
     /// Server start time for uptime calculation
     pub start_time: std::time::Instant,
 
@@ -543,7 +552,20 @@ impl AppState {
         // fail fast on a config bug rather than silently
         // mis-routing requests.
         let shard_count = config.shard_count.unwrap_or(1);
-        let shard_index = config.shard_index.unwrap_or(0);
+        // noetl/ai-meta#116: derive shard_index from the pod's hostname ordinal
+        // (StatefulSet `name-N`) when asked, so one manifest with identical env
+        // gives each pod a distinct shard.  An explicit NOETL_SHARD_INDEX always
+        // wins; a hostname with no trailing ordinal falls back to 0.
+        let shard_index = config.shard_index.unwrap_or_else(|| {
+            if config.shard_index_from_hostname {
+                let hostname = std::env::var("HOSTNAME")
+                    .or_else(|_| std::env::var("COMPUTERNAME"))
+                    .unwrap_or_default();
+                crate::affinity::shard_index_from_hostname(&hostname).unwrap_or(0)
+            } else {
+                0
+            }
+        });
         let shard = ShardConfig::new(shard_index, shard_count).unwrap_or_else(|e| {
             panic!("invalid shard config (NOETL_SHARD_INDEX / NOETL_SHARD_COUNT): {e}")
         });
@@ -557,6 +579,24 @@ impl AppState {
                 "default (no sharding)"
             },
             "Shard configuration initialized"
+        );
+
+        let shard = Arc::new(shard);
+
+        // Execution-affinity router (RFC noetl/ai-meta#116).  Single-owner write
+        // ordering for the off-server drive: every trigger for an execution is
+        // routed to the replica that `owns()` it.  Inert unless the flag is on,
+        // shard_count > 1, and a peer template is set — so prod is unchanged.
+        let affinity = Arc::new(crate::affinity::ExecutionAffinity::new(
+            config.execution_affinity,
+            config.peer_url_template.clone(),
+            shard.clone(),
+        ));
+        tracing::info!(
+            execution_affinity = config.execution_affinity,
+            affinity_active = affinity.active(),
+            peer_url_template = config.peer_url_template.as_deref().unwrap_or("(unset)"),
+            "Execution-affinity router initialized"
         );
 
         // Multi-replica coherence backend (RFC #115 program-scale,
@@ -581,7 +621,8 @@ impl AppState {
             config: Arc::new(config),
             nats,
             snowflake: Arc::new(snowflake),
-            shard: Arc::new(shard),
+            shard,
+            affinity,
             start_time: std::time::Instant::now(),
             orch_cache: Arc::new(OrchStateCache::default()),
             chain_heads: Arc::new(ChainHeads::with_coherence(coherence.clone())),


### PR DESCRIPTION
## Summary

Execution-affinity single-owner write ordering for the off-server drive — RFC
[noetl/ai-meta#116](https://github.com/noetl/ai-meta/issues/116), the
multi-replica WRITE-ORDERING half of #115 program-scale / #107 step 3. Builds on
the KV data-coherence layer shipped in #251 (v3.38.0,
`NOETL_REPLICA_COHERENCE=nats_kv`).

### The race this closes

The KV layer makes 2+ replicas resolve the same chain-head watermark +
descriptor, but the `command.issued` prev read in `handlers::execute` and the
head CAS-advance in `event_write::emit_events` are **two non-atomic steps**:
concurrent cross-replica emits for one execution fork the chain (the off-server
WAL builder can't reassemble it → execution sticks RUNNING). The per-execution
drive lock (`orchestrate_in_flight`) is also per-replica, so two replicas can
drive the same execution concurrently.

### The mechanism — one replica owns an execution

Affinity routes every trigger (`POST /api/events`, which also fires the drive
synchronously) to the single replica that `sharding::ShardConfig::owns` it
(stable XxHash64, the existing `src/sharding.rs` substrate). On the owner the
existing single-process drive lock + in-memory `ChainHeads` make the
read→advance atomic with **no distributed lock on the hot path**. A non-owner
forwards the request (transparent reverse-proxy POST) to the owner and returns
its response. KV coherence composes: it covers genesis-on-a-different-replica +
ownership handoff (with affinity the owner resolves head/descriptor from its
LOCAL write-through cache, so KV becomes the handoff-only vehicle).

**Why forwarding, not a distributed drive lock:** option (ii) (a NATS-KV lease
per drive) adds lease-acquire latency to every drive + lease-expiry edge cases;
affinity solves the chain fork AND the double-drive with one mechanism and reuses
the sharding substrate verbatim.

### Changes

- `src/affinity.rs` — `ExecutionAffinity` router (`active()` gated on flag +
  `shard_count>1` + peer template; `owner_base_url` `{shard}` substitution;
  `route_event` forward-or-local with a one-hop loop guard + degrade-to-local on
  forward failure; `shard_index_from_hostname`). 7 unit tests.
- config: `NOETL_EXECUTION_AFFINITY` (default false), `NOETL_PEER_URL_TEMPLATE`,
  `NOETL_SHARD_INDEX_FROM_HOSTNAME` (StatefulSet ordinal → shard index).
- `handlers::handle_event` forwards to owner when not owned; reconcile poller
  skips non-owned executions.
- metric `noetl_execution_affinity_total{outcome}` (`forwarded_ok` = the
  write-ordering proof series).

### Default-safe

Default-off + single-replica no-op (`owns()` always true at `shard_count<=1`) →
**prod/default behavior bit-for-bit unchanged**. A failed forward degrades to
local processing (no event dropped).

### Validation (2-replica gate-ON kind, StatefulSet, offserver + audit_only + nats_kv + affinity + publish_only)

`kind_validate_replica_coherence.sh` with `NOETL_COHERENCE_DRIVE_AFFINITY=shipped`
**PASSES**: linear/loop/fanout executions COMPLETE; **every** chain
`roots=1 / dangling=0 / walk==total` (no fork — the data the issue showed forking
under concurrent cross-replica emits); `forwarded_ok` advances (cross-replica
single-owner routing); `state_build_event_scans +0` + `hotpath scan +0`
(never-scan across replicas); sole-writer intact (`rows==distinct`,
`__orchestrate__` event rows = 0); `degraded +0`. Single-replica behavior
unchanged. 595 server tests + clippy green.

Known follow-up (separate, pre-existing, surfaced here): the off-server
`from_events` spine is ordered by `event_id`, which breaks under a
chain-order≠id-order inversion that affinity's forwarding makes more likely under
high-concurrency fan-out → one fanout exec in a 9-way concurrent run wedged the
reduce (chain still clean). Tracked in a sibling ai-meta sub-issue (#101-class);
does not affect chain integrity.

Refs noetl/ai-meta#116 noetl/ai-meta#115 noetl/ai-meta#107
