### PR TITLE
feat(orphan-sweep): auto-recover executions orphaned by a dead/rolled worker

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -486,6 +486,81 @@ pub struct AppConfig {
     /// **Default false** — prod/default behavior unchanged.
     #[serde(default)]
     pub shard_index_from_hostname: bool,
+
+    /// **Orphaned-command guardrail sweep** (noetl/ai-meta zombie-exec fix;
+    /// refs #154 / #161 / #163).  Envy maps `NOETL_ORPHAN_SWEEP_ENABLED`.
+    ///
+    /// When a worker pod is rolled or killed mid-execution, the step command it
+    /// had claimed (`command.claimed` carries the dead pod's `worker_id`) never
+    /// gets a `command.completed` / `command.failed` — the worker is gone.  The
+    /// orchestrate reconciler ([`crate::handlers::events::spawn_orchestrator_reconciler`])
+    /// then re-drives `__orchestrate__` every 8s forever: the step is
+    /// outstanding, 0 new commands fan out, and the execution is wedged RUNNING
+    /// permanently — loading the system-pool drive and the noetl.event /
+    /// noetl.command reconcile queries (the "zombie" re-drive loop; prod incident
+    /// exec 330319143314137088 re-drove 111×/15min).
+    ///
+    /// When **true**, a background sweep
+    /// ([`crate::handlers::orphan_sweep::spawn_orphan_command_sweep`]) periodically
+    /// finds RUNNING executions whose latest outstanding `command.claimed` is
+    /// owned by a `worker_id` NOT in the live set (no `noetl.runtime` row with a
+    /// heartbeat within [`Self::orphan_worker_ttl_secs`]) and older than
+    /// [`Self::orphan_sweep_grace_secs`], then terminates each **append-only**
+    /// with a `playbook.failed` event (via the emit_event chokepoint — #103
+    /// sole-writer + idempotent-terminal #118 preserved).  It NEVER touches an
+    /// execution whose outstanding command is held by a live worker, never
+    /// re-executes a side-effecting step, and is rate-limited to
+    /// [`Self::orphan_sweep_max_per_tick`] terminations per tick.  Server-side
+    /// only — off the hot worker claim path.
+    ///
+    /// **Default false** — the sweep task still spawns but returns immediately
+    /// each tick, so prod/default behavior is byte-identical.  Instant rollback =
+    /// flip back to false.
+    #[serde(default)]
+    pub orphan_sweep_enabled: bool,
+
+    /// Seconds between orphaned-command sweep ticks.  Envy maps
+    /// `NOETL_ORPHAN_SWEEP_INTERVAL_SECS`.  Only consulted when
+    /// [`Self::orphan_sweep_enabled`] is on.  Default 60.
+    #[serde(default = "default_orphan_sweep_interval_secs")]
+    pub orphan_sweep_interval_secs: u64,
+
+    /// How long an outstanding `command.claimed` must be un-finished before it is
+    /// eligible for orphan termination, in seconds.  Envy maps
+    /// `NOETL_ORPHAN_SWEEP_GRACE_SECS`.  Kept comfortably above the reconcile
+    /// interval (8s) and the runtime offline threshold so a live worker mid-step
+    /// or a briefly-partitioned worker is never mistaken for dead.  Default 180.
+    #[serde(default = "default_orphan_sweep_grace_secs")]
+    pub orphan_sweep_grace_secs: u64,
+
+    /// A worker is considered LIVE iff a `noetl.runtime` row exists for its
+    /// `worker_id` with a heartbeat within this many seconds.  Envy maps
+    /// `NOETL_ORPHAN_WORKER_TTL_SECS`.  Set above the worker heartbeat interval
+    /// (15s) and the `runtime_offline_seconds` threshold so a crashed worker that
+    /// left a stale `noetl.runtime` row (no graceful deregister) still reads as
+    /// dead.  Default 90 (6 missed 15s beats).
+    #[serde(default = "default_orphan_worker_ttl_secs")]
+    pub orphan_worker_ttl_secs: u64,
+
+    /// Cap on executions terminated per sweep tick (rate limit).  Envy maps
+    /// `NOETL_ORPHAN_SWEEP_MAX_PER_TICK`.  A tick that hits the cap logs the
+    /// remaining backlog (no silent truncation) and clears it over subsequent
+    /// ticks.  Default 20.
+    #[serde(default = "default_orphan_sweep_max_per_tick")]
+    pub orphan_sweep_max_per_tick: usize,
+
+    /// Per-shard `LIMIT` on the candidate scan, and the lookback window bound
+    /// (`orphan_sweep_lookback_secs`) that keeps the query cheap.  Envy maps
+    /// `NOETL_ORPHAN_SWEEP_SCAN_LIMIT`.  Default 500.
+    #[serde(default = "default_orphan_sweep_scan_limit")]
+    pub orphan_sweep_scan_limit: i64,
+
+    /// Only claims newer than this many seconds are scanned — a zombie is
+    /// normally caught within a grace-period of the worker roll, so a wide bound
+    /// (default 48h) catches recent zombies while keeping the scan bounded.  Envy
+    /// maps `NOETL_ORPHAN_SWEEP_LOOKBACK_SECS`.
+    #[serde(default = "default_orphan_sweep_lookback_secs")]
+    pub orphan_sweep_lookback_secs: u64,
 }
 
 /// How the execution-lifecycle hot path reads `noetl.event` — see
@@ -575,6 +650,33 @@ fn default_command_context_max_bytes() -> usize {
     512 * 1024
 }
 
+fn default_orphan_sweep_interval_secs() -> u64 {
+    60
+}
+
+fn default_orphan_sweep_grace_secs() -> u64 {
+    180
+}
+
+fn default_orphan_worker_ttl_secs() -> u64 {
+    90
+}
+
+fn default_orphan_sweep_max_per_tick() -> usize {
+    20
+}
+
+fn default_orphan_sweep_scan_limit() -> i64 {
+    500
+}
+
+fn default_orphan_sweep_lookback_secs() -> u64 {
+    // 48h — a zombie is normally swept within a grace-period of the worker roll,
+    // so this only bounds the candidate scan; wide enough to catch anything a
+    // couple of days old, narrow enough to keep the query off the full log.
+    48 * 60 * 60
+}
+
 fn default_offserver_tail_cap() -> usize {
     // 64 events — far more than the 1–3 event tail between consecutive hops, so a
     // worker index that fell a few hops behind still completes from the attached
@@ -659,6 +761,16 @@ impl Default for AppConfig {
             execution_affinity: false,
             peer_url_template: None,
             shard_index_from_hostname: false,
+            // Zombie-exec guardrail (refs #154/#161/#163): the sweep spawns but
+            // is inert by default — a rolled/crashed worker's orphaned command is
+            // only terminated once ops flips this on.  Instant rollback = false.
+            orphan_sweep_enabled: false,
+            orphan_sweep_interval_secs: default_orphan_sweep_interval_secs(),
+            orphan_sweep_grace_secs: default_orphan_sweep_grace_secs(),
+            orphan_worker_ttl_secs: default_orphan_worker_ttl_secs(),
+            orphan_sweep_max_per_tick: default_orphan_sweep_max_per_tick(),
+            orphan_sweep_scan_limit: default_orphan_sweep_scan_limit(),
+            orphan_sweep_lookback_secs: default_orphan_sweep_lookback_secs(),
         }
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -19,6 +19,7 @@ pub mod internal;
 pub mod keychain;
 pub mod plugins;
 pub mod objects;
+pub mod orphan_sweep;
 pub mod registry;
 pub mod replay;
 pub mod result_store;

--- a/src/handlers/orphan_sweep.rs
+++ b/src/handlers/orphan_sweep.rs
@@ -1,0 +1,467 @@
+//! Orphaned-command guardrail sweep (zombie-exec fix; refs
+//! [#154](https://github.com/noetl/ai-meta/issues/154) /
+//! [#161] / [#163]).
+//!
+//! ## The zombie
+//!
+//! When a worker pod is rolled or killed mid-execution, the step command it had
+//! claimed (`command.claimed` carries the dead pod's `worker_id`) never gets a
+//! `command.completed` / `command.failed` — the worker is gone.  The orchestrate
+//! reconciler ([`crate::handlers::events::spawn_orchestrator_reconciler`]) then
+//! re-drives `__orchestrate__` every 8s forever: the step is outstanding, 0 new
+//! commands fan out, and the execution is wedged `RUNNING` permanently —
+//! loading the system-pool drive and the `noetl.event` / `noetl.command`
+//! reconcile queries.  Prod incident (2026-07-01): exec `330319143314137088`,
+//! owned by dead worker-rust replicaset `5bbc55c678`, re-drove 111×/15min until
+//! a human cleared it by hand.
+//!
+//! ## The guardrail
+//!
+//! Each tick this sweep finds RUNNING executions whose latest outstanding
+//! `command.claimed` is owned by a `worker_id` that is **not live** (no
+//! `noetl.runtime` row with a heartbeat within `orphan_worker_ttl_secs`) and
+//! older than `orphan_sweep_grace_secs`, then terminates each **append-only**
+//! with a `playbook.failed` event.  A worker roll becomes an automatic clean
+//! failure within a bounded time instead of a permanent zombie, and the SPA
+//! gets a terminal response instead of an infinite spinner.
+//!
+//! ## Why this shape (correctness first)
+//!
+//! * **Server-side only** — off the hot worker claim path, so it can never
+//!   fail/re-queue a command a live worker is executing and never adds latency
+//!   to the claim.  Aligns with the data-access boundary (the server owns
+//!   `noetl.*`; this reads `noetl.runtime` + `noetl.event` and appends through
+//!   the emit chokepoint).
+//! * **Fail, not re-queue** — the dead worker released its slot when the pod
+//!   died; emitting `playbook.failed` re-executes *nothing*, so there is zero
+//!   risk of double-executing a side-effecting step.  Re-queueing an
+//!   already-started command could double a side-effect, so v1 terminates
+//!   (the user simply re-sends the turn → a fresh execution).  Safe re-queue of
+//!   provably-not-yet-started commands is a possible future refinement.
+//! * **Never fails live work** — an execution whose outstanding command is held
+//!   by a live worker (heartbeat within TTL) is skipped every tick.
+//! * **Append-only** — emits only `playbook.failed`; no `UPDATE` / `DELETE`.
+//!   Routes through [`crate::handlers::event_write::emit_event`] so #103
+//!   sole-writer ordering and idempotent-terminal (#118) dedup both hold — two
+//!   replicas racing on the same orphan collapse to one terminal.
+//! * **Rate-limited** — at most `orphan_sweep_max_per_tick` terminations per
+//!   tick; a capped tick logs the deferred backlog (no silent truncation).
+//! * **Flag-gated** — default OFF (`NOETL_ORPHAN_SWEEP_ENABLED`); the task
+//!   spawns but returns immediately, so prod/default behavior is byte-identical.
+//!   Instant rollback = flip the flag back to false.
+
+use std::collections::HashSet;
+
+use tracing::{info, warn};
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::state::AppState;
+
+/// One outstanding claimed command that has not finished — the head of a
+/// potentially-wedged execution.  Whether it is actually a zombie depends on
+/// the liveness of [`Self::worker_id`], resolved against `noetl.runtime`.
+#[derive(Debug, Clone)]
+struct OrphanCandidate {
+    execution_id: i64,
+    catalog_id: i64,
+    worker_id: String,
+    node_name: String,
+    /// The `command.claimed` event id — used as the causal parent of the
+    /// terminal `playbook.failed`, keeping the event chain intact.
+    claimed_event_id: i64,
+}
+
+/// Spawn the background orphaned-command sweep.  Safe to spawn unconditionally:
+/// while the flag is off the task logs once and returns, scanning nothing.
+pub fn spawn_orphan_command_sweep(state: AppState) {
+    tokio::spawn(async move {
+        if !state.config.orphan_sweep_enabled {
+            info!(
+                target: "noetl_server::orphan_sweep",
+                "orphan-command sweep: disabled (NOETL_ORPHAN_SWEEP_ENABLED=false) — not scanning"
+            );
+            return;
+        }
+        let interval =
+            std::time::Duration::from_secs(state.config.orphan_sweep_interval_secs.max(1));
+        warn!(
+            target: "noetl_server::orphan_sweep",
+            interval_secs = state.config.orphan_sweep_interval_secs,
+            grace_secs = state.config.orphan_sweep_grace_secs,
+            worker_ttl_secs = state.config.orphan_worker_ttl_secs,
+            max_per_tick = state.config.orphan_sweep_max_per_tick,
+            "orphan-command sweep: ENABLED — dead-worker-orphaned RUNNING executions will be terminated append-only (playbook.failed)"
+        );
+        loop {
+            tokio::time::sleep(interval).await;
+            if let Err(e) = run_orphan_sweep(&state).await {
+                warn!(target: "noetl_server::orphan_sweep", error = %e, "orphan-command sweep: tick failed");
+                crate::metrics::record_orphan_sweep("error");
+            }
+        }
+    });
+}
+
+/// Run one sweep tick: resolve the live-worker set, scan every shard for the
+/// head outstanding claim per non-terminal execution, and terminate the ones
+/// whose owner worker is dead (rate-limited).
+async fn run_orphan_sweep(state: &AppState) -> AppResult<()> {
+    let cfg = &state.config;
+    let grace = cfg.orphan_sweep_grace_secs as i64;
+    let ttl = cfg.orphan_worker_ttl_secs as i64;
+    let lookback = cfg.orphan_sweep_lookback_secs as i64;
+    let scan_limit = cfg.orphan_sweep_scan_limit;
+    let max_per_tick = cfg.orphan_sweep_max_per_tick;
+
+    // 1. Live-worker set.  A worker is LIVE iff a `noetl.runtime` row exists for
+    //    its name with a heartbeat within TTL.  A gracefully-deregistered rolled
+    //    pod is absent (row deleted on shutdown); a crashed pod that left a stale
+    //    row fails the heartbeat cutoff.  `noetl.runtime` is a cluster-wide
+    //    table, so it lives on the cluster pool.
+    let live: HashSet<String> = sqlx::query_as::<_, (String,)>(
+        r#"
+        SELECT name FROM noetl.runtime
+        WHERE kind = 'worker_pool'
+          AND heartbeat >= NOW() - INTERVAL '1 second' * $1
+        "#,
+    )
+    .bind(ttl)
+    .fetch_all(state.pools.cluster())
+    .await?
+    .into_iter()
+    .map(|(name,)| name)
+    .collect();
+
+    // 2. Candidate head-claims across all shards.
+    let per_shard = state
+        .pools
+        .for_each_shard(|_idx, pool| async move {
+            query_orphan_candidates(&pool, grace, lookback, scan_limit).await
+        })
+        .await?;
+
+    let mut candidates: Vec<OrphanCandidate> =
+        per_shard.into_iter().flat_map(|(_, v)| v).collect();
+
+    // Execution affinity (RFC #116): only the owner replica acts, mirroring the
+    // reconcile poller.  Inert with a single replica / affinity off.  Filter
+    // before planning so the per-tick cap counts only this replica's work.
+    if state.affinity.active() {
+        candidates.retain(|c| state.affinity.owns(c.execution_id));
+    }
+    // Oldest claim first (event ids are time-ordered snowflakes) — clear the
+    // longest-wedged executions before the per-tick cap bites.
+    candidates.sort_by_key(|c| c.claimed_event_id);
+
+    let plan = plan_dispositions(&candidates, &live, max_per_tick);
+    let mut deferred = 0usize;
+    for (cand, disp) in candidates.iter().zip(plan.iter()) {
+        crate::metrics::record_orphan_sweep("candidate");
+        match disp {
+            // NEVER terminate an execution whose outstanding command is held by
+            // a live worker — that is in-flight work, not a zombie.
+            Disposition::SkippedLive => crate::metrics::record_orphan_sweep("skipped_live"),
+            Disposition::Capped => {
+                deferred += 1;
+                crate::metrics::record_orphan_sweep("capped");
+            }
+            Disposition::Terminate => match emit_orphan_failed(state, cand).await {
+                Ok(()) => {
+                    crate::metrics::record_orphan_sweep("terminated");
+                    info!(
+                        target: "noetl_server::orphan_sweep",
+                        execution_id = cand.execution_id,
+                        dead_worker = %cand.worker_id,
+                        node_name = %cand.node_name,
+                        "orphan-command sweep: terminated dead-worker-orphaned execution (playbook.failed)"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        target: "noetl_server::orphan_sweep",
+                        execution_id = cand.execution_id,
+                        error = %e,
+                        "orphan-command sweep: emit playbook.failed failed"
+                    );
+                    crate::metrics::record_orphan_sweep("error");
+                }
+            },
+        }
+    }
+
+    if deferred > 0 {
+        warn!(
+            target: "noetl_server::orphan_sweep",
+            deferred,
+            max_per_tick,
+            "orphan-command sweep: per-tick cap hit; deferred orphans to the next tick"
+        );
+    }
+    Ok(())
+}
+
+/// Fate of one head-claim candidate this tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Disposition {
+    /// Owner worker is dead → emit `playbook.failed`.
+    Terminate,
+    /// Owner worker is live → in-flight work, leave untouched.
+    SkippedLive,
+    /// Owner is dead but the per-tick termination budget is spent → next tick.
+    Capped,
+}
+
+/// Pure decision core (the safety-critical part).  Given the head-claim
+/// candidates (already affinity-filtered and oldest-first), the live-worker
+/// set, and the per-tick cap, decide each candidate's fate:
+///
+/// * a candidate whose `worker_id` is in `live` is **always** `SkippedLive` —
+///   this is the invariant that we never fail work a live worker owns;
+/// * otherwise the first `max_per_tick` dead-owned candidates `Terminate` and
+///   the rest are `Capped` (deferred to a later tick).
+///
+/// Live-owned candidates never consume the termination budget.
+fn plan_dispositions(
+    candidates: &[OrphanCandidate],
+    live: &HashSet<String>,
+    max_per_tick: usize,
+) -> Vec<Disposition> {
+    let mut terminated = 0usize;
+    candidates
+        .iter()
+        .map(|c| {
+            if live.contains(&c.worker_id) {
+                Disposition::SkippedLive
+            } else if terminated < max_per_tick {
+                terminated += 1;
+                Disposition::Terminate
+            } else {
+                Disposition::Capped
+            }
+        })
+        .collect()
+}
+
+/// The head outstanding `command.claimed` per non-terminal execution on one
+/// shard, older than the grace period and within the lookback window.
+///
+/// A row is returned only when the claimed command is the execution's *latest*
+/// claim (no newer `command.claimed`) AND that command never finished (no
+/// `command.completed` / `command.failed` for the same step at-or-after the
+/// claim) AND the execution has no terminal `playbook.*` event.  That is
+/// precisely the dead-worker-wedge shape; an execution merely waiting on the
+/// orchestrator to fan out the next step (a different stall the reconciler
+/// already handles) is excluded because its head claim has finished.  Liveness
+/// of the returned `worker_id` is decided by the caller against `noetl.runtime`.
+async fn query_orphan_candidates(
+    pool: &DbPool,
+    grace_secs: i64,
+    lookback_secs: i64,
+    scan_limit: i64,
+) -> AppResult<Vec<OrphanCandidate>> {
+    // `command.claimed` carries the owner in EITHER the `worker_id` column (the
+    // gate-off in-tx write, and the worker's own emit) OR `meta->>'worker_id'`
+    // (the CQRS materialized path stores the owner in meta, leaving the column
+    // NULL) — so read both, exactly as the claim-conflict check in
+    // `handlers::events::claim_command` does.  Keying on the column alone misses
+    // every materialized claim (the common prod shape under the publish-only
+    // gate), so the sweep would find zero candidates.
+    let rows = sqlx::query_as::<_, (i64, i64, Option<String>, Option<String>, i64)>(
+        r#"
+        SELECT
+            c.execution_id,
+            COALESCE(
+                NULLIF(c.catalog_id, 0),
+                (SELECT e2.catalog_id
+                   FROM noetl.event e2
+                  WHERE e2.execution_id = c.execution_id
+                    AND e2.catalog_id <> 0
+                  ORDER BY e2.event_id ASC
+                  LIMIT 1),
+                0
+            ) AS catalog_id,
+            COALESCE(c.worker_id, c.meta->>'worker_id') AS worker_id,
+            c.node_name,
+            c.event_id
+        FROM noetl.event c
+        WHERE c.event_type = 'command.claimed'
+          AND COALESCE(c.worker_id, c.meta->>'worker_id') IS NOT NULL
+          AND c.created_at <  NOW() - INTERVAL '1 second' * $1
+          AND c.created_at >= NOW() - INTERVAL '1 second' * $2
+          AND NOT EXISTS (
+            SELECT 1 FROM noetl.event p
+            WHERE p.execution_id = c.execution_id
+              AND p.event_type IN ('playbook.completed', 'playbook.failed', 'playbook.cancelled')
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM noetl.event c2
+            WHERE c2.execution_id = c.execution_id
+              AND c2.event_type = 'command.claimed'
+              AND c2.created_at > c.created_at
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM noetl.event t
+            WHERE t.execution_id = c.execution_id
+              AND t.node_name = c.node_name
+              AND t.event_type IN ('command.completed', 'command.failed')
+              AND t.created_at >= c.created_at
+          )
+        ORDER BY c.created_at ASC
+        LIMIT $3
+        "#,
+    )
+    .bind(grace_secs)
+    .bind(lookback_secs)
+    .bind(scan_limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(
+            |(execution_id, catalog_id, worker_id, node_name, event_id)| {
+                Some(OrphanCandidate {
+                    execution_id,
+                    catalog_id,
+                    worker_id: worker_id?,
+                    node_name: node_name.unwrap_or_default(),
+                    claimed_event_id: event_id,
+                })
+            },
+        )
+        .collect())
+}
+
+/// Emit the terminal `playbook.failed` for an orphaned execution, append-only,
+/// through the emit chokepoint (so #103 sole-writer + #118 idempotent-terminal
+/// hold).  Parented on the orphaned `command.claimed` so the causal chain stays
+/// intact.  `commands_generated: 0` in the meta mirrors the hand-clear shape.
+async fn emit_orphan_failed(state: &AppState, cand: &OrphanCandidate) -> AppResult<()> {
+    let event_id = state.snowflake.generate()?;
+    let error = format!(
+        "execution orphaned: command '{}' was claimed by worker '{}' which is no longer live \
+         (pod rolled/crashed); terminated by the orphan-command guardrail",
+        cand.node_name, cand.worker_id
+    );
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        cand.execution_id,
+        cand.catalog_id,
+        "playbook.failed",
+        "FAILED",
+        chrono::Utc::now(),
+    )
+    .with_node("playbook")
+    .with_result(serde_json::json!({"status": "FAILED", "context": {"error": error}}))
+    .with_meta(serde_json::json!({
+        "emitted_by": "orphan_command_sweep",
+        "reason": "orphaned_by_dead_worker",
+        "dead_worker_id": cand.worker_id,
+        "orphaned_node": cand.node_name,
+        "commands_generated": 0,
+        "error": error,
+    }))
+    .with_parent_event_id(cand.claimed_event_id);
+    crate::handlers::event_write::emit_event(state, state.pools.pool_for(cand.execution_id), ev)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand(execution_id: i64, worker: &str) -> OrphanCandidate {
+        OrphanCandidate {
+            execution_id,
+            catalog_id: 42,
+            worker_id: worker.to_string(),
+            node_name: "extract_turn".to_string(),
+            claimed_event_id: execution_id + 1,
+        }
+    }
+
+    fn live_set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// A candidate owned by a dead worker (rolled/crashed pod, absent from the
+    /// live set) is terminated.
+    #[test]
+    fn dead_worker_candidate_is_terminated() {
+        let cands = vec![cand(100, "noetl-worker-rust-5bbc55c678-7vd5l")];
+        let live = live_set(&["noetl-worker-rust-c95694c94-m7xvp"]);
+        let plan = plan_dispositions(&cands, &live, 20);
+        assert_eq!(plan, vec![Disposition::Terminate]);
+    }
+
+    /// SAFETY: a candidate owned by a LIVE worker is never terminated — even
+    /// under a huge cap — so a normal in-flight execution is untouched.
+    #[test]
+    fn live_worker_candidate_is_never_terminated() {
+        let cands = vec![
+            cand(100, "noetl-worker-rust-c95694c94-m7xvp"), // live
+            cand(200, "noetl-worker-rust-5bbc55c678-dead"), // dead
+        ];
+        let live = live_set(&["noetl-worker-rust-c95694c94-m7xvp"]);
+        let plan = plan_dispositions(&cands, &live, 20);
+        assert_eq!(
+            plan,
+            vec![Disposition::SkippedLive, Disposition::Terminate]
+        );
+    }
+
+    /// The per-tick cap bounds terminations; the excess dead-owned candidates
+    /// are deferred (Capped), not dropped.
+    #[test]
+    fn cap_defers_excess_dead_candidates() {
+        let cands = vec![
+            cand(100, "dead-a"),
+            cand(200, "dead-b"),
+            cand(300, "dead-c"),
+        ];
+        let live = live_set(&[]);
+        let plan = plan_dispositions(&cands, &live, 2);
+        assert_eq!(
+            plan,
+            vec![
+                Disposition::Terminate,
+                Disposition::Terminate,
+                Disposition::Capped
+            ]
+        );
+    }
+
+    /// Live-owned candidates do NOT consume the termination budget — with a cap
+    /// of 1, the single dead candidate still terminates even though a live one
+    /// precedes it.
+    #[test]
+    fn live_candidates_do_not_consume_budget() {
+        let cands = vec![
+            cand(100, "live-a"),
+            cand(200, "dead-b"),
+            cand(300, "live-c"),
+        ];
+        let live = live_set(&["live-a", "live-c"]);
+        let plan = plan_dispositions(&cands, &live, 1);
+        assert_eq!(
+            plan,
+            vec![
+                Disposition::SkippedLive,
+                Disposition::Terminate,
+                Disposition::SkippedLive
+            ]
+        );
+    }
+
+    /// A zero cap terminates nothing (all dead candidates deferred) — a safe
+    /// "observe only" configuration.
+    #[test]
+    fn zero_cap_terminates_nothing() {
+        let cands = vec![cand(100, "dead-a"), cand(200, "dead-b")];
+        let live = live_set(&[]);
+        let plan = plan_dispositions(&cands, &live, 0);
+        assert_eq!(plan, vec![Disposition::Capped, Disposition::Capped]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -801,6 +801,15 @@ async fn main() -> anyhow::Result<()> {
     // under DB backpressure (e.g. a small Cloud SQL tier behind PgBouncer).
     handlers::events::spawn_orchestrator_reconciler(state.clone());
 
+    // Orphaned-command guardrail sweep (zombie-exec fix; refs #154/#161/#163):
+    // terminates append-only (playbook.failed) any RUNNING execution whose head
+    // outstanding command.claimed is owned by a dead worker (rolled/crashed pod
+    // absent or stale in noetl.runtime) — so a worker roll auto-recovers instead
+    // of re-driving __orchestrate__ forever.  Default OFF
+    // (NOETL_ORPHAN_SWEEP_ENABLED); the task spawns but scans nothing until ops
+    // flips it on, so this is behavior-neutral until enabled.
+    handlers::orphan_sweep::spawn_orphan_command_sweep(state.clone());
+
     // CQRS write-path producer (noetl/ai-meta#103 phase 2a): a background tailer
     // that batch-publishes committed `noetl.event` rows onto the `noetl_events`
     // JetStream stream for the system/projector playbook to fold.  Default OFF

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -149,6 +149,38 @@ pub fn record_orchestrate_drive(stage: &str) {
     orchestrate_drive_total().with_label_values(&[stage]).inc();
 }
 
+// ── Orphaned-command guardrail sweep (zombie-exec fix; refs #154/#161/#163) ───
+
+/// `noetl_orphan_sweep_total{outcome}` — outcomes of the orphaned-command
+/// sweep ([`crate::handlers::orphan_sweep`]).  `outcome` is one of: `candidate`
+/// (a RUNNING exec with an outstanding claimed command was examined),
+/// `terminated` (owner worker dead → `playbook.failed` emitted), `skipped_live`
+/// (owner still a live worker — never failed), `capped` (eligible orphan
+/// deferred to a later tick by the rate limit), `error` (scan / emit failure).
+/// Zero increments while the sweep is off (`NOETL_ORPHAN_SWEEP_ENABLED=false`).
+pub fn orphan_sweep_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_orphan_sweep_total",
+                "Orphaned-command guardrail sweep outcomes, by outcome.",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one orphaned-command sweep outcome (see [`orphan_sweep_total`]).
+pub fn record_orphan_sweep(outcome: &str) {
+    orphan_sweep_total().with_label_values(&[outcome]).inc();
+}
+
 // ── Off-server tail-attach accelerator (noetl/ai-meta#156) ───────────────────
 
 /// `noetl_offserver_tail_attached_total{outcome}` — off-server drive dispatches


### PR DESCRIPTION
## What

Adds a server-side, flag-gated background sweep that terminates executions
**orphaned by a dead/rolled worker**, so a worker roll auto-recovers instead of
re-driving `__orchestrate__` forever.

### The zombie (what this fixes)

When a worker pod is rolled/killed mid-execution, the step command it had
claimed (`command.claimed` carries the pod name in `worker_id` / `meta`) never
gets a `command.completed`/`command.failed`. The orchestrate reconciler
(`spawn_orchestrator_reconciler`, every 8s) then re-drives forever: the step is
outstanding, 0 new commands fan out, the execution is wedged `RUNNING`
permanently — loading the system-pool drive and the `noetl.event`/`noetl.command`
reconcile queries. Prod incident 2026-07-01: exec `330319143314137088` (dead
worker-rust replicaset `5bbc55c678`) re-drove 111×/15min until hand-cleared.
Same failure family as the recurring wedges in noetl/ai-meta#154 / #161 / #163.

## How

`src/handlers/orphan_sweep.rs` — a background task spawned beside the reconciler:

1. **Live-worker set** = `noetl.runtime` rows with a heartbeat within
   `NOETL_ORPHAN_WORKER_TTL_SECS` (90s). Absent (gracefully-deregistered rolled
   pod) OR stale (crashed pod that left a row — `cleanup_stale` is unused) both
   read as dead.
2. **Candidate** = the latest outstanding `command.claimed` per non-terminal
   execution, older than `NOETL_ORPHAN_SWEEP_GRACE_SECS` (180s), whose command
   never finished and whose execution has no `playbook.*` terminal. Reads the
   owner from `COALESCE(worker_id, meta->>'worker_id')` — the materialized claim
   stores it in meta (column NULL), exactly as the claim-conflict check does.
3. If the owner is **dead** → emit `playbook.failed` via the `emit_event`
   chokepoint, rate-limited to `NOETL_ORPHAN_SWEEP_MAX_PER_TICK` (20).

### Correctness (first-order concern)

- **Server-side only**, off the hot worker claim path — no claim latency, and it
  can never fail/re-queue a command a live worker owns.
- **Fail, not re-queue**: the dead worker released its slot when the pod died, so
  `playbook.failed` re-executes nothing — zero double-side-effect risk.
- **Never fails live work**: an execution whose outstanding command is held by a
  live worker (heartbeat within TTL) is skipped every tick.
- **Append-only** via `emit_event`, so #103 sole-writer ordering and #118
  idempotent-terminal both hold (two replicas → one terminal).
- **Flag-gated, default OFF** (`NOETL_ORPHAN_SWEEP_ENABLED`): the task spawns but
  scans nothing until flipped on — prod/default behavior byte-identical. Instant
  rollback = flag off.

Flags: `NOETL_ORPHAN_SWEEP_ENABLED` (false), `_INTERVAL_SECS` (60), `_GRACE_SECS`
(180), `NOETL_ORPHAN_WORKER_TTL_SECS` (90), `_MAX_PER_TICK` (20), `_SCAN_LIMIT`
(500), `_LOOKBACK_SECS` (48h). Metric `noetl_orphan_sweep_total{outcome}`
(`candidate` / `terminated` / `skipped_live` / `capped` / `error`).

## Validation (kind)

5 unit tests on the safety-critical disposition logic (dead→terminate,
live→never terminate, cap defers, live never consumes budget, zero-cap no-op).

End-to-end on kind (server v3.49.0-dev image, sweep on, aggressive timings
grace=20s/ttl=60s/interval=8s), CQRS publish-only gate ON (matches prod):

| exec | owner | result |
| :-- | :-- | :-- |
| A | fabricated dead worker (absent) | **terminated** `playbook.failed` |
| C | present-but-stale worker (heartbeat weeks old) | **terminated** (TTL cutoff) |
| D | genuinely-live worker | **skipped 20×**, RUNNING — then I **force-killed its pod**; ~60s later (TTL + a tick) it was **terminated**, dead_worker=the killed pod |

- **Bounded auto-recovery, not forever-zombie**: D killed at 02:43:21 →
  terminated 02:44:21 (~TTL + one tick).
- **No double-execution**: terminated execs show `playbook_started → command.issued
  → command.claimed → playbook.failed` — the step never re-ran.
- **Idempotent**: exactly one `playbook.failed` per exec despite 8s ticks.
- **No false positives**: D untouched the entire time its worker was alive; 362
  weeks-stale `noetl.runtime` rows in the cluster were correctly treated as dead
  (proves TTL-freshness, not row-existence).
- 0 `error`-outcome increments.

Also cleared 9 pre-existing prod zombies (all `muno/` demo-tenant, orphaned by
the dead `5bbc55c678` replicaset) append-only with the same `playbook.failed`
shape — prod RUNNING count 9 → 0.

## Deploy

Default-off, so merging is behavior-neutral. Prod enablement: set
`NOETL_ORPHAN_SWEEP_ENABLED=true` on `noetl-server-rust` + roll; instant rollback
= flag off / prior image.

Closes noetl/ai-meta#171
Refs noetl/ai-meta#154, noetl/ai-meta#161, noetl/ai-meta#163

🤖 Generated with [Claude Code](https://claude.com/claude-code)
