### PR TITLE
fix(event-write): exactly-one-terminal-per-execution guard (#118)

### DIFF
--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -285,18 +285,48 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     // built per execution), so a single linkage call covers them in order.
     let rows: Vec<EventRow> = {
         let execution_id = rows[0].execution_id;
-        // Stateless off-server drive edge (RFC #115 Phase 4 remainder): stamp the
-        // execute-time descriptor's terminal flag when a terminal event passes
-        // through this chokepoint (cancel via `services::execution::cancel`,
-        // finalize, the orchestrator's own `playbook.completed`/`.failed`).  The
-        // stateless drive reads this flag to stop re-dispatching a terminal
-        // execution WITHOUT rebuilding `WorkflowState` to call `is_terminal()`.
-        if rows.iter().any(|r| is_terminal_event_type(&r.event_type)) {
+        let terminal_in_batch = rows.iter().any(|r| is_terminal_event_type(&r.event_type));
+        // Idempotent terminal (noetl/ai-meta#118): enforce exactly one terminal
+        // event per execution.  A DUPLICATE finalize (a straggler/duplicate drive
+        // under off-server + PUBLISH_ONLY materializer-lag on a single replica)
+        // must be suppressed *before* it reaches the chain linker — otherwise it
+        // arrives after the first terminal evicted the chain head, links to a
+        // `None` head (`prev_event_id = NULL`), and forks the per-execution chain
+        // into a second root (the off-server spine walk then can't reach it → a
+        // benign `event_scan` fallback).  `mark()` returns true for the FIRST
+        // terminal (write it) and false for any later one (drop it).  Multi-replica
+        // execution-affinity (noetl/ai-meta#116) already serialises finalize to the
+        // owner, so this is the single-replica safety net.  Terminal events are
+        // emitted one-at-a-time today, so a suppressed-terminal batch drops to
+        // empty (handled below); filtering rather than early-returning keeps a
+        // hypothetical mixed batch correct.
+        let drop_terminal = terminal_in_batch && !state.finalized_guard.mark(execution_id);
+        if drop_terminal {
+            crate::metrics::record_terminal_dedup("suppressed");
+            tracing::debug!(
+                execution_id,
+                "emit: suppressed duplicate terminal event (execution already finalized; \
+                 noetl/ai-meta#118)"
+            );
+        } else if terminal_in_batch {
+            // Stateless off-server drive edge (RFC #115 Phase 4 remainder): stamp
+            // the execute-time descriptor's terminal flag when the FIRST terminal
+            // event passes through this chokepoint (cancel via
+            // `services::execution::cancel`, finalize, the orchestrator's own
+            // `playbook.completed`/`.failed`).  The stateless drive reads this flag
+            // to stop re-dispatching a terminal execution WITHOUT rebuilding
+            // `WorkflowState` to call `is_terminal()`.
             state.exec_descriptors.mark_terminal(execution_id).await;
         }
-        let ids: Vec<i64> = rows.iter().map(|r| r.event_id).collect();
+        // A suppressed duplicate terminal must not advance the chain head, so drop
+        // it before `link_batch` consumes the batch's ids.
+        let kept: Vec<&EventRow> = rows
+            .iter()
+            .filter(|r| !(drop_terminal && is_terminal_event_type(&r.event_type)))
+            .collect();
+        let ids: Vec<i64> = kept.iter().map(|r| r.event_id).collect();
         let prevs = state.chain_heads.link_batch(execution_id, &ids).await;
-        rows.iter()
+        kept.into_iter()
             .zip(prevs)
             .map(|(r, prev)| {
                 // Respect an explicit prev a producer already set; otherwise
@@ -311,6 +341,10 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
             })
             .collect()
     };
+    // The whole batch was a suppressed duplicate terminal → nothing to write.
+    if rows.is_empty() {
+        return Ok(());
+    }
     let rows = rows.as_slice();
 
     // All rows in a batch share the same execution + catalog, so one decision

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -149,6 +149,39 @@ pub fn record_orchestrate_drive(stage: &str) {
     orchestrate_drive_total().with_label_values(&[stage]).inc();
 }
 
+// ── Terminal-event dedup (noetl/ai-meta#118) ─────────────────────────────────
+
+/// `noetl_terminal_dedup_total{outcome}` — the event-write chokepoint's
+/// exactly-one-terminal-per-execution guard.  `outcome` = `suppressed` (a
+/// DUPLICATE terminal event — a straggler/duplicate finalize under off-server +
+/// PUBLISH_ONLY materializer-lag on a single replica — was dropped before it
+/// could reach the chain linker and orphan as a NULL-`prev_event_id` second
+/// chain root).  Zero increments on a healthy run; any non-zero count is the
+/// race being caught instead of forking the chain.  See
+/// [`crate::state::FinalizedGuard`].
+pub fn terminal_dedup_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_terminal_dedup_total",
+                "Duplicate terminal events suppressed at the event-write chokepoint (noetl/ai-meta#118).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one terminal-event dedup decision (`outcome` = `suppressed`).
+pub fn record_terminal_dedup(outcome: &str) {
+    terminal_dedup_total().with_label_values(&[outcome]).inc();
+}
+
 // ── Atomic-working-item context (RFC noetl/ai-meta#115 Phase 5) ───────────────
 
 /// `noetl_atomic_item_context_total{outcome}` — how the in-process drive sized

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,6 +119,13 @@ pub struct AppState {
     /// execution without reading state.  See [`ExecDescriptors`].
     pub exec_descriptors: Arc<ExecDescriptors>,
 
+    /// Recently-finalized executions, so the [`crate::handlers::event_write`]
+    /// chokepoint enforces exactly one terminal event per execution and a
+    /// duplicate finalize can't orphan the chain with a NULL-`prev_event_id`
+    /// second root (noetl/ai-meta#118).  Bounded + in-memory; see
+    /// [`FinalizedGuard`].
+    pub finalized_guard: Arc<FinalizedGuard>,
+
     /// CQRS write-path publisher (noetl/ai-meta#103 phase 2d-3).  Lazily built
     /// on first use from [`Self::nats`] so the `emit_event` chokepoint can
     /// publish to the `noetl_events` stream when
@@ -453,6 +460,92 @@ impl ExecDescriptors {
     }
 }
 
+/// Bounded set of execution ids that have already emitted a terminal event
+/// (`playbook.completed` / `playbook_failed` / `playbook_cancelled`), so the
+/// event-write chokepoint can keep the **exactly-one-terminal-per-execution**
+/// invariant under the duplicate-finalize race (noetl/ai-meta#118).
+///
+/// The race: under `NOETL_STATE_BUILDER=offserver` + `PUBLISH_ONLY` on a
+/// **single replica**, a high-concurrency fan-out can drive the same execution
+/// to terminal twice — the first drive emits the terminal event (chain-linked to
+/// the head) and then evicts the chain head + descriptor; a straggler/late
+/// trigger then falls through to the server-built path, rebuilds from the
+/// materialized WAL that *hasn't caught up* (so the rebuilt state isn't terminal
+/// yet — the materializer-lag window), drives again, and emits a SECOND terminal
+/// event.  That second event reaches [`ChainHeads::link_batch`] after the head
+/// was evicted → `prev_event_id = NULL` → a second chain root (the orphan), and
+/// the off-server spine walk then can't reach it → a benign `event_scan`
+/// fallback.  Multi-replica execution-affinity (noetl/ai-meta#116) already
+/// serialises every finalize to the owning replica, so it never forks — this
+/// guard is the single-replica equivalent: the first terminal wins, any later
+/// terminal for the same execution is suppressed at the chokepoint *before* it
+/// touches the chain.
+///
+/// In-memory + **bounded** (FIFO eviction past `capacity`) so it never
+/// reintroduces the unbounded per-execution growth RFC #115 Phase 6 removed: the
+/// only window that matters is the straggler + materializer-lag horizon
+/// (seconds), so a few thousand recent ids is ample.  Process-local, like the
+/// sibling [`OrchStateCache`] / [`ExecDescriptors`] in-memory maps — multi-replica
+/// correctness comes from affinity, not from sharing this set.  A server restart
+/// drops the set, but a post-restart straggler is then caught by the
+/// server-built terminal guard (the rebuilt state is terminal once the WAL has
+/// materialized), so correctness never regresses below today.
+pub struct FinalizedGuard {
+    inner: std::sync::Mutex<FinalizedInner>,
+    capacity: usize,
+}
+
+struct FinalizedInner {
+    set: std::collections::HashSet<i64>,
+    queue: std::collections::VecDeque<i64>,
+}
+
+impl Default for FinalizedGuard {
+    fn default() -> Self {
+        // 8192 recent finalized executions — far past the straggler /
+        // materializer-lag horizon, trivially small in memory (≈64 KiB of i64s).
+        Self::new(8192)
+    }
+}
+
+impl FinalizedGuard {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(FinalizedInner {
+                set: std::collections::HashSet::new(),
+                queue: std::collections::VecDeque::new(),
+            }),
+            capacity,
+        }
+    }
+
+    /// Record `execution_id` as finalized.  Returns `true` when it was **newly**
+    /// inserted — i.e. this is the FIRST terminal event for the execution and the
+    /// caller should write it.  Returns `false` when the execution was already
+    /// finalized — a DUPLICATE terminal the caller must suppress so it can't
+    /// orphan the chain.  FIFO-evicts the oldest id once `capacity` is exceeded.
+    pub fn mark(&self, execution_id: i64) -> bool {
+        let mut g = self.inner.lock().unwrap();
+        if !g.set.insert(execution_id) {
+            return false;
+        }
+        g.queue.push_back(execution_id);
+        while g.queue.len() > self.capacity {
+            if let Some(old) = g.queue.pop_front() {
+                g.set.remove(&old);
+            }
+        }
+        true
+    }
+
+    /// True if a terminal event has already been recorded for `execution_id`
+    /// (within the bounded window).  Test/observability helper; the write path
+    /// uses [`Self::mark`] for the atomic check-and-record.
+    pub fn contains(&self, execution_id: i64) -> bool {
+        self.inner.lock().unwrap().set.contains(&execution_id)
+    }
+}
+
 /// Per-execution orchestrator state cache.  The outer `std::Mutex` guards a
 /// short get-or-insert; the inner per-execution `tokio::Mutex` is held across
 /// the orchestrator's DB round-trips so a single execution's triggers serialise
@@ -627,6 +720,7 @@ impl AppState {
             orch_cache: Arc::new(OrchStateCache::default()),
             chain_heads: Arc::new(ChainHeads::with_coherence(coherence.clone())),
             exec_descriptors: Arc::new(ExecDescriptors::with_coherence(coherence)),
+            finalized_guard: Arc::new(FinalizedGuard::default()),
             event_stream_publisher: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
@@ -663,7 +757,7 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChainHeads, ExecDescriptors};
+    use super::{ChainHeads, ExecDescriptors, FinalizedGuard};
 
     // Note: Full tests require a database connection
     // These are placeholder tests for documentation
@@ -672,6 +766,42 @@ mod tests {
     fn test_uptime() {
         // AppState::new requires a real DB pool, so we can't easily test here
         // This is a documentation placeholder
+    }
+
+    // noetl/ai-meta#118: exactly-one-terminal-per-execution.  The chokepoint
+    // calls `mark()` for every terminal event; the FIRST returns true (write it),
+    // any later one returns false (suppress the duplicate before it can orphan
+    // the chain).
+    #[test]
+    fn finalized_guard_first_terminal_wins_duplicate_suppressed() {
+        let g = FinalizedGuard::new(8);
+        assert!(!g.contains(7), "cold execution is not finalized");
+        assert!(g.mark(7), "first terminal for an execution is newly inserted");
+        assert!(g.contains(7), "now recorded as finalized");
+        // Every subsequent terminal for the SAME execution is a duplicate.
+        assert!(!g.mark(7), "second terminal is a suppressed duplicate");
+        assert!(!g.mark(7), "third terminal is still a suppressed duplicate");
+        // A different execution is independent.
+        assert!(g.mark(8), "a different execution's first terminal still wins");
+        assert!(!g.mark(8));
+    }
+
+    #[test]
+    fn finalized_guard_is_bounded_fifo() {
+        // Capacity 2: inserting a third id evicts the oldest, so its terminal
+        // would be (correctly) treated as fresh again — acceptable because the
+        // window only needs to span the seconds-long straggler horizon, far
+        // inside any real capacity.  This asserts the bound holds (no unbounded
+        // growth) rather than infinite memory.
+        let g = FinalizedGuard::new(2);
+        assert!(g.mark(1));
+        assert!(g.mark(2));
+        assert!(g.mark(3)); // evicts id 1 (oldest)
+        assert!(!g.contains(1), "oldest id evicted past capacity");
+        assert!(g.contains(2));
+        assert!(g.contains(3));
+        // id 1 fell out of the window, so it is seen as fresh again.
+        assert!(g.mark(1), "evicted id is fresh again (bounded window)");
     }
 
     // RFC #115 Phase 4 remainder: the execute-time descriptor carries catalog_id


### PR DESCRIPTION
## Summary

Fixes the single-replica off-server chain fork in **noetl/ai-meta#118**: a
duplicate/straggler finalize emits a SECOND `playbook.completed` after the
chain head was evicted, so it links to a `None` head (`prev_event_id = NULL`)
and forks the per-execution chain into a second root — the off-server spine
walk then can't reach it, costing a benign `noetl_state_build_event_scans_total`
fallback.

## Root cause

Under `NOETL_STATE_BUILDER=offserver` + `PUBLISH_ONLY` on a **single replica**, a
high-concurrency fan-out can drive an execution to terminal twice:
1. First drive emits the terminal event (chain-linked) and evicts the chain head + descriptor.
2. A straggler trigger falls through to the server-built path, rebuilds from the
   materialized WAL that hasn't caught up (materializer-lag window → state not
   terminal yet), drives again, and emits a **second** terminal event.
3. That second event reaches `ChainHeads.link_batch` after the head was evicted →
   `prev_event_id = NULL` → second chain root (orphan).

Multi-replica execution-affinity (#116) already serialises finalize to the owner,
so it never forks there — this is the single-replica equivalent.

## Fix

A bounded, process-local `FinalizedGuard` (HashSet + FIFO `VecDeque`, default cap
8192) records executions that have emitted a terminal event. `emit_events`
suppresses any later terminal for the same execution **before** it reaches the
chain linker (a suppressed duplicate never advances/consumes the head). First
terminal wins → exactly one terminal per execution → chain stays single-root
**including** the terminal event.

- `state.rs`: `FinalizedGuard` + `AppState.finalized_guard`.
- `event_write.rs`: `emit_events` consults `finalized_guard.mark()` for terminal
  batches; drops duplicate-terminal rows before `link_batch`; empty batch → `Ok`.
- `metrics.rs`: `noetl_terminal_dedup_total{outcome="suppressed"}`.
- Unit tests: first-wins/duplicate-suppress + bounded FIFO (597 lib tests green).

## Safety

**Gate-off byte-identical.** A duplicate terminal never occurs on the synchronous
in-process drive (the terminal guard fires with synchronous event visibility), so
`mark()` always returns `first=true` and nothing is suppressed. Defaults/PROD
unchanged; no flag added (exactly-one-terminal is an always-correct invariant).

## Validation

- ✅ 597 lib tests pass incl. 2 new `FinalizedGuard` tests.
- ✅ Release image builds; deployed to local kind single-replica off-server.
- ⚠️ End-to-end offserver chain-fork repro could **not** be reproduced this
  session: the local kind off-server drive did not complete executions due to an
  **environmental** WAL state-builder drain issue (durable `noetl_state_builder`
  consumer cursor persists across worker restarts while the in-memory WAL index
  rebuilds empty → `build_offserver_input` always `Incomplete` → terminal never
  fires). This is upstream of and orthogonal to this fix (the
  `noetl_terminal_dedup` path never engaged because completion was blocked). The
  rig assertion (e2e `kadyapam/118-terminals-assertion`) is staged to prove
  `terminals==1` + single-root once a healthy offserver cluster is available.

Refs noetl/ai-meta#118