### PR TITLE
fix(keychain): resolve {{ keychain.* }} templates in tool configs (#151)

### DIFF
--- a/orchestrate-core/src/commands.rs
+++ b/orchestrate-core/src/commands.rs
@@ -370,9 +370,13 @@ impl CommandBuilder {
         let tool_call = ToolCall::from_spec(tool);
         let config_value = serde_json::to_value(&tool_call.config).ok();
 
-        // Render any templates in the config
+        // Render any templates in the config.  `keychain.*` references are
+        // DEFERRED (left verbatim) so the secret is resolved transiently at
+        // user-worker dispatch time instead of being rendered into — and
+        // persisted on — this command (noetl/ai-meta#151).  Every other
+        // template renders exactly as before.
         let config = if let Some(cfg) = config_value {
-            Some(self.renderer.render_value(&cfg, context)?)
+            Some(self.renderer.render_value_deferring_keychain(&cfg, context)?)
         } else {
             None
         };

--- a/orchestrate-core/src/template.rs
+++ b/orchestrate-core/src/template.rs
@@ -287,6 +287,76 @@ impl TemplateRenderer {
         false
     }
 
+    /// Render a nested structure like [`render_value`], but DEFER (return
+    /// verbatim) any string template that references the `keychain.*`
+    /// namespace (noetl/ai-meta#151).
+    ///
+    /// The `keychain.<alias>.<field>` namespace is populated only at
+    /// user-worker dispatch time — resolved transiently so the secret never
+    /// lands in the persisted command / event log (the same discipline the
+    /// `auth:` alias path follows).  The drive builds tool configs against a
+    /// context that has no `keychain`, so rendering `{{ keychain.* }}` here
+    /// would collapse it to an empty string and the downstream HTTP/auth step
+    /// would send an empty credential → 401.  Deferring the whole template
+    /// string lets the worker re-render it against the resolved namespace.
+    ///
+    /// Every non-keychain template renders exactly as [`render_value`] —
+    /// byte-identical for fields that don't reference `keychain`.
+    pub fn render_value_deferring_keychain(
+        &self,
+        value: &serde_json::Value,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> CoreResult<serde_json::Value> {
+        match value {
+            serde_json::Value::String(s) => {
+                if self.template_references_keychain(s) {
+                    Ok(serde_json::Value::String(s.clone()))
+                } else {
+                    self.render_to_value(s, context)
+                }
+            }
+            serde_json::Value::Object(map) => {
+                let mut result = serde_json::Map::new();
+                for (k, v) in map {
+                    let rendered_key = if self.template_references_keychain(k) {
+                        k.clone()
+                    } else {
+                        self.render(k, context)?
+                    };
+                    result.insert(rendered_key, self.render_value_deferring_keychain(v, context)?);
+                }
+                Ok(serde_json::Value::Object(result))
+            }
+            serde_json::Value::Array(arr) => {
+                let result: Result<Vec<_>, _> = arr
+                    .iter()
+                    .map(|v| self.render_value_deferring_keychain(v, context))
+                    .collect();
+                Ok(serde_json::Value::Array(result?))
+            }
+            _ => Ok(value.clone()),
+        }
+    }
+
+    /// True when `s` is a template that references the `keychain` root — e.g.
+    /// `{{ keychain.openai_token.api_key }}`.  Uses minijinja's
+    /// `undeclared_variables(true)` to get the nested dotted paths (same
+    /// mechanism as [`Self::template_has_unresolved_path`]); a fragment that
+    /// won't parse is treated as non-keychain (rendered normally, matching the
+    /// prior behaviour for malformed fragments).
+    fn template_references_keychain(&self, s: &str) -> bool {
+        if !contains_template_syntax(s) {
+            return false;
+        }
+        let tmpl = match self.env.template_from_str(s) {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+        tmpl.undeclared_variables(true)
+            .iter()
+            .any(|path| path == "keychain" || path.starts_with("keychain."))
+    }
+
     /// Evaluate a condition expression.
     pub fn evaluate_condition(
         &self,

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -23,6 +23,7 @@ use crate::playbook::types::Playbook;
 use crate::secrets::{build_secret_provider, dynamic, resolve_keychain_entry_with_meta};
 use crate::services::keychain::KeychainService;
 use crate::services::keychain_refresh::RefreshInflight;
+use crate::template::TemplateRenderer;
 
 /// TTL (seconds) for a keychain-resolved secret cached after a provider fetch.
 /// Execution-scoped, so it's also cleaned up when the execution ends; the TTL
@@ -256,10 +257,55 @@ impl CredentialService {
             }
         };
 
-        // Only provider-backed keychain entries resolve here.
         let Some(kc) = playbook.find_keychain(alias) else {
             return Ok(None);
         };
+
+        // `kind: credential` keychain entry (noetl/ai-meta#151): an entry with
+        // no `provider:` but a `credential:` reference indirects to a stored
+        // credential in `noetl.credential`.  Render the reference against the
+        // execution's workload, fetch that stored credential, and return its
+        // decrypted data object so `{{ keychain.<alias>.<field> }}` resolves.
+        // Without this the entry fell through to the `provider` check below and
+        // returned `None` — the empty-token root cause for the auth0 fixtures.
+        if kc.provider.is_none() {
+            let Some(cred_ref_template) = kc.credential.clone() else {
+                return Ok(None);
+            };
+            let workload_map: HashMap<String, serde_json::Value> = workload
+                .as_ref()
+                .and_then(|w| w.as_object())
+                .map(|m| m.clone().into_iter().collect())
+                .unwrap_or_default();
+            let cred_alias = TemplateRenderer::new()
+                .render(&cred_ref_template, &workload_map)?
+                .trim()
+                .to_string();
+            if cred_alias.is_empty() {
+                tracing::warn!(
+                    execution_id,
+                    alias,
+                    "keychain.resolve: `kind: credential` entry rendered an empty `credential:` reference"
+                );
+                return Ok(None);
+            }
+            return match self.find_credential(&cred_alias).await {
+                Ok(cred_entry) => {
+                    let data = self.cipher.open_storage_json(&cred_entry.data).await?;
+                    tracing::info!(
+                        execution_id,
+                        alias,
+                        credential = %cred_alias,
+                        "keychain.resolve: credential-indirect"
+                    );
+                    Ok(Some(data))
+                }
+                Err(AppError::NotFound(_)) => Ok(None),
+                Err(e) => Err(e),
+            };
+        }
+
+        // Only provider-backed keychain entries resolve past here.
         let Some(provider_id) = kc.provider.as_deref() else {
             return Ok(None);
         };


### PR DESCRIPTION
## Summary

`{{ keychain.<alias>.<field> }}` references in a step's tool config rendered to an empty string → downstream auth calls sent an empty credential → 401 (noetl/ai-meta#151).

Root cause: the drive (`orchestrate-core::build_tool_command`, run in the `system/orchestrate` wasm plug-in) renders tool configs against a context with no `keychain` namespace. Resolving the secret there would also persist it in the command / event log.

## Changes

- **orchestrate-core**: `render_value_deferring_keychain` leaves any string referencing the `keychain` root verbatim; `build_tool_command` uses it. The secret is **deferred** through the drive and resolved transiently at user-worker dispatch (same discipline as `auth:`), so it never lands in `noetl.event`. Non-keychain templates render byte-identically.
- **credential service**: `resolve_via_provider` now resolves `kind: credential` keychain entries (a `credential:` reference, no `provider:`) by rendering the reference against the workload → stored-credential lookup.

## Validation (LOCAL kind)

- `keychain.openai_token.api_key` (secrets/gcp) → OpenAI `GET /v1/models` **200**; `command.issued` carries the **deferred** `{{ }}` (secret NOT in event log).
- `kind: credential` probe → deferred + resolved, no leak.

The worker half (namespace injection + substitution) is noetl/worker#<pending>.

Refs noetl/ai-meta#151