### PR TITLE
fix(orchestrate): surface a non-iterable loop `in:` as a terminal failure

### DIFF
--- a/orchestrate-core/src/evaluator.rs
+++ b/orchestrate-core/src/evaluator.rs
@@ -360,10 +360,27 @@ impl ConditionEvaluator {
                 let n = n.as_u64().unwrap_or(0) as usize;
                 Ok((0..n).map(|i| serde_json::json!(i)).collect())
             }
-            _ => Err(CoreError::Validation(format!(
-                "Loop expression did not evaluate to an iterable: {}",
-                loop_expr
-            ))),
+            other => {
+                // noetl/ai-meta#123: a loop `in:` that renders to a
+                // non-iterable (null / boolean / undefined-from-a-missing
+                // workload key, e.g. `loop: { in: '{{ workload.batch_slots }}' }`
+                // with `batch_slots` absent) MUST surface a deterministic
+                // validation error so the execution fails loudly — rather than
+                // silently producing zero iterations (commands=0) and wedging in
+                // RUNNING forever.  This restores the v3.4.2 behavior.  Note an
+                // *empty* iterable (`[]` / `{}`) is NOT this case — it matches the
+                // `Array` / `Object` arms above and legitimately short-circuits
+                // the loop to its `next`.
+                let kind = match &other {
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::Bool(_) => "boolean",
+                    _ => "non-iterable value",
+                };
+                Err(CoreError::Validation(format!(
+                    "Loop expression '{}' did not evaluate to an iterable (got {})",
+                    loop_expr, kind
+                )))
+            }
         }
     }
 }

--- a/orchestrate-core/src/orchestrator.rs
+++ b/orchestrate-core/src/orchestrator.rs
@@ -65,6 +65,23 @@ fn output_namespace(state: &WorkflowState, step_name: &str) -> Option<serde_json
     Some(out)
 }
 
+/// noetl/ai-meta#123: prepend the offending loop step name to an
+/// `evaluate_loop` error so the surfaced `playbook.failed` names *which*
+/// step's `in:` failed — without nesting a second `Validation error:`
+/// prefix (which `CoreError`'s `Display` would add if the whole error were
+/// re-wrapped).  The inner message (e.g. `Loop expression '…' did not
+/// evaluate to an iterable (got null)`) is preserved verbatim.
+fn prefix_loop_step_error(step_name: &str, e: CoreError) -> CoreError {
+    match e {
+        CoreError::Validation(msg) => {
+            CoreError::Validation(format!("loop step '{step_name}': {msg}"))
+        }
+        CoreError::Template(msg) => {
+            CoreError::Template(format!("loop step '{step_name}': {msg}"))
+        }
+    }
+}
+
 /// Add `ctx` and `workload` namespace shims to a flat variable
 /// context.  Mirrors the same pattern in `CommandBuilder::build_command`
 /// (commands.rs:108-115) so that `{{ ctx.foo }}` and `{{ workload.foo }}`
@@ -825,7 +842,11 @@ impl WorkflowOrchestrator {
 
                 let next_idx = completed as usize;
                 let shimmed = with_ctx_shims(context);
-                let items = self.evaluator.evaluate_loop(loop_cfg.in_expr.as_deref().unwrap_or(""), &shimmed)?;
+                // noetl/ai-meta#123: name the loop step in any surfaced error.
+                let items = self
+                    .evaluator
+                    .evaluate_loop(loop_cfg.in_expr.as_deref().unwrap_or(""), &shimmed)
+                    .map_err(|e| prefix_loop_step_error(step_name, e))?;
                 if next_idx >= items.len() {
                     continue;
                 } // safety guard
@@ -1685,9 +1706,14 @@ impl WorkflowOrchestrator {
                         }
 
                         let shimmed_loop = with_ctx_shims(&current_ctx);
+                        // noetl/ai-meta#123: prepend the offending step name so the
+                        // surfaced `playbook.failed` names *which* loop step's `in:`
+                        // failed (a non-iterable here returns Err, which the caller
+                        // turns into a terminal FAILED — not a silent commands=0).
                         let items = self
                             .evaluator
-                            .evaluate_loop(loop_cfg.in_expr.as_deref().unwrap_or(""), &shimmed_loop)?;
+                            .evaluate_loop(loop_cfg.in_expr.as_deref().unwrap_or(""), &shimmed_loop)
+                            .map_err(|e| prefix_loop_step_error(&current_step_name, e))?;
                         let total: usize = items.len();
 
                         if total == 0 {
@@ -3077,6 +3103,80 @@ workflow:
             .collect();
         assert!(types.contains(&"step.enter"));
         assert!(types.contains(&"step.exit"));
+    }
+
+    #[test]
+    fn test_step_loop_non_iterable_in_fails_loudly() {
+        // noetl/ai-meta#123: a loop whose `in:` renders to a NON-iterable
+        // (here `{{ workload.batch_slots }}` with `batch_slots` absent →
+        // undefined → renders empty → null) must return a deterministic Err
+        // naming the step + expression — NOT silently produce zero iterations
+        // (commands=0) and leave the execution wedged in RUNNING.  The server
+        // boundary turns this Err into a terminal `playbook.failed`.
+        //
+        // Contrast with `test_step_loop_empty_collection_short_circuits`: an
+        // *empty* iterable (`[]`) is legitimate and short-circuits to `next`;
+        // a *non-iterable* expression is the bug this guards against.
+        let orchestrator = WorkflowOrchestrator::new();
+
+        let start = make_step("start", Some("process"));
+        let mut process = make_step("process", Some("end"));
+        process.r#loop = Some(crate::playbook::Loop {
+            in_expr: Some("{{ workload.batch_slots }}".to_string()),
+            cursor: None,
+            iterator: "slot".to_string(),
+            spec: None,
+        });
+        let end = make_step("end", None);
+
+        let events = vec![
+            {
+                let mut e = make_event("playbook_started", None);
+                // `workload` present but WITHOUT `batch_slots` — the repro shape.
+                e.context = Some(serde_json::json!({
+                    "workload": { "other_key": 1 },
+                    "path": "test",
+                    "version": "1"
+                }));
+                e
+            },
+            make_event("command.completed", Some("start")),
+        ];
+
+        let playbook = Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "loop_non_iterable".to_string(),
+                path: Some("test/loop_non_iterable".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, process, end],
+        };
+
+        let result = orchestrator.evaluate(&events, &playbook, Some("command.completed"));
+        let err = result.expect_err(
+            "a non-iterable loop `in:` must return Err, not Ok(commands=0) — the silent wedge",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not evaluate to an iterable"),
+            "error should explain the non-iterable loop, got: {msg}"
+        );
+        assert!(
+            msg.contains("process"),
+            "error should name the offending loop step, got: {msg}"
+        );
+        assert!(
+            msg.contains("workload.batch_slots"),
+            "error should carry the rendered expression, got: {msg}"
+        );
     }
 
     /// Helper: build a step with a Router-style `next` that has

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -3396,6 +3396,30 @@ fn decode_orchestration_result(
         .and_then(|bytes| serde_json::from_slice(&bytes).ok())
 }
 
+/// Decode a base64-wrapped orchestrate-drive ERROR envelope (`{"error": "..."}`)
+/// — the `system/orchestrate` plug-in emits this (instead of an
+/// `OrchestrationResult`) when the off-server drive's `evaluate_state` returns
+/// `Err`: a deterministic, every-retry failure such as an invalid step-body
+/// template, an unknown `next` step, or a loop `in:` expression that does not
+/// evaluate to an iterable (noetl/ai-meta#123).  Returns the error message so
+/// the caller can terminate the execution as FAILED rather than treating the
+/// envelope as an undecodable result and silently no-op'ing — which strands the
+/// run in RUNNING forever (the observability regression #123 fixes).
+///
+/// A *transient* decode miss (missing `output_b64` from a race, truncated
+/// base64) parses as neither an `OrchestrationResult` nor this envelope, so it
+/// stays on the benign `decode_error` re-drive path — only a structured error
+/// envelope is treated as terminal.
+fn decode_orchestrate_error(b64: Option<&str>) -> Option<String> {
+    use base64::Engine;
+    let bytes = b64.and_then(|b64| base64::engine::general_purpose::STANDARD.decode(b64).ok())?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    match v.get("error") {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
 /// Apply the `OrchestrationResult` a worker computed for the worker-driven drive
 /// (noetl/ai-meta#108 slice 3): decode it from the `system/orchestrate`
 /// completion, then emit events + issue commands via `apply_orchestration_result`
@@ -3491,6 +3515,39 @@ async fn apply_worker_orchestration(
     }
 
     let Some(result) = decoded else {
+        // noetl/ai-meta#123: distinguish a deterministic DRIVE ERROR from a
+        // transient decode miss.  When the off-server drive's `evaluate_state`
+        // returns `Err` (invalid template, unknown `next` step, or a loop `in:`
+        // that does not evaluate to an iterable), the `system/orchestrate`
+        // plug-in returns a structured `{"error": "..."}` envelope rather than an
+        // `OrchestrationResult`.  Treating that as an undecodable result and
+        // returning Ok(0) wedges the execution in RUNNING forever (commands=0, no
+        // terminal event) — the exact silent-wedge regression #123 fixes.  The
+        // in-process drive already terminates such failures as `playbook.failed`
+        // (the `evaluate_state` Err arm in `trigger_orchestrator_inner`); the
+        // off-server drive must do the same so a malformed playbook fails loudly.
+        if let Some(err_msg) = decode_orchestrate_error(find_output_b64(payload)) {
+            // catalog_id for the terminal event: prefer the warm execute-time
+            // descriptor (off-server apply path), else 0 — the event still
+            // resolves the run to FAILED and surfaces the message to the client.
+            let catalog_id = state
+                .exec_descriptors
+                .get(execution_id)
+                .await
+                .map(|d| d.catalog_id)
+                .filter(|c| *c != 0)
+                .unwrap_or(0);
+            let msg = format!("Orchestrator drive failed (off-server): {err_msg}");
+            warn!(
+                execution_id,
+                error = %msg,
+                "worker-driven: drive returned a deterministic error envelope — \
+                 terminating execution as FAILED"
+            );
+            crate::metrics::record_orchestrate_drive("drive_error");
+            emit_playbook_failed(state, execution_id, catalog_id, trigger_event_id, &msg).await?;
+            return Ok(0);
+        }
         warn!(
             execution_id,
             "worker-driven: could not decode OrchestrationResult from orchestrate completion \
@@ -4381,5 +4438,40 @@ mod tests {
         let not_a_result =
             base64::engine::general_purpose::STANDARD.encode(b"{\"unexpected\":true}");
         assert!(decode_orchestration_result(Some(&not_a_result)).is_none());
+    }
+
+    #[test]
+    fn decode_orchestrate_error_extracts_drive_error_envelope() {
+        // noetl/ai-meta#123: the off-server drive returns `{"error": "..."}` when
+        // `evaluate_state` fails (e.g. a non-iterable loop `in:`).  The server
+        // must recognise it so it can terminate the run as FAILED instead of
+        // silently no-op'ing on an undecodable result.
+        use base64::Engine;
+        let envelope = serde_json::json!({
+            "error": "evaluate_state: Validation error: loop step 'process': \
+                      Loop expression '{{ workload.batch_slots }}' did not evaluate to an \
+                      iterable (got null)"
+        });
+        let b64 = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&envelope).unwrap());
+        let msg = decode_orchestrate_error(Some(&b64)).expect("envelope decodes to its message");
+        assert!(msg.contains("did not evaluate to an iterable"), "{msg}");
+        assert!(msg.contains("process"), "{msg}");
+
+        // A real OrchestrationResult is NOT an error envelope → None (stays on the
+        // success path, never mis-classified as a failure).
+        let or_json = serde_json::json!({
+            "state": "completed", "commands": [], "should_complete": true, "events_to_emit": []
+        });
+        let or_b64 = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&or_json).unwrap());
+        assert!(decode_orchestrate_error(Some(&or_b64)).is_none());
+
+        // Transient decode misses (None / bad base64 / empty error) stay on the
+        // benign re-drive path, NOT the terminal-fail path.
+        assert!(decode_orchestrate_error(None).is_none());
+        assert!(decode_orchestrate_error(Some("not base64!!!")).is_none());
+        let empty_err = base64::engine::general_purpose::STANDARD.encode(b"{\"error\":\"\"}");
+        assert!(decode_orchestrate_error(Some(&empty_err)).is_none());
     }
 }


### PR DESCRIPTION
## Problem

A `loop` step whose `in:` expression renders to a **non-iterable** value
(e.g. `loop: { in: '{{ workload.batch_slots }}' }` when `batch_slots` is
absent → undefined → null) **silently wedged** the execution at
`commands=0` / RUNNING-forever under the off-server drive — looking
identical to a hang. v3.4.2 returned an explicit validation error; the
current drive lost that surfacing. This observability regression produced
the false-positive noetl/ai-meta#122 during the noetl/ai-meta#120 2×2 repro.

## Root cause

`evaluate_loop` already returns `CoreError::Validation("… did not evaluate
to an iterable")`, and the **in-process** drive already turns that `Err`
into a terminal `playbook.failed`. But under the prod-default **off-server**
drive (`NOETL_ORCHESTRATE_PLUGIN_DRIVE=true`), the `system/orchestrate`
wasm plug-in returns a structured `{"error": "…"}` envelope instead of an
`OrchestrationResult`. `apply_worker_orchestration` couldn't decode that as
a result, logged a WARN, recorded `decode_error`, and returned `Ok(0)` — no
terminal event, so the run sat RUNNING forever.

## Fix

- **orchestrate-core** — keep `evaluate_loop`'s explicit error (now
  `Loop expression '<expr>' did not evaluate to an iterable (got <kind>)`),
  and prefix it with the offending step name at both loop fan-out sites via
  `prefix_loop_step_error`. An *empty* iterable (`[]` / `{}`) still
  short-circuits to `next` — only a *non-iterable* errors.
- **server** — `apply_worker_orchestration` now decodes the drive ERROR
  envelope (`decode_orchestrate_error`) and emits a terminal
  `playbook.failed` (metric `noetl_orchestrate_drive_total{stage="drive_error"}`,
  structured `execution_id`), matching the in-process drive. A transient
  decode miss (no envelope) stays on the benign re-drive path.

## Tests

- `test_step_loop_non_iterable_in_fails_loudly` (orchestrate-core): a loop
  over an absent workload key returns `Err` naming the step + expression,
  not `Ok(commands=0)`. `test_step_loop_empty_collection_short_circuits`
  still passes (`[]` is correct, not an error).
- `decode_orchestrate_error_extracts_drive_error_envelope` (server):
  envelope → message; real `OrchestrationResult` / transient miss → `None`.
- `cargo test` 600 (server) + 135 (orchestrate-core) green; clippy clean.

## Kind validation — prod-exact gate (`PLUGIN_DRIVE=true`, `PUBLISH_ONLY=true`, `STATE_BUILDER=offserver`)

| Case | Before | After |
| --- | --- | --- |
| `loop.in: {{ workload.batch_slots }}` (absent) | RUNNING forever, `commands=0`, no terminal event | **FAILED** — `loop step 'process': Loop expression '{{ workload.batch_slots }}' did not evaluate to an iterable (got null)`; `drive_error` +1; structured `execution_id` |
| `loop.in: {{ workload.batch_slots }}` (`[1,2,3]`) | COMPLETED | **COMPLETED** — 3-way fan-out, unaffected |

0 pod restarts. noetl/ai-meta#120 barrier and noetl/ai-meta#124 binding behavior unaffected.

Refs noetl/ai-meta#123

🤖 Generated with [Claude Code](https://claude.com/claude-code)