### PR TITLE
Phase D minting flip: dual-write window + flag (#104 Phase D)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -326,6 +326,30 @@ pub struct AppConfig {
     #[serde(default)]
     pub result_uri_accept: bool,
 
+    /// **Phase D minting flip** (noetl/ai-meta#104 Phase D).  Envy maps
+    /// `NOETL_RESULT_MINT_AUTHORITATIVE`.
+    ///
+    /// The flip makes the URN → Feather/GCS result tier the **authoritative**
+    /// result store, with `noetl.result_store` demoted to the transitional
+    /// **dual-write fallback** for reversibility.  The authoritative tier write
+    /// and the tier-primary consume path are worker-side (the slim control plane
+    /// does not encode Feather); the server's role under the flag is the
+    /// **dual-write window**: it continues minting + storing `result_store` as
+    /// the reversible fallback leg, and records each such write on
+    /// `noetl_result_store_dual_write_total` so the window is observable.
+    ///
+    /// - **false** (default) — `result_store` is the authoritative store exactly
+    ///   as in Phase A–C; the dual-write counter never moves.  No-op; byte-
+    ///   identical prod/default behavior.
+    /// - **true** — the worker treats the tier as authoritative; the server keeps
+    ///   writing `result_store` (the fallback leg) and counts it.  The actual
+    ///   *retirement* of `result_store` (stop the dual-write) is the OQ5-gated
+    ///   operational decision — **not** Phase D — so flag-off rolls back cleanly.
+    ///
+    /// **Default false** — opt-in, reversible, kind-validated before any rollout.
+    #[serde(default)]
+    pub result_mint_authoritative: bool,
+
     /// **Where the per-execution drive watermark + descriptor live** (RFC
     /// noetl/ai-meta#115 program-scale / noetl/ai-meta#107).  Envy maps
     /// `NOETL_REPLICA_COHERENCE`.
@@ -544,6 +568,9 @@ impl Default for AppConfig {
             // noetl/ai-meta#104 Phase A: the canonical result URI is ignored by
             // default; shadow-accept (parse + validate + record) is opt-in.
             result_uri_accept: false,
+            // noetl/ai-meta#104 Phase D: the minting flip is off by default; the
+            // tier-authoritative + dual-write-fallback behavior is opt-in.
+            result_mint_authoritative: false,
             // noetl/ai-meta#115 program-scale: in-process maps by default; the
             // NATS-KV multi-replica coherence backing is opt-in (and staged).
             replica_coherence: ReplicaCoherence::Local,
@@ -567,6 +594,13 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 8082);
         assert!(!config.debug);
+    }
+
+    #[test]
+    fn test_result_mint_authoritative_defaults_off() {
+        // Phase D (#104): the minting flip is opt-in; default-off must be a true
+        // no-op (no dual-write counting, no behavior change).
+        assert!(!AppConfig::default().result_mint_authoritative);
     }
 
     #[test]

--- a/src/handlers/result_store.rs
+++ b/src/handlers/result_store.rs
@@ -31,6 +31,11 @@ use crate::services::result_store::{parse_noetl_ref, PutResultBody, ResultStoreS
 #[derive(Clone)]
 pub struct ResultStoreDeps {
     pub service: ResultStoreService,
+    /// Phase D minting flip (noetl/ai-meta#104 Phase D): when true the worker
+    /// treats the URN tier as authoritative, so each `result_store` write here is
+    /// the reversible **dual-write fallback leg** — counted on
+    /// `noetl_result_store_dual_write_total`. Off → ordinary authoritative write.
+    pub mint_authoritative: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -74,6 +79,17 @@ pub async fn put_result(
                 "result_store.put: stored",
             );
             crate::metrics::record_result_store_put(elapsed, resp.bytes as usize, "ok");
+            // Phase D (#104): under the minting flip the URN tier is
+            // authoritative and this write is the reversible dual-write fallback
+            // leg — count it so the dual-write window is observable.
+            if deps.mint_authoritative {
+                crate::metrics::record_result_store_dual_write();
+                tracing::debug!(
+                    execution_id,
+                    name = %body.name,
+                    "result_store dual-write (Phase D fallback leg; tier authoritative)",
+                );
+            }
             Ok((StatusCode::OK, Json(resp)))
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,7 @@ fn build_router(
         .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
         .with_state(handlers::result_store::ResultStoreDeps {
             service: result_store_service,
+            mint_authoritative: state.config.result_mint_authoritative,
         });
 
     // Variable routes (transient table)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -331,6 +331,39 @@ pub fn record_result_uri_accept(outcome: &str) {
         .inc();
 }
 
+/// `noetl_result_store_dual_write_total` — over-budget results written to
+/// `noetl.result_store` as the **transitional fallback leg** while the Phase D
+/// minting flip is on (`NOETL_RESULT_MINT_AUTHORITATIVE=true`,
+/// RFC noetl/ai-meta#104 Phase D).
+///
+/// Under the flip the worker treats the URN → Feather/GCS tier as authoritative
+/// and resolves from it first; the server keeps minting + storing `result_store`
+/// so the cutover is reversible (flag-off → `result_store`-authoritative again).
+/// Each such write increments this counter, making the dual-write window
+/// observable. Flag-off it never moves (the dual-write is just the ordinary,
+/// only store). The actual retirement of `result_store` (stopping this write) is
+/// the OQ5-gated operational decision — not Phase D.
+pub fn result_store_dual_write_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_result_store_dual_write_total",
+            "result_store writes that are the dual-write fallback leg under the Phase D minting flip (RFC #104 Phase D).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one `result_store` dual-write (the reversible fallback leg under the
+/// Phase D minting flip).
+pub fn record_result_store_dual_write() {
+    result_store_dual_write_total().inc();
+}
+
 /// `noetl_state_build_event_scans_total` — incremented once each time the drive
 /// path enters the **event-scan** state-construction block (the block that issues
 /// `WHERE execution_id = $1 …` scans of `noetl.event`: the consistency `COUNT`,


### PR DESCRIPTION
Phase D of N of the Event-WAL + derivable result storage umbrella (`Refs noetl/ai-meta#104`). **Flag default-off → byte-identical to Phase A–C (a true no-op). No prod change.**

## What Phase D adds — the minting flip

Phase D makes the URN → Feather/GCS result tier the **authoritative** result store, with `noetl.result_store` demoted to a transitional **dual-write fallback** for reversibility. One flag — `NOETL_RESULT_MINT_AUTHORITATIVE` — turns the whole flip on:

- **Authoritative tier write** (system pool): the result materializer becomes the authoritative tier writer — the flag alone spawns it (no separate `NOETL_RESULT_MATERIALIZER_ENABLED` needed).
- **Resolve-prefers-tier** (consume pool): resolve-by-URN becomes the **primary** read path (the flag alone enables it; no separate `NOETL_RESULT_URI_RESOLVE` needed). The authoritative tier serves the consume.
- **Dual-write window** (server): the server keeps minting + storing `noetl.result_store` as the reversible fallback leg, counted on `noetl_result_store_dual_write_total`.
- **Rollback safety**: a tier miss / parse failure falls back fail-safe to the dual-written `result_store`; the path taken is recorded on `noetl_worker_result_mint_authoritative_total{path}` (`tier` | `legacy_fallback`).

Default-off is a true no-op (no dual-write counting, no resolve-by-URN, legacy `result_store` authoritative exactly as Phase A–C).

## Why the tier write stays worker-side (not a synchronous server mint)

The slim control plane deliberately does **not** carry `arrow` (OQ7), so it cannot encode Feather. The authoritative tier write therefore stays on the worker materializer (async, separate consumer — RFC §3.2, so object-store latency never back-pressures the event audit fold). The async window between the producer mint and the tier write is exactly what the `result_store` dual-write fallback covers during the transition.

## OQ5 is the open decision — NOT decided here

The actual **retirement** of `result_store` (stopping the dual-write) is OQ5 and is **left open for the platform owner**. It is gated on the dual-write-window/retention decision AND a prerequisite: the materializer fetches the over-budget payload **from** `result_store` today, so retiring it requires re-plumbing how the tier write gets the bytes. Phase D ships the dual-write window only; flag-off rolls back cleanly.

## Tests + kind validation

(see #104 comment for the per-leg kind evidence)

---
**This repo (server):** config flag `result_mint_authoritative` (`NOETL_RESULT_MINT_AUTHORITATIVE`, default off); the result_store PUT records each write on the new `noetl_result_store_dual_write_total` counter under the flag (the reversible dual-write fallback leg); `ResultStoreDeps` carries the flag. 613 lib tests pass; heavy graph stays absent from the control plane. Default-off byte-identical.

Pairs with noetl/worker, noetl/ops, noetl/e2e Phase D PRs. **Do not auto-merge** — review-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)