### PR TITLE
perf(command-bus): publish to the EHDB writer without serialising on one mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "ehdb-core"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=d4b623512db279e55b0093cf7207f7b400dd511e#d4b623512db279e55b0093cf7207f7b400dd511e"
+source = "git+https://github.com/noetl/ehdb?rev=03e94be444d48406dccd59969a726ba797f78300#03e94be444d48406dccd59969a726ba797f78300"
 dependencies = [
  "arrow-schema",
  "serde",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "ehdb-feed"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=d4b623512db279e55b0093cf7207f7b400dd511e#d4b623512db279e55b0093cf7207f7b400dd511e"
+source = "git+https://github.com/noetl/ehdb?rev=03e94be444d48406dccd59969a726ba797f78300#03e94be444d48406dccd59969a726ba797f78300"
 dependencies = [
  "ehdb-core",
  "ehdb-l0",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "ehdb-l0"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=d4b623512db279e55b0093cf7207f7b400dd511e#d4b623512db279e55b0093cf7207f7b400dd511e"
+source = "git+https://github.com/noetl/ehdb?rev=03e94be444d48406dccd59969a726ba797f78300#03e94be444d48406dccd59969a726ba797f78300"
 dependencies = [
  "ehdb-core",
  "serde",
@@ -669,7 +669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1882,7 +1882,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "ehdb-core"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=03e94be444d48406dccd59969a726ba797f78300#03e94be444d48406dccd59969a726ba797f78300"
+source = "git+https://github.com/noetl/ehdb?rev=86a24f95841be0d2cf031eba1bcf44c9a627c1d1#86a24f95841be0d2cf031eba1bcf44c9a627c1d1"
 dependencies = [
  "arrow-schema",
  "serde",
@@ -618,19 +618,20 @@ dependencies = [
 [[package]]
 name = "ehdb-feed"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=03e94be444d48406dccd59969a726ba797f78300#03e94be444d48406dccd59969a726ba797f78300"
+source = "git+https://github.com/noetl/ehdb?rev=86a24f95841be0d2cf031eba1bcf44c9a627c1d1#86a24f95841be0d2cf031eba1bcf44c9a627c1d1"
 dependencies = [
  "ehdb-core",
  "ehdb-l0",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "tokio",
 ]
 
 [[package]]
 name = "ehdb-l0"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=03e94be444d48406dccd59969a726ba797f78300#03e94be444d48406dccd59969a726ba797f78300"
+source = "git+https://github.com/noetl/ehdb?rev=86a24f95841be0d2cf031eba1bcf44c9a627c1d1#86a24f95841be0d2cf031eba1bcf44c9a627c1d1"
 dependencies = [
  "ehdb-core",
  "serde",
@@ -1092,7 +1093,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1842,7 +1843,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -1880,7 +1881,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2482,6 +2483,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -2908,7 +2919,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ gcp_auth = "0.12"
 async-nats = "0.38"
 # EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
 # The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
-ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "d4b623512db279e55b0093cf7207f7b400dd511e" }
-ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "d4b623512db279e55b0093cf7207f7b400dd511e" }
+ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "03e94be444d48406dccd59969a726ba797f78300" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "03e94be444d48406dccd59969a726ba797f78300" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ gcp_auth = "0.12"
 async-nats = "0.38"
 # EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
 # The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
-ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "03e94be444d48406dccd59969a726ba797f78300" }
-ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "03e94be444d48406dccd59969a726ba797f78300" }
+ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "86a24f95841be0d2cf031eba1bcf44c9a627c1d1" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "86a24f95841be0d2cf031eba1bcf44c9a627c1d1" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.

--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -19,6 +19,7 @@
 //! the writers being up at boot — matching how it tolerates NATS being absent.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use ehdb_feed::PublishRouter;
 use ehdb_l0::{D1EventLog, EventRecord};
@@ -88,10 +89,19 @@ pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, String> {
 }
 
 /// A lazily-connected EHDB command publisher over the per-shard writers.
+///
+/// The router is held behind the mutex only to *swap* it (lazy connect, redial
+/// after a failure) — never across a publish. A publish clones the `Arc` out,
+/// drops the guard, and then does its round-trip, so concurrent publishes run
+/// concurrently. Holding the lock across the round-trip serialised the control
+/// plane's whole command path behind one writer `fsync` each, which was the
+/// dominant term in command dispatch latency (noetl/ai-meta#205); it also kept
+/// the writer from ever seeing two records at once, so it could never
+/// group-commit them.
 pub struct EhdbCommandPublisher {
     shard_count: u32,
     addrs: BTreeMap<u32, String>,
-    router: Mutex<Option<PublishRouter<D1EventLog>>>,
+    router: Mutex<Option<Arc<PublishRouter<D1EventLog>>>>,
 }
 
 impl EhdbCommandPublisher {
@@ -125,19 +135,31 @@ impl EhdbCommandPublisher {
             String::new(),
             String::from_utf8_lossy(payload).into_owned(),
         );
-        let mut guard = self.router.lock().await;
-        if guard.is_none() {
-            let router = PublishRouter::<D1EventLog>::connect(self.shard_count, self.addrs.clone())
-                .await
-                .map_err(|e| format!("EHDB writer connect failed: {e}"))?;
-            *guard = Some(router);
-        }
-        match guard.as_mut().unwrap().publish(&record).await {
+        // Take a handle to the router, then release the lock: the round-trip
+        // below runs unserialised so concurrent commands reach the writer
+        // together and share one group commit.
+        let router = {
+            let mut guard = self.router.lock().await;
+            if guard.is_none() {
+                let router =
+                    PublishRouter::<D1EventLog>::connect(self.shard_count, self.addrs.clone())
+                        .await
+                        .map_err(|e| format!("EHDB writer connect failed: {e}"))?;
+                *guard = Some(Arc::new(router));
+            }
+            Arc::clone(guard.as_ref().unwrap())
+        };
+        match router.publish(&record).await {
             Ok(seq) => Ok(seq),
             Err(e) => {
                 // Drop the router so the next publish redials (writer restarted,
-                // rolled, or a shard moved).
-                *guard = None;
+                // rolled, or a shard moved) — but only if it is still the one
+                // that failed, so a redial another task already completed is not
+                // thrown away.
+                let mut guard = self.router.lock().await;
+                if guard.as_ref().is_some_and(|r| Arc::ptr_eq(r, &router)) {
+                    *guard = None;
+                }
                 Err(format!("EHDB publish failed: {e}"))
             }
         }


### PR DESCRIPTION
## Context

After the L1 T4 cutover the EHDB command bus was correct but slow:
`issued → claimed` **p50 285–557 ms** vs a ~200 ms NATS baseline. That
gap is the open go/no-go item for **T5 (deleting NATS)** —
noetl/ai-meta#205.

Attribution (harness in noetl/ehdb#301) puts the dominant term **on the
server side**: `EhdbCommandPublisher::publish` held its
`Mutex<PublishRouter>` across the entire publish round-trip, so every
concurrent command queued behind a full RTT plus the writer's ~4 ms
`fsync`.

| concurrent publishers | time waiting for the mutex (p50) |
| --: | --: |
| 1 | 0 ms |
| 16 | 64 ms |
| 64 | **282 ms** |

That is the prod p50, reproduced. The lock had a second cost too: with
only one record ever in flight, the writer never saw two commands at
once, so it could never amortise its `fsync` across them.

## Change

The mutex now guards only the router *slot* — lazy connect and redial —
never a round-trip. `publish` clones the `Arc` out, drops the guard, and
does its round-trip unserialised, so concurrent commands reach the writer
together and share one group commit
(`PublishRouter::publish(&self)`, noetl/ehdb#301).

The failure path re-checks identity with `Arc::ptr_eq` before clearing
the slot, so a redial another task already completed is not discarded.

Also bumps the `ehdb-feed` / `ehdb-l0` pin to pick up the pipelined
router and the writer-side group commit.

## Result

Publish-submit → a worker holds the command, loopback, same load
(full table in noetl/ehdb#301):

| publishers / claimers | before p50 | after p50 |
| :-- | --: | --: |
| 16 / 8 | 63.9 ms | **5.8 ms** |
| 64 / 24 | 281.1 ms | **6.7 ms** |

Latency is now flat in concurrency instead of growing with it.

## Correctness

Nothing about delivery semantics moves here — this is purely *when* the
lock is held. Durability, ordering (#203's writer-assigned ascending
key) and exactly-once all live in the writer and are unchanged; see
noetl/ehdb#301 for their proofs.

Kind validation for the pair is on noetl/ai-meta#205.

## Status — ready, but HOLD the merge

- ehdb pin is **`03e94be`** — [noetl/ehdb#301](https://github.com/noetl/ehdb/pull/301)
  as squash-merged on ehdb `main`. Builds and lints clean against it.
- **Do not merge standalone.** This bundles with the
  [noetl/ai-meta#208](https://github.com/noetl/ai-meta/issues/208)
  writer-restart adoption so prod deploys **once**, and both changes are
  re-measured together in that single rollout.

Refs noetl/ai-meta#205
