### PR TITLE
ci(release): fix cargo publish — version the orchestrate-core path dep + publish member first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate
+      # Publish the workspace member `noetl-orchestrate-core` FIRST — noetl-server
+      # depends on it (path + version), so `cargo publish` of the root crate needs
+      # it resolvable from crates.io (noetl/ai-meta#108; mirrors how noetl-tools
+      # publishes noetl-directives, noetl/ai-meta#92).  Idempotent: skip if this
+      # version is already published (a re-run, or a release that didn't bump the
+      # member — the core moves far less often than the server).
+      - name: Publish noetl-orchestrate-core (if changed)
         if: ${{ env.CRATES_IO_TOKEN != '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_TOKEN }}
-        run: cargo publish
+        run: |
+          set -euo pipefail
+          VER="$(grep -E '^version = ' orchestrate-core/Cargo.toml | head -1 | cut -d'"' -f2)"
+          if cargo search noetl-orchestrate-core 2>/dev/null | grep -q "noetl-orchestrate-core = \"${VER}\""; then
+            echo "noetl-orchestrate-core ${VER} already on crates.io; skipping."
+          else
+            OUTPUT="$(cargo publish -p noetl-orchestrate-core 2>&1)" || {
+              echo "$OUTPUT"
+              echo "$OUTPUT" | grep -q "already exists" && echo "already published; continuing." || exit 1
+            }
+            echo "$OUTPUT"
+            # Give the sparse index a moment so the root crate's publish resolves it.
+            sleep 20
+          fi
+      - name: Publish noetl-server crate
+        if: ${{ env.CRATES_IO_TOKEN != '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_TOKEN }}
+        run: cargo publish -p noetl-server
       - name: Skip publish (no token)
         if: ${{ env.CRATES_IO_TOKEN == '' }}
         run: echo "CRATES_IO_TOKEN is not set; skipping crate publish."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,13 @@ exclude = ["plugins/orchestrate"]
 
 [dependencies]
 # Pure orchestrator drive core (one source → native + wasm32; noetl/ai-meta#108).
-noetl-orchestrate-core = { path = "orchestrate-core" }
+# Carries an explicit `version` alongside the `path` so `cargo publish` of
+# noetl-server resolves the dep from crates.io — a bare path dep has no version
+# and fails publish ("all dependencies must have a version requirement
+# specified when publishing").  The release workflow publishes
+# noetl-orchestrate-core first; mirrors noetl-tools/noetl-directives
+# (noetl/ai-meta#92).
+noetl-orchestrate-core = { version = "0.1.0", path = "orchestrate-core" }
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time", "sync"] }
 


### PR DESCRIPTION
## Problem

The `release-server` workflow's `publish-crate` job has failed on **every** run
(workflow_dispatch on each release since the orchestrate-core extraction):

```
all dependencies must have a version requirement specified when publishing.
dependency `noetl-orchestrate-core` does not specify a version
```

`noetl-server` depends on the workspace member `noetl-orchestrate-core`
(extracted for the server-dissolution program, noetl/ai-meta#108) by a **bare
`path`**. `cargo publish` rejects path-only deps — a published crate's
dependencies must carry a version so they resolve from crates.io.

## Fix

Mirrors how `noetl-tools` already handles `noetl-directives` (noetl/ai-meta#92):

1. **`Cargo.toml`** — add `version = "0.1.0"` alongside the `path` on the
   `noetl-orchestrate-core` dep. The `path` still wins for local/workspace
   builds; the `version` is what `cargo publish` records.
2. **`.github/workflows/release.yml`** — publish `noetl-orchestrate-core`
   **first** (idempotent: skips if the version is already on crates.io, tolerates
   "already exists" on a re-run), then `cargo publish -p noetl-server`, so the
   member crate is resolvable from the index when the root crate publishes.

## Verification

Local, as far as possible without a live crates.io upload:

- `cargo publish -p noetl-orchestrate-core --dry-run` — packages **and verifies
  clean** (no path deps of its own).
- `cargo publish -p noetl-server --dry-run --no-verify` — the original
  `does not specify a version` packaging error is **gone**; it now only reports
  `no matching package named noetl-orchestrate-core found` on the crates.io
  index, which is exactly the condition the member-first publish step resolves
  at release time.

Full validation (the member actually publishing, then the root resolving it)
happens on the next real `release-server` run. No binary behavior changes —
`Cargo.toml`/workflow only.