### PR TITLE
feat(events): ensure sibling noetl_result_materializer consumer (#104 Phase B)

### DIFF
--- a/src/nats/event_publisher.rs
+++ b/src/nats/event_publisher.rs
@@ -58,6 +58,17 @@ pub const PROJECTOR_CONSUMER: &str = "noetl_projector";
 /// has its own ack cursor.
 pub const MATERIALIZER_CONSUMER: &str = "noetl_materializer";
 
+/// Durable pull consumer the **result materializer** drains
+/// (noetl/ai-meta#104 Phase B).  A *separate* consumer from
+/// [`MATERIALIZER_CONSUMER`] by design: the result materializer writes the
+/// over-budget Feather/JSON result tier to object store, whose I/O latency must
+/// never back-pressure the `noetl.event` audit fold the lag alert guards.  Each
+/// drains the same stream with its own ack cursor.  Ensured unconditionally
+/// (like the projector/materializer consumers) so the cursor exists from the
+/// stream's birth; an idle consumer (Phase B flag default-off on the worker)
+/// just sits at the stream tail and costs nothing under `limits` retention.
+pub const RESULT_MATERIALIZER_CONSUMER: &str = "noetl_result_materializer";
+
 /// Publishes full events onto the `noetl_events` JetStream stream.
 #[derive(Clone)]
 pub struct EventStreamPublisher {
@@ -82,6 +93,10 @@ impl EventStreamPublisher {
         // projector (→ projection_snapshot) and the materializer (→ noetl.event).
         Self::ensure_consumer(&js, PROJECTOR_CONSUMER).await?;
         Self::ensure_consumer(&js, MATERIALIZER_CONSUMER).await?;
+        // The result materializer (noetl/ai-meta#104 Phase B) is a sibling
+        // drainer on its own cursor — ensured here so its consumer exists even
+        // when no worker drains it yet (flag default-off).
+        Self::ensure_consumer(&js, RESULT_MATERIALIZER_CONSUMER).await?;
         Ok(Self { js })
     }
 


### PR DESCRIPTION
Phase B of N for **Event WAL + Derivable Result Storage** (noetl/ai-meta#104).

The result materialiser (worker, noetl/worker Phase B PR) drains `noetl_events` on its **own** durable consumer — distinct from the event materialiser's `noetl_materializer` — so object-store latency never back-pressures the `noetl.event` audit fold the materializer-lag alert guards.

This PR ensures that consumer (`noetl_result_materializer`) at stream-birth alongside the projector/materialiser consumers in `EventStreamPublisher::new`. Idempotent `create_consumer`; ensured unconditionally (like the existing two) so the cursor exists even when no worker drains it yet — an idle consumer with the worker flag default-off sits at the stream tail and costs nothing under `limits` retention.

**No new dependencies** — the control plane stays slim. 609 lib tests pass.

Validated on local kind under the prod-exact off-server gate (PUBLISH_ONLY + off-server drive + materializer sole-writer): with the worker flag on, over-budget tabular results produced a real Arrow `.feather` and non-tabular a `.json` at the derived §7 key; flag off was a true no-op; the event-materializer sole-writer invariants held every leg (per-exec event_rows==distinct, catalog_id=0 rows=0, __orchestrate__ rows=0, mat dup=0). See the e2e rig (noetl/e2e Phase B PR).

Refs noetl/ai-meta#104 (Phase B of N — B–F remain; #104 stays open).