### PR TITLE
fix(drive): route system executions through server-built state under the off-server gate (#121)

### DIFF
--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -202,11 +202,19 @@ async fn is_system_execution(state: &AppState, catalog_id: i64) -> bool {
             .await
             .ok()
             .flatten();
-    let is_sys = path.as_deref().map(|p| p.starts_with("system/")).unwrap_or(false);
+    let is_sys = path.as_deref().map(is_system_path).unwrap_or(false);
     if let Ok(mut m) = SYSTEM_CATALOG.write() {
         m.insert(catalog_id, is_sys);
     }
     is_sys
+}
+
+/// A catalog path identifies a **system-pool** playbook iff it lives under the
+/// `system/` namespace.  Pulled out of [`is_system_execution`] so the predicate
+/// — the thing the off-server-drive gate in `events.rs` ultimately turns on
+/// (noetl/ai-meta#121) — is unit-testable without a live catalog row.
+fn is_system_path(path: &str) -> bool {
+    path.starts_with("system/")
 }
 
 /// True when this execution's events should be PUBLISHED rather than INSERTed:
@@ -437,6 +445,27 @@ mod tests {
         }
         for t in ["command.completed", "command.failed", "step.enter", "playbook_started"] {
             assert!(!is_terminal_event_type(t), "{t} must NOT be terminal");
+        }
+    }
+
+    #[test]
+    fn system_path_detection_gates_the_offserver_drive() {
+        // noetl/ai-meta#121 — `should_publish` is false for `system/*` execs, so
+        // the off-server WAL drive in events.rs is gated off for them and they
+        // fall through to the server-built path.  `is_system_path` is the leaf
+        // predicate that whole chain turns on.  System paths drain the stream and
+        // INSERT their events (never published to `noetl_events`), so they must
+        // be detected; user paths publish and stay on the off-server path.
+        for p in ["system/scheduled_cleanup", "system/event_materializer", "system/projector"] {
+            assert!(is_system_path(p), "{p} must be detected as a system path");
+        }
+        for p in [
+            "weather/forecast",
+            "user/system_report", // `system` not at the path root
+            "systems/monitor",    // prefix is `system/`, not `system`
+            "",
+        ] {
+            assert!(!is_system_path(p), "{p} must NOT be detected as a system path");
         }
     }
 

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2666,7 +2666,22 @@ async fn trigger_orchestrator_inner(
         )
     {
         if let Some(desc) = state.exec_descriptors.get(execution_id).await {
-            if desc.catalog_id != 0 {
+            // The stateless off-server drive builds `WorkflowState` from the
+            // `noetl_events` WAL spine on the worker.  ONLY events that PUBLISH
+            // reach that stream — and `should_publish` is false for system-pool
+            // executions (`system/...`), whose events are INSERTed straight to
+            // `noetl.event` and never enter the WAL (they drain the stream, so
+            // they can't depend on it).  Routing a system execution to the
+            // stateless drive means the worker's WAL build can NEVER complete →
+            // it returns the `__offserver_retry__` no-op forever and the
+            // reconciler re-drives in a loop (noetl/ai-meta#121: the wedged
+            // `system/scheduled_cleanup` execs).  Gate the stateless drive on
+            // `should_publish(catalog_id)` so system executions fall through to
+            // the server-built path below — which reads `noetl.event` (where the
+            // system events DO live) and ships the built state to the worker.
+            if desc.catalog_id != 0
+                && crate::handlers::event_write::should_publish(state, desc.catalog_id).await
+            {
                 return dispatch_offserver_stateless_drive(
                     state,
                     execution_id,
@@ -2676,8 +2691,10 @@ async fn trigger_orchestrator_inner(
                 .await;
             }
         }
-        // Cold/incomplete descriptor → fall through to the server-built path,
-        // which re-seeds the descriptor so subsequent drives go stateless.
+        // Cold/incomplete descriptor, or a system execution whose events never
+        // reach the WAL → fall through to the server-built path, which re-seeds
+        // the descriptor and (for system execs) ships the built state so the
+        // worker drives off `run_state` instead of an unservable WAL spine.
     }
 
     // 1. Incremental state with bounded rebuild (noetl/ai-meta#100, #101 block b).
@@ -3064,10 +3081,16 @@ async fn trigger_orchestrator_inner(
         // (lag / cold) — so progress + correctness never regress below the
         // server-built `run_state` path.  Default `server` → the state is the
         // sole drive input exactly as today.
+        // Off-server WAL build applies only to executions whose events PUBLISH to
+        // `noetl_events` — system executions (`should_publish` false) INSERT their
+        // events and never enter the WAL (noetl/ai-meta#121), so the worker would
+        // burn its retry window on an unservable WAL spine before falling back to
+        // `run_state`.  Drive those purely server-built (`offserver=false` → the
+        // worker uses the shipped `state` via `run_state` directly, no WAL probe).
         let offserver = matches!(
             state.config.state_builder,
             crate::config::StateBuilder::Offserver
-        );
+        ) && crate::handlers::event_write::should_publish(state, catalog_id).await;
         let input = serde_json::json!({
             "state": cache.state.as_ref().expect("state present after rebuild"),
             "latest_ts": latest_ts,


### PR DESCRIPTION
## Summary

Completes the last `#121` off-server-cutover blocker: under the full off-server gate
(`PUBLISH_ONLY=true` + `STATE_BUILDER=offserver`) `system/*` executions wedge in a
permanent `__offserver_retry__` re-drive loop. This gates **both** off-server-drive
decision sites in `trigger_orchestrator_inner` on `should_publish(catalog_id)` so
system executions fall through to the server-built `run_state` path, while regular
(publishable) executions keep driving off-server unchanged.

Server-only change (`+57/-5`). PROD default (`STATE_BUILDER=server`) is untouched.

## Root cause

The stateless off-server drive builds `WorkflowState` from the `noetl_events` WAL
spine on the worker. Only **published** events reach that stream, and
`should_publish` is **false** for system-pool executions (`system/...`): their events
INSERT straight to `noetl.event` and never enter the WAL (they *drain* the stream, so
they can't depend on it). Routing a system execution to the stateless drive means the
worker's WAL build can never complete → it returns the `__offserver_retry__` no-op
forever and the reconciler re-drives in a loop. The `#256` `command.claimed`
chain-link (already merged, v3.39.4) was a real chain-integrity fix but **not** the
cause of this loop — kind validation under the prod config confirmed the loop persists
with the claim linked.

## Fix

Gate the off-server WAL drive on `should_publish(catalog_id)` in both places it is chosen:

- `trigger_orchestrator_inner` stateless dispatch — skip `dispatch_offserver_stateless_drive`
  for a non-publishing (system) execution; fall through to the server-built path, which
  reads `noetl.event` (where system events live) and ships the built state to the worker.
- worker-driven dispatch — compute `offserver = state_builder==Offserver && should_publish(catalog_id)`,
  so a system execution drives off the shipped `run_state` directly instead of probing an
  unservable WAL spine.

Non-system executions are unaffected (`should_publish=true` → identical off-server path),
so this does not regress the `#256` off-server win.

Also extracts the `system/`-path predicate into a pure `is_system_path` helper with a unit
test (the leaf the whole gate turns on).

## Validation — local kind, full off-server gate

`PUBLISH_ONLY=true`, `STATE_BUILDER=offserver` (server + system-pool),
`PLUGIN_DRIVE=true`, `MATERIALIZER_ENABLED=true`.

**Before (unfixed v3.39.2 under the gate):** `system/scheduled_cleanup` stays `RUNNING`;
system-pool worker loops `off-server drive (stateless): WAL chain incomplete; returning no-op,
server reconcile will re-drive` — 9 re-drives across 9 distinct `__orchestrate__` command ids,
climbing without terminating. The #121 signature.

**After (this fix):**
- The previously-wedged execution went `RUNNING → COMPLETED` the moment the fixed server
  took over (reconciler re-drove it via server-built state).
- A fresh `system/scheduled_cleanup` → `COMPLETED` with **0** WAL-chain-incomplete loops.
  Server log: `worker-driven: dispatched system/orchestrate to the pool offserver=false`.
- **Regular-exec regression:** `test/simple_loop` → `COMPLETED` and still drove off-server
  (`stateless drive: dispatched ... (no server state build)`) — `#256` win intact.

**Invariants:**
- Fresh system exec + regular exec: `roots=1`, `dangling=0`, `dup_ids=0`.
- Materializer sole-writer: `projected_total == acked_total == drained_total = 29`,
  `duplicates=0`, `project_errors=0`, consumer lag/ack_pending = 0.
- Worker off-server state builder `event_scans_total = 0` (never scans `noetl.event`).
- Server `state_build_event_scans = 4` — exclusively the system execs' server-built path
  reading `noetl.event` (the intended fix behavior; published off-server path scans zero).

## Tests

`cargo test` (612 tests) + `cargo clippy --all-targets` green. New unit test
`system_path_detection_gates_the_offserver_drive`.

Server-only ship → next release v3.39.5 (server rebuild; worker stays v5.40.3).
The prod re-cutover is a separate follow-up — this PR does not touch prod.

Closes noetl/ai-meta#121
