### PR TITLE
feat(offserver): scope tail-attach to allowlisted playbooks (#156)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "noetl-server"
-version = "3.48.0"
+version = "3.49.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noetl-server"
-version = "3.48.0"
+version = "3.49.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/noetl/noetl"

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -332,6 +332,34 @@ pub struct AppConfig {
     #[serde(default = "default_offserver_tail_cap")]
     pub offserver_tail_cap: usize,
 
+    /// **Scope the tail-attach accelerator to specific playbooks** (by path /
+    /// name prefix).  Envy maps `NOETL_OFFSERVER_TAIL_PLAYBOOK_PREFIXES`
+    /// (comma-separated).
+    ///
+    /// The global flag-on form of [`Self::offserver_attach_tail`] regressed the
+    /// **auth/login** path: that drive runs behind the gateway's hard ~15s
+    /// callback timeout, and flag-on the multi-hop auth chain hit a per-hop stall
+    /// that pushed it past the deadline → login outage (noetl/ai-meta#156 RESTORE,
+    /// 2026-06-29).  The planner has no equivalent hard client deadline, so the
+    /// same accelerator is pure win there.
+    ///
+    /// This list scopes *which* executions receive the attached tail:
+    /// - **empty** (default) — the accelerator applies to **all** off-server
+    ///   executions exactly as before; backward-compatible with the original
+    ///   global flag.  Do not use this form in prod until the auth-path
+    ///   regression is root-caused.
+    /// - **non-empty** — an execution receives `tail_events` only when its
+    ///   playbook `metadata.path` (or, as a fallback, `metadata.name`) starts
+    ///   with one of these prefixes.  Every other execution — including
+    ///   `api_integration/auth0/*` — gets an empty tail, i.e. exactly today's
+    ///   drain-served path (flag-off-equivalent), so login is safe **by
+    ///   construction** regardless of why the auth shape regressed.
+    ///
+    /// Prod value (planner + its MCP children, never auth):
+    /// `muno/playbooks/itinerary-planner,automation/agents/mcp/`.
+    #[serde(default)]
+    pub offserver_tail_playbook_prefixes: Vec<String>,
+
     /// **Shadow-accept the canonical result URI** (RFC noetl/ai-meta#104
     /// Phase A).  Envy maps `NOETL_RESULT_URI_ACCEPT`.
     ///
@@ -595,6 +623,32 @@ impl AppConfig {
     pub fn bind_address(&self) -> String {
         format!("{}:{}", self.host, self.port)
     }
+
+    /// Whether the off-server tail-attach accelerator (noetl/ai-meta#156) applies
+    /// to the execution whose playbook has this `path` / `name`.
+    ///
+    /// - Master flag off → never (no-op, as today).
+    /// - Master flag on, empty prefix list → applies to all (the original global
+    ///   behavior).
+    /// - Master flag on, non-empty prefix list → applies only when `path` (or, as
+    ///   a fallback, `name`) starts with one of the configured prefixes.
+    ///
+    /// Auth/session playbooks (`api_integration/auth0/*`) are kept off the prod
+    /// allowlist, so they always get an empty tail (today's drain-served path) and
+    /// the 15s-gateway-timeout regression cannot recur for login.
+    pub fn tail_attach_applies(&self, playbook_path: &str, playbook_name: &str) -> bool {
+        if !self.offserver_attach_tail {
+            return false;
+        }
+        if self.offserver_tail_playbook_prefixes.is_empty() {
+            return true;
+        }
+        self.offserver_tail_playbook_prefixes.iter().any(|prefix| {
+            let prefix = prefix.trim();
+            !prefix.is_empty()
+                && (playbook_path.starts_with(prefix) || playbook_name.starts_with(prefix))
+        })
+    }
 }
 
 impl Default for AppConfig {
@@ -641,6 +695,11 @@ impl Default for AppConfig {
             // `tail_events`, prod/default behavior + memory cost are unchanged.
             offserver_attach_tail: false,
             offserver_tail_cap: default_offserver_tail_cap(),
+            // noetl/ai-meta#156: empty prefix list → the accelerator (when on)
+            // applies to all off-server executions, as the original global flag
+            // did.  Prod scopes it to the planner (+ MCP children) so the auth
+            // path keeps today's drain-served behavior.
+            offserver_tail_playbook_prefixes: Vec::new(),
             // noetl/ai-meta#104 Phase A: the canonical result URI is ignored by
             // default; shadow-accept (parse + validate + record) is opt-in.
             result_uri_accept: false,
@@ -697,6 +756,36 @@ mod tests {
         let cfg = AppConfig::default();
         assert!(!cfg.offserver_attach_tail);
         assert_eq!(cfg.offserver_tail_cap, 64);
+        assert!(cfg.offserver_tail_playbook_prefixes.is_empty());
+    }
+
+    #[test]
+    fn test_tail_attach_scoping() {
+        // Master flag off → never, regardless of prefixes.
+        let mut cfg = AppConfig::default();
+        assert!(!cfg.tail_attach_applies("muno/playbooks/itinerary-planner", "muno_itinerary_planner"));
+
+        // Flag on, empty allowlist → applies to all (original global behavior).
+        cfg.offserver_attach_tail = true;
+        assert!(cfg.tail_attach_applies("api_integration/auth0/auth0_login", "auth0_login"));
+
+        // Flag on, scoped allowlist → planner (+ MCP children) in, auth out.
+        cfg.offserver_tail_playbook_prefixes = vec![
+            "muno/playbooks/itinerary-planner".to_string(),
+            "automation/agents/mcp/".to_string(),
+        ];
+        assert!(cfg.tail_attach_applies("muno/playbooks/itinerary-planner", "muno_itinerary_planner"));
+        assert!(cfg.tail_attach_applies("automation/agents/mcp/duffel", "duffel_mcp"));
+        // The auth/login + session-validate drives — the parked regression — stay off.
+        assert!(!cfg.tail_attach_applies("api_integration/auth0/auth0_login", "auth0_login"));
+        assert!(!cfg.tail_attach_applies(
+            "api_integration/auth0/auth0_validate_session",
+            "auth0_validate_session"
+        ));
+        // Match by name as a fallback when path is absent.
+        cfg.offserver_tail_playbook_prefixes = vec!["muno_itinerary_planner".to_string()];
+        assert!(cfg.tail_attach_applies("", "muno_itinerary_planner"));
+        assert!(!cfg.tail_attach_applies("", "auth0_login"));
     }
 
     #[test]

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2613,12 +2613,23 @@ async fn dispatch_offserver_stateless_drive(
     // drain to catch up (the source of the per-hop variance).  Empty when the
     // accelerator is off or the ring holds nothing (cold dispatch) → the worker
     // falls back to today's drain-served path, so worst case equals today.
-    let tail_events = if state.config.offserver_attach_tail {
+    // noetl/ai-meta#156: scope the accelerator to the allowlisted playbooks
+    // (planner + MCP children).  Auth/login executions fall here with the master
+    // flag on but no prefix match → empty tail → today's drain-served path, so the
+    // 15s-gateway-timeout login regression cannot recur.
+    let tail_attach = state
+        .config
+        .tail_attach_applies(playbook.metadata.path.as_deref().unwrap_or(""), &playbook.metadata.name);
+    let tail_events = if tail_attach {
         state.chain_tails.snapshot(execution_id)
     } else {
         Vec::new()
     };
-    crate::metrics::record_offserver_tail_attached(tail_events.len());
+    if !tail_attach && state.config.offserver_attach_tail {
+        crate::metrics::record_offserver_tail_scoped_out();
+    } else {
+        crate::metrics::record_offserver_tail_attached(tail_events.len());
+    }
 
     let input = serde_json::json!({
         "__offserver_build__": true,
@@ -3127,13 +3138,25 @@ async fn trigger_orchestrator_inner(
         // only meaningful on the off-server path (`offserver` true), where the
         // worker self-sources the spine.  Empty when the flag is off or nothing is
         // buffered; the server-built `state` here is the fallback regardless.
-        let tail_events = if offserver && state.config.offserver_attach_tail {
+        // noetl/ai-meta#156: scope the accelerator to the allowlisted playbooks
+        // (planner + MCP children); auth executions get an empty tail even with the
+        // master flag on, keeping today's drain-served path (no login regression).
+        let tail_attach = offserver
+            && state.config.tail_attach_applies(
+                playbook.metadata.path.as_deref().unwrap_or(""),
+                &playbook.metadata.name,
+            );
+        let tail_events = if tail_attach {
             state.chain_tails.snapshot(execution_id)
         } else {
             Vec::new()
         };
         if offserver {
-            crate::metrics::record_offserver_tail_attached(tail_events.len());
+            if !tail_attach && state.config.offserver_attach_tail {
+                crate::metrics::record_offserver_tail_scoped_out();
+            } else {
+                crate::metrics::record_offserver_tail_attached(tail_events.len());
+            }
         }
         let input = serde_json::json!({
             "state": cache.state.as_ref().expect("state present after rebuild"),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -154,10 +154,12 @@ pub fn record_orchestrate_drive(stage: &str) {
 /// `noetl_offserver_tail_attached_total{outcome}` — off-server drive dispatches
 /// by whether the server attached a non-empty per-execution event tail
 /// ([`crate::state::ChainTails`]).  `outcome` = `attached` (the dispatch carried
-/// `tail_events` so the worker can advance its WAL index drain-independently) or
+/// `tail_events` so the worker can advance its WAL index drain-independently),
 /// `empty` (the ring held nothing for this execution — a cold dispatch falling
-/// back to today's drain-served path).  Zero increments when the accelerator is
-/// off (`NOETL_OFFSERVER_ATTACH_TAIL=false`).
+/// back to today's drain-served path), or `scoped_out` (the master flag is on
+/// but this playbook is outside the `NOETL_OFFSERVER_TAIL_PLAYBOOK_PREFIXES`
+/// allowlist — e.g. the auth path — so the drive intentionally carries no tail).
+/// Zero increments when the accelerator is off (`NOETL_OFFSERVER_ATTACH_TAIL=false`).
 pub fn offserver_tail_attached_total() -> &'static IntCounterVec {
     static M: OnceLock<IntCounterVec> = OnceLock::new();
     M.get_or_init(|| {
@@ -208,6 +210,15 @@ pub fn record_offserver_tail_attached(n: usize) {
         offserver_tail_attached_total().with_label_values(&["attached"]).inc();
         offserver_tail_size().observe(n as f64);
     }
+}
+
+/// Record an off-server drive dispatch whose playbook is **outside** the
+/// tail-attach allowlist (`NOETL_OFFSERVER_TAIL_PLAYBOOK_PREFIXES`) while the
+/// master flag is on — e.g. the auth/login path (noetl/ai-meta#156).  The drive
+/// carries no tail and keeps today's drain-served behavior; this counter makes
+/// the scoping observable (auth executions should land here, never in `attached`).
+pub fn record_offserver_tail_scoped_out() {
+    offserver_tail_attached_total().with_label_values(&["scoped_out"]).inc();
 }
 
 // ── Terminal-event dedup (noetl/ai-meta#118) ─────────────────────────────────


### PR DESCRIPTION
## What

Scopes the off-server tail-attach accelerator (noetl/ai-meta#156) to an
allowlist of playbook path/name prefixes, so it can be re-enabled for the
Muno planner **without** touching the auth/login path that the global
flag-on form regressed on 2026-06-29.

## Why

Global `NOETL_OFFSERVER_ATTACH_TAIL=true` pushed the multi-hop `auth0_login`
drive past the gateway's hard ~15s callback budget → login outage (the
accelerator was then parked flag-off). The planner has no equivalent hard
client deadline, so the accelerator is pure win there.

## How

New `NOETL_OFFSERVER_TAIL_PLAYBOOK_PREFIXES` (comma-separated):
- **empty** (default) → applies to all off-server executions (the original
  global behavior; backward-compatible).
- **non-empty** → an execution gets `tail_events` only when its playbook
  `metadata.path` (or `name`) starts with one of the prefixes. Everything
  else — including `api_integration/auth0/*` — gets an empty tail = today's
  drain-served path, so **login is safe by construction**.

Prod value: `muno/playbooks/itinerary-planner,automation/agents/mcp/`.

- `config`: `offserver_tail_playbook_prefixes` + `tail_attach_applies()`
- both off-server dispatch sites (stateless edge + legacy) gate on it
- metric outcome `scoped_out` makes the auth exclusion observable
- worker unchanged (it applies whatever tail it receives)

## Validation

- Unit: `test_tail_attach_scoping` — `auth0_login` + `auth0_validate_session`
  excluded; planner + MCP children included.
- Kind: planner-path arm → `attached`, auth-path arm → `scoped_out`
  (`attached` unchanged), both COMPLETED, byte-identical normalized folded
  state (output-equivalence). Harness:
  `repos/ops/automation/development/validate-tail-attach-scope.sh`.
- Full lib suite green (634), clippy clean.

Refs noetl/ai-meta#156

🤖 Generated with [Claude Code](https://claude.com/claude-code)