### PR TITLE
feat(offserver): attach per-execution event tail to drive dispatch (#156)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -296,6 +296,42 @@ pub struct AppConfig {
     #[serde(default)]
     pub atomic_item_context: bool,
 
+    /// **Attach the per-execution event tail to the off-server drive dispatch**
+    /// (noetl/ai-meta#156).  Envy maps `NOETL_OFFSERVER_ATTACH_TAIL`.
+    ///
+    /// The off-server drive's per-hop cost is today coupled to **global**
+    /// `noetl_events` WAL volume, not to this execution's work: the worker's
+    /// `build_offserver_input` serves only once the pool-side WAL drain — one
+    /// ephemeral `DeliverAll` consumer racing the whole stream under one mutex —
+    /// has independently pulled + indexed this hop's `expected_head`.  Under load
+    /// the drain lags past the worker's 1s drive-retry budget and the hop drops to
+    /// the server's 8s reconcile tick → the ~8–13s per-hop variance #156 pins.
+    ///
+    /// When **true**, the server (the producer of these events) keeps a small
+    /// bounded per-execution ring of the `noetl_events` payloads it just published
+    /// ([`crate::state::ChainTails`]) and attaches them to the
+    /// `__offserver_build__` dispatch as `tail_events`.  The worker applies that
+    /// tail into its WAL index **before** building, so a warm-index hop serves on
+    /// the first build attempt — drain-independent — collapsing the per-hop cost
+    /// to O(tail) ≈ constant and removing the reconcile cliff.  The drain stays
+    /// the cold-rebuild / crash-recovery backstop: an insufficient tail (a gap, or
+    /// a post-restart cold index whose genesis predates the ring) leaves the build
+    /// `Incomplete` and falls through to exactly today's retry/drain/reconcile
+    /// path — so correctness is preserved, worst case equals today.
+    ///
+    /// **Default false** — the ring is never populated and `tail_events` is never
+    /// attached, so prod/default behavior (and memory cost) is byte-identical.
+    #[serde(default)]
+    pub offserver_attach_tail: bool,
+
+    /// Cap on the per-execution [`crate::state::ChainTails`] ring size, in events
+    /// (noetl/ai-meta#156).  Envy maps `NOETL_OFFSERVER_TAIL_CAP`.  Only consulted
+    /// when [`Self::offserver_attach_tail`] is on.  Sized to cover the tail between
+    /// consecutive hops plus a wide safety margin (a planner turn is ~10 hops of a
+    /// few events each); the ring evicts oldest-first and is dropped on terminal.
+    #[serde(default = "default_offserver_tail_cap")]
+    pub offserver_tail_cap: usize,
+
     /// **Shadow-accept the canonical result URI** (RFC noetl/ai-meta#104
     /// Phase A).  Envy maps `NOETL_RESULT_URI_ACCEPT`.
     ///
@@ -539,6 +575,14 @@ fn default_command_context_max_bytes() -> usize {
     512 * 1024
 }
 
+fn default_offserver_tail_cap() -> usize {
+    // 64 events — far more than the 1–3 event tail between consecutive hops, so a
+    // worker index that fell a few hops behind still completes from the attached
+    // ring alone.  ~64 × few-KB × concurrent executions worst-case is a few tens
+    // of MB; in practice most executions hold far fewer than the cap.
+    64
+}
+
 impl AppConfig {
     /// Load configuration from environment variables.
     ///
@@ -592,6 +636,11 @@ impl Default for AppConfig {
             // noetl/ai-meta#115 Phase 5: full-context dispatch by default; the
             // atomic-working-item minimal-slice narrowing is opt-in (and staged).
             atomic_item_context: false,
+            // noetl/ai-meta#156: the off-server tail-attach accelerator is off by
+            // default — the ring is never populated, no dispatch carries
+            // `tail_events`, prod/default behavior + memory cost are unchanged.
+            offserver_attach_tail: false,
+            offserver_tail_cap: default_offserver_tail_cap(),
             // noetl/ai-meta#104 Phase A: the canonical result URI is ignored by
             // default; shadow-accept (parse + validate + record) is opt-in.
             result_uri_accept: false,
@@ -639,6 +688,15 @@ mod tests {
         // default so the gated build is behavior-neutral; only the explicit
         // operational flip (NOETL_RESULT_STORE_DUAL_WRITE=false) retires it.
         assert!(AppConfig::default().result_store_dual_write);
+    }
+
+    #[test]
+    fn test_offserver_attach_tail_defaults_off() {
+        // noetl/ai-meta#156: the tail-attach accelerator is opt-in; default-off
+        // must be a true no-op (ring never populated, no `tail_events` dispatched).
+        let cfg = AppConfig::default();
+        assert!(!cfg.offserver_attach_tail);
+        assert_eq!(cfg.offserver_tail_cap, 64);
     }
 
     #[test]

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -359,8 +359,17 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     // covers the batch.
     if should_publish(state, rows[0].catalog_id).await {
         if let Some(pubr) = publisher(state).await {
+            // noetl/ai-meta#156: when the tail-attach accelerator is on, keep the
+            // `to_stream_json()` payloads we publish in the per-execution ring so
+            // the off-server drive dispatch can carry the new tail to the worker
+            // directly — letting it advance its WAL index without waiting on the
+            // global-stream drain.  This is the SAME bytes we publish (the chain
+            // link is already stamped above), so the attached tail is byte-identical
+            // to what the worker would have drained off `noetl_events`.
+            let mut tail_payloads: Vec<serde_json::Value> = Vec::new();
             for row in rows {
-                let bytes = serde_json::to_vec(&row.to_stream_json()).map_err(|e| {
+                let stream_json = row.to_stream_json();
+                let bytes = serde_json::to_vec(&stream_json).map_err(|e| {
                     crate::error::AppError::Internal(format!("event publish encode: {e}"))
                 })?;
                 pubr.publish_event(row.event_id, &row.event_type, &bytes)
@@ -369,6 +378,16 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
                         crate::error::AppError::Internal(format!("event publish: {e}"))
                     })?;
                 crate::metrics::record_event_published(&row.event_type);
+                if state.config.offserver_attach_tail {
+                    tail_payloads.push(stream_json);
+                }
+            }
+            if state.config.offserver_attach_tail && !tail_payloads.is_empty() {
+                state.chain_tails.push(
+                    rows[0].execution_id,
+                    &tail_payloads,
+                    state.config.offserver_tail_cap,
+                );
             }
             return Ok(());
         }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2561,6 +2561,7 @@ async fn dispatch_offserver_stateless_drive(
         state.exec_descriptors.evict(execution_id).await;
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id).await;
+        state.chain_tails.evict(execution_id); // noetl/ai-meta#156: drop the tail ring too
         crate::metrics::record_orchestrate_drive("stateless_terminal_skip");
         debug!(
             execution_id,
@@ -2606,6 +2607,19 @@ async fn dispatch_offserver_stateless_drive(
             })?;
     let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
 
+    // noetl/ai-meta#156: attach the per-execution event tail the server just
+    // published so the worker advances its WAL index to `expected_head`
+    // immediately — drain-independent — instead of parking on the global-stream
+    // drain to catch up (the source of the per-hop variance).  Empty when the
+    // accelerator is off or the ring holds nothing (cold dispatch) → the worker
+    // falls back to today's drain-served path, so worst case equals today.
+    let tail_events = if state.config.offserver_attach_tail {
+        state.chain_tails.snapshot(execution_id)
+    } else {
+        Vec::new()
+    };
+    crate::metrics::record_offserver_tail_attached(tail_events.len());
+
     let input = serde_json::json!({
         "__offserver_build__": true,
         // No server-built `state` fallback rides the stateless command; the
@@ -2619,6 +2633,10 @@ async fn dispatch_offserver_stateless_drive(
         "trigger_event_id": trigger_event_id,
         "playbook": &playbook,
         "expected_head": expected_head,
+        // noetl/ai-meta#156: the recently-published events for this execution
+        // (oldest→newest).  The worker applies them to its WAL index before
+        // building, so a warm-index hop serves on the first build attempt.
+        "tail_events": tail_events,
     });
 
     crate::handlers::execute::dispatch_orchestrate_command(
@@ -2967,6 +2985,7 @@ async fn trigger_orchestrator_inner(
         drop(cache);
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
+        state.chain_tails.evict(execution_id); // noetl/ai-meta#156: drop the tail ring too
         state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
         debug!(
             execution_id,
@@ -3104,6 +3123,18 @@ async fn trigger_orchestrator_inner(
             state.config.state_builder,
             crate::config::StateBuilder::Offserver
         ) && crate::handlers::event_write::should_publish(state, catalog_id).await;
+        // noetl/ai-meta#156: same tail-attach accelerator as the stateless edge —
+        // only meaningful on the off-server path (`offserver` true), where the
+        // worker self-sources the spine.  Empty when the flag is off or nothing is
+        // buffered; the server-built `state` here is the fallback regardless.
+        let tail_events = if offserver && state.config.offserver_attach_tail {
+            state.chain_tails.snapshot(execution_id)
+        } else {
+            Vec::new()
+        };
+        if offserver {
+            crate::metrics::record_offserver_tail_attached(tail_events.len());
+        }
         let input = serde_json::json!({
             "state": cache.state.as_ref().expect("state present after rebuild"),
             "latest_ts": latest_ts,
@@ -3111,6 +3142,9 @@ async fn trigger_orchestrator_inner(
             "trigger_event_type": trigger_event_type,
             "__offserver_build__": offserver,
             "execution_id": execution_id,
+            // noetl/ai-meta#156: recently-published tail for this execution; the
+            // worker applies it to its WAL index before building.
+            "tail_events": tail_events,
             // The server's dispatch watermark (the highest event applied to the
             // server-built state).  The worker's WAL build serves only once its
             // pool-side index has caught up to this head — so the off-server
@@ -3227,6 +3261,7 @@ async fn trigger_orchestrator_inner(
         drop(cache);
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
+        state.chain_tails.evict(execution_id); // noetl/ai-meta#156: drop the tail ring too
         state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
     }
 
@@ -3772,6 +3807,7 @@ async fn apply_worker_orchestration(
         drop(cache);
         state.orch_cache.evict(execution_id);
         state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
+        state.chain_tails.evict(execution_id); // noetl/ai-meta#156: drop the tail ring too
         state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
     }
     Ok(commands_generated)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -149,6 +149,67 @@ pub fn record_orchestrate_drive(stage: &str) {
     orchestrate_drive_total().with_label_values(&[stage]).inc();
 }
 
+// ── Off-server tail-attach accelerator (noetl/ai-meta#156) ───────────────────
+
+/// `noetl_offserver_tail_attached_total{outcome}` — off-server drive dispatches
+/// by whether the server attached a non-empty per-execution event tail
+/// ([`crate::state::ChainTails`]).  `outcome` = `attached` (the dispatch carried
+/// `tail_events` so the worker can advance its WAL index drain-independently) or
+/// `empty` (the ring held nothing for this execution — a cold dispatch falling
+/// back to today's drain-served path).  Zero increments when the accelerator is
+/// off (`NOETL_OFFSERVER_ATTACH_TAIL=false`).
+pub fn offserver_tail_attached_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_offserver_tail_attached_total",
+                "Off-server drive dispatches by tail-attach outcome (noetl/ai-meta#156).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// `noetl_offserver_tail_size` — distribution of the number of events the server
+/// attaches to an off-server drive dispatch (noetl/ai-meta#156).  Observed only
+/// when a non-empty tail is attached; the magnitude shows the tail stays O(few
+/// events) rather than O(global-stream).
+pub fn offserver_tail_size() -> &'static Histogram {
+    static M: OnceLock<Histogram> = OnceLock::new();
+    M.get_or_init(|| {
+        let h = Histogram::with_opts(
+            HistogramOpts::new(
+                "noetl_offserver_tail_size",
+                "Events attached to an off-server drive dispatch (noetl/ai-meta#156).",
+            )
+            .buckets(vec![1.0, 2.0, 3.0, 5.0, 8.0, 16.0, 32.0, 64.0]),
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(h.clone()))
+            .expect("histogram registration must succeed");
+        h
+    })
+}
+
+/// Record one off-server drive dispatch's tail-attach outcome.  `n` is the number
+/// of events attached (0 → the `empty` outcome; the size histogram is observed
+/// only for a non-empty tail).
+pub fn record_offserver_tail_attached(n: usize) {
+    if n == 0 {
+        offserver_tail_attached_total().with_label_values(&["empty"]).inc();
+    } else {
+        offserver_tail_attached_total().with_label_values(&["attached"]).inc();
+        offserver_tail_size().observe(n as f64);
+    }
+}
+
 // ── Terminal-event dedup (noetl/ai-meta#118) ─────────────────────────────────
 
 /// `noetl_terminal_dedup_total{outcome}` — the event-write chokepoint's

--- a/src/state.rs
+++ b/src/state.rs
@@ -106,6 +106,15 @@ pub struct AppState {
     /// walkable singly-linked list.  See [`ChainHeads`].
     pub chain_heads: Arc<ChainHeads>,
 
+    /// Per-execution event-tail ring for the off-server drive tail-attach
+    /// accelerator (noetl/ai-meta#156).  Populated at the `noetl_events` publish
+    /// chokepoint with the payloads the server just published, drained at
+    /// off-server drive dispatch so the worker advances its WAL index without
+    /// waiting on the global-stream drain.  Only touched when
+    /// `config.offserver_attach_tail` is on; otherwise it stays empty.  See
+    /// [`ChainTails`].
+    pub chain_tails: Arc<ChainTails>,
+
     /// Execute-time descriptors for the stateless off-server drive edge (RFC
     /// #115 Phase 4 remainder, noetl/ai-meta#107 step 2).  Carries the
     /// execution-scoped, immutable facts the drive dispatch needs —
@@ -308,6 +317,80 @@ impl ChainHeads {
             }
         }
         self.map.lock().unwrap().get(&execution_id).copied()
+    }
+}
+
+/// Per-execution **event tail** ring for the off-server drive tail-attach
+/// accelerator (noetl/ai-meta#156).  In-memory only, populated by the server at
+/// the `noetl_events` publish chokepoint ([`crate::handlers::event_write::emit_events`])
+/// and drained at off-server drive dispatch ([`crate::handlers::events`]).
+///
+/// ## Why this exists
+///
+/// The off-server drive's per-hop latency is today coupled to **global**
+/// `noetl_events` WAL volume, not to one execution's work: the worker serves a
+/// hop only once the pool-side WAL drain (one ephemeral `DeliverAll` consumer
+/// racing the entire stream under one mutex) has independently pulled + indexed
+/// this hop's `expected_head`.  Under load the drain lags past the worker's ~1s
+/// drive-retry budget and the hop drops to the server's 8s reconcile tick — the
+/// per-hop variance #156 pins.
+///
+/// The server is the **producer** of every event the worker needs, and stamps
+/// the same `to_stream_json()` payload it publishes to `noetl_events`.  Keeping
+/// the most-recent `cap` of those payloads per execution lets the dispatch carry
+/// the new tail to the worker directly, so the worker advances its WAL index
+/// without waiting on the drain.  The ring is the only new state; it never reads
+/// the DB and holds at most `cap` events per non-terminal execution.
+///
+/// ## Bounded + best-effort
+///
+/// The ring evicts oldest-first at `cap` and is dropped wholesale on a terminal
+/// event (alongside [`ChainHeads::evict`]).  It is an **accelerator, not a source
+/// of truth**: the worker's WAL index + drain remain authoritative.  If the
+/// attached tail is insufficient to complete the chain to genesis (a gap, or a
+/// post-restart cold worker index whose genesis predates the ring), the worker's
+/// build is `Incomplete` and falls through to exactly today's retry/drain/
+/// reconcile path — so correctness is preserved, worst case equals today.
+#[derive(Default)]
+pub struct ChainTails {
+    map: std::sync::Mutex<std::collections::HashMap<i64, std::collections::VecDeque<serde_json::Value>>>,
+}
+
+impl ChainTails {
+    /// Append the just-published `noetl_events` payloads for one execution,
+    /// evicting oldest-first so the ring never exceeds `cap`.  `cap == 0` is a
+    /// no-op (the accelerator stays disabled regardless of the flag).  Called from
+    /// the publish branch of the event-write chokepoint, in emit order.
+    pub fn push(&self, execution_id: i64, payloads: &[serde_json::Value], cap: usize) {
+        if cap == 0 || payloads.is_empty() {
+            return;
+        }
+        let mut map = self.map.lock().unwrap();
+        let ring = map.entry(execution_id).or_default();
+        for p in payloads {
+            ring.push_back(p.clone());
+        }
+        while ring.len() > cap {
+            ring.pop_front();
+        }
+    }
+
+    /// Snapshot the current tail for an execution (oldest→newest), or an empty
+    /// vec when nothing is buffered.  Cloned out under the lock so the caller can
+    /// attach it to the dispatch without holding the mutex across an `await`.
+    pub fn snapshot(&self, execution_id: i64) -> Vec<serde_json::Value> {
+        self.map
+            .lock()
+            .unwrap()
+            .get(&execution_id)
+            .map(|ring| ring.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Drop a terminal execution's ring — frees memory.  Called alongside
+    /// [`ChainHeads::evict`] on the terminal-event paths.
+    pub fn evict(&self, execution_id: i64) {
+        self.map.lock().unwrap().remove(&execution_id);
     }
 }
 
@@ -719,6 +802,7 @@ impl AppState {
             start_time: std::time::Instant::now(),
             orch_cache: Arc::new(OrchStateCache::default()),
             chain_heads: Arc::new(ChainHeads::with_coherence(coherence.clone())),
+            chain_tails: Arc::new(ChainTails::default()),
             exec_descriptors: Arc::new(ExecDescriptors::with_coherence(coherence)),
             finalized_guard: Arc::new(FinalizedGuard::default()),
             event_stream_publisher: Arc::new(tokio::sync::OnceCell::new()),
@@ -757,7 +841,7 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChainHeads, ExecDescriptors, FinalizedGuard};
+    use super::{ChainHeads, ChainTails, ExecDescriptors, FinalizedGuard};
 
     // Note: Full tests require a database connection
     // These are placeholder tests for documentation
@@ -766,6 +850,44 @@ mod tests {
     fn test_uptime() {
         // AppState::new requires a real DB pool, so we can't easily test here
         // This is a documentation placeholder
+    }
+
+    // noetl/ai-meta#156: the per-execution event-tail ring is a bounded,
+    // oldest-first FIFO, snapshot-able, evicted on terminal.
+    #[test]
+    fn chain_tails_ring_is_bounded_fifo() {
+        let tails = ChainTails::default();
+        let ev = |id: i64| serde_json::json!({ "event_id": id });
+
+        // cap == 0 → disabled, nothing buffered regardless of the flag.
+        tails.push(1, &[ev(10)], 0);
+        assert!(tails.snapshot(1).is_empty(), "cap 0 must buffer nothing");
+
+        // Append within cap → snapshot is oldest→newest.
+        tails.push(1, &[ev(10), ev(11)], 3);
+        tails.push(1, &[ev(12)], 3);
+        let ids: Vec<i64> = tails
+            .snapshot(1)
+            .iter()
+            .map(|v| v["event_id"].as_i64().unwrap())
+            .collect();
+        assert_eq!(ids, vec![10, 11, 12]);
+
+        // Exceeding cap evicts oldest-first.
+        tails.push(1, &[ev(13), ev(14)], 3);
+        let ids: Vec<i64> = tails
+            .snapshot(1)
+            .iter()
+            .map(|v| v["event_id"].as_i64().unwrap())
+            .collect();
+        assert_eq!(ids, vec![12, 13, 14], "ring keeps the newest `cap` events");
+
+        // Per-execution isolation.
+        assert!(tails.snapshot(2).is_empty());
+
+        // Terminal eviction frees the ring.
+        tails.evict(1);
+        assert!(tails.snapshot(1).is_empty());
     }
 
     // noetl/ai-meta#118: exactly-one-terminal-per-execution.  The chokepoint


### PR DESCRIPTION
## Problem (noetl/ai-meta#156)

The off-server drive's per-hop latency is coupled to **global** `noetl_events` WAL
volume, not to one execution's work. The worker serves a hop only once its
pool-side drain — one ephemeral `DeliverAll` consumer racing the entire stream
under one mutex — has independently pulled + indexed this hop's `expected_head`.
Under load the drain lags past the worker's ~1s drive-retry budget and the hop
drops to **this server's fixed 8s reconcile tick** → the per-hop variance #156
pins.

## Fix

The server is the producer of every event the worker needs. This adds a bounded
per-execution event-tail ring (`ChainTails`) populated at the `noetl_events`
publish chokepoint with the exact `to_stream_json()` payloads it publishes, and
attaches the ring to the `__offserver_build__` dispatch as `tail_events`. The
worker (paired PR noetl/worker#142) applies that tail to its WAL index before
building, so a warm-index hop serves **drain-independently** — per-hop cost
O(tail), no reconcile cliff.

## Surface

- `ChainTails` on `AppState` — `push` (publish chokepoint), `snapshot` (dispatch),
  `evict` (terminal, alongside `chain_heads`).
- Attached on both the stateless edge (`dispatch_offserver_stateless_drive`, the
  prod path) and the legacy `__offserver_build__` path.
- Config: `NOETL_OFFSERVER_ATTACH_TAIL` (default **off**),
  `NOETL_OFFSERVER_TAIL_CAP` (default 64).
- Metrics: `noetl_offserver_tail_attached_total{outcome}` + `noetl_offserver_tail_size`.

## Why it's safe (additive, flag-gated)

- Default off → the ring is never populated, no dispatch carries `tail_events`;
  prod/default behavior **and memory cost** are byte-identical.
- The attached tail is the **same bytes** the server publishes to `noetl_events`
  (chain link already stamped), so it is an accelerator, never a source of truth.
  An insufficient tail leaves the worker build `Incomplete` → today's
  drain/reconcile fallback. Worst case equals today.
- Ring is bounded (evicts oldest-first) and dropped on terminal — no unbounded
  growth. Unit test: `state::tests::chain_tails_ring_is_bounded_fifo`.

The before/after **per-hop latency distribution** is measured on the real
primitives in the worker PR (noetl/worker#142): drain-only scales with global
backlog then cliffs to 8s+ (misses); tail-attach is flat sub-ms with zero misses.

**Review-only — do not merge to prod without sign-off** (semantic-release `feat:`
cuts a server release). Full kind end-to-end output-equivalence + rollback plan
tracked in noetl/ai-meta#156.

Refs noetl/ai-meta#156