### PR TITLE
fix: pagination self-loop wedge + large-result artifact-get resolve 404 (kind #179)

### DIFF
--- a/orchestrate-core/src/orchestrator.rs
+++ b/orchestrate-core/src/orchestrator.rs
@@ -1157,12 +1157,28 @@ impl WorkflowOrchestrator {
                 if !forward_reachable(target, steps).contains(src_name.as_str()) {
                     continue;
                 }
-                // (3) recency: src completed strictly after target.
-                let src_done = state.steps.get(src_name).and_then(|s| s.completed_at);
-                let tgt_done = state.steps.get(target).and_then(|s| s.completed_at);
-                match (src_done, tgt_done) {
-                    (Some(s), Some(t)) if s > t => {}
-                    _ => continue,
+                // (3) recency: src completed strictly after target — EXCEPT for a
+                // self-loop (`src == target`, e.g. a pagination step whose own
+                // `next` arc re-enters it under a `when:` guard off its `set:`
+                // ctx mutations).  A self-loop is its own back-edge: there is one
+                // step and one `completed_at`, so the strict recency comparison
+                // `s > t` can never hold (`s == t`) and the arc would never be
+                // recognised — the step wedges Completed, its exit arc stays
+                // Pending (protected by `structural_loop_branch_points`), and the
+                // execution hangs with no terminal event (the
+                // `test_pagination_max_iterations` / `test_pagination_retry`
+                // 14-event stall).  Conditions (1) `is_step_done` and (2) cycle
+                // already hold, so a self-loop is a genuine loop back-edge;
+                // classify it directly.  Termination stays guard-driven: the
+                // self arc's `when:` (e.g. `iteration_count < max_iterations`)
+                // goes false and the arc stops matching, so the exit arc fires.
+                if src_name != target {
+                    let src_done = state.steps.get(src_name).and_then(|s| s.completed_at);
+                    let tgt_done = state.steps.get(target).and_then(|s| s.completed_at);
+                    match (src_done, tgt_done) {
+                        (Some(s), Some(t)) if s > t => {}
+                        _ => continue,
+                    }
                 }
                 loop_back_arcs.insert((src_name.clone(), target.clone()));
                 loop_branch_points.insert(src_name.clone());
@@ -4631,6 +4647,64 @@ workflow:
         }
     }
 
+    /// A **self-loop** counter playbook: a single step `fetch` whose own `next`
+    /// arc re-enters `fetch` while the guard holds — the exact shape of
+    /// `tests/pagination/{max_iterations,retry}` (a step that loops to itself,
+    /// not a 2-cycle through a separate brancher). Regression fixture for the
+    /// self-loop back-edge classification (self-loop `src == target`, where the
+    /// strict recency test can never fire).
+    fn make_self_loop_playbook() -> Playbook {
+        use crate::playbook::{NextArc, NextRouter, NextRouterSpec};
+        let start = make_step_with_set(
+            "start",
+            NextSpec::Single("fetch".to_string()),
+            &[("ctx.counter", "{{ workload.counter }}")],
+        );
+        let fetch = {
+            let mut s = make_step_with_set(
+                "fetch",
+                NextSpec::Router(NextRouter {
+                    spec: Some(NextRouterSpec {
+                        mode: Some("exclusive".to_string()),
+                    }),
+                    arcs: vec![
+                        NextArc {
+                            step: "fetch".to_string(),
+                            when: Some("{{ ctx.counter < 3 }}".to_string()),
+                            set_vars: None,
+                        },
+                        NextArc {
+                            step: "validate".to_string(),
+                            when: Some("{{ ctx.counter >= 3 }}".to_string()),
+                            set_vars: None,
+                        },
+                    ],
+                }),
+                &[("ctx.counter", "{{ fetch.next_counter }}")],
+            );
+            s.desc = Some("self-loop pagination head".to_string());
+            s
+        };
+        let validate = make_step("validate", Some("end"));
+        let end = make_step("end", None);
+        Playbook {
+            api_version: "noetl.io/v2".to_string(),
+            kind: "Playbook".to_string(),
+            metadata: Metadata {
+                name: "self_loop".to_string(),
+                path: Some("test/self_loop".to_string()),
+                description: None,
+                labels: None,
+                extra: HashMap::new(),
+            },
+            workload: None,
+            vars: None,
+            keychain: None,
+            workbook: None,
+            workflow: vec![start, fetch, validate, end],
+        }
+    }
+
     /// Persist an `EventToEmit` into a growing event log the way
     /// `handlers::events::trigger_orchestrator` does: a `context`
     /// payload is wrapped in the `{status, context}` result envelope so
@@ -4766,6 +4840,86 @@ workflow:
         assert_eq!(
             work_dispatched_counters, vec![0, 1, 2],
             "counter must advance 0->1->2 monotonically, not thrash",
+        );
+    }
+
+    #[test]
+    fn test_self_loop_reenters_and_terminates() {
+        // Regression for the pagination self-loop wedge
+        // (tests/pagination/{max_iterations,retry}): a step whose own `next` arc
+        // re-enters itself (`src == target`) must be recognised as a loop
+        // back-edge and re-dispatch each iteration until its guard goes false,
+        // then take the exit arc. Before the fix the strict recency test
+        // (`src.completed_at > target.completed_at`) could never hold for a
+        // self-loop (same step, same `completed_at`), so the arc was never
+        // classified, the step wedged `Completed`, and the execution hung with
+        // no terminal event (the 14-event stall).
+        let orchestrator = WorkflowOrchestrator::new();
+        let playbook = make_self_loop_playbook();
+        let t0 = DateTime::from_timestamp(0, 0).unwrap();
+        let mut seq = 0i64;
+
+        let mut log: Vec<Event> = Vec::new();
+        {
+            let mut started = make_event("playbook_started", None);
+            started.event_id = 0;
+            started.timestamp = t0;
+            started.context = Some(serde_json::json!({
+                "workload": { "counter": 0 },
+                "path": "test/self_loop",
+                "version": "1",
+            }));
+            log.push(started);
+        }
+
+        let mut fetch_dispatched_counters: Vec<i64> = Vec::new();
+        let mut trigger: Option<&str> = None;
+        let mut completed = false;
+
+        for _pass in 0..40 {
+            let result = orchestrator
+                .evaluate(&log, &playbook, trigger)
+                .expect("evaluate must not error");
+
+            if result.should_complete {
+                completed = true;
+                break;
+            }
+            for emit in &result.events_to_emit {
+                persist_emit(&mut log, emit, &mut seq, t0);
+            }
+            if result.commands.is_empty() {
+                // Nothing dispatched and not complete — the self-loop wedge.
+                break;
+            }
+            for command in &result.commands {
+                let step = command.step_name.as_str();
+                let seen = command
+                    .context
+                    .as_ref()
+                    .and_then(|c| c.get("counter"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(-1);
+                let done_result = match step {
+                    "fetch" => serde_json::json!({ "next_counter": seen + 1 }),
+                    _ => serde_json::json!({}),
+                };
+                if step == "fetch" {
+                    fetch_dispatched_counters.push(seen);
+                }
+                simulate_worker(&mut log, step, done_result, &mut seq, t0);
+            }
+            trigger = Some("command.completed");
+        }
+
+        assert!(
+            completed,
+            "self-loop did not terminate; fetch dispatched with counters {:?}",
+            fetch_dispatched_counters,
+        );
+        assert_eq!(
+            fetch_dispatched_counters, vec![0, 1, 2],
+            "self-loop must re-enter fetch 0->1->2 then exit, not wedge after the first iteration",
         );
     }
 

--- a/src/db/queries/object_store.rs
+++ b/src/db/queries/object_store.rs
@@ -99,6 +99,64 @@ pub async fn get(pool: &DbPool, object_key: &str) -> AppResult<Option<ObjectRow>
     }))
 }
 
+/// Resolve an over-budget result's JSON-tier object by its canonical logical
+/// coordinates (noetl/ai-meta#104 Phase C read path for the explicit
+/// `artifact get` / `result_fetch` lazy-load surface).
+///
+/// The producer-staged / materialised result-tier object lives at the §7
+/// physical key
+/// `noetl/env=…/region=…/cell=…/shard=…/tenant=…/project=…/date=…/execution=<eid>/results/<step>/<frame>/<row>/<attempt>.json`.
+/// The caller (`resolve_ref`) has the canonical logical coordinates
+/// (`<eid>/<step>/<frame>/<row>/<attempt>`) from the worker-stamped
+/// `reference.uri` but NOT the env/region/cell/shard/date placement prefix
+/// (that needs the cell registry + the snowflake date partition). Rather than
+/// reconstruct the full key — which would drag the cell-placement + arrow-decode
+/// graph onto the lean control plane — anchor on the placement-independent
+/// **suffix**: the logical tail is unique per `(execution, step, frame, row,
+/// attempt)`, so a single suffix match resolves the object without knowing the
+/// physical placement.
+///
+/// Scoped to the JSON tier (`.json`): a non-tabular over-budget result stores
+/// its scrubbed `result.context` as JSON, byte-identical to what the legacy
+/// `result_store` row held, so the returned body matches the legacy resolve
+/// contract exactly. Tabular results tier as Arrow Feather and are resolved via
+/// the worker's bulk-binding `resolve_by_urn` path (which owns the arrow decode
+/// the control plane deliberately does not carry).
+///
+/// `logical_tail` is `<step>/<frame>/<row>/<attempt>`; LIKE metacharacters in it
+/// are escaped so a step name with `%`/`_` cannot widen the match.
+pub async fn get_result_tier_json(
+    pool: &DbPool,
+    execution_id: i64,
+    logical_tail: &str,
+) -> AppResult<Option<ObjectRow>> {
+    // Escape LIKE metacharacters (\ % _) in the caller-supplied tail so the
+    // match stays anchored to exactly this result's coordinates.
+    let escaped_tail = logical_tail
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    let pattern = format!("%/execution={execution_id}/results/{escaped_tail}.json");
+    let rows = sqlx::query(
+        r#"
+        SELECT digest, media_type, bytes
+        FROM noetl.object_store
+        WHERE object_key LIKE $1 ESCAPE '\'
+        ORDER BY created_at DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(pattern)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().next().map(|r| ObjectRow {
+        digest: r.get::<String, _>("digest"),
+        media_type: r.get::<String, _>("media_type"),
+        bytes: r.get::<Vec<u8>, _>("bytes"),
+    }))
+}
+
 /// List object keys under `prefix` (most-recently-written first), capped at
 /// `limit`. Backs the result-tier GC sweep ([noetl/ai-meta#104](https://github.com/noetl/ai-meta/issues/104)
 /// Phase F) for the Postgres backend.

--- a/src/handlers/result_store.rs
+++ b/src/handlers/result_store.rs
@@ -20,7 +20,9 @@ use axum::{
 use serde::Deserialize;
 
 use crate::error::AppResult;
-use crate::services::result_store::{parse_noetl_ref, PutResultBody, ResultStoreService};
+use crate::services::result_store::{
+    parse_result_ref, PutResultBody, ResultRef, ResultStoreService,
+};
 
 // ---------------------------------------------------------------------------
 // Handler state
@@ -165,7 +167,15 @@ pub async fn resolve_ref(
 
     let t0 = std::time::Instant::now();
 
-    let parsed = match parse_noetl_ref(&params.r#ref) {
+    // Accept BOTH reference shapes (noetl/ai-meta#104):
+    //   - Legacy `noetl://execution/<eid>/result/<name>/<id>` → `noetl.result_store`.
+    //   - Canonical `noetl://<tenant>/<project>/results/<eid>/<step>/<frame>/<row>/<attempt>`
+    //     → the #104 object tier (the authoritative byte source under dual-write
+    //     retirement).  The worker exposes the canonical URI as a step's `_ref`
+    //     when the tier is authoritative, so the `artifact get` / `result_fetch`
+    //     lazy-load surface can resolve an over-budget result even though the
+    //     legacy `result_store` row was never written.
+    let parsed = match parse_result_ref(&params.r#ref) {
         Ok(r) => r,
         Err(msg) => {
             tracing::warn!(
@@ -182,10 +192,21 @@ pub async fn resolve_ref(
         }
     };
 
-    let execution_id = parsed.execution_id;
-    let name = parsed.name.clone();
-
-    let result = deps.service.resolve(&parsed).await;
+    let (execution_id, name, result) = match &parsed {
+        ResultRef::Legacy(l) => (
+            l.execution_id,
+            l.name.clone(),
+            deps.service.resolve(l).await,
+        ),
+        ResultRef::Canonical(loc) => {
+            // Best-effort coords for the log/metric fields; resolution itself
+            // re-parses inside `resolve_canonical`.
+            let (eid, step) = noetl_locator::ResultCoordinates::from_locator(loc)
+                .map(|c| (c.execution_id, c.step))
+                .unwrap_or((0, params.r#ref.clone()));
+            (eid, step, deps.service.resolve_canonical(loc).await)
+        }
+    };
     let elapsed = t0.elapsed().as_secs_f64();
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -500,6 +500,15 @@ fn build_router(
             "/api/internal/objects/{*key}",
             put(handlers::objects::put).get(handlers::objects::get),
         )
+        // Producer-staged result-tier objects (noetl/ai-meta#104) carry the
+        // same over-budget tool results the `PUT /api/result/{execution_id}`
+        // route accepts — 10s of MB (e.g. test_storage_tiers stages a 15 MB
+        // `test_large_storage` result). Without a matching limit this route
+        // inherits axum's 2 MB default and 413s the write; producer-staging
+        // swallows the error (best-effort), so the tier object silently never
+        // lands and a later `artifact get` resolves 404. Mirror the 64 MB cap
+        // the result-store route uses.
+        .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
         .with_state(handlers::objects::ObjectStoreDeps {
             pool: db_pool.clone(),
             backend: object_backend.clone(),

--- a/src/services/result_store.rs
+++ b/src/services/result_store.rs
@@ -342,6 +342,54 @@ impl ResultStoreService {
         .await?;
         Ok(row.map(|r| r.data))
     }
+
+    /// Resolve a **canonical** result reference
+    /// (`noetl://<tenant>/<project>/results/<eid>/<step>/<frame>/<row>/<attempt>`)
+    /// from the #104 object tier (noetl/ai-meta#104 Phase C read path).
+    ///
+    /// Under the dual-write-retired regime (`NOETL_RESULT_STORE_DUAL_WRITE=false`,
+    /// `NOETL_RESULT_MINT_AUTHORITATIVE=true`) the legacy `noetl.result_store`
+    /// row is not written — the object tier is the authoritative byte source. The
+    /// worker exposes the canonical logical URI as a step's `_ref`, so the
+    /// explicit `artifact get` / `result_fetch` lazy-load surface arrives here
+    /// with a `Canonical` reference. Resolve it from the JSON tier (the byte
+    /// source is the scrubbed `result.context`, byte-identical to what the legacy
+    /// `result_store` row held). Tabular (Feather) tiers are resolved via the
+    /// worker's `resolve_by_urn` bulk-binding path.
+    ///
+    /// Returns `None` when no matching tier object exists (caller → 404).
+    pub async fn resolve_canonical(
+        &self,
+        loc: &noetl_locator::ResourceLocator,
+    ) -> AppResult<Option<serde_json::Value>> {
+        let coords = match noetl_locator::ResultCoordinates::from_locator(loc) {
+            Ok(c) => c,
+            // A non-`results` locator (e.g. a datasets/ URI) is not a resolvable
+            // result reference — treat as not-found rather than an error.
+            Err(_) => return Ok(None),
+        };
+        let logical_tail = format!(
+            "{}/{}/{}/{}",
+            coords.step, coords.frame, coords.row, coords.attempt
+        );
+        let obj = crate::db::queries::object_store::get_result_tier_json(
+            &self.pool,
+            coords.execution_id,
+            &logical_tail,
+        )
+        .await?;
+        match obj {
+            Some(o) => {
+                let value: serde_json::Value = serde_json::from_slice(&o.bytes).map_err(|e| {
+                    AppError::Internal(format!(
+                        "result_store.resolve_canonical: decode JSON tier: {e}"
+                    ))
+                })?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two independent kind-validation regressions, both surfaced by the full-functionality sweep (noetl/ai-meta#179 Phase 1):

### BUG-1 — pagination self-loop continuation wedge (orchestrate-core)

A workflow step whose own `next` arc re-enters itself (`src == target`) — the shape of `tests/pagination/max_iterations` and `tests/pagination/retry`, where a `fetch` step loops to itself under a `when:` guard off its own `set:` ctx mutations — was never recognised as a loop back-edge. The `#85` back-edge classifier gates on a **strict** recency test (`src.completed_at > target.completed_at`), which for a self-loop compares the same step's `completed_at` to itself (`s > s` = false), so the arc fell through to `continue`. The step wedged `Completed`, its exit arc stayed `Pending` (protected by `structural_loop_branch_points`), nothing dispatched, and the execution hung with no terminal event — the 14-event stall.

**Fix:** treat a self-loop (`src == target`) as a loop back-edge directly. Conditions (1) `is_step_done` and (2) cycle already hold; the recency test is meaningless for a single step. Termination stays guard-driven — the self arc's `when:` (e.g. `iteration_count < max_iterations`) goes false and the exit arc fires. Two-cycle loops (`work → gate → work`) are unchanged.

Regression test `test_self_loop_reenters_and_terminates` drives a single self-looping counter step pass-by-pass and asserts it re-enters `0→1→2` then exits, where before it wedged after iteration 1.

### BUG-2 — large-result `artifact get` resolve 404 (result-store handler)

Under the dual-write-retired regime (`NOETL_RESULT_STORE_DUAL_WRITE=false` + `NOETL_RESULT_MINT_AUTHORITATIVE=true`, #104 OQ5) the `noetl.result_store` row is never written — the #104 object tier is the authoritative byte source. But `GET /api/result/resolve` (the `artifact get` / `result_fetch` lazy-load surface) still read **only** `noetl.result_store`, so resolving a large result's `_ref` returned `404 result not found` (`test_output_select`, `test_storage_tiers`, `test_gcs_storage`). Basic large-result extraction passed because it never *resolves* the ref (only checks `_ref is defined`); the bulk-binding path already resolves via the worker's `resolve_by_urn`.

**Fix:** `/api/result/resolve` now accepts **both** reference shapes via the existing `parse_result_ref` (#104 Phase A):
- Legacy `noetl://execution/<eid>/result/<name>/<id>` → `noetl.result_store` (unchanged).
- Canonical `noetl://<tenant>/<project>/results/<eid>/<step>/<frame>/<row>/<attempt>` → the JSON object tier, via a placement-independent suffix match on `noetl.object_store` (`get_result_tier_json`). The returned body is the scrubbed `result.context` — byte-identical to what the legacy `result_store` row held. Tabular (Feather) tiers keep resolving through the worker's `resolve_by_urn` bulk-binding path (which owns the arrow decode the control plane deliberately does not carry).

The paired worker change (noetl/worker) exposes the canonical logical URI as a step's `_ref` when the tier is authoritative, so `{{ step._ref }}` is a tier-resolvable reference. The two ship together.

**Third facet — object-store PUT body limit.** `test_storage_tiers` stages a 15 MB `test_large_storage` result. The `PUT /api/internal/objects/{key}` route (the producer-stage tier write) had no `DefaultBodyLimit`, so it inherited axum's 2 MB default and 413'd the write; producer-staging swallows the error (best-effort), so the tier object silently never landed and the later `artifact get` still resolved 404. Lifted the object-store route to the same 64 MB cap the `result_store` PUT route already uses (it accepts the same over-budget payloads).

## Why it respects the frozen OQ5 dual-write

No change to `result_store_dual_write` / `result_mint_authoritative` defaults or write path. The retired dual-write stays retired; this only teaches the **read** side to serve from the authoritative tier the write side already populates (producer-stage).

## Kind validation

Built locally (`noetl-server:v3.54.0-rc2`, `noetl-worker:v5.71.0-rc1`), loaded into `kind-noetl` (podman provider), all pools rolled. All five fixtures reach terminal `COMPLETED`:

| Fixture | execution_id | status |
| :-- | :-- | :-- |
| `test_pagination_max_iterations` (BUG-1) | 333161728579735552 | COMPLETED (34 ev) |
| `test_pagination_retry` (BUG-1) | 333161730580418560 | COMPLETED (48 ev) |
| `test_output_select` (BUG-2) | 333161732509798400 | COMPLETED (31 ev) |
| `test_storage_tiers` (BUG-2, 15 MB tier) | 333161735034769408 | COMPLETED (55 ev) |
| `test_gcs_storage` (BUG-2) | 333161736813154304 | COMPLETED (25 ev) |

Before: BUG-1 fixtures wedged at 14 events (no terminal); BUG-2 fixtures `FAILED` with `/api/result/resolve returned 404`. Regression check: `test_pagination_offset` (non-self-loop) + the passing pagination/loop/fanout set stay green.

Refs noetl/ai-meta#179
