### PR TITLE
fix(orchestrate-core): defer task_sequence sub-task templates with unresolved bindings (#124)

### DIFF
--- a/orchestrate-core/src/commands.rs
+++ b/orchestrate-core/src/commands.rs
@@ -527,8 +527,16 @@ fn render_pipeline_config(
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
 
-            let rendered =
-                renderer.render_value(&serde_json::Value::Object(filtered), context)?;
+            // noetl/ai-meta#124: render the non-deferred fields, but DEFER
+            // (preserve verbatim) any template that references a value
+            // unresolved at command-build time — e.g. `url`/`params` that
+            // reference `{{ iter.* }}` or a sibling sub-task's result, which a
+            // PRIOR sub-task's `set:` block only produces at worker runtime.
+            // Rendering those now (Chainable) collapses them to empty before
+            // task_sequence's per-sub-task binding runs; the worker re-renders
+            // the deferred templates against the running context.
+            let rendered = renderer
+                .render_value_deferring_unresolved(&serde_json::Value::Object(filtered), context)?;
             let mut rendered_spec = match rendered {
                 serde_json::Value::Object(m) => m,
                 other => {
@@ -806,6 +814,90 @@ mod tests {
         assert_eq!(command.step_name, "pipeline_step");
         assert_eq!(command.tool.kind, "task_sequence");
         assert!(command.tool.config.is_some());
+    }
+
+    /// noetl/ai-meta#124: in a distributed `task_sequence`, a later sub-task's
+    /// templates that reference a value a PRIOR sub-task produces at runtime —
+    /// a forward `set:`, a policy-rule `set:`, or a sibling result — must be
+    /// preserved VERBATIM by the server's command build so the worker's
+    /// task_sequence renders them per-sub-task against the running context.
+    /// Before the fix they were rendered against the step-entry context at
+    /// build time and collapsed to empty (Chainable undefined), so
+    /// `fetch_batch`'s `{{ iter.data_type }}` URL segment vanished → 404 → 0
+    /// rows.  Resolvable fields (`{{ api_url }}`) still render now.
+    #[test]
+    fn test_pipeline_defers_forward_policy_and_sibling_bindings() {
+        let renderer = TemplateRenderer::new();
+
+        // Step-entry context: `api_url` is resolvable now; `iter` exists as the
+        // loop namespace but carries NO `fwd_dt`/`pol_dt` yet (a prior sub-task
+        // `set:`s them at runtime), and the sibling label `t1` is absent.
+        let mut context = HashMap::new();
+        context.insert("api_url".to_string(), serde_json::json!("http://api.test"));
+        context.insert("iter".to_string(), serde_json::json!({ "slot": 1 }));
+
+        let config = serde_json::json!([
+            {
+                "t1": {
+                    "kind": "postgres",
+                    "command": "SELECT 1",
+                    "set": { "iter.fwd_dt": "{{ output.data.dt }}" },
+                    "spec": { "policy": { "rules": [
+                        { "else": { "then": { "do": "continue",
+                            "set": { "iter.pol_dt": "{{ output.data.dt }}" } } } }
+                    ] } }
+                }
+            },
+            {
+                "t2": {
+                    "kind": "http",
+                    "method": "GET",
+                    "url": "{{ api_url }}/v1/{{ iter.fwd_dt }}",
+                    "params": {
+                        "fwd": "{{ iter.fwd_dt }}",
+                        "pol": "{{ iter.pol_dt }}",
+                        "sib": "{{ t1.dt }}",
+                        "sibd": "{{ t1.data.dt }}",
+                        "resolvable": "{{ api_url }}"
+                    }
+                }
+            }
+        ]);
+
+        let out = render_pipeline_config(&renderer, &config, &context).unwrap();
+        let arr = out.as_array().unwrap();
+
+        // t1 keeps `set` + `spec` verbatim (runtime-only, restored as-is).
+        let t1 = &arr[0]["t1"];
+        assert_eq!(
+            t1["set"]["iter.fwd_dt"],
+            serde_json::json!("{{ output.data.dt }}")
+        );
+        assert!(t1["spec"]["policy"]["rules"].is_array());
+
+        let t2 = &arr[1]["t2"];
+
+        // The mixed url references an unresolved path → the WHOLE string is
+        // deferred verbatim so the worker resolves both `api_url` and the
+        // runtime ref.  (Pre-resolving `api_url` server-side buys nothing.)
+        assert_eq!(
+            t2["url"],
+            serde_json::json!("{{ api_url }}/v1/{{ iter.fwd_dt }}"),
+            "mixed url with a runtime ref must defer verbatim"
+        );
+
+        // FWD / POL / SIB / SIBD all preserved verbatim (non-empty for the
+        // worker to render); the resolvable-only field renders now.
+        let p = &t2["params"];
+        assert_eq!(p["fwd"], serde_json::json!("{{ iter.fwd_dt }}"));
+        assert_eq!(p["pol"], serde_json::json!("{{ iter.pol_dt }}"));
+        assert_eq!(p["sib"], serde_json::json!("{{ t1.dt }}"));
+        assert_eq!(p["sibd"], serde_json::json!("{{ t1.data.dt }}"));
+        assert_eq!(
+            p["resolvable"],
+            serde_json::json!("http://api.test"),
+            "a fully-resolvable field must still render at build time"
+        );
     }
 
     // ---- ctx / workload namespace shim tests (noetl/ai-meta#74) ----

--- a/orchestrate-core/src/template.rs
+++ b/orchestrate-core/src/template.rs
@@ -205,6 +205,88 @@ impl TemplateRenderer {
         }
     }
 
+    /// Render a nested structure like [`render_value`], but DEFER (return
+    /// verbatim) any string template that references a variable path which is
+    /// unresolved in `context`.  Used for distributed `task_sequence`
+    /// sub-task configs (noetl/ai-meta#124): the server builds the command
+    /// against the *step-entry* context, but a later sub-task's `url` /
+    /// `params` may reference `{{ iter.* }}` / sibling-result values produced
+    /// only at worker runtime by a prior sub-task's `set:` block.  Rendering
+    /// those now (under `Chainable`) silently collapses them to empty before
+    /// the worker's per-sub-task binding runs.  Deferring the whole template
+    /// string lets the worker's task_sequence re-render it against the richer
+    /// running context (which is a superset of the build-time context — it
+    /// carries the same flattened workload / step-result keys plus prior
+    /// sub-tasks' `set:` writes and sibling results).  Fully-resolvable
+    /// templates still render now, so non-sequence and already-resolvable
+    /// fields are byte-identical to [`render_value`].
+    pub fn render_value_deferring_unresolved(
+        &self,
+        value: &serde_json::Value,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> CoreResult<serde_json::Value> {
+        match value {
+            serde_json::Value::String(s) => {
+                if self.template_has_unresolved_path(s, context) {
+                    Ok(serde_json::Value::String(s.clone()))
+                } else {
+                    self.render_to_value(s, context)
+                }
+            }
+            serde_json::Value::Object(map) => {
+                let mut result = serde_json::Map::new();
+                for (k, v) in map {
+                    // Keys are rarely templated; defer an unresolved key too.
+                    let rendered_key = if self.template_has_unresolved_path(k, context) {
+                        k.clone()
+                    } else {
+                        self.render(k, context)?
+                    };
+                    result.insert(
+                        rendered_key,
+                        self.render_value_deferring_unresolved(v, context)?,
+                    );
+                }
+                Ok(serde_json::Value::Object(result))
+            }
+            serde_json::Value::Array(arr) => {
+                let result: Result<Vec<_>, _> = arr
+                    .iter()
+                    .map(|v| self.render_value_deferring_unresolved(v, context))
+                    .collect();
+                Ok(serde_json::Value::Array(result?))
+            }
+            _ => Ok(value.clone()),
+        }
+    }
+
+    /// True when `s` contains template syntax that references at least one
+    /// variable path absent from `context` — meaning a downstream renderer
+    /// (the worker's task_sequence) must resolve it instead of collapsing it
+    /// to empty here.  Uses minijinja's `undeclared_variables(true)` to get
+    /// the nested dotted paths the template references (same mechanism as
+    /// [`crate::input_binding`]).  A fragment that won't parse as a standalone
+    /// template is deferred conservatively.
+    fn template_has_unresolved_path(
+        &self,
+        s: &str,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> bool {
+        if !contains_template_syntax(s) {
+            return false;
+        }
+        let tmpl = match self.env.template_from_str(s) {
+            Ok(t) => t,
+            Err(_) => return true,
+        };
+        for path in tmpl.undeclared_variables(true) {
+            if !path_resolves(context, &path) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Evaluate a condition expression.
     pub fn evaluate_condition(
         &self,
@@ -242,6 +324,36 @@ impl TemplateRenderer {
 /// Check if a string contains Jinja2 template syntax.
 fn contains_template_syntax(s: &str) -> bool {
     (s.contains("{{") && s.contains("}}")) || (s.contains("{%") && s.contains("%}"))
+}
+
+/// True when the dotted `path` resolves to a present key in `context`.
+/// `iter.data_type` resolves only when the `iter` map actually carries a
+/// `data_type` key — so a sub-task that references a value a prior sub-task
+/// will `set:` at runtime reads as unresolved here (and is deferred to the
+/// worker).  Descending into a non-object (array index, scalar) stops the
+/// walk and treats the reference as resolvable up to that point — the worker
+/// resolves the remainder identically.  A present-but-null value counts as
+/// resolved (null is a legitimate build-time value, not a missing one).
+fn path_resolves(context: &HashMap<String, serde_json::Value>, path: &str) -> bool {
+    let mut segs = path.split('.');
+    let root = match segs.next() {
+        Some(r) if !r.is_empty() => r,
+        _ => return false,
+    };
+    let mut cur = match context.get(root) {
+        Some(v) => v,
+        None => return false,
+    };
+    for seg in segs {
+        match cur {
+            serde_json::Value::Object(m) => match m.get(seg) {
+                Some(v) => cur = v,
+                None => return false,
+            },
+            _ => return true,
+        }
+    }
+    true
 }
 
 /// Convert a JSON HashMap to a minijinja Value.


### PR DESCRIPTION
## Summary

Fixes the distributed `task_sequence` forward-data-binding regression
(noetl/ai-meta#124). Inside a multi-tool (`task_sequence`) step, a later
sub-task's templates that reference a value a **prior** sub-task produces at
runtime — a forward `set:`, a policy-rule `set:`, or a sibling result — were
rendered to **empty** at command-build time, before the worker's per-sub-task
binding ran.

Concretely, in `pft_flow_test`'s batch path: `claim_batch` (postgres) writes
`iter.data_type` via its policy `set:`, then `fetch_batch` (http) has
`url: '{{ api_url }}/api/v1/pft/batch/{{ iter.data_type }}'`. The server
pre-rendered that url against the step-entry context (no `iter.data_type` yet)
under `UndefinedBehavior::Chainable`, collapsing the segment to empty →
`/api/v1/pft/batch/` → 404 → 0 rows.

## Root cause

`orchestrate-core/src/commands.rs::render_pipeline_config` preserved
`set`/`args`/`spec`/`command` verbatim but rendered every **other** sub-task
field (`url`, `params`, `method`, …) against the step-entry context. Runtime-only
references (`{{ iter.* }}`, sibling labels) silently became empty before the
worker's `task_sequence` re-render (`repos/tools` `task_sequence.rs`).

## Fix

New `TemplateRenderer::render_value_deferring_unresolved`: render only templates
whose variable paths **all resolve** in the build-time context; any template
referencing an unresolved path is preserved **verbatim** so the worker
re-renders it against the per-sub-task running context (a superset — same
flattened workload / step-result keys plus prior sub-tasks' `set:` writes and
sibling results). Detection reuses minijinja `undeclared_variables(true)`, the
same mechanism `input_binding` already uses; `path_resolves` walks the dotted
path against the context.

Resolvable fields render exactly as before, so non-sequence steps and
already-resolvable sub-task fields are byte-identical to the prior path.

## Tests

- `test_pipeline_defers_forward_policy_and_sibling_bindings` — encodes the
  2-task forward + policy + sibling expectation: FWD/POL/SIB/SIBD preserved
  non-empty; a fully-resolvable `{{ api_url }}` field still renders at build time.
- `cargo test` 134/134 green; `cargo clippy --all-targets` clean.

## Kind validation (prod-exact gate)

Built `localhost/noetl-server:124-binding` (v3.39.2 + this fix), loaded into
kind, rolled `noetl-server-rust` with `PUBLISH_ONLY=true / STATE_BUILDER=server
/ PLUGIN_DRIVE=true` (worker `119-rehydrate`). The orchestrate WASM re-seeded by
digest on boot.

**Binding fix verified:** worker logs now show `fetch_batch` hitting
`http://paginated-api…/api/v1/pft/batch/mds`, `/assessments`, `/vital_signs`,
`/demographics` — i.e. `iter.data_type` propagates end-to-end (previously the
segment was empty). Cutover invariants hold: roots=1, dangling=0, forks=0,
total==distinct events, `__orchestrate__` event rows=0, materializer
drained==projected==acked (sole-writer).

## Scope note

The pft **batch benchmark** does not complete end-to-end yet: with the binding
fixed, the batch path surfaces two further, distinct, pre-existing Python→Rust
regressions outside this change — (1) the Rust `http` tool nests the response
under `body` where playbooks read `output.data.data` (Python-era contract), and
(2) the Rust worker's `task_sequence` implements only `do: fail`, not
`do: jump`/`break`/`retry`, so each loop slot processes one batch and never
drains. Both are filed separately and are out of scope for this binding fix.

Refs noetl/ai-meta#124