### PR TITLE
fix(command-bus): widen the EHDB publish retry to span a writer pod restart (#208)

### DIFF
--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -120,15 +120,34 @@ impl EhdbCommandPublisher {
         !self.addrs.is_empty()
     }
 
-    /// How many times a publish is attempted before it gives up. A writer
-    /// restart breaks every socket the router holds, so the first attempt after
-    /// one always fails; the retries carry the command across the gap while the
-    /// replacement pod's endpoint appears (noetl/ai-meta#208).
-    const PUBLISH_ATTEMPTS: u32 = 3;
-    /// Pause between publish attempts — long enough for a pod swap's endpoint
-    /// update, short enough that the API request behind this publish is not held
-    /// up noticeably.
-    const RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
+    /// How long a publish keeps retrying before it gives up — sized to span a
+    /// writer **pod restart**, not just a broken socket.
+    ///
+    /// The first cut of this retry (3 attempts × 250 ms) covered ~0.5 s of
+    /// retrying, which is enough to redial a socket the writer closed cleanly but
+    /// far short of a pod swap. The measured prod gap is ~2.7 s from the writer's
+    /// SIGTERM to a re-dialable replacement — terminate, reschedule, reopen the
+    /// durable log, rebind the ingest listener, endpoint propagate — and a rollout
+    /// under load or a cold image pull is longer. So the window closed while the
+    /// writer was still coming back and two `POST /api/execute` calls returned 500
+    /// during the restart: fail-closed, no silent loss, but not transparent, which
+    /// is the bar for a bus that has no NATS behind it after T5.
+    ///
+    /// 10 s covers the observed gap with room for a slow reschedule. It is a
+    /// ceiling, not a cost: a healthy publish still returns on the first attempt,
+    /// and the only request that waits is one that would otherwise have failed.
+    const PUBLISH_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+    /// First pause between publish attempts. Short, so a transient broken socket
+    /// (the common case — the writer is already back) costs ~100 ms rather than a
+    /// quarter second.
+    const RETRY_BACKOFF_INITIAL: std::time::Duration = std::time::Duration::from_millis(100);
+    /// Ceiling on the exponential backoff, so a long gap is still probed ~every
+    /// second rather than sleeping through the writer's return.
+    const RETRY_BACKOFF_MAX: std::time::Duration = std::time::Duration::from_millis(1_000);
+    /// Hard cap on attempts — a backstop against a pathological zero-cost failure
+    /// spinning inside the deadline. With the backoff schedule above, the deadline
+    /// is what actually ends the loop.
+    const PUBLISH_ATTEMPTS: u32 = 32;
 
     /// Publish one command notification onto the EHDB bus. `execution_id` routes
     /// the shard; `event_id` is the sort key; `payload` is the notification JSON.
@@ -146,8 +165,10 @@ impl EhdbCommandPublisher {
     /// dropped this way is only recovered by the orphaned-command guardrail
     /// (noetl/ai-meta#171), and after T5 there is no NATS to fall back to.
     ///
-    /// So a failed attempt now redials and publishes again, up to
-    /// [`PUBLISH_ATTEMPTS`](Self::PUBLISH_ATTEMPTS). A retry can only ever
+    /// So a failed attempt redials and publishes again, with exponential backoff,
+    /// until [`PUBLISH_DEADLINE`](Self::PUBLISH_DEADLINE) elapses — a window sized
+    /// to span a writer pod restart rather than just a broken socket. A retry can
+    /// only ever
     /// *duplicate* a command — if the record was appended but its ack was lost,
     /// the retry appends a second copy — and duplicate delivery is already what
     /// the bus's `ack_wait` redelivery produces, so the worker's claim path
@@ -166,14 +187,16 @@ impl EhdbCommandPublisher {
             String::new(),
             String::from_utf8_lossy(payload).into_owned(),
         );
+        let started = std::time::Instant::now();
         let mut last_err = String::new();
+        let mut backoff = Self::RETRY_BACKOFF_INITIAL;
         for attempt in 1..=Self::PUBLISH_ATTEMPTS {
             let router = match self.router().await {
                 Ok(r) => r,
                 Err(e) => {
                     last_err = e;
-                    if attempt < Self::PUBLISH_ATTEMPTS {
-                        tokio::time::sleep(Self::RETRY_BACKOFF).await;
+                    if !Self::sleep_before_retry(started, &mut backoff).await {
+                        break;
                     }
                     continue;
                 }
@@ -185,6 +208,7 @@ impl EhdbCommandPublisher {
                             execution_id,
                             event_id,
                             attempt,
+                            waited_ms = started.elapsed().as_millis() as u64,
                             "EHDB command published after redialing the writer"
                         );
                     }
@@ -201,20 +225,51 @@ impl EhdbCommandPublisher {
                         *guard = None;
                     }
                     drop(guard);
-                    if attempt < Self::PUBLISH_ATTEMPTS {
-                        tracing::warn!(
-                            execution_id,
-                            event_id,
-                            attempt,
-                            error = %last_err,
-                            "EHDB publish failed; redialing the writer and retrying"
-                        );
-                        tokio::time::sleep(Self::RETRY_BACKOFF).await;
+                    tracing::warn!(
+                        execution_id,
+                        event_id,
+                        attempt,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        error = %last_err,
+                        "EHDB publish failed; redialing the writer and retrying"
+                    );
+                    if !Self::sleep_before_retry(started, &mut backoff).await {
+                        break;
                     }
                 }
             }
         }
+        tracing::error!(
+            execution_id,
+            event_id,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            error = %last_err,
+            "EHDB publish gave up after the retry window"
+        );
         Err(last_err)
+    }
+
+    /// Wait out the backoff before the next publish attempt, doubling it (capped
+    /// at [`RETRY_BACKOFF_MAX`](Self::RETRY_BACKOFF_MAX)). Returns `false` when
+    /// the [`PUBLISH_DEADLINE`](Self::PUBLISH_DEADLINE) leaves no room for another
+    /// attempt, so the caller stops instead of sleeping past it — the deadline is
+    /// the total wall-clock the caller's request can be held, not a per-attempt
+    /// budget.
+    async fn sleep_before_retry(
+        started: std::time::Instant,
+        backoff: &mut std::time::Duration,
+    ) -> bool {
+        let remaining = match Self::PUBLISH_DEADLINE.checked_sub(started.elapsed()) {
+            Some(r) => r,
+            None => return false,
+        };
+        let nap = (*backoff).min(remaining);
+        if nap.is_zero() {
+            return false;
+        }
+        tokio::time::sleep(nap).await;
+        *backoff = (*backoff * 2).min(Self::RETRY_BACKOFF_MAX);
+        true
     }
 
     /// The live router, connecting it if this is the first use or the previous
@@ -267,8 +322,9 @@ mod tests {
     fn writer_addr_parsing_accepts_dns_names() {
         // Finding #2 (noetl/ai-meta#194): a K8s service DNS name is NOT a
         // parseable `SocketAddr`, but must be kept for resolution at connect.
-        let m =
-            parse_writer_addrs("0@noetl-cmdbus-writer.noetl.svc.cluster.local:9100,1@writer-1:9100");
+        let m = parse_writer_addrs(
+            "0@noetl-cmdbus-writer.noetl.svc.cluster.local:9100,1@writer-1:9100",
+        );
         assert_eq!(m.len(), 2);
         assert_eq!(m[&0], "noetl-cmdbus-writer.noetl.svc.cluster.local:9100");
         assert_eq!(m[&1], "writer-1:9100");

--- a/tests/publish_retry_window.rs
+++ b/tests/publish_retry_window.rs
@@ -1,0 +1,184 @@
+//! noetl/ai-meta#208 follow-up — the EHDB publish retry must span a **writer pod
+//! restart**, not just a broken socket.
+//!
+//! The first cut of the retry (3 attempts × 250 ms ≈ 0.5 s of retrying) redialed
+//! a cleanly-closed socket fine but ran out while the writer was still coming
+//! back: the measured prod gap from the writer's SIGTERM to a re-dialable
+//! replacement is ~2.7 s, and two `POST /api/execute` calls returned 500 during
+//! it. Fail-closed and no silent loss, but not transparent — and after T5 there
+//! is no NATS behind the bus.
+//!
+//! These tests drive the real `EhdbCommandPublisher` against a real ehdb ingest
+//! listener that is taken away and brought back on the same address, which is
+//! exactly the shape of a pod swap from the server's side.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ehdb_l0::substrate::DurableSubstrate;
+use ehdb_l0::{D1EventLog, L0Config, L0Engine, LocalFsSubstrate};
+use noetl_server::command_bus::EhdbCommandPublisher;
+use tokio::net::TcpListener;
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    static N: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = N.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(format!("noetl-pub-retry-{tag}-{}-{n}", std::process::id()))
+}
+
+/// A writer serving ingest on `addr`, on its own runtime in its own thread.
+///
+/// The runtime is the unit of teardown on purpose: aborting a `serve_ingest`
+/// task only stops the *accept loop*, leaving already-accepted connections alive
+/// — so the server's router would keep publishing down a socket a real pod swap
+/// would have severed, and the test would prove nothing. Dropping the whole
+/// runtime drops every task and every socket with it, which is the pod-gone
+/// shape.
+struct Writer {
+    stop: Option<std::sync::mpsc::Sender<()>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Writer {
+    fn spawn(dir: std::path::PathBuf, obj: std::path::PathBuf, addr: std::net::SocketAddr) -> Self {
+        let (stop, stop_rx) = std::sync::mpsc::channel::<()>();
+        let (ready, ready_rx) = std::sync::mpsc::channel::<()>();
+        let thread = std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async move {
+                let listener = TcpListener::bind(addr).await.expect("writer bind");
+                let store: Arc<dyn DurableSubstrate> =
+                    Arc::new(LocalFsSubstrate::new(&obj).unwrap());
+                let engine = L0Engine::<D1EventLog>::open(L0Config::d1(&dir), store).unwrap();
+                let writer = Arc::new(ehdb_feed::FeedWriter::new(engine));
+                tokio::spawn(ehdb_feed::serve_ingest(listener, writer));
+                ready.send(()).ok();
+                let _ = tokio::task::spawn_blocking(move || stop_rx.recv()).await;
+            });
+            // `rt` drops here: listener + every accepted connection go with it.
+        });
+        ready_rx.recv().expect("writer came up");
+        Self {
+            stop: Some(stop),
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for Writer {
+    fn drop(&mut self) {
+        drop(self.stop.take());
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+async fn free_addr() -> std::net::SocketAddr {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    drop(l);
+    addr
+}
+
+fn publisher(addr: std::net::SocketAddr) -> EhdbCommandPublisher {
+    let mut addrs = BTreeMap::new();
+    addrs.insert(0u32, addr.to_string());
+    EhdbCommandPublisher::new(1, addrs)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_publish_survives_a_writer_gap_longer_than_the_old_window() {
+    let (obj, local) = (unique_dir("obj"), unique_dir("local"));
+    let addr = free_addr().await;
+
+    let pubr = publisher(addr);
+    let w = Writer::spawn(local.clone(), obj.clone(), addr);
+    assert!(
+        pubr.publish(1, 1, b"{\"execution_pool\":\"shared\"}")
+            .await
+            .is_ok(),
+        "baseline publish reaches a live writer"
+    );
+
+    // The writer goes away, and comes back 2.5 s later — past the old 0.5 s
+    // retry window, inside the new one.
+    drop(w);
+    const GAP: Duration = Duration::from_millis(2_500);
+    let (o2, l2) = (obj.clone(), local.clone());
+    let restart = tokio::task::spawn_blocking(move || {
+        std::thread::sleep(GAP);
+        Writer::spawn(l2, o2, addr)
+    });
+
+    let started = Instant::now();
+    let result = pubr.publish(2, 2, b"{\"execution_pool\":\"shared\"}").await;
+    let waited = started.elapsed();
+    let replacement = restart.await.unwrap();
+
+    assert!(
+        result.is_ok(),
+        "publish must ride out the restart, got: {result:?} after {waited:?}"
+    );
+    assert!(
+        waited >= Duration::from_millis(2_000),
+        "it really did wait out the gap rather than hitting a still-live writer ({waited:?})"
+    );
+    assert!(
+        waited < Duration::from_secs(10),
+        "and returned as soon as the writer was back, not at the deadline ({waited:?})"
+    );
+
+    drop(replacement);
+    for d in [&obj, &local] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_writer_that_never_returns_fails_closed_within_the_deadline() {
+    // The deadline is a ceiling on how long a caller's request is held: a bus
+    // that is genuinely gone must still surface an error rather than hang.
+    let addr = free_addr().await;
+    let pubr = publisher(addr);
+
+    let started = Instant::now();
+    let result = pubr.publish(3, 3, b"{\"execution_pool\":\"shared\"}").await;
+    let waited = started.elapsed();
+
+    assert!(result.is_err(), "no writer at all must fail, not hang");
+    assert!(
+        waited >= Duration::from_secs(9),
+        "it used the retry window before giving up ({waited:?})"
+    );
+    assert!(
+        waited < Duration::from_secs(15),
+        "and gave up at the deadline rather than retrying forever ({waited:?})"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_healthy_publish_pays_nothing_for_the_wider_window() {
+    // The window is a ceiling, not a cost — the common path must not slow down.
+    let (obj, local) = (unique_dir("fast-obj"), unique_dir("fast-local"));
+    let addr = free_addr().await;
+    let _w = Writer::spawn(local.clone(), obj.clone(), addr);
+    let pubr = publisher(addr);
+
+    let started = Instant::now();
+    for i in 0..20i64 {
+        pubr.publish(i, i, b"{\"execution_pool\":\"shared\"}")
+            .await
+            .unwrap();
+    }
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "20 healthy publishes took {elapsed:?} — the retry path is not on the happy path"
+    );
+
+    for d in [&obj, &local] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+}


### PR DESCRIPTION
Follow-up to #290, from the #208 prod validation.

## The gap

#290's retry is sized for a *broken socket*, not a *pod restart*: 3 attempts × 250 ms is ~0.5 s of retrying. The measured gap from the writer's SIGTERM to a re-dialable replacement is **~2.7 s** — terminate, reschedule, reopen the durable log, rebind the ingest listener, endpoint propagate. So the window closed while the writer was still coming back and **two `POST /api/execute` calls returned 500** during the restart.

That is fail-closed (`command.issued` is durable; the orphaned-command guardrail noetl/ai-meta#171 recovers it) — but a writer restart should be invisible to callers, and after T5 there is no NATS behind the bus.

## The change

Fixed attempt count → a wall-clock deadline:

| | before | after |
|---|---|---|
| window | 3 × 250 ms ≈ 0.5 s | `PUBLISH_DEADLINE` = 10 s |
| backoff | flat 250 ms | 100 ms, ×2, capped at 1 s |
| attempts | 3 | 32 (backstop; the deadline ends the loop) |

The deadline is a **ceiling, not a cost**: a healthy publish still returns on the first attempt, the only request that waits is one that would otherwise have failed, and a writer that is genuinely gone still fails closed within ~10 s rather than hanging. The first pause also drops 250 ms → 100 ms, so the common case (writer already back) recovers *faster* than before.

Give-up now logs `elapsed_ms`; success-after-retry logs `waited_ms`. The restart cost is visible instead of inferred.

## Tests

`tests/publish_retry_window.rs` drives the real `EhdbCommandPublisher` against a real `ehdb_feed::serve_ingest` listener taken away and brought back on the same address:

- `a_publish_survives_a_writer_gap_longer_than_the_old_window` — 2.5 s gap (past the old window), publish succeeds, and it verifiably waited rather than hitting a still-live writer.
- `a_writer_that_never_returns_fails_closed_within_the_deadline` — errors at the deadline, does not hang.
- `a_healthy_publish_pays_nothing_for_the_wider_window` — 20 publishes in < 2 s.

The writer harness owns its own tokio runtime deliberately: aborting a `serve_ingest` task only stops the accept loop, so already-accepted connections survive and the publish would succeed down a socket a real pod swap would have severed. Dropping the runtime is the pod-gone shape.

## Validation posture

`cargo build` / `cargo clippy --all-targets` clean; the new integration test passes. **Not deployed** — this rides the same held bundle as server#289 (#205 adoption) so prod deploys once.

Refs noetl/ai-meta#208