### PR TITLE
chore(deps): re-pin ehdb to e457249 (per-subject lag + resume signal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "ehdb-core"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=86a24f95841be0d2cf031eba1bcf44c9a627c1d1#86a24f95841be0d2cf031eba1bcf44c9a627c1d1"
+source = "git+https://github.com/noetl/ehdb?rev=e4572492b8373bd3bf8e347d09f2f3fbd9808dd5#e4572492b8373bd3bf8e347d09f2f3fbd9808dd5"
 dependencies = [
  "arrow-schema",
  "serde",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "ehdb-feed"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=86a24f95841be0d2cf031eba1bcf44c9a627c1d1#86a24f95841be0d2cf031eba1bcf44c9a627c1d1"
+source = "git+https://github.com/noetl/ehdb?rev=e4572492b8373bd3bf8e347d09f2f3fbd9808dd5#e4572492b8373bd3bf8e347d09f2f3fbd9808dd5"
 dependencies = [
  "ehdb-core",
  "ehdb-l0",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "ehdb-l0"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=86a24f95841be0d2cf031eba1bcf44c9a627c1d1#86a24f95841be0d2cf031eba1bcf44c9a627c1d1"
+source = "git+https://github.com/noetl/ehdb?rev=e4572492b8373bd3bf8e347d09f2f3fbd9808dd5#e4572492b8373bd3bf8e347d09f2f3fbd9808dd5"
 dependencies = [
  "ehdb-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ gcp_auth = "0.12"
 async-nats = "0.38"
 # EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
 # The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
-ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "86a24f95841be0d2cf031eba1bcf44c9a627c1d1" }
-ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "86a24f95841be0d2cf031eba1bcf44c9a627c1d1" }
+ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "e4572492b8373bd3bf8e347d09f2f3fbd9808dd5" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "e4572492b8373bd3bf8e347d09f2f3fbd9808dd5" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.


### PR DESCRIPTION
Picks up [noetl/ehdb#303](https://github.com/noetl/ehdb/pull/303) (`ehdb_feed_subject_lag`) and [noetl/ehdb#304](https://github.com/noetl/ehdb/pull/304) (`ResumeReport` + `ehdb_feed_shard_resume_*`).

Neither changes the wire protocol the server's publish path speaks — both are writer-side metrics surfaces consumed by noetl/worker. The re-pin is here so server and worker run **one** ehdb revision in prod rather than two, keeping the `ehdb-feed` publish/ingest contract trivially identical across the pair for the T5-readiness deploy.

Builds clean; `tests/publish_retry_window.rs` (3 tests, the #291 retry window) still passes on the new rev.

Refs noetl/ai-meta#194, noetl/ai-meta#208