### PR TITLE
ci: build to Artifact Registry via Cloud Build (additive to GHCR)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,56 @@ jobs:
             ghcr.io/noetl/server:${{ needs.verify-version.outputs.version }}
             ghcr.io/noetl/server:latest
 
+  # Additive Artifact Registry path.  Builds the SAME release version
+  # on Cloud Build (native amd64, in us-central1 next to the GKE
+  # cluster) and pushes to
+  # us-central1-docker.pkg.dev/<project>/noetl/server-rust.
+  #
+  # WHY THIS IS DECOUPLED: `needs` lists only ``verify-version`` -- not
+  # publish-image.  The GHCR path is the release artifact of record and
+  # must not be able to fail because of an AR problem, and
+  # ``github-release`` gates on publish-image only, so nothing here can
+  # block a release.  This job is purely additive.
+  #
+  # WHY IT IS OFF BY DEFAULT: the `if` requires two repo *variables*
+  # (Settings > Secrets and variables > Actions > Variables).  Until
+  # they are set the job is skipped, so merging this file changes
+  # nothing about today's pipeline.
+  #
+  #   GCP_WIF_PROVIDER  projects/<NUM>/locations/global/workloadIdentityPools/github/providers/noetl
+  #   GCP_CLOUDBUILD_SA gh-actions-cloudbuild@<project>.iam.gserviceaccount.com
+  #   GCP_PROJECT_ID    shastaratech-noetl-prod   (optional; defaults below)
+  #
+  # Auth is Workload Identity Federation -- keyless, no long-lived JSON
+  # service-account key in GitHub secrets.
+  publish-ar:
+    runs-on: ubuntu-latest
+    needs: [verify-version]
+    if: ${{ needs.verify-version.outputs.has_dockerfile == 'true' && vars.GCP_WIF_PROVIDER != '' && vars.GCP_CLOUDBUILD_SA != '' }}
+    permissions:
+      contents: read
+      # Required for the OIDC token that WIF exchanges for GCP creds.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_CLOUDBUILD_SA }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Cloud Build -> Artifact Registry
+        env:
+          VERSION: ${{ needs.verify-version.outputs.version }}
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'shastaratech-noetl-prod' }}
+        run: |
+          set -euo pipefail
+          gcloud builds submit \
+            --project="${PROJECT_ID}" \
+            --region=us-central1 \
+            --config=cloudbuild.yaml \
+            --substitutions=_VERSION="${VERSION}" \
+            .
+
   github-release:
     runs-on: ubuntu-latest
     needs: [verify-version, publish-image]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,136 @@
+# Cloud Build: native amd64 image build -> Artifact Registry.
+#
+# WHY amd64-ONLY: Cloud Build has no arm64 machine type (the enum is
+# e2-medium, e2-standard-2, e2-highcpu-8, e2-highcpu-32, n1-highcpu-8,
+# n1-highcpu-32 -- all x86_64).  An arm64 build here would run under
+# QEMU, which for Rust/cargo-chef is 6-10x slower than native and is
+# exactly the regression noetl/ai-meta#44 removed from GitHub Actions.
+#
+# For this repo amd64-only is not even a narrowing: the existing GHCR
+# publish-image job has no `platforms:` key, so ghcr.io/noetl/server is
+# *already* amd64-only today (verified against the live manifest).
+# This config matches that arch and adds the AR destination; the GHCR
+# job is untouched.
+#
+# GKE (shastaratech-noetl-prod, Autopilot) runs amd64, so the AR copy
+# only ever needs amd64.
+#
+# CACHING: Cloud Build VMs are ephemeral, so the Docker layer cache is
+# cold every run and cargo-chef's `cook` layer -- plus the separate
+# wasm32 plug-in stage -- would rebuild from scratch each time.  A
+# buildx registry cache (`mode=max`, which exports intermediate stages)
+# is kept alongside the image in AR under the `:buildcache` tag.
+
+substitutions:
+  _AR_HOST: us-central1-docker.pkg.dev
+  _AR_PROJECT: shastaratech-noetl-prod
+  _AR_REPO: noetl
+  # Image name matches what the prod manifests already reference
+  # (us-central1-docker.pkg.dev/.../noetl/server-rust:v3.52.0).
+  _IMAGE: server-rust
+  # Release version WITHOUT the leading "v" (e.g. 3.58.0).  Leave empty
+  # to derive it from Cargo.toml.
+  _VERSION: ""
+  _PUSH_LATEST: "true"
+
+options:
+  # 8 vCPU.  E2_HIGHCPU_32 would be the natural pick for a cargo
+  # build, but this project has NO quota for the 32-vCPU type:
+  #
+  #   FAILED_PRECONDITION: due to quota restrictions, Cloud Build
+  #   cannot run builds of this machine type in this region
+  #
+  # That is the default posture for a new project; lifting it needs a
+  # quota increase for "Cloud Build / CPUs" in us-central1 (console:
+  # IAM & Admin > Quotas, filter cloudbuild.googleapis.com).
+  # E2_HIGHCPU_8 was verified available and is still 2x the 4-vCPU
+  # GitHub-hosted runner the GHCR job uses.  Bump this line to
+  # E2_HIGHCPU_32 once the quota lands; nothing else changes.
+  machineType: E2_HIGHCPU_8
+  diskSizeGb: 200
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 2400s
+
+steps:
+  - id: resolve-version
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        VERSION="${_VERSION}"
+        if [[ -z "$$VERSION" ]]; then
+          VERSION=$$(grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
+        fi
+        VERSION="$${VERSION#v}"
+        if [[ -z "$$VERSION" ]]; then
+          echo "FATAL: could not resolve a version" >&2
+          exit 1
+        fi
+        echo -n "$$VERSION" > /workspace/VERSION
+        echo "resolved version: $$VERSION"
+
+  # buildx is pinned rather than taken from whatever the base image
+  # bundles.  The docker-container driver does not inherit Cloud
+  # Build's ambient credential helper, so authenticate explicitly with
+  # the build SA token from the metadata server.
+  - id: buildx-bootstrap
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        # `docker/buildx-bin` carries no CMD/ENTRYPOINT, and `docker
+        # create` refuses an image with no command ("Error response
+        # from daemon: No command specified").  The container is only
+        # ever a file source for `docker cp` -- it is never started --
+        # so any placeholder command satisfies the daemon.
+        docker create --name bx docker/buildx-bin:0.19.3 noop
+        docker cp bx:/buildx /workspace/buildx
+        docker rm bx
+        chmod +x /workspace/buildx
+        /workspace/buildx version
+
+        TOKEN=$$(curl -sf -H 'Metadata-Flavor: Google' \
+          'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token' \
+          | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+        if [[ -z "$$TOKEN" ]]; then
+          echo "FATAL: could not obtain an access token from the metadata server" >&2
+          exit 1
+        fi
+        echo -n "$$TOKEN" | docker login -u oauth2accesstoken --password-stdin "https://${_AR_HOST}"
+
+  - id: build-push
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        VERSION=$$(cat /workspace/VERSION)
+        REPO="${_AR_HOST}/${_AR_PROJECT}/${_AR_REPO}/${_IMAGE}"
+
+        /workspace/buildx create --name cb --driver docker-container --use
+        /workspace/buildx inspect --bootstrap
+
+        TAGS="--tag $${REPO}:v$${VERSION}"
+        if [[ "${_PUSH_LATEST}" == "true" ]]; then
+          TAGS="$${TAGS} --tag $${REPO}:latest"
+        fi
+
+        # shellcheck disable=SC2086
+        /workspace/buildx build \
+          --platform linux/amd64 \
+          --file ./Dockerfile \
+          $${TAGS} \
+          --cache-from "type=registry,ref=$${REPO}:buildcache" \
+          --cache-to   "type=registry,ref=$${REPO}:buildcache,mode=max" \
+          --provenance=false \
+          --push \
+          .
+
+        echo "=== pushed ==="
+        echo "$${REPO}:v$${VERSION}"


### PR DESCRIPTION
## What

Adds an **additive** Artifact Registry publish path for `server-rust`,
built on Cloud Build in `us-central1` — the same region as the GKE
cluster that pulls it.

Nothing about the existing GHCR path changes.

Sibling of noetl/worker#194.

## Why

Today's images reach AR by `crane`-copying them from GHCR after the
fact. That works but it is a manual step, and the build itself runs on
a 4-vCPU GitHub-hosted runner. This gives us:

- **Co-location** — `us-central1-docker.pkg.dev/shastaratech-noetl-prod/noetl/server-rust`
  sits next to the cluster instead of pulling cross-cloud from ghcr.io.
- **Faster amd64 builds** — 8 vCPU instead of 4, plus a registry-backed
  buildx cache (`mode=max`, so cargo-chef's `cook` layer and the
  separate wasm32 plug-in stage are reused rather than rebuilt cold).

## Files

| File | Change |
| :-- | :-- |
| `cloudbuild.yaml` | New. Resolves the version, bootstraps a pinned buildx, builds amd64 natively, pushes `:v<version>` + `:latest` to AR with a `:buildcache` registry cache. |
| `.github/workflows/release.yml` | New `publish-ar` job. |

`.dockerignore` already carries the `**/target` entry, so no change is
needed here — the equivalent fix in worker#194 is bringing that repo to
parity with this one.

## Why amd64-only

For this repo it is not even a narrowing: the existing GHCR
`publish-image` job has **no `platforms:` key**, so `ghcr.io/noetl/server`
is already amd64-only today. This config matches that arch and adds the
AR destination.

Separately, Cloud Build has no arm64 machine type at all, so an arm64
build here would run under QEMU — the 6-10x regression that
noetl/ai-meta#44 removed from GitHub Actions. GKE runs amd64.

## Why this cannot regress the release

The `publish-ar` job lists **only `verify-version`** in `needs` — not
`publish-image`. And `github-release` gates on `publish-image`, which
knows nothing about this job. So an AR failure cannot fail the GHCR job
and cannot block a release.

It is also **skipped by default**: the `if` requires two repo variables
that do not exist yet, so merging this changes nothing about today's
pipeline until someone opts in.

## Verification

The identically-shaped worker config was proven with a real
`gcloud builds submit` against `shastaratech-noetl-prod` — see
noetl/worker#194. Three environment fixes were needed and are baked
into both configs:

1. The Cloud Build service account (`986938120811-compute@`) had **no**
   project roles — missing `logging.logWriter` and read access to the
   source-staging bucket. Granted (bucket-scoped where possible).
2. `E2_HIGHCPU_32` is **quota-blocked** on this project
   (`FAILED_PRECONDITION: due to quota restrictions...`). Config uses
   `E2_HIGHCPU_8`, verified available; a one-line bump once quota lands.
3. `docker create` against `docker/buildx-bin` fails with *"No command
   specified"* — that image carries no CMD. Fixed with a placeholder
   command; the container is only a `docker cp` file source.

This repo's own config has not had a dedicated proof build run against
it yet — the worker build was used as the proof since the two configs
differ only in image name and the wasm plug-in stage.

## Enabling the AR path

Set two repo variables (Settings → Secrets and variables → Actions →
Variables). Until both exist the job stays skipped:

```
GCP_WIF_PROVIDER   projects/986938120811/locations/global/workloadIdentityPools/github/providers/noetl
GCP_CLOUDBUILD_SA  gh-actions-cloudbuild@shastaratech-noetl-prod.iam.gserviceaccount.com
```

Auth is Workload Identity Federation — keyless, no long-lived JSON
service-account key in GitHub secrets. The GCP-side setup commands are
in the session report.
