### PR TITLE
fix: off-server WAL-chain-incomplete loop on system executions (#121)

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1127,14 +1127,42 @@ pub async fn claim_command(
                 .with_worker_id(Some(request.worker_id.clone())),
             );
         } else {
+            // One-level event chain (RFC #115 Phase 2): stamp `prev_event_id`
+            // from the per-execution chain head + advance the head, EXACTLY as
+            // the `event_write::emit_events` chokepoint does for every other
+            // server-originated event.  This gate-off branch writes the
+            // `command.claimed` row in-tx (atomic with the claim), so it never
+            // passed through that chokepoint — leaving `prev_event_id = NULL`
+            // AND the chain head un-advanced.  The orphan that produced
+            // (noetl/ai-meta#121): the next worker event (`command.started`)
+            // linked back to `command.issued`, skipping the unlinked
+            // `command.claimed`, so the off-server `chain_walk_from` hit a
+            // NULL-prev non-genesis head, reported the spine `Incomplete`, and
+            // the server reconciler re-drove the execution in a loop.  Linking
+            // here keeps the chain `command.issued → command.claimed →
+            // command.started …` walkable so the off-server builder completes.
+            // `link_batch` advances the head before the INSERT — the same
+            // advance-then-write ordering `emit_events` already uses; a (rare)
+            // commit failure leaves an advanced head re-derived on restart, no
+            // worse than the chokepoint path.  Gate-on (publish) links via the
+            // post-commit `emit_event` above, so this is only reached gate-off.
+            let prev_event_id = state
+                .chain_heads
+                .link_batch(execution_id, &[claim_event_id])
+                .await
+                .into_iter()
+                .next()
+                .flatten();
             sqlx::query(
                 r#"
                 INSERT INTO noetl.event (
                     event_id, execution_id, catalog_id, event_type,
-                    node_id, node_name, status, result, meta, worker_id, created_at
+                    node_id, node_name, status, result, meta, worker_id,
+                    prev_event_id, created_at
                 ) VALUES (
                     $1, $2, $3, $4,
-                    $5, $6, $7, $8, $9, $10, $11
+                    $5, $6, $7, $8, $9, $10,
+                    $11, $12
                 )
                 "#,
             )
@@ -1148,6 +1176,7 @@ pub async fn claim_command(
             .bind(claim_result)
             .bind(claim_meta)
             .bind(&request.worker_id)
+            .bind(prev_event_id)
             .bind(chrono::Utc::now())
             .execute(&mut *tx)
             .await?;
@@ -1287,11 +1316,19 @@ pub async fn handle_batch_events(
         )
         .await?;
     } else {
+        // Same one-level chain stamping the `event_write::emit_events`
+        // chokepoint performs (noetl/ai-meta#121): this gate-off batch INSERT
+        // bypasses it, so link each row's `prev_event_id` from the
+        // per-execution chain head + advance the head here, in batch order, so
+        // the gate-off chain stays walkable for the off-server builder.  Rows in
+        // a batch share one execution.
+        let ids: Vec<i64> = rows.iter().map(|r| r.event_id).collect();
+        let prevs = state.chain_heads.link_batch(execution_id, &ids).await;
         let mut qb = sqlx::QueryBuilder::new(
             "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
-             node_id, node_name, status, result, meta, worker_id, created_at) ",
+             node_id, node_name, status, result, meta, worker_id, prev_event_id, created_at) ",
         );
-        qb.push_values(rows.iter(), |mut b, r| {
+        qb.push_values(rows.iter().zip(prevs.iter()), |mut b, (r, prev)| {
             b.push_bind(r.event_id)
                 .push_bind(execution_id)
                 .push_bind(catalog_id)
@@ -1302,6 +1339,7 @@ pub async fn handle_batch_events(
                 .push_bind(&r.result_obj)
                 .push_bind(&r.meta_obj)
                 .push_bind(&request.worker_id)
+                .push_bind(*prev)
                 .push_bind(now);
         });
         qb.build().execute(&mut *tx).await?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -931,4 +931,89 @@ mod tests {
         assert_eq!(heads.link_batch(7, &[]).await, Vec::<Option<i64>>::new());
         assert_eq!(heads.head(7).await, None);
     }
+
+    /// Walk `prev_event_id` backward from `head`, returning the reconstructed
+    /// sequence (root-first).  Returns `None` if the walk hits a non-genesis
+    /// event whose `prev` is `NULL` — exactly the off-server `chain_walk_from`
+    /// →`build_spine_to` `Incomplete` condition (the WAL-chain-incomplete loop).
+    /// `genesis` is the lowest id (`playbook_started`) whose `NULL` prev is the
+    /// legitimate chain root.
+    fn walk_chain(
+        head: Option<i64>,
+        prev_of: &std::collections::HashMap<i64, Option<i64>>,
+        genesis: i64,
+    ) -> Option<Vec<i64>> {
+        let mut walked = Vec::new();
+        let mut cur = head;
+        while let Some(id) = cur {
+            walked.push(id);
+            match prev_of.get(&id).copied().flatten() {
+                Some(prev) => cur = Some(prev),
+                None if id == genesis => cur = None, // reached the real root
+                None => return None,                // orphaned non-genesis head
+            }
+        }
+        walked.reverse();
+        Some(walked)
+    }
+
+    /// noetl/ai-meta#121: a `command.claimed` written through a path that
+    /// bypasses the chain-link chokepoint (the gate-off in-tx claim INSERT)
+    /// gets `prev_event_id = NULL` AND never advances the head, so the next
+    /// event (`command.started`) links back to `command.issued`, skipping the
+    /// orphaned claim.  The off-server spine walk from the orphan head then
+    /// can't reach genesis → `Incomplete` → re-drive loop.  This test models
+    /// the orphan (the bug) and the linked sequence (the fix), asserting the
+    /// pointer walk only completes once the claim is linked.
+    #[tokio::test]
+    async fn chain_head_claim_orphan_vs_linked() {
+        // Snowflake-ish ascending ids for one execution.
+        let (started, issued, claimed, cmd_started) = (100_i64, 101, 102, 103);
+
+        // --- BUG: command.claimed bypasses link_batch (raw in-tx INSERT). ---
+        // The chokepoint links playbook_started, command.issued, then (skipping
+        // the claim) command.started off the un-advanced head (= command.issued).
+        let buggy = ChainHeads::default();
+        let mut prev_of = std::collections::HashMap::new();
+        for (id, prev) in [started, issued]
+            .iter()
+            .zip(buggy.link_batch(7, &[started, issued]).await)
+        {
+            prev_of.insert(*id, prev);
+        }
+        // The claim is written WITHOUT the chokepoint: NULL prev, head untouched.
+        prev_of.insert(claimed, None);
+        // command.started links off the still-at-`issued` head, skipping claimed.
+        for (id, prev) in [cmd_started]
+            .iter()
+            .zip(buggy.link_batch(7, &[cmd_started]).await)
+        {
+            prev_of.insert(*id, prev);
+        }
+        assert_eq!(prev_of[&cmd_started], Some(issued), "started skips claimed");
+        assert_eq!(prev_of[&claimed], None, "claimed is an orphan (NULL prev)");
+        // If the orphan ever becomes the head, the off-server walk can't complete.
+        assert_eq!(
+            walk_chain(Some(claimed), &prev_of, started),
+            None,
+            "orphan claim head → WAL chain incomplete (the re-drive loop)"
+        );
+
+        // --- FIX: command.claimed flows through link_batch like every event. ---
+        let fixed = ChainHeads::default();
+        let mut prev_of = std::collections::HashMap::new();
+        let seq = [started, issued, claimed, cmd_started];
+        for (id, prev) in seq.iter().zip(fixed.link_batch(7, &seq).await) {
+            prev_of.insert(*id, prev);
+        }
+        assert_eq!(prev_of[&claimed], Some(issued), "claim links to command.issued");
+        assert_eq!(prev_of[&cmd_started], Some(claimed), "started links to claim");
+        assert_eq!(fixed.head(7).await, Some(cmd_started));
+        // The off-server spine walk now reconstructs the full sequence — complete.
+        assert_eq!(
+            walk_chain(fixed.head(7).await, &prev_of, started),
+            Some(seq.to_vec()),
+            "linked claim → off-server chain-walk completes (no re-drive loop)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Resolves the off-server re-drive loop that wedged `system/scheduled_cleanup`
executions in prod (single-replica, `PUBLISH_ONLY=true`, `STATE_BUILDER=offserver`)
— logging `off-server drive (stateless): WAL chain incomplete; returning no-op,
server reconcile will re-drive` 24–43× over minutes.

Two distinct defects, both surfaced and fixed:

### 1. `command.claimed` orphaned with NULL `prev_event_id` (chain integrity)

The explicit claim handler (`POST /api/commands/{event_id}/claim`) wrote
`command.claimed` with a raw in-tx `INSERT INTO noetl.event` that bypassed the
`event_write::emit_events` chokepoint — so it never stamped `prev_event_id` and
never advanced the per-execution `ChainHeads` head. This branch runs whenever
`should_publish` is false, which is **every** `system/` playbook even under a
global `PUBLISH_ONLY=true` (system executions drain the stream, so their events
INSERT rather than publish). Result, exactly the prod chain:

```
playbook_started   prev=NULL        (genesis)
command.issued     prev=started
command.claimed    prev=NULL        (orphan — raw INSERT, head not advanced)
command.started    prev=command.issued   (skips the orphaned claim)
call.done          prev=command.started
command.completed  prev=call.done
```

**Fix:** stamp `prev_event_id` from `ChainHeads::link_batch` on the gate-off claim
INSERT — same advance-then-write the chokepoint already does for every other
server-originated event (the gate-on branch already links via the post-commit
`emit_event`). Also closes the identical bypass in the gate-off
`handle_batch_events` raw INSERT.

### 2. System executions routed to an unservable off-server WAL drive (the loop)

Linking the claim was necessary but **not** the loop's cause. Kind validation
showed the loop persisted with the chain fully linked. Root cause: the stateless
off-server drive builds `WorkflowState` from the `noetl_events` WAL spine on the
worker, but **only published events reach that stream** — system executions
(`should_publish` false) INSERT to `noetl.event` and never enter the WAL. So the
worker's WAL build for a system execution can never complete (`expected_head` is
never in its index) → permanent `__offserver_retry__` no-op → reconciler loop. A
non-system playbook completes offserver in seconds; a system one loops forever.

**Fix:** gate the off-server WAL drive on `should_publish(catalog_id)` in both
decision points —
- `trigger_orchestrator_inner`: skip `dispatch_offserver_stateless_drive` for a
  system execution; fall through to the server-built path, which reads
  `noetl.event` (where the system events live) and ships the built state.
- worker-driven dispatch: `offserver = state_builder==Offserver && should_publish(catalog_id)`,
  so a system execution drives off the shipped `run_state` directly instead of
  probing an unservable WAL spine.

Non-system executions are unaffected (`should_publish=true` → identical offserver
path). The PROD default (`STATE_BUILDER=server`) is untouched.

## Tests

- `state::tests::chain_head_claim_orphan_vs_linked` models the orphan (bug) vs the
  linked sequence (fix) and asserts the off-server pointer-walk only completes once
  the claim is linked.
- `cargo test --lib` 598 passed; `cargo clippy` clean (pre-existing doc warnings only).

## Kind validation (prod-exact gate: `PUBLISH_ONLY=true` + `STATE_BUILDER=offserver`)

Ran `system/scheduled_cleanup` on a single-replica kind server.

**BEFORE** (pre-fix image):
- `command.claimed prev=NULL` (orphan), `command.started → command.issued` skips it
- `WAL chain incomplete` re-drive loop 17×+, execution wedged `RUNNING` 120s+

**AFTER** (this PR):
- full chain linked, **zero orphans** (both `command.claimed → command.issued`)
- **0** `WAL chain incomplete` lines, execution **COMPLETED in 6s**, terminal
  `playbook.completed` present
- non-system playbook offserver unaffected (completes in seconds)

## Note on the prod-stuck executions

The 4 already-wedged prod execs are pre-fix rows; this PR stops *new* system
executions from looping. Remediating the existing 4 (cancel to stop the churn) is
tracked separately and is not part of this code change.

Closes noetl/ai-meta#121