### PR TITLE
feat(result-store): gate the result_store dual-write for OQ5 retirement (#104)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -350,6 +350,33 @@ pub struct AppConfig {
     #[serde(default)]
     pub result_mint_authoritative: bool,
 
+    /// **`result_store` dual-write switch** (noetl/ai-meta#104 OQ5 retirement).
+    /// Envy maps `NOETL_RESULT_STORE_DUAL_WRITE`.
+    ///
+    /// Under the Phase D minting flip the URN → Feather/GCS result tier is the
+    /// authoritative byte source and `noetl.result_store` is only the reversible
+    /// **dual-write fallback leg**.  Once the OQ5 soak proved tier resolution
+    /// never falls back to the store (`result_resolve_total{outcome=~"fallback_.*"}`
+    /// held at 0), the store write is dead weight.  This flag retires it:
+    ///
+    /// - **true** (default) — the `PUT /api/result/{eid}` handler mints + INSERTs
+    ///   the `noetl.result_store` row exactly as before.  Byte-identical to
+    ///   prod/default behavior; the retirement is a no-op until explicitly flipped.
+    /// - **false** — the handler still mints + returns a byte-identical
+    ///   `ResultPutResponse` (so the worker's `reference` block is unchanged), but
+    ///   **skips the `noetl.result_store` INSERT**.  Counted on
+    ///   `noetl_result_store_dual_write_skipped_total`.  The #104 result-tier write
+    ///   path (producer-stage / materializer / object store) is untouched, and
+    ///   resolution still serves from the tier.
+    ///
+    /// Existing `result_store` rows are never deleted — the flag only stops *new*
+    /// writes, so flipping it back to **true** re-arms the dual-write one step away.
+    ///
+    /// **Default true** — behavior-neutral; the only behavioral change is the
+    /// explicit operational flip after the OQ5 soak passes.
+    #[serde(default = "default_true")]
+    pub result_store_dual_write: bool,
+
     /// **Where the per-execution drive watermark + descriptor live** (RFC
     /// noetl/ai-meta#115 program-scale / noetl/ai-meta#107).  Envy maps
     /// `NOETL_REPLICA_COHERENCE`.
@@ -571,6 +598,9 @@ impl Default for AppConfig {
             // noetl/ai-meta#104 Phase D: the minting flip is off by default; the
             // tier-authoritative + dual-write-fallback behavior is opt-in.
             result_mint_authoritative: false,
+            // noetl/ai-meta#104 OQ5 retirement: the result_store dual-write stays
+            // ON by default — behavior-neutral until the explicit operational flip.
+            result_store_dual_write: true,
             // noetl/ai-meta#115 program-scale: in-process maps by default; the
             // NATS-KV multi-replica coherence backing is opt-in (and staged).
             replica_coherence: ReplicaCoherence::Local,
@@ -601,6 +631,14 @@ mod tests {
         // Phase D (#104): the minting flip is opt-in; default-off must be a true
         // no-op (no dual-write counting, no behavior change).
         assert!(!AppConfig::default().result_mint_authoritative);
+    }
+
+    #[test]
+    fn test_result_store_dual_write_defaults_on() {
+        // #104 OQ5 retirement: the dual-write to noetl.result_store stays ON by
+        // default so the gated build is behavior-neutral; only the explicit
+        // operational flip (NOETL_RESULT_STORE_DUAL_WRITE=false) retires it.
+        assert!(AppConfig::default().result_store_dual_write);
     }
 
     #[test]

--- a/src/handlers/result_store.rs
+++ b/src/handlers/result_store.rs
@@ -36,6 +36,12 @@ pub struct ResultStoreDeps {
     /// the reversible **dual-write fallback leg** — counted on
     /// `noetl_result_store_dual_write_total`. Off → ordinary authoritative write.
     pub mint_authoritative: bool,
+    /// `result_store` dual-write switch (noetl/ai-meta#104 OQ5 retirement,
+    /// `NOETL_RESULT_STORE_DUAL_WRITE`). **true** (default) → the handler INSERTs
+    /// the `noetl.result_store` row as before. **false** → the handler skips the
+    /// INSERT (the #104 result tier is authoritative) but still returns a
+    /// byte-identical ref; counted on `noetl_result_store_dual_write_skipped_total`.
+    pub dual_write: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -65,29 +71,52 @@ pub async fn put_result(
     let _g = span.enter();
 
     let t0 = std::time::Instant::now();
-    let result = deps.service.put(execution_id, &body).await;
+    // #104 OQ5 retirement: when the dual-write is retired
+    // (`NOETL_RESULT_STORE_DUAL_WRITE=false`) the handler mints a byte-identical
+    // ref but skips the `noetl.result_store` INSERT — the #104 result tier is the
+    // authoritative byte source, so resolution still serves from the tier. Default
+    // (flag on) → ordinary INSERT, behavior-neutral.
+    let result = if deps.dual_write {
+        deps.service.put(execution_id, &body).await
+    } else {
+        deps.service.mint_ref_only(execution_id, &body)
+    };
     let elapsed = t0.elapsed().as_secs_f64();
 
     match result {
         Ok(resp) => {
-            tracing::info!(
-                execution_id,
-                name = %body.name,
-                bytes = resp.bytes,
-                result_ref = %resp.r#ref,
-                duration_seconds = elapsed,
-                "result_store.put: stored",
-            );
-            crate::metrics::record_result_store_put(elapsed, resp.bytes as usize, "ok");
-            // Phase D (#104): under the minting flip the URN tier is
-            // authoritative and this write is the reversible dual-write fallback
-            // leg — count it so the dual-write window is observable.
-            if deps.mint_authoritative {
-                crate::metrics::record_result_store_dual_write();
+            if deps.dual_write {
+                tracing::info!(
+                    execution_id,
+                    name = %body.name,
+                    bytes = resp.bytes,
+                    result_ref = %resp.r#ref,
+                    duration_seconds = elapsed,
+                    "result_store.put: stored",
+                );
+                crate::metrics::record_result_store_put(elapsed, resp.bytes as usize, "ok");
+                // Phase D (#104): under the minting flip the URN tier is
+                // authoritative and this write is the reversible dual-write
+                // fallback leg — count it so the dual-write window is observable.
+                if deps.mint_authoritative {
+                    crate::metrics::record_result_store_dual_write();
+                    tracing::debug!(
+                        execution_id,
+                        name = %body.name,
+                        "result_store dual-write (Phase D fallback leg; tier authoritative)",
+                    );
+                }
+            } else {
+                // Dual-write retired: no row written, ref still minted so the
+                // worker's `reference` block is byte-identical. Count the skip so
+                // "0 new writes" is observable against a flat put_total.
+                crate::metrics::record_result_store_dual_write_skipped();
                 tracing::debug!(
                     execution_id,
                     name = %body.name,
-                    "result_store dual-write (Phase D fallback leg; tier authoritative)",
+                    result_ref = %resp.r#ref,
+                    duration_seconds = elapsed,
+                    "result_store.put: skipped (dual-write retired; #104 tier authoritative)",
                 );
             }
             Ok((StatusCode::OK, Json(resp)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,7 @@ fn build_router(
         .with_state(handlers::result_store::ResultStoreDeps {
             service: result_store_service,
             mint_authoritative: state.config.result_mint_authoritative,
+            dual_write: state.config.result_store_dual_write,
         });
 
     // Variable routes (transient table)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -400,6 +400,37 @@ pub fn record_result_store_dual_write() {
     result_store_dual_write_total().inc();
 }
 
+/// `noetl_result_store_dual_write_skipped_total` — `PUT /api/result/{eid}`
+/// requests whose `noetl.result_store` INSERT was **skipped** because the
+/// dual-write was retired (`NOETL_RESULT_STORE_DUAL_WRITE=false`, RFC
+/// noetl/ai-meta#104 OQ5 retirement).
+///
+/// The handler still mints + returns a byte-identical `ResultPutResponse` (the
+/// worker's `reference` block is unchanged); only the DB row is not written. This
+/// counter climbing while `noetl_result_store_put_total{status="ok"}` stays flat
+/// is the on-prod signal that the store write is retired — resolution continues
+/// to serve from the #104 result tier. Flag-on it never moves.
+pub fn result_store_dual_write_skipped_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_result_store_dual_write_skipped_total",
+            "result_store INSERTs skipped because the dual-write was retired (NOETL_RESULT_STORE_DUAL_WRITE=false, RFC #104 OQ5).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one skipped `result_store` write (the retired dual-write under
+/// `NOETL_RESULT_STORE_DUAL_WRITE=false`).
+pub fn record_result_store_dual_write_skipped() {
+    result_store_dual_write_skipped_total().inc();
+}
+
 /// `noetl_state_build_event_scans_total` — incremented once each time the drive
 /// path enters the **event-scan** state-construction block (the block that issues
 /// `WHERE execution_id = $1 …` scans of `noetl.event`: the consistency `COUNT`,

--- a/src/services/result_store.rs
+++ b/src/services/result_store.rs
@@ -232,19 +232,17 @@ impl ResultStoreService {
         Self { pool, snowflake }
     }
 
-    /// Store one result and return the minted `ResultPutResponse`.
+    /// Mint the `noetl.result_store` row + its `ResultPutResponse` from a
+    /// request body, **without** touching the DB.
     ///
-    /// Steps:
-    /// 1. Serialise `data` → JSON bytes; measure + SHA-256.
-    /// 2. Mint a snowflake `result_id`.
-    /// 3. Build the `noetl://` URI.
-    /// 4. INSERT into `noetl.result_store`.
-    /// 5. Return the response.
-    pub async fn put(
+    /// Shared by [`put`](Self::put) (which then INSERTs the row) and
+    /// [`mint_ref_only`](Self::mint_ref_only) (which drops it).  Steps 1–3 of the
+    /// store contract: serialise → measure + SHA-256 → mint snowflake → build URI.
+    fn prepare(
         &self,
         execution_id: i64,
         body: &PutResultBody,
-    ) -> AppResult<ResultPutResponse> {
+    ) -> AppResult<(ResultStoreRow, ResultPutResponse)> {
         // Serialise to measure bytes + compute hash.
         let serialised = serde_json::to_vec(&body.data)
             .map_err(|e| AppError::Internal(format!("result_store.put: serialise: {e}")))?;
@@ -277,16 +275,54 @@ impl ResultStoreService {
             expires_at: None,
         };
 
-        queries::insert(&self.pool, &row).await?;
-
-        Ok(ResultPutResponse {
+        let response = ResultPutResponse {
             r#ref: noetl_ref,
             store: "db".to_string(),
             scope: body.scope.clone(),
             bytes: bytes as u64,
             sha256: Some(sha256_hex),
             expires_at: None,
-        })
+        };
+
+        Ok((row, response))
+    }
+
+    /// Store one result and return the minted `ResultPutResponse`.
+    ///
+    /// Steps:
+    /// 1. Serialise `data` → JSON bytes; measure + SHA-256.
+    /// 2. Mint a snowflake `result_id`.
+    /// 3. Build the `noetl://` URI.
+    /// 4. INSERT into `noetl.result_store`.
+    /// 5. Return the response.
+    pub async fn put(
+        &self,
+        execution_id: i64,
+        body: &PutResultBody,
+    ) -> AppResult<ResultPutResponse> {
+        let (row, response) = self.prepare(execution_id, body)?;
+        queries::insert(&self.pool, &row).await?;
+        Ok(response)
+    }
+
+    /// Mint the `ResultPutResponse` **without** writing the `noetl.result_store`
+    /// row — the dual-write-retired path (noetl/ai-meta#104 OQ5,
+    /// `NOETL_RESULT_STORE_DUAL_WRITE=false`).
+    ///
+    /// Returns a byte-identical response to [`put`](Self::put) (same minted ref,
+    /// same `bytes`/`sha256`/`scope`/`store`), so the worker's `reference` block is
+    /// unchanged — but no row is persisted.  The #104 result tier is the
+    /// authoritative byte source under the minting flip, so resolution still
+    /// serves from the tier; this only stops the dead-weight store write.  Existing
+    /// rows are untouched (frozen), so flipping the flag back re-arms the
+    /// dual-write one step away.
+    pub fn mint_ref_only(
+        &self,
+        execution_id: i64,
+        body: &PutResultBody,
+    ) -> AppResult<ResultPutResponse> {
+        let (_row, response) = self.prepare(execution_id, body)?;
+        Ok(response)
     }
 
     /// Resolve a parsed `NoetlRef` back to the stored `data` JSON.
@@ -315,6 +351,52 @@ impl ResultStoreService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- mint_ref_only (dual-write retirement, #104 OQ5) ---
+
+    /// `mint_ref_only` is the `NOETL_RESULT_STORE_DUAL_WRITE=false` path: it must
+    /// mint a byte-identical `ResultPutResponse` **without** touching the DB. We
+    /// prove that by handing it a lazy pool pointed at an unreachable address —
+    /// if it ever connected, the call would error; it doesn't.
+    #[tokio::test]
+    async fn mint_ref_only_builds_ref_without_db_write() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://invalid:invalid@127.0.0.1:1/none")
+            .expect("lazy pool construction must not connect");
+        let snowflake = Arc::new(SnowflakeGenerator::new(1).expect("machine id 1 is valid"));
+        let svc = ResultStoreService::new(pool, snowflake);
+
+        let body = PutResultBody {
+            name: "my_step".to_string(),
+            data: serde_json::json!({ "columns": ["id"], "rows": [[1], [2], [3]] }),
+            scope: "execution".to_string(),
+            source_step: Some("my_step".to_string()),
+            store: None,
+            ttl: None,
+            correlation: None,
+            compress: false,
+        };
+
+        let resp = svc
+            .mint_ref_only(42, &body)
+            .expect("mint_ref_only must succeed without the DB");
+
+        // Byte-identical response shape to `put` (sans the row): minted ref on the
+        // canonical coordinates, store label, real byte count + sha256.
+        assert!(
+            resp.r#ref.starts_with("noetl://execution/42/result/my_step/"),
+            "ref tail: {}",
+            resp.r#ref
+        );
+        assert_eq!(resp.store, "db");
+        assert_eq!(resp.scope, "execution");
+        assert!(resp.bytes > 0, "byte count must be measured");
+        assert!(resp.sha256.is_some(), "sha256 must be computed");
+        // The ref parses back cleanly (the worker's reference block stays valid).
+        let parsed = parse_noetl_ref(&resp.r#ref).expect("minted ref must parse");
+        assert_eq!(parsed.execution_id, 42);
+        assert_eq!(parsed.name, "my_step");
+    }
 
     // --- parse_noetl_ref ---
 


### PR DESCRIPTION
## What

Adds `NOETL_RESULT_STORE_DUAL_WRITE` (**default `true` = current behavior**), the gate that retires the `noetl.result_store` dual-write for [noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104) OQ5.

Under the Phase D minting flip the URN → Feather/GCS result tier is the authoritative byte source and `result_store` is only the reversible **dual-write fallback leg**. The OQ5 soak proved tier resolution never falls back to the store (`mint_authoritative{path="legacy_fallback"}` / `result_resolve_total{outcome=~"fallback_.*"}` held at 0 over 72h), so the store write is dead weight. This flag stops it.

## How

- `false` → the `PUT /api/result/{eid}` handler mints + returns a **byte-identical** `ResultPutResponse` (worker `reference` block unchanged) via the new `ResultStoreService::mint_ref_only()`, but **skips the `noetl.result_store` INSERT**. Counted on `noetl_result_store_dual_write_skipped_total`.
- `true` (default) → ordinary mint + INSERT, exactly as today. Behavior-neutral until explicitly flipped.

**Scope:** only the worker→server tool-result dual-write through this handler is gated. The server-internal `__command_context__` offload ([#114](https://github.com/noetl/ai-meta/issues/114), a direct `ResultStoreService::put()` call) is untouched. Existing `result_store` rows are **never deleted** (frozen) — flipping back to `true` re-arms the dual-write one step away.

## Tests / validation

- Unit: `mint_ref_only_builds_ref_without_db_write` (lazy/never-connected pool proves no DB touch), `result_store_dual_write_defaults_on`. 631 lib tests pass; no new clippy warnings.
- **Kind-validated both ways** (gated image + producer-stage worker `5.46.2` + mint/producer/uri_resolve):
  - **flag ON** → result_store row written (180→181), `result_store_put_total{ok}=1`, execution COMPLETED.
  - **flag OFF** → **0 new rows** (182→182 across 2 runs), `dual_write_skipped_total` climbs 1→2, `put_total` flat, producer stages the tier (`staged_json`), over-budget bulk-bind resolves from the tier (`mint_authoritative{path=tier}`, **no `legacy_fallback`**, worker `resolve{resolved_json}`), executions COMPLETED, 0 resolve/producer errors, 0 restarts.

## Wiki

`noetl-server-wiki` `deployment-specification.md` env-var catalogue updated (server.wiki@02da49e).

Refs noetl/ai-meta#104