### PR TITLE
feat(result): GCS object backend + cell registry resolve-by-URN read side (#104 Phase C of N)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+target/
+**/target/

--- a/src/handlers/cells.rs
+++ b/src/handlers/cells.rs
@@ -1,0 +1,22 @@
+//! Cell endpoint registry handler ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) Phase C).
+//!
+//! `GET /api/internal/cells` — the server-served read-side cell map the
+//! resolve-by-URN path consults to turn a derived `(region, cell, shard)` into a
+//! concrete placement. See [`crate::services::cell_registry`] for the contract
+//! and the fail-safe miss behavior (OQ6).
+
+use axum::{extract::State, Json};
+
+use crate::services::cell_registry::CellRegistry;
+
+/// Injected registry (built once from env at startup).
+#[derive(Clone)]
+pub struct CellRegistryDeps {
+    pub registry: CellRegistry,
+}
+
+/// `GET /api/internal/cells` — return the cell endpoint map.
+pub async fn list_cells(State(deps): State<CellRegistryDeps>) -> Json<CellRegistry> {
+    crate::metrics::record_cell_registry_request();
+    Json(deps.registry.clone())
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains all route handlers organized by domain.
 
 pub mod catalog;
+pub mod cells;
 pub mod container_callback;
 pub mod credentials;
 pub mod cross_region;

--- a/src/handlers/objects.rs
+++ b/src/handlers/objects.rs
@@ -1,5 +1,5 @@
-//! Object-store endpoints (noetl/ai-meta#105 Round 5) — the server-mediated
-//! backend for a plug-in's `noetl.object_put` capability (the Feather tier).
+//! Object-store endpoints (noetl/ai-meta#105 Round 5; backend selector added in
+//! [noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) Phase C).
 //!
 //! - `PUT /api/internal/objects/{*key}` — write an object (raw body) at the §7
 //!   physical key; the server computes the SHA-256 digest and stores it.
@@ -9,6 +9,10 @@
 //! (`noetl/env=…/region=…/cell=…/shard=…/…/results/<step>/<frame>/<row>/<attempt>.feather`)
 //! resolves. Under `/api/internal/*`, the service-account-gated family —
 //! workers reach NoETL-owned data only through the server API.
+//!
+//! The bytes land in whichever [`ObjectBackend`] the server resolved at startup
+//! (`NOETL_OBJECT_STORE_BACKEND`): Postgres `BYTEA` (Phase B default) or a GCS
+//! bucket (Phase C). The HTTP contract is identical across backends.
 
 use axum::{
     body::Bytes,
@@ -20,8 +24,17 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::db::{queries::object_store, DbPool};
+use crate::db::DbPool;
 use crate::error::AppResult;
+use crate::services::object_backend::ObjectBackend;
+
+/// Injected object-store deps: the Postgres pool (for the Postgres backend) plus
+/// the resolved backend selector.
+#[derive(Clone)]
+pub struct ObjectStoreDeps {
+    pub pool: DbPool,
+    pub backend: ObjectBackend,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct PutQuery {
@@ -38,7 +51,7 @@ pub struct PutResponse {
 
 /// `PUT /api/internal/objects/{*key}` — store the raw body at `key`.
 pub async fn put(
-    State(pool): State<DbPool>,
+    State(deps): State<ObjectStoreDeps>,
     Path(key): Path<String>,
     Query(q): Query<PutQuery>,
     body: Bytes,
@@ -47,8 +60,13 @@ pub async fn put(
     let media_type = q
         .media_type
         .unwrap_or_else(|| "application/octet-stream".to_string());
-    object_store::put(&pool, &key, &digest, &media_type, &body).await?;
-    tracing::debug!(object_key = %key, digest = %digest, bytes = body.len(), "stored object");
+    let outcome = deps
+        .backend
+        .put(&deps.pool, &key, &digest, &media_type, &body)
+        .await;
+    crate::metrics::record_object_store_op(deps.backend.label(), "put", outcome.is_ok());
+    outcome?;
+    tracing::debug!(object_key = %key, digest = %digest, bytes = body.len(), backend = deps.backend.label(), "stored object");
     Ok(Json(PutResponse {
         key,
         digest,
@@ -58,11 +76,10 @@ pub async fn put(
 
 /// `GET /api/internal/objects/{*key}` — serve the object bytes, content-typed by
 /// its media type with the digest as an ETag.
-pub async fn get(
-    State(pool): State<DbPool>,
-    Path(key): Path<String>,
-) -> AppResult<Response> {
-    let Some(row) = object_store::get(&pool, &key).await? else {
+pub async fn get(State(deps): State<ObjectStoreDeps>, Path(key): Path<String>) -> AppResult<Response> {
+    let fetched = deps.backend.get(&deps.pool, &key).await;
+    crate::metrics::record_object_store_op(deps.backend.label(), "get", fetched.is_ok());
+    let Some(row) = fetched? else {
         return Ok((StatusCode::NOT_FOUND, format!("object {key} not found")).into_response());
     };
     Ok((

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,14 @@ fn build_router(
         .allow_methods(Any)
         .allow_headers(Any);
 
+    // Object-store backend + cell endpoint registry (RFC noetl/ai-meta#104
+    // Phase C).  Both are env-driven (default off → Postgres object backend,
+    // single-cell seed), built once here and cloned into their route state.
+    let object_backend =
+        noetl_server::services::object_backend::ObjectBackend::from_env();
+    let cell_registry =
+        noetl_server::services::cell_registry::CellRegistry::from_env(&object_backend);
+
     // Health check routes (no auth required)
     let mut health_routes = Router::new()
         .route("/health", get(handlers::health_check))
@@ -432,14 +440,30 @@ fn build_router(
             "/api/internal/plugins/{*path}",
             post(handlers::plugins::register).get(handlers::plugins::fetch),
         )
-        // Object store (noetl/ai-meta#105 Round 5) — server-mediated backend for
-        // a plug-in's `noetl.object_put` capability (the Feather tier), keyed by
-        // the §7 physical object key.
+        .with_state(db_pool.clone());
+
+    // Object store (noetl/ai-meta#105 Round 5; backend selector noetl/ai-meta#104
+    // Phase C) — server-mediated backend for a plug-in's `noetl.object_put`
+    // capability (the Feather tier), keyed by the §7 physical object key. Its own
+    // group because it carries the resolved `ObjectBackend` (Postgres | GCS) in
+    // state alongside the pool.
+    let object_store_routes = Router::new()
         .route(
             "/api/internal/objects/{*key}",
             put(handlers::objects::put).get(handlers::objects::get),
         )
-        .with_state(db_pool.clone());
+        .with_state(handlers::objects::ObjectStoreDeps {
+            pool: db_pool.clone(),
+            backend: object_backend.clone(),
+        });
+
+    // Cell endpoint registry (noetl/ai-meta#104 Phase C) — the read-side cell map
+    // the resolve-by-URN path consults. Single-cell seed today; fail-safe miss.
+    let cell_routes = Router::new()
+        .route("/api/internal/cells", get(handlers::cells::list_cells))
+        .with_state(handlers::cells::CellRegistryDeps {
+            registry: cell_registry,
+        });
 
     // Gateway push-ingress config endpoint (noetl/ai-meta#90 Phase 3).  The
     // gateway calls GET /api/internal/ingress/{listener} (service-account
@@ -507,6 +531,8 @@ fn build_router(
         .merge(sharding_routes)
         .merge(database_routes)
         .merge(internal_routes)
+        .merge(object_store_routes)
+        .merge(cell_routes)
         .merge(ingress_routes)
         .merge(system_routes)
         .merge(dashboard_routes)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1356,6 +1356,59 @@ pub fn record_result_store_resolve(duration_seconds: f64, status: &str) {
         .observe(duration_seconds);
 }
 
+/// `noetl_object_store_ops_total{backend,op,outcome}` — object-store backend I/O
+/// (RFC #104 Phase C). `backend` is `postgres`/`gcs`, `op` is `put`/`get`,
+/// `outcome` is `ok`/`error`. The GCS-backend deltas are the proof the Feather
+/// tier read/write goes through GCS under the flag.
+pub fn object_store_ops_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_object_store_ops_total",
+                "Object-store backend operations by backend, op, and outcome (RFC #104 Phase C).",
+            ),
+            &["backend", "op", "outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one object-store backend operation outcome.
+pub fn record_object_store_op(backend: &str, op: &str, ok: bool) {
+    object_store_ops_total()
+        .with_label_values(&[backend, op, if ok { "ok" } else { "error" }])
+        .inc();
+}
+
+/// `noetl_cell_registry_requests_total` — `GET /api/internal/cells` hits (RFC
+/// #104 Phase C). The resolve-by-URN read path consults the registry once per
+/// process (cached), so this is low-volume; its delta proves the read side is
+/// wired to the server-served registry rather than local env.
+pub fn cell_registry_requests_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_cell_registry_requests_total",
+            "GET /api/internal/cells requests served (RFC #104 Phase C cell endpoint registry).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one cell-registry request.
+pub fn record_cell_registry_request() {
+    cell_registry_requests_total().inc();
+}
+
 /// Secrets-Wallet Phase 7c: histogram of token auto-renewal wall-clock
 /// latency.  Buckets `[0.05, 0.1, 0.25, 0.5, 1, 2, 5]` — span the range
 /// where auth round-trips actually live.  Observed regardless of

--- a/src/services/cell_registry.rs
+++ b/src/services/cell_registry.rs
@@ -1,0 +1,136 @@
+//! Cell endpoint registry ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) Phase C, RFC §4.3).
+//!
+//! The derivable §7 physical key carries `region`/`cell`/`shard` segments. A
+//! consumer that knows `(tenant, project, execution_id)` **derives** the home
+//! shard with zero central lookup (`ResultCoordinates::shard_key`); the only
+//! thing that needs a registry is turning a **cell** into a concrete
+//! placement/bucket/endpoint. Phase B seeded that single-cell on the *write*
+//! side from worker env (`CellSeed`); Phase C generalizes it to a
+//! **server-served** map the *read* path consults, so a multi-cell grid can grow
+//! without changing names.
+//!
+//! `GET /api/internal/cells` returns the map. Today it is a single-cell seed
+//! (`default_cell`) derived from the same `NOETL_RESULT_CELL*` env the materializer
+//! reads, so the read-side placement matches the write-side placement byte for
+//! byte. Multi-cell entries and shard→cell routing are an additive follow-up.
+//!
+//! **Miss behavior (OQ6 — resolved fail-safe).** The registry never fails an
+//! execution. If a consumer can't reach the registry, or a cell can't be
+//! resolved, the resolve-by-URN read path falls back to the authoritative
+//! `noetl.result_store` / inline result and increments a fallback metric — never
+//! a hard failure, never silent data loss. The registry is an optimization seam,
+//! not a single point of failure.
+
+use serde::Serialize;
+
+use crate::services::object_backend::ObjectBackend;
+
+/// One cell's placement + physical object-store binding.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CellEntry {
+    /// Cell id (the `cell=` §7 segment), e.g. `local-0`.
+    pub cell: String,
+    /// Deployment env (the `env=` §7 segment), e.g. `dev` / `prod`.
+    pub env: String,
+    /// Region (the `region=` §7 segment), e.g. `local` / `usw2`.
+    pub region: String,
+    /// Object-store provider backing this cell (`gcs` / `postgres`).
+    pub provider: String,
+    /// Bucket (empty for the Postgres backend).
+    pub bucket: String,
+    /// Object-store endpoint (empty for the Postgres backend).
+    pub endpoint: String,
+}
+
+/// The cell endpoint registry — single-cell seed today, multi-cell ready.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CellRegistry {
+    /// Shard space size; the §7 `shard=` segment is `shard_key % shard_count`.
+    pub shard_count: u32,
+    /// The cell every shard homes on in the single-cell seed.
+    pub default_cell: String,
+    /// Known cells (one today).
+    pub cells: Vec<CellEntry>,
+}
+
+impl CellRegistry {
+    /// Build from the same env the worker materializer's `CellSeed` reads, plus
+    /// the object-store backend (for `provider`/`bucket`/`endpoint`), so the
+    /// read-side placement matches the write-side §7 key exactly.
+    pub fn from_env(backend: &ObjectBackend) -> Self {
+        let env = std::env::var("NOETL_RESULT_CELL_ENV").unwrap_or_else(|_| "dev".to_string());
+        let region =
+            std::env::var("NOETL_RESULT_CELL_REGION").unwrap_or_else(|_| "local".to_string());
+        let cell = std::env::var("NOETL_RESULT_CELL").unwrap_or_else(|_| "local-0".to_string());
+        let shard_count = std::env::var("NOETL_RESULT_SHARD_COUNT")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(256)
+            .max(1);
+        let (provider, bucket, endpoint) = match backend {
+            ObjectBackend::Postgres => ("postgres".to_string(), String::new(), String::new()),
+            ObjectBackend::Gcs(_) => (
+                "gcs".to_string(),
+                std::env::var("NOETL_OBJECT_STORE_GCS_BUCKET").unwrap_or_default(),
+                std::env::var("NOETL_OBJECT_STORE_GCS_ENDPOINT").unwrap_or_default(),
+            ),
+        };
+        let entry = CellEntry {
+            cell: cell.clone(),
+            env,
+            region,
+            provider,
+            bucket,
+            endpoint,
+        };
+        CellRegistry {
+            shard_count,
+            default_cell: cell,
+            cells: vec![entry],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Single sequential test (shared process env → parallel tests would race).
+    #[test]
+    fn from_env_seed_and_overrides() {
+        let keys = [
+            "NOETL_RESULT_CELL_ENV",
+            "NOETL_RESULT_CELL_REGION",
+            "NOETL_RESULT_CELL",
+            "NOETL_RESULT_SHARD_COUNT",
+        ];
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        // Defaults mirror the worker `CellSeed::from_env` defaults exactly.
+        let reg = CellRegistry::from_env(&ObjectBackend::Postgres);
+        assert_eq!(reg.shard_count, 256);
+        assert_eq!(reg.default_cell, "local-0");
+        assert_eq!(reg.cells.len(), 1);
+        let c = &reg.cells[0];
+        assert_eq!(c.cell, "local-0");
+        assert_eq!(c.env, "dev");
+        assert_eq!(c.region, "local");
+        assert_eq!(c.provider, "postgres");
+
+        // Overrides flow through.
+        std::env::set_var("NOETL_RESULT_CELL_ENV", "prod");
+        std::env::set_var("NOETL_RESULT_CELL_REGION", "usw2");
+        std::env::set_var("NOETL_RESULT_CELL", "usw2-a");
+        std::env::set_var("NOETL_RESULT_SHARD_COUNT", "512");
+        let reg = CellRegistry::from_env(&ObjectBackend::Postgres);
+        assert_eq!(reg.shard_count, 512);
+        assert_eq!(reg.default_cell, "usw2-a");
+        assert_eq!(reg.cells[0].env, "prod");
+        assert_eq!(reg.cells[0].region, "usw2");
+
+        for k in keys {
+            std::env::remove_var(k);
+        }
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,9 +4,11 @@
 //! between handlers and database queries.
 
 pub mod catalog;
+pub mod cell_registry;
 pub mod credential;
 pub mod event;
 pub mod event_stream;
+pub mod object_backend;
 pub mod execution;
 pub mod internal;
 pub mod keychain;

--- a/src/services/object_backend.rs
+++ b/src/services/object_backend.rs
@@ -1,0 +1,287 @@
+//! Object-store backend selector ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) Phase C).
+//!
+//! Phase B introduced the server-mediated object endpoint
+//! (`PUT/GET /api/internal/objects/{*key}`) backed by Postgres `BYTEA`
+//! (`db::queries::object_store`). Phase C wires a **GCS** backend behind the same
+//! HTTP contract so the Feather/JSON result tier can live in object store, where
+//! it belongs (the RFC §5.3 durable cross-node tier), and the resolve-by-URN read
+//! path reads it from there.
+//!
+//! Selection is by env (`NOETL_OBJECT_STORE_BACKEND`):
+//!
+//! - **`postgres`** (default) — the Phase B behavior, byte-identical. The bytes
+//!   live in `noetl.object_store`. Prod/default is unchanged.
+//! - **`gcs`** — the bytes live in a GCS bucket. The server talks to GCS (or a
+//!   GCS-compatible endpoint — a [fake-gcs-server] emulator on kind) over the
+//!   GCS JSON API via the existing `reqwest` client. No new heavy dependency: the
+//!   slim control plane stays slim (no `gcp_auth`, no `object_store` crate).
+//!
+//! The endpoint is **server-mediated** end to end
+//! ([data-access-boundary.md](https://github.com/noetl/ai-meta/blob/main/agents/rules/data-access-boundary.md)):
+//! workers never reach GCS directly — they `PUT`/`GET` through the server, which
+//! holds the bucket binding and (in prod) the workload-identity credential.
+//!
+//! [fake-gcs-server]: https://github.com/fsouza/fake-gcs-server
+//!
+//! ## Auth
+//!
+//! The kind/emulator path needs no credential (fake-gcs-server is open). Real-GCS
+//! auth (GKE workload identity / a bearer token) is a prod-rollout concern wired
+//! in a later phase; the emulator path proves the read/write contract on kind.
+//! When `NOETL_OBJECT_STORE_GCS_TOKEN` is set it is sent as a bearer token, so a
+//! token-bearing deployment works without a code change.
+
+use sha2::{Digest, Sha256};
+
+use crate::db::{queries::object_store, queries::object_store::ObjectRow, DbPool};
+use crate::error::{AppError, AppResult};
+
+/// The resolved object-store backend (built once at startup from env).
+#[derive(Clone)]
+pub enum ObjectBackend {
+    /// Bytes in `noetl.object_store` (Phase B default; prod/default behavior).
+    Postgres,
+    /// Bytes in a GCS bucket (or GCS-compatible emulator) via the JSON API.
+    Gcs(GcsBackend),
+}
+
+/// GCS (or GCS-compatible) backend configuration.
+#[derive(Clone)]
+pub struct GcsBackend {
+    client: reqwest::Client,
+    /// Base endpoint, no trailing slash (`https://storage.googleapis.com` for
+    /// real GCS, `http://fake-gcs-server:4443` for the kind emulator).
+    endpoint: String,
+    /// Target bucket.
+    bucket: String,
+    /// Optional bearer token (empty for the open emulator).
+    token: String,
+}
+
+impl ObjectBackend {
+    /// Build the backend from env. Defaults to `Postgres` (Phase B behavior).
+    /// A `gcs` selection with no bucket falls back to `Postgres` with a WARN so a
+    /// misconfiguration degrades to the durable default rather than failing
+    /// object I/O outright.
+    pub fn from_env() -> Self {
+        let backend = std::env::var("NOETL_OBJECT_STORE_BACKEND")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        match backend.as_str() {
+            "gcs" => {
+                let bucket = std::env::var("NOETL_OBJECT_STORE_GCS_BUCKET")
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                if bucket.is_empty() {
+                    tracing::warn!(
+                        "NOETL_OBJECT_STORE_BACKEND=gcs but NOETL_OBJECT_STORE_GCS_BUCKET is \
+                         unset; falling back to the Postgres object backend"
+                    );
+                    return ObjectBackend::Postgres;
+                }
+                let endpoint = std::env::var("NOETL_OBJECT_STORE_GCS_ENDPOINT")
+                    .unwrap_or_else(|_| "https://storage.googleapis.com".to_string())
+                    .trim_end_matches('/')
+                    .to_string();
+                let token = std::env::var("NOETL_OBJECT_STORE_GCS_TOKEN").unwrap_or_default();
+                tracing::info!(endpoint = %endpoint, bucket = %bucket, "object store backend: GCS (#104 Phase C)");
+                ObjectBackend::Gcs(GcsBackend {
+                    client: reqwest::Client::new(),
+                    endpoint,
+                    bucket,
+                    token,
+                })
+            }
+            _ => ObjectBackend::Postgres,
+        }
+    }
+
+    /// Stable label for metrics / logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ObjectBackend::Postgres => "postgres",
+            ObjectBackend::Gcs(_) => "gcs",
+        }
+    }
+
+    /// Store the object at `key`. Idempotent overwrite (content-addressed §7 key).
+    pub async fn put(
+        &self,
+        pool: &DbPool,
+        key: &str,
+        digest: &str,
+        media_type: &str,
+        bytes: &[u8],
+    ) -> AppResult<()> {
+        match self {
+            ObjectBackend::Postgres => object_store::put(pool, key, digest, media_type, bytes).await,
+            ObjectBackend::Gcs(g) => g.put(key, media_type, bytes).await,
+        }
+    }
+
+    /// Fetch the object at `key`, or `None` (caller → HTTP 404).
+    pub async fn get(&self, pool: &DbPool, key: &str) -> AppResult<Option<ObjectRow>> {
+        match self {
+            ObjectBackend::Postgres => object_store::get(pool, key).await,
+            ObjectBackend::Gcs(g) => g.get(key).await,
+        }
+    }
+}
+
+impl GcsBackend {
+    /// Upload via the GCS JSON API `uploadType=media` (the object name rides as a
+    /// query param, so `reqwest` URL-encodes it). Works against real GCS and the
+    /// fake-gcs-server emulator alike.
+    async fn put(&self, key: &str, media_type: &str, bytes: &[u8]) -> AppResult<()> {
+        let url = format!("{}/upload/storage/v1/b/{}/o", self.endpoint, self.bucket);
+        let mut req = self
+            .client
+            .post(&url)
+            .query(&[("uploadType", "media"), ("name", key)])
+            .header(reqwest::header::CONTENT_TYPE, media_type)
+            .body(bytes.to_vec());
+        if !self.token.is_empty() {
+            req = req.bearer_auth(&self.token);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("gcs object put {key}: {e}")))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AppError::Internal(format!(
+                "gcs object put {key}: HTTP {} {}",
+                status.as_u16(),
+                body
+            )));
+        }
+        Ok(())
+    }
+
+    /// Download via the GCS JSON API `alt=media`. The object name is a path
+    /// segment, so it is percent-encoded (slashes become `%2F`). Returns `None`
+    /// on 404 (so the resolver falls back fail-safe), errors on other non-2xx.
+    async fn get(&self, key: &str) -> AppResult<Option<ObjectRow>> {
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}",
+            self.endpoint,
+            self.bucket,
+            percent_encode_segment(key)
+        );
+        let mut req = self.client.get(&url).query(&[("alt", "media")]);
+        if !self.token.is_empty() {
+            req = req.bearer_auth(&self.token);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("gcs object get {key}: {e}")))?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AppError::Internal(format!(
+                "gcs object get {key}: HTTP {} {}",
+                status.as_u16(),
+                body
+            )));
+        }
+        let media_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| AppError::Internal(format!("gcs object get {key} body: {e}")))?
+            .to_vec();
+        let digest = hex::encode(Sha256::digest(&bytes));
+        Ok(Some(ObjectRow {
+            digest,
+            media_type,
+            bytes,
+        }))
+    }
+}
+
+/// Percent-encode one path segment per RFC 3986 (encode everything but the
+/// unreserved set `A-Za-z0-9-._~`), so a slash-bearing §7 object key becomes a
+/// single GCS JSON-API path segment (`/` → `%2F`, `=` → `%3D`).
+fn percent_encode_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() * 3);
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{b:02X}"));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // One sequential test: mutating process env from several parallel tests
+    // races (the runner shares one process), so all `from_env` assertions live
+    // in a single body that fully controls + resets env.
+    #[test]
+    fn from_env_backend_selection() {
+        for k in [
+            "NOETL_OBJECT_STORE_BACKEND",
+            "NOETL_OBJECT_STORE_GCS_BUCKET",
+            "NOETL_OBJECT_STORE_GCS_ENDPOINT",
+        ] {
+            std::env::remove_var(k);
+        }
+
+        // Default → Postgres (prod/default behavior).
+        assert_eq!(ObjectBackend::from_env().label(), "postgres");
+
+        // gcs requested but no bucket → fail-safe to Postgres.
+        std::env::set_var("NOETL_OBJECT_STORE_BACKEND", "gcs");
+        assert_eq!(ObjectBackend::from_env().label(), "postgres");
+
+        // gcs + bucket → GCS, endpoint trailing slash trimmed.
+        std::env::set_var("NOETL_OBJECT_STORE_GCS_BUCKET", "noetl-results");
+        std::env::set_var("NOETL_OBJECT_STORE_GCS_ENDPOINT", "http://fake-gcs:4443/");
+        match ObjectBackend::from_env() {
+            ObjectBackend::Gcs(g) => {
+                assert_eq!(g.endpoint, "http://fake-gcs:4443");
+                assert_eq!(g.bucket, "noetl-results");
+            }
+            _ => panic!("expected gcs"),
+        }
+
+        for k in [
+            "NOETL_OBJECT_STORE_BACKEND",
+            "NOETL_OBJECT_STORE_GCS_BUCKET",
+            "NOETL_OBJECT_STORE_GCS_ENDPOINT",
+        ] {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[test]
+    fn percent_encodes_physical_key_segment() {
+        let key = "noetl/env=dev/region=local/cell=local-0/shard=s0053/results/start/0/0/1.feather";
+        let enc = percent_encode_segment(key);
+        assert!(enc.contains("%2F"), "slashes encoded: {enc}");
+        assert!(enc.contains("%3D"), "equals encoded: {enc}");
+        assert!(!enc.contains('/'), "no raw slash: {enc}");
+        // unreserved chars (letters, digits, `.`, `-`) pass through verbatim
+        assert!(enc.ends_with("1.feather"), "tail unreserved: {enc}");
+    }
+}


### PR DESCRIPTION
## #104 Phase C — server side of the resolve-by-URN read path

Phase C is the first phase that **reads** the Feather/JSON result tier Phase B writes. This PR is the server half: a GCS-compatible object backend + the server-served cell registry that the worker's resolve-by-URN path consults.

### What lands
- **`services/object_backend.rs`** — object store abstraction with a GCS backend (`NOETL_OBJECT_STORE_BACKEND=gcs`) for PUT/GET of the derived §7 result keys; default is the Postgres backend (today's path), so this is opt-in and reversible.
- **`services/cell_registry.rs`** + **`GET /api/internal/cells`** (`handlers/cells.rs`) — the read-side cell endpoint map (shard_count + default_cell + per-cell env/region/provider/bucket/endpoint) the worker derives placement from.
- Wired in `main.rs` (registry built from env; route registered).

### New environment variables (server)
| Var | Default | Required | Meaning |
|---|---|---|---|
| `NOETL_OBJECT_STORE_BACKEND` | unset → Postgres | no | `gcs` opts into the GCS object backend; unset/unknown → Postgres (`noetl.result_store`). `gcs` with empty bucket → WARN + Postgres fallback. |
| `NOETL_OBJECT_STORE_GCS_BUCKET` | — | with `BACKEND=gcs` | Bucket holding the §7 result keys. |
| `NOETL_OBJECT_STORE_GCS_ENDPOINT` | `https://storage.googleapis.com` | no | Override for an emulator (kind: fake-gcs-server). Trailing slash trimmed. |
| `NOETL_OBJECT_STORE_GCS_TOKEN` | — (anonymous) | no | Bearer token; empty = anonymous (emulator). |
| `NOETL_RESULT_CELL` | `local-0` | no | Cell id results home on (registry `default_cell`). Must match the materializer's write-side cell. |
| `NOETL_RESULT_CELL_ENV` | `dev` | no | Cell env segment of the §7 key. |
| `NOETL_RESULT_CELL_REGION` | `local` | no | Cell region segment of the §7 key. |
| `NOETL_RESULT_SHARD_COUNT` | `256` | no | Shard count for the stable shard-hash placement (min 1). |

Wiki deployment-spec updated in the same change set (per wiki-maintenance Rule 2a).

### Validation
Kind 3-pass `kind_validate_result_resolve.sh` (prod-exact off-server gate: `PUBLISH_ONLY=true` + `PLUGIN_DRIVE=true` + materializer sole-writer), against fake-gcs-server. Server side proven: `gcs put Δ=4` (materializer wrote the tier), `gcs get Δ=2` (served the object to the worker's resolve-by-URN). Sole-writer invariants intact every leg.

Pairs with: noetl/worker#<resolve-by-URN read path + B1> and noetl/e2e#<rig>.

See noetl/ai-meta#104. Default-off; reversible.