### PR TITLE
result-tier GC: conservative dry-run-first sweeper (#104 Phase F)

### DIFF
--- a/src/db/queries/object_store.rs
+++ b/src/db/queries/object_store.rs
@@ -98,3 +98,42 @@ pub async fn get(pool: &DbPool, object_key: &str) -> AppResult<Option<ObjectRow>
         bytes: r.get::<Vec<u8>, _>("bytes"),
     }))
 }
+
+/// List object keys under `prefix` (most-recently-written first), capped at
+/// `limit`. Backs the result-tier GC sweep ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104)
+/// Phase F) for the Postgres backend.
+pub async fn list_keys(pool: &DbPool, prefix: &str, limit: i64) -> AppResult<Vec<String>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT object_key
+        FROM noetl.object_store
+        WHERE object_key LIKE $1 || '%'
+        ORDER BY created_at DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(prefix)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| r.get::<String, _>("object_key"))
+        .collect())
+}
+
+/// Delete the object at `object_key`. Returns `true` if a row was removed
+/// (idempotent — a missing key is `false`, not an error). Backs the result-tier
+/// GC sweep ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) Phase F).
+pub async fn delete(pool: &DbPool, object_key: &str) -> AppResult<bool> {
+    let result = sqlx::query(
+        r#"
+        DELETE FROM noetl.object_store
+        WHERE object_key = $1
+        "#,
+    )
+    .bind(object_key)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -21,6 +21,7 @@ pub mod plugins;
 pub mod objects;
 pub mod replay;
 pub mod result_store;
+pub mod result_tier;
 pub mod runtime;
 pub mod secret_audit;
 pub mod sharding;

--- a/src/handlers/result_tier.rs
+++ b/src/handlers/result_tier.rs
@@ -1,0 +1,71 @@
+//! Result-tier GC endpoint ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104)
+//! Phase F).
+//!
+//! `POST /api/internal/result-tier/gc` — sweep the Feather/JSON result tier for
+//! provably-dead objects and (unless `dry_run`) reclaim them. Service-account
+//! gated like the rest of `/api/internal/*`; the `system/scheduled_cleanup`
+//! playbook is the caller (data-access-boundary.md — workers never touch the
+//! object store directly).
+//!
+//! The endpoint is a **no-op unless `NOETL_RESULT_TIER_GC` is set** and defaults
+//! to **dry-run** (lists dead candidates, deletes nothing). The safety invariant
+//! — never delete a live-referenced object — lives in
+//! [`crate::services::result_tier_gc`] and is unit-tested there.
+
+use axum::{extract::State, Json};
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::handlers::internal::RequireInternalApiToken;
+use crate::services::object_backend::ObjectBackend;
+use crate::services::result_tier_gc::{self, GcReport, GcRequest};
+
+/// Injected GC deps: the pool (for the `noetl.event` liveness query) plus the
+/// resolved object backend (for list + delete).
+#[derive(Clone)]
+pub struct ResultTierDeps {
+    pub pool: DbPool,
+    pub backend: ObjectBackend,
+}
+
+/// `POST /api/internal/result-tier/gc` — run one sweep. An empty body sweeps the
+/// `noetl/` prefix in dry-run with default limit + grace.
+#[tracing::instrument(skip(deps, _token, body))]
+pub async fn gc(
+    State(deps): State<ResultTierDeps>,
+    _token: RequireInternalApiToken,
+    body: Option<Json<GcRequest>>,
+) -> AppResult<Json<GcReport>> {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
+    let report = result_tier_gc::sweep(&deps.pool, &deps.backend, &req).await?;
+
+    // Observability: one counter, deltas tell the story (no_op when the gate is
+    // off, scanned/deleted/skipped_live/errors otherwise).
+    if !report.enabled {
+        crate::metrics::record_result_tier_gc("no_op", 1);
+    } else {
+        crate::metrics::record_result_tier_gc("scanned", report.scanned as u64);
+        crate::metrics::record_result_tier_gc("deleted", report.deleted as u64);
+        crate::metrics::record_result_tier_gc("skipped_live", report.skipped_live as u64);
+        crate::metrics::record_result_tier_gc("skipped_grace", report.skipped_grace as u64);
+        crate::metrics::record_result_tier_gc(
+            "skipped_unparseable",
+            report.skipped_unparseable as u64,
+        );
+        crate::metrics::record_result_tier_gc("error", report.errors as u64);
+    }
+
+    tracing::info!(
+        enabled = report.enabled,
+        dry_run = report.dry_run,
+        prefix = %report.prefix,
+        scanned = report.scanned,
+        deleted = report.deleted,
+        skipped_live = report.skipped_live,
+        skipped_grace = report.skipped_grace,
+        skipped_unparseable = report.skipped_unparseable,
+        errors = report.errors,
+        "result-tier GC sweep done (#104 Phase F)"
+    );
+    Ok(Json(report))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,6 +466,21 @@ fn build_router(
             registry: cell_registry,
         });
 
+    // Result-tier GC (noetl/ai-meta#104 Phase F) — the conservative, dry-run-first
+    // sweeper that reclaims only provably-dead tier objects (execution aged out of
+    // the event log; never a live-referenced object). Gated `NOETL_RESULT_TIER_GC`
+    // (default off → no-op). Carries the pool (liveness query) + the object backend
+    // (list + delete) in state.
+    let result_tier_routes = Router::new()
+        .route(
+            "/api/internal/result-tier/gc",
+            post(handlers::result_tier::gc),
+        )
+        .with_state(handlers::result_tier::ResultTierDeps {
+            pool: db_pool.clone(),
+            backend: object_backend.clone(),
+        });
+
     // Gateway push-ingress config endpoint (noetl/ai-meta#90 Phase 3).  The
     // gateway calls GET /api/internal/ingress/{listener} (service-account
     // gated) to resolve a push subscription's verify scheme + Wallet-resolved
@@ -534,6 +549,7 @@ fn build_router(
         .merge(internal_routes)
         .merge(object_store_routes)
         .merge(cell_routes)
+        .merge(result_tier_routes)
         .merge(ingress_routes)
         .merge(system_routes)
         .merge(dashboard_routes)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1442,6 +1442,39 @@ pub fn record_cell_registry_request() {
     cell_registry_requests_total().inc();
 }
 
+/// `noetl_result_tier_gc_total{outcome}` — result-tier GC sweep outcomes (RFC
+/// #104 Phase F). `outcome` is `no_op` (gate off), `scanned`, `deleted`,
+/// `skipped_live`, `skipped_grace`, `skipped_unparseable`, or `error`. The
+/// `skipped_live` series is the proof the sweep never reclaims a live-referenced
+/// object; `deleted` advances only when a provably-dead object is removed.
+pub fn result_tier_gc_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_result_tier_gc_total",
+                "Result-tier GC sweep outcomes by outcome (RFC #104 Phase F).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record `n` result-tier GC outcomes of a kind (a sweep records one delta per
+/// outcome class, so the counter sums cleanly across sweeps).
+pub fn record_result_tier_gc(outcome: &str, n: u64) {
+    if n > 0 {
+        result_tier_gc_total()
+            .with_label_values(&[outcome])
+            .inc_by(n);
+    }
+}
+
 /// Secrets-Wallet Phase 7c: histogram of token auto-renewal wall-clock
 /// latency.  Buckets `[0.05, 0.1, 0.25, 0.5, 1, 2, 5]` — span the range
 /// where auth round-trips actually live.  Observed regardless of

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod keychain_refresh;
 pub mod orch_snapshot;
 pub mod replay;
 pub mod result_store;
+pub mod result_tier_gc;
 pub mod runtime;
 pub mod secret_audit;
 pub mod ui_schema;

--- a/src/services/object_backend.rs
+++ b/src/services/object_backend.rs
@@ -128,6 +128,28 @@ impl ObjectBackend {
             ObjectBackend::Gcs(g) => g.get(key).await,
         }
     }
+
+    /// List object keys under `prefix`, capped at `limit`. Backs the result-tier
+    /// GC sweep ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104)
+    /// Phase F). The ordering is best-effort per backend (Postgres → newest
+    /// first; GCS → lexicographic, the JSON-API default); the GC sweep does not
+    /// depend on order, only on coverage up to `limit`.
+    pub async fn list(&self, pool: &DbPool, prefix: &str, limit: usize) -> AppResult<Vec<String>> {
+        match self {
+            ObjectBackend::Postgres => object_store::list_keys(pool, prefix, limit as i64).await,
+            ObjectBackend::Gcs(g) => g.list(prefix, limit).await,
+        }
+    }
+
+    /// Delete the object at `key`. Idempotent: a missing key is `Ok(false)`, not
+    /// an error. Backs the result-tier GC sweep
+    /// ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) Phase F).
+    pub async fn delete(&self, pool: &DbPool, key: &str) -> AppResult<bool> {
+        match self {
+            ObjectBackend::Postgres => object_store::delete(pool, key).await,
+            ObjectBackend::Gcs(g) => g.delete(key).await,
+        }
+    }
 }
 
 impl GcsBackend {
@@ -209,6 +231,108 @@ impl GcsBackend {
             bytes,
         }))
     }
+
+    /// List object names under `prefix` via the GCS JSON API
+    /// (`GET …/o?prefix=…&maxResults=…`), following `nextPageToken` until `limit`
+    /// keys are collected or the listing is exhausted. The `prefix` rides as a
+    /// query param (the client URL-encodes it). Works against real GCS and the
+    /// fake-gcs-server emulator alike.
+    async fn list(&self, prefix: &str, limit: usize) -> AppResult<Vec<String>> {
+        let url = format!("{}/storage/v1/b/{}/o", self.endpoint, self.bucket);
+        let mut keys: Vec<String> = Vec::new();
+        let mut page_token: Option<String> = None;
+        // Bound the page walk so a pathological listing can't loop forever.
+        for _ in 0..1000 {
+            let remaining = limit.saturating_sub(keys.len());
+            if remaining == 0 {
+                break;
+            }
+            let max_results = remaining.min(1000).to_string();
+            let mut query: Vec<(&str, &str)> = vec![("prefix", prefix), ("maxResults", &max_results)];
+            if let Some(tok) = page_token.as_deref() {
+                query.push(("pageToken", tok));
+            }
+            let mut req = self.client.get(&url).query(&query);
+            if !self.token.is_empty() {
+                req = req.bearer_auth(&self.token);
+            }
+            let resp = req
+                .send()
+                .await
+                .map_err(|e| AppError::Internal(format!("gcs object list {prefix}: {e}")))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(AppError::Internal(format!(
+                    "gcs object list {prefix}: HTTP {} {}",
+                    status.as_u16(),
+                    body
+                )));
+            }
+            let page: GcsListPage = resp
+                .json()
+                .await
+                .map_err(|e| AppError::Internal(format!("gcs object list {prefix} decode: {e}")))?;
+            for item in page.items {
+                keys.push(item.name);
+                if keys.len() >= limit {
+                    break;
+                }
+            }
+            match page.next_page_token {
+                Some(tok) if keys.len() < limit => page_token = Some(tok),
+                _ => break,
+            }
+        }
+        Ok(keys)
+    }
+
+    /// Delete the object at `key` via the GCS JSON API
+    /// (`DELETE …/o/<percent-encoded-key>`). Idempotent: a 404 (already gone) is
+    /// `Ok(false)`; a 2xx is `Ok(true)`; other non-2xx errors.
+    async fn delete(&self, key: &str) -> AppResult<bool> {
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}",
+            self.endpoint,
+            self.bucket,
+            percent_encode_segment(key)
+        );
+        let mut req = self.client.delete(&url);
+        if !self.token.is_empty() {
+            req = req.bearer_auth(&self.token);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| AppError::Internal(format!("gcs object delete {key}: {e}")))?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AppError::Internal(format!(
+                "gcs object delete {key}: HTTP {} {}",
+                status.as_u16(),
+                body
+            )));
+        }
+        Ok(true)
+    }
+}
+
+/// One page of a GCS JSON-API object listing (`…/o` response).
+#[derive(serde::Deserialize)]
+struct GcsListPage {
+    #[serde(default)]
+    items: Vec<GcsListItem>,
+    #[serde(rename = "nextPageToken", default)]
+    next_page_token: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct GcsListItem {
+    name: String,
 }
 
 /// Percent-encode one path segment per RFC 3986 (encode everything but the

--- a/src/services/result_tier_gc.rs
+++ b/src/services/result_tier_gc.rs
@@ -1,0 +1,405 @@
+//! Result-tier garbage collection ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104)
+//! Phase F).
+//!
+//! The Feather/JSON result tier (Phase B–D) is durable object storage addressed
+//! by the §7 physical key. Like any durable store it accrues objects whose
+//! executions have aged out of retention, plus the occasional orphan (an object
+//! written by the materializer for an execution whose events were later pruned).
+//! This module is the **safe, conservative, flag-gated sweeper** that reclaims
+//! only provably-dead objects.
+//!
+//! ## Safety invariant (the load-bearing property)
+//!
+//! **The sweep never deletes a live-referenced object.** An object is *live* when
+//! its execution still has at least one surviving row in `noetl.event` — i.e. the
+//! execution is still within retention and reachable from the audit log. A live
+//! object is skipped before any deletion is even considered, in dry-run and
+//! delete mode alike. The proof is the unit test [`tests::live_object_is_never_dead`]:
+//! [`decide`] returns [`Decision::SkipLive`] for any age / grace whenever the
+//! execution has surviving events.
+//!
+//! An object is a GC candidate (*dead*) only when **all** of:
+//!
+//! 1. its key parses to an `execution=<eid>` segment (unparseable → skipped, never
+//!    deleted — we never reason about a key we don't understand);
+//! 2. the execution has **no** surviving events in `noetl.event` (aged out of the
+//!    event-retention window the `system/scheduled_cleanup` playbook enforces, or
+//!    an orphan never referenced by a surviving event);
+//! 3. the object is **older than the grace window** (derived from the execution_id
+//!    snowflake mint time) — so a just-minted execution whose events have not yet
+//!    materialized is never mistaken for dead.
+//!
+//! ## What this sweep deliberately does NOT do
+//!
+//! - It does **not** reap superseded attempt versions (keep-every URN, RFC OQ1) —
+//!   that policy is still open; the sweep is attempt-agnostic, reclaiming whole
+//!   aged-out executions, never one attempt of a still-live execution.
+//! - It does **not** drive `noetl.result_store` retirement (RFC OQ5). Tier GC
+//!   keys off **execution retention** (surviving events), independent of the
+//!   dual-write fallback's lifecycle. The two are decoupled by design.
+//!
+//! Gated by `NOETL_RESULT_TIER_GC` (default off → the endpoint is a no-op).
+
+use serde::{Deserialize, Serialize};
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::services::object_backend::ObjectBackend;
+
+/// `NOETL_RESULT_TIER_GC` — master switch for the result-tier sweep. Default off
+/// → the GC endpoint returns a no-op report and deletes nothing.
+pub fn gc_enabled() -> bool {
+    matches!(
+        std::env::var("NOETL_RESULT_TIER_GC")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Default number of objects a single sweep examines.
+fn default_limit() -> usize {
+    1000
+}
+
+/// Default grace window (seconds) before an unreferenced object is eligible.
+/// One day — comfortably longer than any materializer lag, so an in-flight
+/// execution whose events have not yet landed is never mistaken for dead.
+fn default_grace_seconds() -> i64 {
+    86_400
+}
+
+/// Default key prefix the sweep scans — the §7 object-key root.
+fn default_prefix() -> String {
+    "noetl/".to_string()
+}
+
+/// GC sweep request (POST body). All fields optional; an empty body sweeps the
+/// `noetl/` prefix in **dry-run** with the default limit + grace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GcRequest {
+    /// When `true` (the default) the sweep lists dead candidates but deletes
+    /// nothing. Set `false` to actually delete the candidates.
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    /// Object-key prefix to scan (default `noetl/`).
+    #[serde(default = "default_prefix")]
+    pub prefix: String,
+    /// Maximum objects to examine in one sweep.
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// Minimum object age (seconds, from the execution_id mint time) before an
+    /// unreferenced object is eligible for deletion.
+    #[serde(default = "default_grace_seconds")]
+    pub grace_seconds: i64,
+}
+
+fn default_dry_run() -> bool {
+    true
+}
+
+impl Default for GcRequest {
+    fn default() -> Self {
+        Self {
+            dry_run: default_dry_run(),
+            prefix: default_prefix(),
+            limit: default_limit(),
+            grace_seconds: default_grace_seconds(),
+        }
+    }
+}
+
+/// One dead object the sweep identified.
+#[derive(Debug, Clone, Serialize)]
+pub struct GcCandidate {
+    pub key: String,
+    pub execution_id: i64,
+    /// Why the object is dead (`unreferenced` — no surviving event for its
+    /// execution; covers both aged-out and orphan).
+    pub reason: &'static str,
+    /// Whether this candidate was actually deleted (`false` in dry-run).
+    pub deleted: bool,
+}
+
+/// GC sweep report (POST response).
+#[derive(Debug, Clone, Serialize)]
+pub struct GcReport {
+    /// Echo of the `NOETL_RESULT_TIER_GC` gate. When `false` the sweep is a
+    /// no-op and every other field is zero/empty.
+    pub enabled: bool,
+    pub dry_run: bool,
+    pub prefix: String,
+    /// Objects examined.
+    pub scanned: usize,
+    /// Objects deleted (always 0 in dry-run).
+    pub deleted: usize,
+    /// Objects skipped because their execution still has surviving events.
+    pub skipped_live: usize,
+    /// Objects skipped because they are younger than the grace window.
+    pub skipped_grace: usize,
+    /// Objects skipped because the key did not parse to an `execution=` segment.
+    pub skipped_unparseable: usize,
+    /// Delete failures (non-fatal; counted, the sweep continues).
+    pub errors: usize,
+    /// The dead objects (deleted, or would-be-deleted in dry-run).
+    pub candidates: Vec<GcCandidate>,
+}
+
+impl GcReport {
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            dry_run: true,
+            prefix: String::new(),
+            scanned: 0,
+            deleted: 0,
+            skipped_live: 0,
+            skipped_grace: 0,
+            skipped_unparseable: 0,
+            errors: 0,
+            candidates: Vec::new(),
+        }
+    }
+}
+
+/// The per-object verdict. A pure function of the object's parsed execution_id,
+/// whether that execution has surviving events, the object's age, and the grace
+/// window — isolated from any I/O so the safety invariant is unit-testable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Skip: the key did not parse to an `execution=` segment.
+    SkipUnparseable,
+    /// Skip: the execution still has surviving events (live-referenced).
+    SkipLive,
+    /// Skip: the object is younger than the grace window.
+    SkipGrace,
+    /// Dead: reclaim.
+    Dead,
+}
+
+/// Decide one object's fate. **Live always wins** — when `has_live_events` is
+/// true the verdict is [`Decision::SkipLive`] regardless of age or grace, which
+/// is the safety invariant the sweep rests on. Order: unparseable → live →
+/// grace → dead.
+pub fn decide(
+    execution_id: Option<i64>,
+    has_live_events: bool,
+    age_seconds: Option<i64>,
+    grace_seconds: i64,
+) -> Decision {
+    let Some(_eid) = execution_id else {
+        return Decision::SkipUnparseable;
+    };
+    if has_live_events {
+        return Decision::SkipLive;
+    }
+    // A young object whose events have not yet materialized is protected.
+    // An undecodable age (shouldn't happen for a real eid) is treated as young.
+    match age_seconds {
+        Some(age) if age >= grace_seconds => Decision::Dead,
+        _ => Decision::SkipGrace,
+    }
+}
+
+/// Parse the `execution=<eid>` segment out of a §7 physical object key. Returns
+/// `None` for any key without a numeric `execution=` segment (never panics).
+pub fn parse_execution_id(key: &str) -> Option<i64> {
+    key.split('/')
+        .find_map(|seg| seg.strip_prefix("execution="))
+        .and_then(|v| v.parse::<i64>().ok())
+}
+
+/// Seconds since an execution_id was minted, derived from the snowflake
+/// timestamp (`ms = (id >> 22) + NOETL_EPOCH_MS`). `None` for a non-positive or
+/// future-dated id, or before the NoETL epoch — the caller then treats the
+/// object as young (protected by grace).
+pub fn age_seconds(execution_id: i64, now_ms: u64) -> Option<i64> {
+    if execution_id <= 0 {
+        return None;
+    }
+    let mint_ms = ((execution_id as u64) >> 22) + crate::snowflake::NOETL_EPOCH_MS;
+    if mint_ms > now_ms {
+        return None;
+    }
+    Some(((now_ms - mint_ms) / 1000) as i64)
+}
+
+/// Whether `execution_id` has at least one surviving row in `noetl.event` — the
+/// liveness signal. The execution-level check is intentionally the most
+/// conservative: an object is live as long as *any* event of its execution
+/// survives, so the sweep reclaims an object only once its whole execution has
+/// aged out of the audit log.
+async fn execution_has_events(pool: &DbPool, execution_id: i64) -> AppResult<bool> {
+    let row: (bool,) =
+        sqlx::query_as("SELECT EXISTS(SELECT 1 FROM noetl.event WHERE execution_id = $1)")
+            .bind(execution_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(row.0)
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Run one result-tier GC sweep. No-op (and deletes nothing) unless
+/// `NOETL_RESULT_TIER_GC` is set. Best-effort per object: a delete failure is
+/// counted on `errors` and the sweep continues.
+pub async fn sweep(pool: &DbPool, backend: &ObjectBackend, req: &GcRequest) -> AppResult<GcReport> {
+    if !gc_enabled() {
+        return Ok(GcReport::disabled());
+    }
+
+    let keys = backend.list(pool, &req.prefix, req.limit).await?;
+    let now = now_ms();
+
+    let mut report = GcReport {
+        enabled: true,
+        dry_run: req.dry_run,
+        prefix: req.prefix.clone(),
+        scanned: 0,
+        deleted: 0,
+        skipped_live: 0,
+        skipped_grace: 0,
+        skipped_unparseable: 0,
+        errors: 0,
+        candidates: Vec::new(),
+    };
+
+    for key in keys {
+        report.scanned += 1;
+        let eid = parse_execution_id(&key);
+
+        // The liveness lookup only runs once we have an eid — an unparseable key
+        // is never deletable, so we short-circuit without touching the DB.
+        let has_live = match eid {
+            Some(id) => execution_has_events(pool, id).await?,
+            None => false,
+        };
+        let age = eid.and_then(|id| age_seconds(id, now));
+
+        match decide(eid, has_live, age, req.grace_seconds) {
+            Decision::SkipUnparseable => {
+                report.skipped_unparseable += 1;
+            }
+            Decision::SkipLive => {
+                report.skipped_live += 1;
+            }
+            Decision::SkipGrace => {
+                report.skipped_grace += 1;
+            }
+            Decision::Dead => {
+                let id = eid.expect("Dead verdict implies a parsed execution_id");
+                let mut deleted = false;
+                if !req.dry_run {
+                    match backend.delete(pool, &key).await {
+                        Ok(_) => {
+                            report.deleted += 1;
+                            deleted = true;
+                        }
+                        Err(e) => {
+                            report.errors += 1;
+                            tracing::warn!(execution_id = id, object_key = %key, error = %e, "result-tier GC delete failed");
+                            continue;
+                        }
+                    }
+                }
+                report.candidates.push(GcCandidate {
+                    key,
+                    execution_id: id,
+                    reason: "unreferenced",
+                    deleted,
+                });
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_execution_id_from_physical_key() {
+        let key = "noetl/env=dev/region=local/cell=local-0/shard=s0053/tenant=default/\
+                   project=default/date=2026-06-22/execution=325/results/start/0/0/1.feather";
+        assert_eq!(parse_execution_id(key), Some(325));
+    }
+
+    #[test]
+    fn unparseable_keys_yield_none() {
+        // No execution= segment.
+        assert_eq!(parse_execution_id("noetl/env=dev/results/x/0/0/1.feather"), None);
+        // Non-numeric execution.
+        assert_eq!(parse_execution_id("noetl/execution=abc/results/x.json"), None);
+        assert_eq!(parse_execution_id(""), None);
+    }
+
+    // THE safety invariant: a live-referenced object is NEVER dead, for any age
+    // or grace window, in dry-run or delete mode (the verdict gates both).
+    #[test]
+    fn live_object_is_never_dead() {
+        for age in [Some(-10), Some(0), Some(1), Some(1_000_000), None] {
+            for grace in [0, 1, 86_400, i64::MAX] {
+                assert_eq!(
+                    decide(Some(42), true, age, grace),
+                    Decision::SkipLive,
+                    "live object must skip (age={age:?}, grace={grace})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dead_only_when_unreferenced_and_past_grace() {
+        // Unreferenced + old enough → Dead.
+        assert_eq!(decide(Some(7), false, Some(100_000), 86_400), Decision::Dead);
+        // Unreferenced but too young → protected by grace.
+        assert_eq!(decide(Some(7), false, Some(10), 86_400), Decision::SkipGrace);
+        // Unreferenced, age exactly at the grace boundary → Dead (>=).
+        assert_eq!(decide(Some(7), false, Some(86_400), 86_400), Decision::Dead);
+        // Unreferenced, undecodable age → treated as young, protected.
+        assert_eq!(decide(Some(7), false, None, 86_400), Decision::SkipGrace);
+        // Unparseable key → never deletable, regardless of liveness/age.
+        assert_eq!(decide(None, false, Some(100_000), 0), Decision::SkipUnparseable);
+    }
+
+    #[test]
+    fn age_seconds_handles_edges() {
+        // Non-positive id → None (treated as young).
+        assert_eq!(age_seconds(0, 10_000_000_000_000), None);
+        assert_eq!(age_seconds(-1, 10_000_000_000_000), None);
+        // A future-minted id (now before mint) → None.
+        let future_eid = 1i64 << 22; // mint_ms = 1 + epoch
+        assert_eq!(age_seconds(future_eid, 0), None);
+        // A real-ish past id → positive age.
+        // eid encoding 1000 ms after epoch: ((1000) << 22).
+        let eid = 1000i64 << 22;
+        let now = crate::snowflake::NOETL_EPOCH_MS + 5_000; // 5s later
+        assert_eq!(age_seconds(eid, now), Some(4)); // (5000-1000)/1000 = 4
+    }
+
+    #[test]
+    fn default_request_is_dry_run_safe() {
+        let req = GcRequest::default();
+        assert!(req.dry_run, "default must be dry-run");
+        assert_eq!(req.prefix, "noetl/");
+        assert_eq!(req.grace_seconds, 86_400);
+    }
+
+    #[test]
+    fn disabled_report_is_inert() {
+        let r = GcReport::disabled();
+        assert!(!r.enabled);
+        assert_eq!(r.deleted, 0);
+        assert!(r.candidates.is_empty());
+    }
+}


### PR DESCRIPTION
## #104 Phase F of N — result-tier GC (server side)

Garbage-collection for the Feather/JSON result tier (RFC §5.2). A
conservative, **dry-run-first**, flag-gated sweeper that reclaims only
**provably-dead** objects and **never deletes a live-referenced one**.

`Refs noetl/ai-meta#104`

### What this adds

- **Object backend** gains `list(prefix)` + `delete(key)` on both the GCS
  (JSON-API) and Postgres backends.
- **`services/result_tier_gc`** — the sweep. An object is dead iff its §7 key
  parses an `execution=<eid>` segment, that execution has **no surviving
  `noetl.event` row** (aged out / orphan), **and** it is past a grace window
  (from the eid snowflake mint time). The verdict is a pure function
  (`decide`) so the safety invariant is unit-tested: **live always wins** —
  `decide(eid, has_live_events=true, …) == SkipLive` for any age/grace.
- **`POST /api/internal/result-tier/gc`** — service-account gated, `dry_run`
  **default true**, gated by `NOETL_RESULT_TIER_GC` (default off → disabled
  no-op report).
- Metric `noetl_result_tier_gc_total{outcome}`.

### Deliberately scoped OUT (not guessed)

- **Attempt-version reaping** (OQ1, still open) — the sweep is attempt-agnostic.
- **`result_store` retirement** (OQ5) — tier GC keys off **execution
  retention** (surviving events), independent of the dual-write lifecycle.

### Tests

- 7 new unit tests (key parse, age decode, the live-never-dead safety
  invariant, dead-only-when-unreferenced-and-past-grace, dry-run-safe default).
- 620 server lib tests pass; 0 new clippy warnings.

### Kind validation

Validated under the prod-exact off-server gate + fake-gcs by
`noetl/e2e` `kind_validate_result_tier_gc_dr.sh` — GC-1 dry-run lists the dead
orphan + skips the live object + deletes nothing; GC-2 delete reclaims only the
orphan while the live-referenced object survives + still serves; GC-3 flag-off
is a true no-op. Cutover invariants intact. (See the issue for the full run.)

Default-off → byte-identical no-op. Review-only; not for auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
