### PR TITLE
ci: stop publishing noetl-server binary crate to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,21 @@ jobs:
             # Give the sparse index a moment so the root crate's publish resolves it.
             sleep 20
           fi
-      - name: Publish noetl-server crate
-        if: ${{ env.CRATES_IO_TOKEN != '' }}
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_TOKEN }}
-        run: cargo publish -p noetl-server
+      # noetl-server is a server BINARY, not a library.  The release
+      # artifact is the container image (ghcr.io/noetl/server, published
+      # by the publish-image job below); nothing on crates.io depends on
+      # noetl-server (verified: 0 reverse dependencies).  The crate also
+      # carries git-only dependencies (ehdb-feed / ehdb-l0, added by the
+      # EHDB NATS-takeover wiring in v3.55.0), and `cargo publish` rejects
+      # a crate whose git deps carry no version ("all dependencies must
+      # have a version requirement specified when publishing.  dependency
+      # `ehdb-feed` does not specify a version").  So this step could not
+      # succeed and we intentionally do NOT publish the noetl-server crate
+      # to crates.io.  The noetl-orchestrate-core library above is still
+      # published for anyone who wants the pure drive core.
+      # See https://github.com/noetl/ai-meta/issues/200.
+      - name: Publish noetl-server crate (intentionally skipped — binary, not a library)
+        run: echo "noetl-server is a binary; the release artifact is ghcr.io/noetl/server. Not publishing to crates.io (0 reverse deps; git-only ehdb deps forbid cargo publish)."
       - name: Skip publish (no token)
         if: ${{ env.CRATES_IO_TOKEN == '' }}
         run: echo "CRATES_IO_TOKEN is not set; skipping crate publish."


### PR DESCRIPTION
## Problem

The `publish-crate` job in `release.yml` has failed on every release
since **v3.55.0** (red on v3.55.0 / v3.56.0 / v3.57.0 / v3.58.0). The
`cargo publish -p noetl-server` step errors:

```
error: failed to verify manifest at `.../Cargo.toml`
Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency `ehdb-feed` does not specify a version
```

noetl-server picked up git-only dependencies `ehdb-feed` / `ehdb-l0`
(EHDB NATS-takeover wiring, v3.55.0), and `cargo publish` forbids
publishing a crate whose git deps carry no version.

**Only the crates.io publish is affected.** In the same run,
`publish-image` and `github-release` are green — `cargo build` and the
container-image build resolve git deps fine. `ghcr.io/noetl/server:3.58.0`
is published and healthy; the deploy path is unchanged.

## Fix

Stop publishing the `noetl-server` **binary** crate to crates.io:

- It's a server binary — the release artifact is the container image,
  not a library.
- **0 reverse dependencies** on crates.io (verified via the
  reverse-dependencies API; max published was 3.54.0). Nothing consumes
  it.

The `noetl-server` publish step is replaced with a documented no-op.
**The `noetl-orchestrate-core` library publish is untouched** — it's a
genuine library (pure drive core, native + wasm32) and keeps
publishing.

Surgical: only the `noetl-server` step changed; no other release step
touched.

Refs https://github.com/noetl/ai-meta/issues/200

🤖 Generated with [Claude Code](https://claude.com/claude-code)