### PR TITLE
fix(ehdb): bump ehdb pin to d4b6235 — command-bus delivery-loss fix (#203)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "ehdb-core"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=fa730e0b6b3a57e661518e8aa6e16b198121c576#fa730e0b6b3a57e661518e8aa6e16b198121c576"
+source = "git+https://github.com/noetl/ehdb?rev=d4b623512db279e55b0093cf7207f7b400dd511e#d4b623512db279e55b0093cf7207f7b400dd511e"
 dependencies = [
  "arrow-schema",
  "serde",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "ehdb-feed"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=fa730e0b6b3a57e661518e8aa6e16b198121c576#fa730e0b6b3a57e661518e8aa6e16b198121c576"
+source = "git+https://github.com/noetl/ehdb?rev=d4b623512db279e55b0093cf7207f7b400dd511e#d4b623512db279e55b0093cf7207f7b400dd511e"
 dependencies = [
  "ehdb-core",
  "ehdb-l0",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "ehdb-l0"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=fa730e0b6b3a57e661518e8aa6e16b198121c576#fa730e0b6b3a57e661518e8aa6e16b198121c576"
+source = "git+https://github.com/noetl/ehdb?rev=d4b623512db279e55b0093cf7207f7b400dd511e#d4b623512db279e55b0093cf7207f7b400dd511e"
 dependencies = [
  "ehdb-core",
  "serde",
@@ -678,7 +678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1892,7 +1892,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ gcp_auth = "0.12"
 async-nats = "0.38"
 # EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
 # The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
-ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "fa730e0b6b3a57e661518e8aa6e16b198121c576" }
-ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "fa730e0b6b3a57e661518e8aa6e16b198121c576" }
+ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "d4b623512db279e55b0093cf7207f7b400dd511e" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "d4b623512db279e55b0093cf7207f7b400dd511e" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.


### PR DESCRIPTION
## Summary

Bumps the ehdb git-rev pin to **d4b6235** (noetl/ehdb#300 — the noetl/ai-meta#203 command-bus delivery-loss fix): the feed writer now assigns the ordering key (`append_writer_assigned`) so the single-writer shard log stays ascending and no ingested command is silently dropped when the server's snowflake command ids arrive out of order under concurrent publish. This is the L1 T4 prod-flip blocker.

Verified `cargo check` compiles against the new rev (the #299 subject API + #300 writer-assign did not break usage). No code change — the fix is entirely in the ehdb crates; the returned sort key stays the opaque ack token.

Merging cuts a semantic-release version + image carrying the fix, for the kind re-validation under sustained load ahead of retrying the prod L1 T4 flip.

Refs noetl/ai-meta#203 (server publish path unchanged; keeps pins coherent with the worker + rebuilds the server image against the fixed crates)