### PR TITLE
feat(command-bus): L1 T4 server publish wiring behind NOETL_COMMAND_BUS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-schema"
+version = "53.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +613,38 @@ dependencies = [
  "sha2",
  "signature",
  "subtle",
+]
+
+[[package]]
+name = "ehdb-core"
+version = "0.1.0"
+source = "git+https://github.com/noetl/ehdb?rev=ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c#ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c"
+dependencies = [
+ "arrow-schema",
+ "serde",
+]
+
+[[package]]
+name = "ehdb-feed"
+version = "0.1.0"
+source = "git+https://github.com/noetl/ehdb?rev=ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c#ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c"
+dependencies = [
+ "ehdb-core",
+ "ehdb-l0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "ehdb-l0"
+version = "0.1.0"
+source = "git+https://github.com/noetl/ehdb?rev=ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c#ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c"
+dependencies = [
+ "ehdb-core",
+ "serde",
+ "serde_json",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1449,6 +1490,8 @@ dependencies = [
  "chrono",
  "ctor",
  "dotenvy",
+ "ehdb-feed",
+ "ehdb-l0",
  "envy",
  "gcp_auth",
  "hex",
@@ -3102,6 +3145,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "rand 0.8.6",
+ "serde",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,10 @@ gcp_auth = "0.12"
 
 # NATS messaging
 async-nats = "0.38"
+# EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
+# The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
+ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.

--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -1,0 +1,173 @@
+//! **L1 T4 — the EHDB command bus (flag-gated).**
+//!
+//! Selects the transport that carries command notifications to workers, behind
+//! [`NOETL_COMMAND_BUS`](CommandBusMode). Default `nats` leaves today's path
+//! untouched. `ehdb` publishes each command to the per-shard EHDB writer (the
+//! cutover). `shadow` publishes to **both** — NATS stays authoritative and
+//! workers keep consuming it, while the same command is mirrored onto the EHDB
+//! bus so a shadow consumer can verify parity before any flip.
+//!
+//! A command notification maps to a D1 [`EventRecord`]: `event_id` is the sort
+//! key (monotonic → the single-writer ascending contract holds per shard),
+//! `execution_id` is the shard key (`shard_for_execution` is byte-identical to
+//! the server/worker `shard_for`), and the notification JSON is the payload —
+//! the worker decodes it back and fetches full command details from the API,
+//! exactly as it does off NATS today.
+//!
+//! The publisher is **lazy-connected**: it dials the writers on first publish
+//! (and drops + redials on error), so the stateless server never hard-depends on
+//! the writers being up at boot — matching how it tolerates NATS being absent.
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+
+use ehdb_feed::PublishRouter;
+use ehdb_l0::{D1EventLog, EventRecord};
+use tokio::sync::Mutex;
+
+/// Which transport carries command notifications (env `NOETL_COMMAND_BUS`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CommandBusMode {
+    /// Publish to NATS only — today's path (default).
+    #[default]
+    Nats,
+    /// Publish to the per-shard EHDB writer only — the cutover.
+    Ehdb,
+    /// Publish to both: NATS authoritative, EHDB mirrored for parity comparison.
+    Shadow,
+}
+
+impl CommandBusMode {
+    /// Parse the `NOETL_COMMAND_BUS` value; anything unrecognised is the safe
+    /// default (`nats`).
+    pub fn from_env_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "ehdb" => Self::Ehdb,
+            "shadow" => Self::Shadow,
+            _ => Self::Nats,
+        }
+    }
+
+    /// Whether this mode publishes to the EHDB bus.
+    pub fn publishes_ehdb(self) -> bool {
+        matches!(self, Self::Ehdb | Self::Shadow)
+    }
+
+    /// Whether this mode publishes to NATS.
+    pub fn publishes_nats(self) -> bool {
+        matches!(self, Self::Nats | Self::Shadow)
+    }
+}
+
+/// Parse `NOETL_COMMAND_BUS_WRITER_ADDRS` = `"0@host:port,1@host:port,..."` into
+/// a shard→address map. Entries that don't parse are skipped (logged by the
+/// caller); an empty map means "no writers configured".
+pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, SocketAddr> {
+    let mut out = BTreeMap::new();
+    for entry in spec.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let Some((shard, addr)) = entry.split_once('@') else {
+            continue;
+        };
+        let (Ok(shard), Ok(addr)) = (
+            shard.trim().parse::<u32>(),
+            addr.trim().parse::<SocketAddr>(),
+        ) else {
+            continue;
+        };
+        out.insert(shard, addr);
+    }
+    out
+}
+
+/// A lazily-connected EHDB command publisher over the per-shard writers.
+pub struct EhdbCommandPublisher {
+    shard_count: u32,
+    addrs: BTreeMap<u32, SocketAddr>,
+    router: Mutex<Option<PublishRouter<D1EventLog>>>,
+}
+
+impl EhdbCommandPublisher {
+    /// A publisher routing over `shard_count` shards to the writers at `addrs`.
+    pub fn new(shard_count: u32, addrs: BTreeMap<u32, SocketAddr>) -> Self {
+        Self {
+            shard_count: shard_count.max(1),
+            addrs,
+            router: Mutex::new(None),
+        }
+    }
+
+    /// Whether any writer address is configured.
+    pub fn is_configured(&self) -> bool {
+        !self.addrs.is_empty()
+    }
+
+    /// Publish one command notification onto the EHDB bus. `execution_id` routes
+    /// the shard; `event_id` is the sort key; `payload` is the notification JSON.
+    /// Returns the writer-assigned sort key. Lazily (re)connects the router.
+    pub async fn publish(
+        &self,
+        execution_id: i64,
+        event_id: i64,
+        payload: &[u8],
+    ) -> Result<u64, String> {
+        let record = EventRecord::new(
+            event_id as u64,
+            execution_id.to_string(),
+            String::new(),
+            String::from_utf8_lossy(payload).into_owned(),
+        );
+        let mut guard = self.router.lock().await;
+        if guard.is_none() {
+            let router = PublishRouter::<D1EventLog>::connect(self.shard_count, self.addrs.clone())
+                .await
+                .map_err(|e| format!("EHDB writer connect failed: {e}"))?;
+            *guard = Some(router);
+        }
+        match guard.as_mut().unwrap().publish(&record).await {
+            Ok(seq) => Ok(seq),
+            Err(e) => {
+                // Drop the router so the next publish redials (writer restarted,
+                // rolled, or a shard moved).
+                *guard = None;
+                Err(format!("EHDB publish failed: {e}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_parsing_defaults_to_nats() {
+        assert_eq!(CommandBusMode::from_env_value("nats"), CommandBusMode::Nats);
+        assert_eq!(CommandBusMode::from_env_value("EHDB"), CommandBusMode::Ehdb);
+        assert_eq!(
+            CommandBusMode::from_env_value(" Shadow "),
+            CommandBusMode::Shadow
+        );
+        assert_eq!(
+            CommandBusMode::from_env_value("garbage"),
+            CommandBusMode::Nats
+        );
+        assert_eq!(CommandBusMode::default(), CommandBusMode::Nats);
+        assert!(CommandBusMode::Shadow.publishes_ehdb() && CommandBusMode::Shadow.publishes_nats());
+        assert!(CommandBusMode::Ehdb.publishes_ehdb() && !CommandBusMode::Ehdb.publishes_nats());
+        assert!(!CommandBusMode::Nats.publishes_ehdb() && CommandBusMode::Nats.publishes_nats());
+    }
+
+    #[test]
+    fn writer_addr_parsing() {
+        let m = parse_writer_addrs("0@127.0.0.1:9100, 1@127.0.0.1:9101 ,bad,2@10.0.0.5:9100");
+        assert_eq!(m.len(), 3);
+        assert_eq!(m[&0], "127.0.0.1:9100".parse().unwrap());
+        assert_eq!(m[&1], "127.0.0.1:9101".parse().unwrap());
+        assert_eq!(m[&2], "10.0.0.5:9100".parse().unwrap());
+        assert!(parse_writer_addrs("").is_empty());
+    }
+}

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -194,6 +194,22 @@ pub struct AppConfig {
     #[serde(default)]
     pub command_shard_count: Option<u32>,
 
+    /// noetl/ai-meta#194 L1 T4 — the command-bus transport. Envy maps
+    /// `NOETL_COMMAND_BUS`. `nats` (default / any unrecognised value) keeps
+    /// today's path; `ehdb` publishes commands to the per-shard EHDB writer
+    /// (the cutover); `shadow` publishes to both (NATS authoritative, EHDB
+    /// mirrored for parity). Parsed by [`crate::command_bus::CommandBusMode`].
+    #[serde(default)]
+    pub command_bus: Option<String>,
+
+    /// noetl/ai-meta#194 L1 T4 — the per-shard EHDB writers' ingest addresses,
+    /// `"0@host:port,1@host:port,..."`. Envy maps
+    /// `NOETL_COMMAND_BUS_WRITER_ADDRS`. Only consulted when [`Self::command_bus`]
+    /// selects `ehdb`/`shadow`. Empty → no writers configured (publishes skipped
+    /// with a WARN, like NATS-not-configured).
+    #[serde(default)]
+    pub command_bus_writer_addrs: Option<String>,
+
     /// Maximum serialised size (bytes) of a `command.issued` event's `context`
     /// before it is offloaded to the result store (noetl/ai-meta#114).  When the
     /// off-server orchestrate drive (`orchestrate_plugin_drive`) builds the next
@@ -807,6 +823,8 @@ impl Default for AppConfig {
             // noetl/ai-meta#166 Phase 5: server-routed shard publish is opt-in.
             shard_subject_route: false,
             command_shard_count: None,
+            command_bus: None,
+            command_bus_writer_addrs: None,
             command_context_max_bytes: default_command_context_max_bytes(),
             // noetl/ai-meta#115 Phase 3: event-scan is the default; chain_walk is opt-in.
             state_build_mode: StateBuildMode::EventScan,
@@ -903,7 +921,9 @@ mod tests {
     fn test_tail_attach_scoping() {
         // Master flag off → never, regardless of prefixes.
         let mut cfg = AppConfig::default();
-        assert!(!cfg.tail_attach_applies("muno/playbooks/itinerary-planner", "muno_itinerary_planner"));
+        assert!(
+            !cfg.tail_attach_applies("muno/playbooks/itinerary-planner", "muno_itinerary_planner")
+        );
 
         // Flag on, empty allowlist → applies to all (original global behavior).
         cfg.offserver_attach_tail = true;
@@ -914,7 +934,9 @@ mod tests {
             "muno/playbooks/itinerary-planner".to_string(),
             "automation/agents/mcp/".to_string(),
         ];
-        assert!(cfg.tail_attach_applies("muno/playbooks/itinerary-planner", "muno_itinerary_planner"));
+        assert!(
+            cfg.tail_attach_applies("muno/playbooks/itinerary-planner", "muno_itinerary_planner")
+        );
         assert!(cfg.tail_attach_applies("automation/agents/mcp/duffel", "duffel_mcp"));
         // The auth/login + session-validate drives — the parked regression — stay off.
         assert!(!cfg.tail_attach_applies("api_integration/auth0/auth0_login", "auth0_login"));

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -331,8 +331,14 @@ pub(crate) async fn execute_one(
             DedupOutcome::Duplicate {
                 existing_execution_id,
             } => {
-                emit_deduplicated_event(state, scope, &dedup.key, existing_execution_id, execution_id)
-                    .await;
+                emit_deduplicated_event(
+                    state,
+                    scope,
+                    &dedup.key,
+                    existing_execution_id,
+                    execution_id,
+                )
+                .await;
                 crate::metrics::record_execute_outcome(entry, "duplicate");
                 info!(
                     subscription_id = scope,
@@ -401,10 +407,7 @@ pub(crate) async fn execute_one(
         _ => None,
     };
     let routing = CommandRouting {
-        pool: request
-            .execution_pool
-            .clone()
-            .filter(|s| !s.is_empty()),
+        pool: request.execution_pool.clone().filter(|s| !s.is_empty()),
         trace,
     };
 
@@ -497,14 +500,12 @@ async fn emit_deduplicated_event(
         // Cold descriptor under audit_only: catalog_id from `noetl.command` — the
         // synchronous queue — ZERO `noetl.event` read.
         crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "served_command");
-        sqlx::query_scalar(
-            "SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1",
-        )
-        .bind(scope)
-        .fetch_optional(state.pools.pool_for(scope))
-        .await
-        .ok()
-        .flatten()
+        sqlx::query_scalar("SELECT catalog_id FROM noetl.command WHERE execution_id = $1 LIMIT 1")
+            .bind(scope)
+            .fetch_optional(state.pools.pool_for(scope))
+            .await
+            .ok()
+            .flatten()
     } else {
         crate::metrics::record_event_hotpath_read("dedup_audit_catalog", "scan");
         sqlx::query_scalar(
@@ -517,7 +518,10 @@ async fn emit_deduplicated_event(
         .flatten()
     };
     let Some(catalog_id) = catalog_id else {
-        tracing::debug!(subscription_id = scope, "dedup audit: no catalog_id for scope; skipping audit event");
+        tracing::debug!(
+            subscription_id = scope,
+            "dedup audit: no catalog_id for scope; skipping audit event"
+        );
         return;
     };
     let context = serde_json::json!({
@@ -681,7 +685,10 @@ async fn emit_playbook_started_event(
 /// Inherit the W3C trace context (RFC §7.4) from a parent execution's
 /// `playbook_started` event so a child run joins the same distributed trace.
 /// Best-effort: a missing parent / missing trace simply yields `None`.
-async fn inherit_parent_trace(state: &AppState, parent_execution_id: i64) -> Option<serde_json::Value> {
+async fn inherit_parent_trace(
+    state: &AppState,
+    parent_execution_id: i64,
+) -> Option<serde_json::Value> {
     // RFC #115 Phase 6: under `event_read_path=audit_only`, read the parent's
     // trace off its in-memory execute-time descriptor (its `routing_meta` is the
     // `playbook_started` meta this query reads) — ZERO `noetl.event` read.  A cold
@@ -692,7 +699,10 @@ async fn inherit_parent_trace(state: &AppState, parent_execution_id: i64) -> Opt
     ) {
         if let Some(desc) = state.exec_descriptors.get(parent_execution_id).await {
             if desc.catalog_id != 0 {
-                crate::metrics::record_event_hotpath_read("inherit_parent_trace", "served_descriptor");
+                crate::metrics::record_event_hotpath_read(
+                    "inherit_parent_trace",
+                    "served_descriptor",
+                );
                 return desc
                     .routing_meta
                     .as_ref()
@@ -1035,7 +1045,10 @@ pub(crate) async fn persist_engine_commands_batch(
 
         let event_id = state.snowflake.generate()?;
         let command_id = if let Some(iter) = command.iterator.as_ref() {
-            format!("{}:{}:{}:i{}", execution_id, step.step, event_id, iter.index)
+            format!(
+                "{}:{}:{}:i{}",
+                execution_id, step.step, event_id, iter.index
+            )
         } else {
             format!("{}:{}:{}", execution_id, step.step, event_id)
         };
@@ -1078,7 +1091,10 @@ pub(crate) async fn persist_engine_commands_batch(
                     "iterator_step".to_string(),
                     serde_json::json!(iter.iterator_step.clone()),
                 );
-                map.insert("item_var".to_string(), serde_json::json!(iter.item_var.clone()));
+                map.insert(
+                    "item_var".to_string(),
+                    serde_json::json!(iter.item_var.clone()),
+                );
             }
         }
         if let Some(trace) = routing.trace.as_ref() {
@@ -1363,7 +1379,8 @@ async fn generate_initial_commands(
         // ranges and strings to splits), the initial-dispatch boundary
         // enforces strict array typing so callers pass an explicit list.
         let renderer = crate::template::TemplateRenderer::new();
-        let raw_value = renderer.render_to_value(loop_cfg.in_expr.as_deref().unwrap_or(""), &context)?;
+        let raw_value =
+            renderer.render_to_value(loop_cfg.in_expr.as_deref().unwrap_or(""), &context)?;
 
         let items: Vec<serde_json::Value> = match raw_value {
             serde_json::Value::Array(arr) => arr,
@@ -1603,14 +1620,10 @@ async fn publish_command_notification(
     playbook: &crate::playbook::types::Playbook,
     routing: &CommandRouting,
 ) -> AppResult<()> {
-    let Some(nats_client) = state.nats.as_ref() else {
-        tracing::warn!(
-            execution_id,
-            event_id,
-            "NATS not configured; command notification skipped — worker won't claim this command"
-        );
-        return Ok(());
-    };
+    // noetl/ai-meta#194 L1 T4 — the command-bus transport. `nats` (default)
+    // preserves the exact path below; `ehdb`/`shadow` also/only publish to the
+    // EHDB writer (see the dispatch after the notification is built).
+    let mode = state.command_bus_mode;
 
     // Pool segment selection (noetl/ai-meta#90 Phase 2).  Precedence:
     //   1. an explicit per-execution `execution_pool` override (the
@@ -1676,23 +1689,75 @@ async fn publish_command_notification(
     let payload = serde_json::to_vec(&notification)
         .map_err(|e| AppError::Internal(format!("Serialize command notification: {e}")))?;
 
-    let js = async_nats::jetstream::new((**nats_client).clone());
-    js.publish(subject.clone(), payload.into())
-        .await
-        .map_err(|e| AppError::Internal(format!("NATS publish failed: {e}")))?
-        .await
-        .map_err(|e| AppError::Internal(format!("NATS publish ack failed: {e}")))?;
+    // --- EHDB command bus (L1 T4) --------------------------------------------
+    // In `ehdb`/`shadow` mode, mirror the command onto the per-shard EHDB writer
+    // (routed by execution_id; event_id is the sort key). In `ehdb` mode a
+    // publish failure fails the dispatch (the command wasn't delivered); in
+    // `shadow` mode NATS is authoritative, so a failure is logged and swallowed.
+    if mode.publishes_ehdb() {
+        match state.ehdb_command_publisher.as_ref() {
+            Some(publisher) => match publisher.publish(execution_id, event_id, &payload).await {
+                Ok(seq) => {
+                    tracing::info!(
+                        execution_id,
+                        event_id,
+                        ehdb_sort_key = seq,
+                        command_id = %command_id,
+                        "Published command notification to EHDB bus"
+                    );
+                }
+                Err(e) => {
+                    if matches!(mode, crate::command_bus::CommandBusMode::Ehdb) {
+                        return Err(AppError::Internal(format!("EHDB command publish: {e}")));
+                    }
+                    tracing::warn!(
+                        execution_id,
+                        event_id,
+                        error = %e,
+                        "EHDB shadow command publish failed (NATS authoritative)"
+                    );
+                }
+            },
+            None if matches!(mode, crate::command_bus::CommandBusMode::Ehdb) => {
+                tracing::warn!(
+                    execution_id,
+                    event_id,
+                    "EHDB command bus selected but no writers configured; command not delivered"
+                );
+            }
+            None => {}
+        }
+    }
 
-    crate::metrics::record_command_publish(publish_route, pool_segment);
+    // --- NATS command bus (today's path) -------------------------------------
+    if mode.publishes_nats() {
+        let Some(nats_client) = state.nats.as_ref() else {
+            tracing::warn!(
+                execution_id,
+                event_id,
+                "NATS not configured; command notification skipped — worker won't claim this command"
+            );
+            return Ok(());
+        };
 
-    tracing::info!(
-        execution_id,
-        event_id,
-        %subject,
-        route = publish_route,
-        command_id = %command_id,
-        "Published command notification to NATS"
-    );
+        let js = async_nats::jetstream::new((**nats_client).clone());
+        js.publish(subject.clone(), payload.into())
+            .await
+            .map_err(|e| AppError::Internal(format!("NATS publish failed: {e}")))?
+            .await
+            .map_err(|e| AppError::Internal(format!("NATS publish ack failed: {e}")))?;
+
+        crate::metrics::record_command_publish(publish_route, pool_segment);
+
+        tracing::info!(
+            execution_id,
+            event_id,
+            %subject,
+            route = publish_route,
+            command_id = %command_id,
+            "Published command notification to NATS"
+        );
+    }
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 
 pub mod affinity;
 pub mod coherence;
+pub mod command_bus;
 pub mod config;
 pub mod crypto;
 pub mod db;
@@ -61,11 +62,11 @@ pub mod sanitize;
 pub mod secrets;
 pub mod services;
 pub mod sharding;
-pub mod system_plugins;
-pub mod tls;
 pub mod snowflake;
 pub mod state;
+pub mod system_plugins;
 pub mod template;
+pub mod tls;
 
 pub use error::{AppError, AppResult};
 pub use result_ext::ResultExt;

--- a/src/state.rs
+++ b/src/state.rs
@@ -142,6 +142,16 @@ pub struct AppState {
     /// (default) path never builds it and the gate-on path ensures the stream
     /// exactly once.  `None` inner stays uninitialised until the first publish.
     pub event_stream_publisher: Arc<tokio::sync::OnceCell<crate::nats::EventStreamPublisher>>,
+
+    /// noetl/ai-meta#194 L1 T4 — the command-bus transport mode
+    /// (`NOETL_COMMAND_BUS`; default `nats`). Selects whether command
+    /// notifications go to NATS, the EHDB writer, or both (shadow).
+    pub command_bus_mode: crate::command_bus::CommandBusMode,
+
+    /// noetl/ai-meta#194 L1 T4 — the lazily-connected EHDB command publisher.
+    /// `Some` only when `command_bus_mode` publishes to EHDB and writers are
+    /// configured; `None` keeps the NATS-only path with zero new state.
+    pub ehdb_command_publisher: Option<Arc<crate::command_bus::EhdbCommandPublisher>>,
 }
 
 /// Cached orchestrator state for one execution, advanced incrementally.
@@ -180,7 +190,6 @@ pub struct ExecOrchState {
     /// only; a server restart re-derives the drive from the event log.
     pub orchestrate_in_flight: bool,
 }
-
 
 /// Per-execution chain head for the one-level event chain (RFC #115 Phase 2,
 /// noetl/ai-meta#115 §4).  Maps `execution_id → event_id of the last event
@@ -289,16 +298,15 @@ impl ChainHeads {
         if self.coherence.enabled() {
             match self.coherence.get_head(execution_id).await {
                 crate::coherence::KvRead::Hit(v) => {
-                    let local_had = self
-                        .map
-                        .lock()
-                        .unwrap()
-                        .insert(execution_id, v)
-                        .is_some();
+                    let local_had = self.map.lock().unwrap().insert(execution_id, v).is_some();
                     crate::metrics::record_replica_coherence(
                         "chain_head",
                         "head",
-                        if local_had { "kv_local_hit" } else { "kv_remote_hit" },
+                        if local_had {
+                            "kv_local_hit"
+                        } else {
+                            "kv_remote_hit"
+                        },
                     );
                     return Some(v);
                 }
@@ -353,7 +361,9 @@ impl ChainHeads {
 /// reconcile path — so correctness is preserved, worst case equals today.
 #[derive(Default)]
 pub struct ChainTails {
-    map: std::sync::Mutex<std::collections::HashMap<i64, std::collections::VecDeque<serde_json::Value>>>,
+    map: std::sync::Mutex<
+        std::collections::HashMap<i64, std::collections::VecDeque<serde_json::Value>>,
+    >,
 }
 
 impl ChainTails {
@@ -496,7 +506,11 @@ impl ExecDescriptors {
                     crate::metrics::record_replica_coherence(
                         "descriptor",
                         "get",
-                        if local.is_some() { "kv_local_hit" } else { "kv_remote_hit" },
+                        if local.is_some() {
+                            "kv_local_hit"
+                        } else {
+                            "kv_remote_hit"
+                        },
                     );
                     self.map.lock().unwrap().insert(execution_id, desc.clone());
                     return Some(desc);
@@ -506,11 +520,7 @@ impl ExecDescriptors {
                     return None;
                 }
                 crate::coherence::KvRead::Unavailable => {
-                    crate::metrics::record_replica_coherence(
-                        "descriptor",
-                        "get",
-                        "kv_unavailable",
-                    );
+                    crate::metrics::record_replica_coherence("descriptor", "get", "kv_unavailable");
                     return local;
                 }
             }
@@ -635,9 +645,7 @@ impl FinalizedGuard {
 /// (different executions never contend).
 #[derive(Default)]
 pub struct OrchStateCache {
-    map: std::sync::Mutex<
-        std::collections::HashMap<i64, Arc<tokio::sync::Mutex<ExecOrchState>>>,
-    >,
+    map: std::sync::Mutex<std::collections::HashMap<i64, Arc<tokio::sync::Mutex<ExecOrchState>>>>,
 }
 
 impl OrchStateCache {
@@ -791,12 +799,49 @@ impl AppState {
             "Replica coherence backend initialized"
         );
 
+        // noetl/ai-meta#194 L1 T4 — the command-bus transport. Default `nats`
+        // leaves the path unchanged and builds no EHDB state. `ehdb`/`shadow`
+        // build a lazily-connected publisher over the per-shard writers (routed
+        // by `command_shard_count`, which must match the worker pool's shards).
+        let command_bus_mode = crate::command_bus::CommandBusMode::from_env_value(
+            config.command_bus.as_deref().unwrap_or("nats"),
+        );
+        let ehdb_command_publisher = if command_bus_mode.publishes_ehdb() {
+            let addrs = crate::command_bus::parse_writer_addrs(
+                config.command_bus_writer_addrs.as_deref().unwrap_or(""),
+            );
+            let shard_count = config.command_shard_count.unwrap_or(1);
+            if addrs.is_empty() {
+                tracing::warn!(
+                    ?command_bus_mode,
+                    "NOETL_COMMAND_BUS selects EHDB but NOETL_COMMAND_BUS_WRITER_ADDRS is empty; \
+                     EHDB command publishes will be skipped"
+                );
+                None
+            } else {
+                tracing::info!(
+                    ?command_bus_mode,
+                    shard_count,
+                    writers = addrs.len(),
+                    "EHDB command bus enabled"
+                );
+                Some(Arc::new(crate::command_bus::EhdbCommandPublisher::new(
+                    shard_count,
+                    addrs,
+                )))
+            }
+        } else {
+            None
+        };
+
         Self {
             db,
             pools,
             config: Arc::new(config),
             nats,
             snowflake: Arc::new(snowflake),
+            command_bus_mode,
+            ehdb_command_publisher,
             shard,
             affinity,
             start_time: std::time::Instant::now(),
@@ -819,11 +864,7 @@ impl AppState {
     /// built from [`ShardingConfig::from_env`] so the production
     /// path honors `NOETL_SHARDS` if set.  Test code that
     /// already has a `DbPool` in hand uses this shim.
-    pub fn new_legacy(
-        db: DbPool,
-        config: AppConfig,
-        nats: Option<async_nats::Client>,
-    ) -> Self {
+    pub fn new_legacy(db: DbPool, config: AppConfig, nats: Option<async_nats::Client>) -> Self {
         let pools = DbPoolMap::from_single_pool(db.clone());
         Self::new(db, pools, config, nats)
     }
@@ -898,13 +939,19 @@ mod tests {
     fn finalized_guard_first_terminal_wins_duplicate_suppressed() {
         let g = FinalizedGuard::new(8);
         assert!(!g.contains(7), "cold execution is not finalized");
-        assert!(g.mark(7), "first terminal for an execution is newly inserted");
+        assert!(
+            g.mark(7),
+            "first terminal for an execution is newly inserted"
+        );
         assert!(g.contains(7), "now recorded as finalized");
         // Every subsequent terminal for the SAME execution is a duplicate.
         assert!(!g.mark(7), "second terminal is a suppressed duplicate");
         assert!(!g.mark(7), "third terminal is still a suppressed duplicate");
         // A different execution is independent.
-        assert!(g.mark(8), "a different execution's first terminal still wins");
+        assert!(
+            g.mark(8),
+            "a different execution's first terminal still wins"
+        );
         assert!(!g.mark(8));
     }
 
@@ -937,7 +984,12 @@ mod tests {
         let d = ExecDescriptors::default();
         assert!(d.get(7).await.is_none(), "cold execution has no descriptor");
 
-        d.seed(7, 42, Some(serde_json::json!({"execution_pool": "default"}))).await;
+        d.seed(
+            7,
+            42,
+            Some(serde_json::json!({"execution_pool": "default"})),
+        )
+        .await;
         let got = d.get(7).await.expect("seeded");
         assert_eq!(got.catalog_id, 42);
         assert_eq!(got.routing_meta.unwrap()["execution_pool"], "default");
@@ -948,7 +1000,10 @@ mod tests {
         d.mark_terminal(7).await;
         let got = d.get(7).await.expect("still present");
         assert!(got.terminal, "terminal flag set");
-        assert_eq!(got.catalog_id, 42, "catalog_id preserved across terminal stamp");
+        assert_eq!(
+            got.catalog_id, 42,
+            "catalog_id preserved across terminal stamp"
+        );
 
         d.evict(7).await;
         assert!(d.get(7).await.is_none(), "evicted");
@@ -964,7 +1019,10 @@ mod tests {
         d.seed(9, 0, None).await;
         let got = d.get(9).await.expect("present");
         assert!(got.terminal, "terminal flag survives a seed");
-        assert_eq!(got.catalog_id, 0, "catalog_id stays 0 (nothing real to seed yet)");
+        assert_eq!(
+            got.catalog_id, 0,
+            "catalog_id stays 0 (nothing real to seed yet)"
+        );
         // A real seed fills catalog_id, still keeping terminal.
         d.seed(9, 55, Some(serde_json::json!({"x": 1}))).await;
         let got = d.get(9).await.expect("present");
@@ -990,7 +1048,11 @@ mod tests {
         // links each row to the previous one in order; the first to the head.
         let prevs = heads.link_batch(7, &[10, 11, 12]).await;
         assert_eq!(prevs, vec![None, Some(10), Some(11)]);
-        assert_eq!(heads.head(7).await, Some(12), "head advances to the last id");
+        assert_eq!(
+            heads.head(7).await,
+            Some(12),
+            "head advances to the last id"
+        );
         // A following batch continues the chain from the advanced head.
         let prevs = heads.link_batch(7, &[20, 21]).await;
         assert_eq!(prevs, vec![Some(12), Some(20)]);
@@ -1041,7 +1103,11 @@ mod tests {
         heads.link_batch(7, &[10]).await;
         assert_eq!(heads.head(7).await, Some(10));
         heads.evict(7).await;
-        assert_eq!(heads.head(7).await, None, "evicted execution starts a fresh chain");
+        assert_eq!(
+            heads.head(7).await,
+            None,
+            "evicted execution starts a fresh chain"
+        );
         // After eviction the next event is treated as a root again.
         let prevs = heads.link_batch(7, &[20]).await;
         assert_eq!(prevs, vec![None]);
@@ -1072,7 +1138,7 @@ mod tests {
             match prev_of.get(&id).copied().flatten() {
                 Some(prev) => cur = Some(prev),
                 None if id == genesis => cur = None, // reached the real root
-                None => return None,                // orphaned non-genesis head
+                None => return None,                 // orphaned non-genesis head
             }
         }
         walked.reverse();
@@ -1128,8 +1194,16 @@ mod tests {
         for (id, prev) in seq.iter().zip(fixed.link_batch(7, &seq).await) {
             prev_of.insert(*id, prev);
         }
-        assert_eq!(prev_of[&claimed], Some(issued), "claim links to command.issued");
-        assert_eq!(prev_of[&cmd_started], Some(claimed), "started links to claim");
+        assert_eq!(
+            prev_of[&claimed],
+            Some(issued),
+            "claim links to command.issued"
+        );
+        assert_eq!(
+            prev_of[&cmd_started],
+            Some(claimed),
+            "started links to claim"
+        );
         assert_eq!(fixed.head(7).await, Some(cmd_started));
         // The off-server spine walk now reconstructs the full sequence — complete.
         assert_eq!(


### PR DESCRIPTION
## L1 T4 (step 2) — noetl-server publish wiring

Wires the server's command dispatch to the EHDB command bus behind a new flag,
**defaulting to `nats` so today's path is byte-identical**.

`NOETL_COMMAND_BUS = nats (default) | ehdb | shadow`:
- **nats** — publish command notifications to NATS only (unchanged).
- **ehdb** — publish to the per-shard EHDB writer only (the cutover); a publish
  failure fails the dispatch (command not delivered).
- **shadow** — publish to **both**: NATS authoritative + workers keep consuming it,
  EHDB mirrored for parity comparison; an EHDB failure is logged, not fatal.

### How
New `command_bus` module: `CommandBusMode` + a **lazily-connected**
`EhdbCommandPublisher` over `PublishRouter<D1EventLog>` (the `ehdb-feed` git dep —
the write half from noetl/ehdb#295). A command notification maps to a D1
`EventRecord`: `event_id` = sort key (monotonic → single-writer ascending contract
holds per shard), `execution_id` = shard key (`shard_for_execution` is
byte-identical to the server/worker `shard_for`), notification JSON = payload (the
worker decodes it and fetches full command details from the API, exactly as off
NATS today). Routed by `command_shard_count` (must equal the worker pool's shard
count). Lazy connect + drop-on-error redial, so the stateless server never
hard-depends on the writers being up at boot.

Config: `NOETL_COMMAND_BUS` + `NOETL_COMMAND_BUS_WRITER_ADDRS`
(`0@host:port,1@host:port`). Dispatch in `publish_command_notification`: EHDB first
(mirror/cutover), then the unchanged NATS block, each guarded by the mode.

### Verification
- `cargo check --lib` + `--bins` clean; `cargo fmt --check` clean.
- `command_bus` unit tests pass (mode parsing defaults to nats; writer-addr parsing).
- Default `nats` path unchanged (mode gates the EHDB block off; the NATS block is
  the prior code verbatim).

kind/local only, **additive, default off, no image built here, no prod**. Part of
the L1 T4 wiring (see noetl/ai-meta#194); worker consume wiring + KEDA scaler
follow, then the flagged worker-image build.

Refs noetl/ai-meta#194