### PR TITLE
feat(command-bus): DNS-resolvable writer addrs (L1 T4 finding #2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "ehdb-core"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c#ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c"
+source = "git+https://github.com/noetl/ehdb?rev=fa730e0b6b3a57e661518e8aa6e16b198121c576#fa730e0b6b3a57e661518e8aa6e16b198121c576"
 dependencies = [
  "arrow-schema",
  "serde",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "ehdb-feed"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c#ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c"
+source = "git+https://github.com/noetl/ehdb?rev=fa730e0b6b3a57e661518e8aa6e16b198121c576#fa730e0b6b3a57e661518e8aa6e16b198121c576"
 dependencies = [
  "ehdb-core",
  "ehdb-l0",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "ehdb-l0"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c#ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c"
+source = "git+https://github.com/noetl/ehdb?rev=fa730e0b6b3a57e661518e8aa6e16b198121c576#fa730e0b6b3a57e661518e8aa6e16b198121c576"
 dependencies = [
  "ehdb-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ gcp_auth = "0.12"
 async-nats = "0.38"
 # EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
 # The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
-ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c" }
-ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "ccdef55c0a7f50faf1a37c6bb7e4c2d89ef6bb3c" }
+ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "fa730e0b6b3a57e661518e8aa6e16b198121c576" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "fa730e0b6b3a57e661518e8aa6e16b198121c576" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.

--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -19,7 +19,6 @@
 //! the writers being up at boot — matching how it tolerates NATS being absent.
 
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
 
 use ehdb_feed::PublishRouter;
 use ehdb_l0::{D1EventLog, EventRecord};
@@ -60,9 +59,13 @@ impl CommandBusMode {
 }
 
 /// Parse `NOETL_COMMAND_BUS_WRITER_ADDRS` = `"0@host:port,1@host:port,..."` into
-/// a shard→address map. Entries that don't parse are skipped (logged by the
-/// caller); an empty map means "no writers configured".
-pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, SocketAddr> {
+/// a shard→address map. The address is kept as a `host:port` **string**, not a
+/// parsed `SocketAddr`, so a Kubernetes service DNS name
+/// (`noetl-cmdbus-writer.noetl.svc.cluster.local:9100`) passes and is resolved
+/// at connect time (finding #2, noetl/ai-meta#194). Entries missing an `@`, a
+/// numeric shard, or a `:port` separator are skipped; an empty map means "no
+/// writers configured".
+pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, String> {
     let mut out = BTreeMap::new();
     for entry in spec.split(',') {
         let entry = entry.trim();
@@ -72,13 +75,14 @@ pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, SocketAddr> {
         let Some((shard, addr)) = entry.split_once('@') else {
             continue;
         };
-        let (Ok(shard), Ok(addr)) = (
-            shard.trim().parse::<u32>(),
-            addr.trim().parse::<SocketAddr>(),
-        ) else {
+        let Ok(shard) = shard.trim().parse::<u32>() else {
             continue;
         };
-        out.insert(shard, addr);
+        let addr = addr.trim();
+        if addr.is_empty() || !addr.contains(':') {
+            continue;
+        }
+        out.insert(shard, addr.to_string());
     }
     out
 }
@@ -86,13 +90,14 @@ pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, SocketAddr> {
 /// A lazily-connected EHDB command publisher over the per-shard writers.
 pub struct EhdbCommandPublisher {
     shard_count: u32,
-    addrs: BTreeMap<u32, SocketAddr>,
+    addrs: BTreeMap<u32, String>,
     router: Mutex<Option<PublishRouter<D1EventLog>>>,
 }
 
 impl EhdbCommandPublisher {
-    /// A publisher routing over `shard_count` shards to the writers at `addrs`.
-    pub fn new(shard_count: u32, addrs: BTreeMap<u32, SocketAddr>) -> Self {
+    /// A publisher routing over `shard_count` shards to the writers at `addrs`
+    /// (`host:port` strings — DNS names resolved at connect time).
+    pub fn new(shard_count: u32, addrs: BTreeMap<u32, String>) -> Self {
         Self {
             shard_count: shard_count.max(1),
             addrs,
@@ -165,9 +170,22 @@ mod tests {
     fn writer_addr_parsing() {
         let m = parse_writer_addrs("0@127.0.0.1:9100, 1@127.0.0.1:9101 ,bad,2@10.0.0.5:9100");
         assert_eq!(m.len(), 3);
-        assert_eq!(m[&0], "127.0.0.1:9100".parse().unwrap());
-        assert_eq!(m[&1], "127.0.0.1:9101".parse().unwrap());
-        assert_eq!(m[&2], "10.0.0.5:9100".parse().unwrap());
+        assert_eq!(m[&0], "127.0.0.1:9100");
+        assert_eq!(m[&1], "127.0.0.1:9101");
+        assert_eq!(m[&2], "10.0.0.5:9100");
         assert!(parse_writer_addrs("").is_empty());
+    }
+
+    #[test]
+    fn writer_addr_parsing_accepts_dns_names() {
+        // Finding #2 (noetl/ai-meta#194): a K8s service DNS name is NOT a
+        // parseable `SocketAddr`, but must be kept for resolution at connect.
+        let m =
+            parse_writer_addrs("0@noetl-cmdbus-writer.noetl.svc.cluster.local:9100,1@writer-1:9100");
+        assert_eq!(m.len(), 2);
+        assert_eq!(m[&0], "noetl-cmdbus-writer.noetl.svc.cluster.local:9100");
+        assert_eq!(m[&1], "writer-1:9100");
+        // A host with no `:port` separator is rejected.
+        assert!(parse_writer_addrs("0@nohost").is_empty());
     }
 }

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -204,6 +204,7 @@ async fn validate_session_inner(
     // exact same validity CASE (expired / session-inactive / user-inactive →
     // invalid; else valid).  Parameterised bind replaces the playbook's
     // jsonb-escaped literal — same match semantics, safer quoting.
+    #[allow(clippy::type_complexity)] // one-off sqlx query-row tuple
     let row: Option<(i32, Option<String>, String, Option<String>, bool)> = sqlx::query_as(
         r#"
         SELECT
@@ -430,6 +431,7 @@ async fn login_create_session(
     // Identical CTE to auth0_login.create_user_session: upsert the Auth0 user,
     // copy same-email roles, create a fresh session, resolve the role names.
     // Parameterised binds replace the playbook's jsonb-escaped literals.
+    #[allow(clippy::type_complexity)] // one-off sqlx query-row tuple
     let row: Option<(String, i32, Option<String>, String, Option<String>, serde_json::Value)> =
         sqlx::query_as(
             r#"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -472,7 +472,7 @@ pub fn record_state_build(mode: &str, outcome: &str) {
 ///   `WHERE execution_id` scan — cold descriptor, or `event_read_path=event_scan`).
 ///
 /// The never-scan invariant proof (RFC §7): under `event_read_path=audit_only`
-/// + `state_builder=offserver`, across a full execution lifecycle the
+/// with `state_builder=offserver`, across a full execution lifecycle the
 /// `{outcome="scan"}` series stays **flat** (Δ0) while the lifecycle still
 /// completes — every hot-path event read was served from a read model, and
 /// `noetl.event` was scanned by nobody on the hot path.  Pairs with the

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -386,13 +386,12 @@ fn validate_spool_config(spool: &serde_yaml::Value) -> AppResult<()> {
                 )));
             }
         }
-        "local_disk" => {
-            if !nonempty("path") {
+        "local_disk"
+            if !nonempty("path") => {
                 return Err(AppError::Validation(
                     "subscription 'spool.backend' 'local_disk' requires a non-empty 'path'".into(),
                 ));
             }
-        }
         _ => {}
     }
     // `credential` is optional for gcs/s3 — absent means ADC / Workload

--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -337,7 +337,7 @@ impl ExecutionService {
             .into_iter()
             .flat_map(|(_idx, rows)| rows)
             .collect();
-        merged.sort_by(|a, b| b.3.cmp(&a.3));
+        merged.sort_by_key(|b| std::cmp::Reverse(b.3));
 
         // Stage 3 — cluster-master catalog lookup for the
         // (deduped) catalog_id set.  One SELECT regardless of

--- a/src/services/ui_schema.rs
+++ b/src/services/ui_schema.rs
@@ -284,11 +284,10 @@ fn extract_directives_from_line(line: &str) -> Directive {
                     d.credential = Some(strip_quotes(&raw_value));
                 }
             }
-            "description" => {
-                if !raw_value.is_empty() {
+            "description"
+                if !raw_value.is_empty() => {
                     d.description = Some(strip_quotes(&raw_value));
                 }
-            }
             _ => {
                 // Unknown directive — silently ignored to mirror Python.
             }


### PR DESCRIPTION
Adopts ehdb-feed `fa730e0`. Resolves L1 T4 kind-validation finding #2 (noetl/ai-meta#194): `parse_writer_addrs` keeps `NOETL_COMMAND_BUS_WRITER_ADDRS` as `host:port` strings and passes them through to `PublishRouter::connect`, which resolves DNS at connect time — a K8s service name works directly. New test `writer_addr_parsing_accepts_dns_names`.

Finding #1 (pool routing) needs no server change — the server already stamps `execution_pool` on every notification, which the worker-side coordinator routes on.

Also clears pre-existing clippy-1.97.1 lint debt blocking `-D warnings` — no behaviour change.

Gate: `cargo clippy --all-targets -D warnings` + `cargo test` green on 1.97.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)