### PR TITLE
Server-routed per-shard command publish for the off-server drive (#166 Phase 5)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -169,6 +169,31 @@ pub struct AppConfig {
     #[serde(default)]
     pub shard_count: Option<u32>,
 
+    /// noetl/ai-meta#166 Phase 5 (server-routed publish). When `true`, the
+    /// server publishes an execution's **system-pool** command notifications to
+    /// a per-shard subject `noetl.commands.system.shard.<n>.<eid>` (where
+    /// `n = shard_for(eid, command_shard_count)`) instead of the legacy
+    /// `noetl.commands.system.<eid>`, so the owning drive replica's per-shard
+    /// consumer filter receives it first with no Phase-4 NAK redirect. Envy maps
+    /// `NOETL_SHARD_SUBJECT_ROUTE`. **Default `false`** → legacy subject, exact
+    /// current behavior. Safe to flip even before the worker fleet switches to
+    /// per-shard filters: the shard subject is a subtree of the pool wildcard,
+    /// so a broad-filter consumer still receives it and falls through to the
+    /// Phase-4 NAK path (subject subsumption; see [`crate::sharding::command_subject`]).
+    #[serde(default)]
+    pub shard_subject_route: bool,
+
+    /// noetl/ai-meta#166 Phase 5 — the **worker pool's** drive-shard count used
+    /// to route command notifications when [`Self::shard_subject_route`] is on.
+    /// Envy maps `NOETL_COMMAND_SHARD_COUNT`. This is a **distinct axis** from
+    /// [`Self::shard_count`] (`NOETL_SHARD_COUNT`, which shards the server's own
+    /// `noetl.event`/`noetl.command` tables across server replicas) — the two
+    /// must not be conflated. Must equal the system worker pool's
+    /// `NOETL_SHARD_COUNT`. When unset or `1`, shard routing is a no-op (legacy
+    /// subject) even if [`Self::shard_subject_route`] is on.
+    #[serde(default)]
+    pub command_shard_count: Option<u32>,
+
     /// Maximum serialised size (bytes) of a `command.issued` event's `context`
     /// before it is offloaded to the result store (noetl/ai-meta#114).  When the
     /// off-server orchestrate drive (`orchestrate_plugin_drive`) builds the next
@@ -779,6 +804,9 @@ impl Default for AppConfig {
             server_machine_id: None,
             shard_index: None,
             shard_count: None,
+            // noetl/ai-meta#166 Phase 5: server-routed shard publish is opt-in.
+            shard_subject_route: false,
+            command_shard_count: None,
             command_context_max_bytes: default_command_context_max_bytes(),
             // noetl/ai-meta#115 Phase 3: event-scan is the default; chain_walk is opt-in.
             state_build_mode: StateBuildMode::EventScan,

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1629,7 +1629,24 @@ async fn publish_command_notification(
             _ => "shared",
         },
     };
-    let subject = format!("noetl.commands.{}.{}", pool_segment, execution_id);
+    // noetl/ai-meta#166 Phase 5: route the system pool's commands to a per-shard
+    // subject so the owning drive replica's per-shard consumer receives them
+    // first (no Phase-4 NAK redirect). Default off → legacy pool subject. The
+    // shard subject stays under `noetl.commands.<pool>.>`, so flipping the flag
+    // before the fleet switches to per-shard filters degrades to the NAK path
+    // rather than dropping a hop (see `sharding::command_subject`).
+    let command_shard_count = state.config.command_shard_count.unwrap_or(1);
+    let subject = crate::sharding::command_subject(
+        pool_segment,
+        execution_id,
+        state.config.shard_subject_route,
+        command_shard_count,
+    );
+    let publish_route = if subject.contains(".shard.") {
+        "sharded"
+    } else {
+        "legacy"
+    };
 
     let server_url = state
         .config
@@ -1666,10 +1683,13 @@ async fn publish_command_notification(
         .await
         .map_err(|e| AppError::Internal(format!("NATS publish ack failed: {e}")))?;
 
+    crate::metrics::record_command_publish(publish_route, pool_segment);
+
     tracing::info!(
         execution_id,
         event_id,
         %subject,
+        route = publish_route,
         command_id = %command_id,
         "Published command notification to NATS"
     );

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -181,6 +181,41 @@ pub fn record_orphan_sweep(outcome: &str) {
     orphan_sweep_total().with_label_values(&[outcome]).inc();
 }
 
+// ── Server-routed command publish (noetl/ai-meta#166 Phase 5) ────────────────
+
+/// `noetl_command_publish_total{route,pool}` — command notifications published
+/// to NATS, by routing shape. `route` = `sharded` (published to the per-shard
+/// subject `noetl.commands.<pool>.shard.<n>.<eid>` under
+/// `NOETL_SHARD_SUBJECT_ROUTE`) or `legacy` (the pool subject
+/// `noetl.commands.<pool>.<eid>`). `pool` is the resolved pool segment
+/// (`system`/`shared`/`subscription`/…). With server-routing off every publish
+/// is `legacy`; the `sharded` series only materialises once the flag is on and
+/// `NOETL_COMMAND_SHARD_COUNT > 1` for the system pool.
+pub fn command_publish_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_command_publish_total",
+                "Command notifications published to NATS, by routing shape (noetl/ai-meta#166).",
+            ),
+            &["route", "pool"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one command-notification publish (see [`command_publish_total`]).
+pub fn record_command_publish(route: &str, pool: &str) {
+    command_publish_total()
+        .with_label_values(&[route, pool])
+        .inc();
+}
+
 // ── Off-server tail-attach accelerator (noetl/ai-meta#156) ───────────────────
 
 /// `noetl_offserver_tail_attached_total{outcome}` — off-server drive dispatches

--- a/src/sharding.rs
+++ b/src/sharding.rs
@@ -203,6 +203,56 @@ pub fn shard_for(execution_id: i64, shard_count: u32) -> u32 {
     (h.finish() % shard_count as u64) as u32
 }
 
+/// The pool segment whose commands carry the sharded off-server state cache
+/// and are therefore eligible for per-shard subject routing (noetl/ai-meta#166
+/// Phase 5). Only the system pool runs the stateful off-server drive builder;
+/// the `shared` / `subscription` pools are stateless-ish and stay on the legacy
+/// subject so their commands aren't needlessly pinned to a single shard replica.
+pub const ROUTABLE_POOL: &str = "system";
+
+/// Build the NATS command-notification subject for one command.
+///
+/// noetl/ai-meta#166 Phase 5 (server-routed publish). Two shapes:
+///
+/// - **Legacy** (`shard_route` off, or `command_shard_count <= 1`, or the pool
+///   is not [`ROUTABLE_POOL`]):
+///   `noetl.commands.<pool>.<execution_id>` — today's exact subject.
+/// - **Sharded** (`shard_route` on, `command_shard_count > 1`, routable pool):
+///   `noetl.commands.<pool>.shard.<n>.<execution_id>` where
+///   `n = shard_for(execution_id, command_shard_count)` — the **same**
+///   XxHash64 ownership hash the worker re-implements byte-for-byte
+///   ([`shard_for`]), so the owning shard replica's per-shard consumer filter
+///   (`noetl.commands.<pool>.shard.<n>.>`) receives it first with no NAK
+///   redirect.
+///
+/// **Subject subsumption is the safety property**: the sharded subject is a
+/// subtree of the legacy pool wildcard `noetl.commands.<pool>.>`. A replica
+/// still bound to the broad filter (a fleet mid-rollout, or a shard with no
+/// dedicated consumer) *still receives* the shard-routed command and falls
+/// through to the Phase-4 NAK-affinity path — so a "wrong" route degrades to
+/// the existing NAK path, never drops a hop. `claim_command` atomicity remains
+/// the single exactly-once gate regardless of which consumer delivers it.
+///
+/// `command_shard_count` is the **worker pool's** drive-shard count
+/// (`NOETL_COMMAND_SHARD_COUNT`), a distinct axis from the server's own
+/// [`ShardConfig::shard_count`] (`NOETL_SHARD_COUNT`, which shards the
+/// `noetl.event`/`noetl.command` tables across server replicas). Do not
+/// conflate them.
+pub fn command_subject(
+    pool: &str,
+    execution_id: i64,
+    shard_route: bool,
+    command_shard_count: u32,
+) -> String {
+    let routed = shard_route && command_shard_count > 1 && pool == ROUTABLE_POOL;
+    if routed {
+        let n = shard_for(execution_id, command_shard_count);
+        format!("noetl.commands.{pool}.shard.{n}.{execution_id}")
+    } else {
+        format!("noetl.commands.{pool}.{execution_id}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,5 +430,103 @@ mod tests {
         assert_eq!(cfg.shard_index, 0);
         assert_eq!(cfg.shard_count, 1);
         assert!(cfg.owns(42));
+    }
+
+    // ---- command_subject (noetl/ai-meta#166 Phase 5) -----------------
+
+    #[test]
+    fn command_subject_legacy_when_route_off() {
+        // Flag off → today's exact subject regardless of count.
+        assert_eq!(
+            command_subject("system", 325, false, 4),
+            "noetl.commands.system.325"
+        );
+        assert_eq!(
+            command_subject("shared", 99, false, 4),
+            "noetl.commands.shared.99"
+        );
+    }
+
+    #[test]
+    fn command_subject_legacy_when_single_shard() {
+        // Flag on but count<=1 → no-op, legacy subject (single owner = today).
+        assert_eq!(
+            command_subject("system", 325, true, 1),
+            "noetl.commands.system.325"
+        );
+        assert_eq!(
+            command_subject("system", 325, true, 0),
+            "noetl.commands.system.325"
+        );
+    }
+
+    #[test]
+    fn command_subject_legacy_for_non_routable_pool() {
+        // Only the system pool is shard-routed; shared/subscription stay legacy
+        // even with the flag on and count>1 (their commands aren't shard-pinned).
+        assert_eq!(
+            command_subject("shared", 325, true, 4),
+            "noetl.commands.shared.325"
+        );
+        assert_eq!(
+            command_subject("subscription", 325, true, 4),
+            "noetl.commands.subscription.325"
+        );
+    }
+
+    #[test]
+    fn command_subject_routes_system_pool_by_shard_for() {
+        // Sharded subject uses shard_for(eid, count) — the identical hash the
+        // worker re-implements, so the owner's per-shard filter matches.
+        let count = 4;
+        for eid in [1_i64, 42, 325, 320_816_801_799_737_344, i64::MAX] {
+            let n = shard_for(eid, count);
+            assert_eq!(
+                command_subject("system", eid, true, count),
+                format!("noetl.commands.system.shard.{n}.{eid}"),
+            );
+        }
+    }
+
+    #[test]
+    fn shard_for_matches_worker_pinned_vectors() {
+        // Cross-repo parity guard. The worker re-implements this hash byte-for-
+        // byte (`noetl/worker` src/sharding.rs, twox-hash 1.6.3, seed 0, LE
+        // bytes) and pins the SAME vectors in
+        // `tests::shard_for_matches_server_pinned_vectors`. These are the
+        // resolved literals; a twox-hash major bump (or a seed/endianness
+        // change) on EITHER side breaks this test instead of silently routing
+        // a command to a subject no worker consumes. Owner-first delivery is
+        // correct only while these two impls agree — that is exactly what this
+        // pins. Do NOT edit the literals to "fix" a failure; a change here means
+        // the two repos diverged and the shard subject would miss its owner.
+        assert_eq!(shard_for(320_816_801_799_737_344, 16), 14);
+        assert_eq!(shard_for(1, 4), 1);
+        assert_eq!(shard_for(42, 4), 3);
+        assert_eq!(shard_for(325, 4), 0);
+        assert_eq!(shard_for(325, 8), 4);
+        assert_eq!(shard_for(i64::MAX, 4), 0);
+    }
+
+    #[test]
+    fn command_subject_pins_the_full_shard_subject() {
+        // The exact wire subject a shard-4 owner's consumer must filter.
+        assert_eq!(
+            command_subject("system", 325, true, 8),
+            "noetl.commands.system.shard.4.325"
+        );
+    }
+
+    #[test]
+    fn command_subject_sharded_is_subtree_of_legacy_wildcard() {
+        // Subject subsumption: the shard subject lives under
+        // `noetl.commands.system.>`, so a broad-filter consumer still receives
+        // it (degrade-to-NAK safety). Assert the prefix relationship holds.
+        let sharded = command_subject("system", 325, true, 8);
+        assert!(
+            sharded.starts_with("noetl.commands.system."),
+            "shard subject {sharded} must sit under the pool wildcard"
+        );
+        assert!(sharded.contains(".shard."));
     }
 }

--- a/tests/shard_publish_routing.rs
+++ b/tests/shard_publish_routing.rs
@@ -1,0 +1,177 @@
+//! Deterministic owner-first delivery proof for server-routed shard publish
+//! (noetl/ai-meta#166 Phase 5, leg 1).
+//!
+//! Phase 4 validated the *worker-side* NAK affinity with a deterministic
+//! competing-consumer harness (`noetl/worker` `tests/affinity_multi_replica.rs`)
+//! rather than a live 2-pod StatefulSet, because a real per-pod
+//! `NOETL_SHARD_INDEX` is an ops change out of a code PR's scope. This test
+//! mirrors that approach for the *server-side* publish: it models JetStream
+//! subject-filter matching and drives the **real** `command_subject` /
+//! `shard_for` to prove, without a cluster:
+//!
+//! 1. **Owner-first, zero misroute** — under per-shard consumer filters
+//!    (`noetl.commands.system.shard.<i>.>`), every routed command matches
+//!    **exactly one** consumer: the owner `shard_for(eid)`. No command lands on
+//!    a non-owner (the redirect the Phase-4 shared consumer paid ≈1/drive at 2
+//!    shards drops to 0).
+//! 2. **Subject subsumption (degrade-to-NAK safety)** — every routed command
+//!    *also* matches the broad pool filter `noetl.commands.system.>`, so a
+//!    replica still on the broad filter (fleet mid-rollout / a shard with no
+//!    live consumer) still receives it and falls through to the Phase-4 NAK
+//!    path. A wrong route degrades to NAK, never drops a hop.
+//! 3. **Legacy equivalence (flag off)** — with routing off, the subject is the
+//!    exact `noetl.commands.system.<eid>` the broad filter serves and no
+//!    per-shard filter matches, i.e. byte-identical to today.
+
+use noetl_server::sharding::{command_subject, shard_for};
+
+/// Minimal model of NATS subject-token matching for the two wildcard forms the
+/// worker's `NATS_FILTER_SUBJECT` uses: a literal token, `*` (exactly one
+/// token), and a trailing `>` (one-or-more remaining tokens). This is the
+/// documented JetStream filter semantics — the property under test is that our
+/// *subjects* land where our *filters* expect, not that async-nats implements
+/// matching (it does).
+fn subject_matches_filter(subject: &str, filter: &str) -> bool {
+    let subj: Vec<&str> = subject.split('.').collect();
+    let filt: Vec<&str> = filter.split('.').collect();
+    let mut i = 0;
+    while i < filt.len() {
+        match filt[i] {
+            ">" => return i < subj.len(), // `>` matches one-or-more remaining tokens
+            _ if i >= subj.len() => return false,
+            "*" => {}                     // matches exactly this one token
+            tok if tok == subj[i] => {}   // literal token match
+            _ => return false,
+        }
+        i += 1;
+    }
+    i == subj.len()
+}
+
+const N: u32 = 4; // model a 4-shard system pool
+const POOL: &str = "system";
+
+/// A representative spread of snowflake-shaped execution ids.
+fn sample_eids() -> Vec<i64> {
+    let base = 320_816_801_799_737_344_i64;
+    (0..2_000).map(|i| base + i as i64).collect()
+}
+
+fn per_shard_filter(i: u32) -> String {
+    format!("noetl.commands.{POOL}.shard.{i}.>")
+}
+
+fn broad_filter() -> String {
+    format!("noetl.commands.{POOL}.>")
+}
+
+#[test]
+fn routed_command_lands_on_exactly_the_owner_shard() {
+    for eid in sample_eids() {
+        let subject = command_subject(POOL, eid, true, N);
+        let owner = shard_for(eid, N);
+
+        // Exactly one per-shard consumer receives it, and it is the owner.
+        let mut receivers: Vec<u32> = Vec::new();
+        for i in 0..N {
+            if subject_matches_filter(&subject, &per_shard_filter(i)) {
+                receivers.push(i);
+            }
+        }
+        assert_eq!(
+            receivers,
+            vec![owner],
+            "eid {eid} subject {subject} must match exactly the owner shard {owner}"
+        );
+    }
+}
+
+#[test]
+fn owner_first_means_zero_redirects_across_the_fleet() {
+    // Aggregate proof: over the whole sample, the count of (command, non-owner
+    // consumer) deliveries is 0. Under the Phase-4 shared consumer this count
+    // was ≈ (fleet-1)/fleet × drives (the redirect tax); server-routing drives
+    // it to exactly 0.
+    let mut misroutes = 0usize;
+    let mut owner_hits = 0usize;
+    for eid in sample_eids() {
+        let subject = command_subject(POOL, eid, true, N);
+        let owner = shard_for(eid, N);
+        for i in 0..N {
+            if subject_matches_filter(&subject, &per_shard_filter(i)) {
+                if i == owner {
+                    owner_hits += 1;
+                } else {
+                    misroutes += 1;
+                }
+            }
+        }
+    }
+    assert_eq!(misroutes, 0, "no command may land on a non-owner shard");
+    assert_eq!(owner_hits, sample_eids().len(), "every command reaches its owner");
+}
+
+#[test]
+fn routed_command_is_subsumed_by_the_broad_pool_filter() {
+    // Degrade-to-NAK safety: a broad-filter replica still receives every
+    // shard-routed command, so flipping server-routing on before the fleet
+    // switches to per-shard filters is behaviour == Phase-4 (NAK steering),
+    // never a dropped hop.
+    for eid in sample_eids() {
+        let subject = command_subject(POOL, eid, true, N);
+        assert!(
+            subject_matches_filter(&subject, &broad_filter()),
+            "routed subject {subject} must still match the broad pool filter"
+        );
+    }
+}
+
+#[test]
+fn legacy_subject_matches_broad_filter_and_no_per_shard_filter() {
+    // Flag off → exact today's subject: broad filter serves it, no per-shard
+    // filter matches (byte-identical to pre-Phase-5).
+    for eid in sample_eids() {
+        let subject = command_subject(POOL, eid, false, N);
+        assert_eq!(subject, format!("noetl.commands.{POOL}.{eid}"));
+        assert!(subject_matches_filter(&subject, &broad_filter()));
+        for i in 0..N {
+            assert!(
+                !subject_matches_filter(&subject, &per_shard_filter(i)),
+                "legacy subject {subject} must NOT match per-shard filter {i}"
+            );
+        }
+    }
+}
+
+#[test]
+fn non_system_pool_is_never_shard_routed() {
+    // The shared/subscription pools stay on the legacy subject even with the
+    // flag on — their commands aren't shard-pinned.
+    for pool in ["shared", "subscription"] {
+        for eid in [1_i64, 42, 320_816_801_799_737_344] {
+            let subject = command_subject(pool, eid, true, N);
+            assert_eq!(subject, format!("noetl.commands.{pool}.{eid}"));
+            assert!(!subject.contains(".shard."));
+        }
+    }
+}
+
+#[test]
+fn subject_matches_filter_model_is_correct() {
+    // Guard the model itself so the proofs above rest on correct matching.
+    assert!(subject_matches_filter("noetl.commands.system.shard.2.325", "noetl.commands.system.>"));
+    assert!(subject_matches_filter(
+        "noetl.commands.system.shard.2.325",
+        "noetl.commands.system.shard.2.>"
+    ));
+    assert!(!subject_matches_filter(
+        "noetl.commands.system.shard.2.325",
+        "noetl.commands.system.shard.3.>"
+    ));
+    assert!(subject_matches_filter("noetl.commands.system.325", "noetl.commands.system.>"));
+    // `>` requires at least one trailing token.
+    assert!(!subject_matches_filter("noetl.commands.system", "noetl.commands.system.>"));
+    // `*` matches exactly one token.
+    assert!(subject_matches_filter("noetl.commands.system.325", "noetl.commands.*.325"));
+    assert!(!subject_matches_filter("noetl.commands.system.a.325", "noetl.commands.*.325"));
+}


### PR DESCRIPTION
**Review-only. Flags default OFF (behavior-neutral). No prod rollout in this PR.**

Closes noetl/server#272 · Refs noetl/ai-meta#166 (Phase 5, leg 1)

## What
The Phase-4 execution-affinity model (live on prod) routes drive hops via a
worker-side NAK on a shared consumer, paying ~1 redirect per drive at 2 shards
(random first-delivery hits the non-owner ~half the time). This makes the
**server** publish each system-pool command to a per-shard subject so the owner
receives it first — zero NAK redirects.

When `NOETL_SHARD_SUBJECT_ROUTE=true` and `NOETL_COMMAND_SHARD_COUNT=N>1`, the
server routes an execution's system-pool command notifications to:

```
noetl.commands.system.shard.<n>.<eid>     n = shard_for(eid, N)
```

Each shard-`n` replica binds a per-shard consumer filtered
`noetl.commands.system.shard.<n>.>` (ops/env — `NATS_FILTER_SUBJECT` +
`NATS_CONSUMER` are already env-driven, so **no worker change**).

## Correctness (pure delivery steering)
- **Owner-first, zero misroute** — uses the *identical* XxHash64 ownership hash
  the worker re-implements (twox-hash 1.6.3, seed 0, LE bytes); pinned to
  literal cross-repo parity vectors so a hash drift on either side fails a test
  rather than silently routing to a subject no worker consumes.
- **Subject subsumption = degrade-to-NAK safety** — the shard subject is a
  subtree of the pool wildcard `noetl.commands.system.>`, so a broad-filter
  replica (fleet mid-rollout, or a shard with no live consumer) still receives
  the command and falls through to the Phase-4 NAK path. A wrong route degrades
  to NAK, never drops a hop. `claim_command` atomicity stays the single
  exactly-once gate.
- **Rebalance-safe** — changing N re-homes an execution cache-cold (new owner
  cold-loads the Phase-2/3 shard; old owner's cache ages out). No object copied,
  no hop dropped/duplicated.

## Config axis note
`NOETL_COMMAND_SHARD_COUNT` is the **worker pool's** drive-shard count — a
distinct axis from `NOETL_SHARD_COUNT` (which shards the server's own
event/command tables). The two are never conflated.

## Flags (default OFF → today's exact subject)
- `NOETL_SHARD_SUBJECT_ROUTE=false`
- `NOETL_COMMAND_SHARD_COUNT=1` (count<=1 or non-system pool → legacy subject)

## Observability
`noetl_command_publish_total{route=legacy|sharded, pool}`.

## Validation
- **Unit**: subject-builder flag matrix; shard-for cross-repo parity pins; subject subsumption; non-system pools never routed. `cargo test --lib` 657 green.
- **Deterministic owner-first proof** (`tests/shard_publish_routing.rs`, mirrors Phase 4's harness): 2000 executions × 4 shards → **0 misroutes**, every command reaches exactly its owner, every routed subject subsumed by the broad filter, legacy subjects match no per-shard filter.
- **Live kind JetStream** (cluster `kind-noetl`): per-shard consumers received *exactly* their shard's messages (3/0 and 0/2 — zero cross-shard leakage), broad consumer received all 5 (subsumption). Live `NOETL_COMMANDS` stream subjects `[noetl.commands, noetl.commands.>]` (limits retention) **capture** the shard subtree — rollout precondition met.
- clippy: no new warnings (7 pre-existing).

## Not touched
result_store / OQ5 / `NOETL_RESULT_STORE_DUAL_WRITE` / #156 tail-attach /
Phase-2 shadow-write / Phase-3 read-flag / Phase-4 affinity behavior / IAM /
secrets.

## Proposed prod rollout (NOT executed — separate gated step)
1. Merge → release → image. Wiki: add the 2 env vars to server `deployment-specification` (Rule 2a).
2. Roll image flags-off (behavior-neutral).
3. Mode A: flip `NOETL_SHARD_SUBJECT_ROUTE=true` + `NOETL_COMMAND_SHARD_COUNT=2`; fleet keeps broad filters → behavior == Phase-4 (NAK steering), watch `command_publish_total{sharded}` rise.
4. Mode B: ops PR gives each system-pool shard replica its own `NATS_CONSUMER` + `NATS_FILTER_SUBJECT=noetl.commands.system.shard.<n>.>`; watch `affinity_decisions{redirected}` → 0.
5. Rollback at any step = flag off / revert filters; deeper = prior image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)