### PR TITLE
feat(event-bus): NOETL_EVENT_BUS — dual-publish events to NATS and EHDB

### DIFF
--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -1,0 +1,161 @@
+//! **L1 T3 — the EHDB events bus (flag-gated).**
+//!
+//! Selects the transport that carries `noetl.event` payloads to their four
+//! consumers, behind [`NOETL_EVENT_BUS`](EventBusMode). The events sibling of
+//! [`crate::command_bus`], and deliberately the same shape: `nats` (default)
+//! leaves today's path untouched, `shadow` publishes to **both** with NATS
+//! authoritative, `ehdb` publishes to EHDB only.
+//!
+//! **What is actually at stake here.** The server runs with
+//! `NOETL_EVENT_INGEST_PUBLISH_ONLY=true`, so it writes **zero** `noetl.event`
+//! rows itself — every event publishes to the stream, and the worker-side
+//! `noetl_materializer` draining it is the *sole writer* of the durable event
+//! log. This bus therefore carries the write path of the platform's
+//! append-only source of truth, not just the SPA's live updates. A dropped
+//! event here is a hole in the audit log, which is why `shadow` exists and why
+//! the cutover is per-consumer (noetl/ai-meta#212).
+//!
+//! **Publish semantics differ from the command bus in one way that matters.**
+//! A command is claimed by exactly one worker, so a duplicate is cheap — the
+//! second claimer is told it is already claimed. An event fans out to every
+//! consumer, and a duplicate becomes a duplicate `noetl.event` row unless
+//! something dedupes it. NATS gets that from the `Nats-Msg-Id` dedup window;
+//! on the EHDB side the `event_id` rides in the record so the materializer's
+//! `events/project` call (keyed on `event_id`) collapses it. Retry is still
+//! at-least-once, because losing an event is worse than repeating one.
+
+use std::collections::BTreeMap;
+
+use crate::command_bus::{parse_writer_addrs, EhdbCommandPublisher};
+
+/// Which transport carries event payloads (env `NOETL_EVENT_BUS`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EventBusMode {
+    /// Publish to NATS only — today's path (default).
+    #[default]
+    Nats,
+    /// Publish to the per-shard EHDB events writer only — the cutover.
+    Ehdb,
+    /// Publish to both: NATS authoritative, EHDB mirrored for parity comparison.
+    Shadow,
+}
+
+impl EventBusMode {
+    /// Parse the `NOETL_EVENT_BUS` value; anything unrecognised is the safe
+    /// default (`nats`). Matching [`CommandBusMode`](crate::command_bus::CommandBusMode)
+    /// exactly is deliberate: an operator who has flipped the command bus should
+    /// not have to learn a second vocabulary, and a typo must never silently
+    /// stop publishing to NATS.
+    pub fn from_env_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "ehdb" => Self::Ehdb,
+            "shadow" => Self::Shadow,
+            _ => Self::Nats,
+        }
+    }
+
+    /// Whether this mode publishes to the EHDB events feed.
+    pub fn publishes_ehdb(self) -> bool {
+        matches!(self, Self::Ehdb | Self::Shadow)
+    }
+
+    /// Whether this mode publishes to NATS.
+    pub fn publishes_nats(self) -> bool {
+        matches!(self, Self::Nats | Self::Shadow)
+    }
+}
+
+/// The events-feed publisher.
+///
+/// A thin wrapper over [`EhdbCommandPublisher`], which is not command-specific
+/// in any way that matters here: it is a lazily-connected, shard-routing,
+/// retry-across-a-writer-restart publisher of `EventRecord`s. Reusing it means
+/// the events path inherits the #208 retry window (sized to span a writer pod
+/// restart) and the #205 no-mutex-across-the-round-trip fix for free, rather
+/// than re-deriving both and getting one of them subtly wrong.
+pub struct EhdbEventPublisher {
+    inner: EhdbCommandPublisher,
+}
+
+impl EhdbEventPublisher {
+    /// A publisher routing over `shard_count` shards to the events writers at
+    /// `addrs` (`host:port` strings — DNS names resolved at connect time).
+    pub fn new(shard_count: u32, addrs: BTreeMap<u32, String>) -> Self {
+        Self {
+            inner: EhdbCommandPublisher::new(shard_count, addrs),
+        }
+    }
+
+    /// Build from `NOETL_EVENT_BUS_WRITER_ADDRS` / `NOETL_EVENT_SHARD_COUNT`.
+    pub fn from_env() -> Self {
+        let addrs =
+            parse_writer_addrs(&std::env::var("NOETL_EVENT_BUS_WRITER_ADDRS").unwrap_or_default());
+        let shard_count = std::env::var("NOETL_EVENT_SHARD_COUNT")
+            .ok()
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .unwrap_or(1);
+        Self::new(shard_count, addrs)
+    }
+
+    /// Whether any writer address is configured.
+    pub fn is_configured(&self) -> bool {
+        self.inner.is_configured()
+    }
+
+    /// Publish one event onto the EHDB events feed.
+    ///
+    /// `execution_id` routes the shard, `event_id` is the record's identity (the
+    /// dedup key the materializer projects on), and `payload` is the same
+    /// `to_stream_json()` body published to NATS — byte-identical on purpose, so
+    /// shadow parity is a straight comparison rather than a schema translation.
+    ///
+    /// `event_type` is carried inside the payload, which is where
+    /// `ehdb_feed::event_feed_subject` reads it to derive the
+    /// `events.<event_type>` routing subject — the analog of the NATS subject
+    /// `noetl.events.<event_type>`.
+    pub async fn publish_event(
+        &self,
+        execution_id: i64,
+        event_id: i64,
+        payload: &[u8],
+    ) -> Result<u64, String> {
+        self.inner.publish(execution_id, event_id, payload).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_parses_like_the_command_bus_and_defaults_safe() {
+        assert_eq!(EventBusMode::from_env_value("nats"), EventBusMode::Nats);
+        assert_eq!(EventBusMode::from_env_value("EHDB"), EventBusMode::Ehdb);
+        assert_eq!(
+            EventBusMode::from_env_value(" Shadow "),
+            EventBusMode::Shadow
+        );
+        // The important one: a typo must not silently stop publishing to NATS.
+        assert_eq!(EventBusMode::from_env_value("ehbd"), EventBusMode::Nats);
+        assert_eq!(EventBusMode::from_env_value(""), EventBusMode::Nats);
+        assert_eq!(EventBusMode::default(), EventBusMode::Nats);
+    }
+
+    #[test]
+    fn shadow_publishes_both_ehdb_publishes_only_ehdb() {
+        assert!(EventBusMode::Shadow.publishes_ehdb() && EventBusMode::Shadow.publishes_nats());
+        assert!(EventBusMode::Ehdb.publishes_ehdb() && !EventBusMode::Ehdb.publishes_nats());
+        assert!(!EventBusMode::Nats.publishes_ehdb() && EventBusMode::Nats.publishes_nats());
+    }
+
+    #[test]
+    fn an_unconfigured_publisher_reports_itself_unconfigured() {
+        let p = EhdbEventPublisher::new(1, BTreeMap::new());
+        assert!(!p.is_configured());
+        let p = EhdbEventPublisher::new(
+            1,
+            parse_writer_addrs("0@noetl-cmdbus-writer-0.noetl.svc.cluster.local:9103"),
+        );
+        assert!(p.is_configured());
+    }
+}

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -358,7 +358,24 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     // All rows in a batch share the same execution + catalog, so one decision
     // covers the batch.
     if should_publish(state, rows[0].catalog_id).await {
-        if let Some(pubr) = publisher(state).await {
+        // noetl/ai-meta#212 L1 T3 — which transports are live for this batch.
+        //
+        // The NATS publisher is resolved only when the mode actually wants NATS.
+        // That matters for the end state: once `NOETL_EVENT_BUS=ehdb`, this path
+        // must still publish even though there is no NATS publisher to build —
+        // otherwise the server silently falls through to `insert_rows` and starts
+        // writing event rows itself, double-writing against the materializer that
+        // is already the sole writer.
+        let nats_pub = if state.event_bus_mode.publishes_nats() {
+            publisher(state).await
+        } else {
+            None
+        };
+        let ehdb_live =
+            state.event_bus_mode.publishes_ehdb() && state.ehdb_event_publisher.is_some();
+        // A transport is available when the mode wants it AND it is usable.
+        let nats_live = state.event_bus_mode.publishes_nats() && nats_pub.is_some();
+        if nats_live || ehdb_live {
             // noetl/ai-meta#156: when the tail-attach accelerator is on, keep the
             // `to_stream_json()` payloads we publish in the per-execution ring so
             // the off-server drive dispatch can carry the new tail to the worker
@@ -372,11 +389,26 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
                 let bytes = serde_json::to_vec(&stream_json).map_err(|e| {
                     crate::error::AppError::Internal(format!("event publish encode: {e}"))
                 })?;
-                pubr.publish_event(row.event_id, &row.event_type, &bytes)
-                    .await
-                    .map_err(|e| {
-                        crate::error::AppError::Internal(format!("event publish: {e}"))
-                    })?;
+                if let Some(pubr) = nats_pub.as_ref() {
+                    pubr.publish_event(row.event_id, &row.event_type, &bytes)
+                        .await
+                        .map_err(|e| {
+                            crate::error::AppError::Internal(format!("event publish: {e}"))
+                        })?;
+                }
+                // noetl/ai-meta#212 L1 T3 — mirror onto the EHDB events feed.
+                // The SAME bytes as NATS gets, so shadow parity is a straight
+                // comparison rather than a schema translation.
+                if ehdb_live {
+                    publish_event_to_ehdb(
+                        state,
+                        rows[0].execution_id,
+                        row.event_id,
+                        &row.event_type,
+                        &bytes,
+                    )
+                    .await?;
+                }
                 crate::metrics::record_event_published(&row.event_type);
                 if state.config.offserver_attach_tail {
                     tail_payloads.push(stream_json);
@@ -391,7 +423,7 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
             }
             return Ok(());
         }
-        // NATS unavailable / stream unbuildable → fall through to INSERT.
+        // No transport available → fall through to INSERT.
     }
 
     insert_rows(pool, rows).await
@@ -539,5 +571,52 @@ mod tests {
         let r = EventRow::new(1, 1, 1, "step.enter", "ENTERED", Utc::now()).with_node("s");
         assert_eq!(r.node_id.as_deref(), Some("s"));
         assert_eq!(r.node_name.as_deref(), Some("s"));
+    }
+}
+
+/// Mirror one event onto the EHDB events feed (noetl/ai-meta#212 L1 T3).
+///
+/// **Failure semantics differ by mode, deliberately.**
+///
+/// In `shadow`, NATS is authoritative and this publish is an observation. A
+/// failure is logged and counted but must **not** fail the caller's request —
+/// shadow exists to de-risk the cutover, and a shadow path that can take down
+/// event ingest is a bigger risk than the one it is measuring.
+///
+/// In `ehdb`, this is the only path the durable event log has. A failure is
+/// returned so the caller sees a 500 and retries, rather than the event being
+/// dropped silently. Fail-closed is the right posture once nothing is behind it.
+async fn publish_event_to_ehdb(
+    state: &crate::state::AppState,
+    execution_id: i64,
+    event_id: i64,
+    event_type: &str,
+    bytes: &[u8],
+) -> Result<(), crate::error::AppError> {
+    let Some(publisher) = state.ehdb_event_publisher.as_ref() else {
+        return Ok(());
+    };
+    match publisher.publish_event(execution_id, event_id, bytes).await {
+        Ok(_) => {
+            crate::metrics::record_ehdb_event_published(event_type);
+            Ok(())
+        }
+        Err(e) if state.event_bus_mode == crate::event_bus::EventBusMode::Shadow => {
+            crate::metrics::record_ehdb_event_publish_error(event_type);
+            tracing::warn!(
+                execution_id,
+                event_id,
+                event_type,
+                error = %e,
+                "EHDB shadow event publish failed; NATS remains authoritative"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            crate::metrics::record_ehdb_event_publish_error(event_type);
+            Err(crate::error::AppError::Internal(format!(
+                "EHDB event publish: {e}"
+            )))
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 pub mod affinity;
 pub mod coherence;
 pub mod command_bus;
+pub mod event_bus;
 pub mod config;
 pub mod crypto;
 pub mod db;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -873,6 +873,66 @@ pub fn record_event_published(event_type: &str) {
         .inc();
 }
 
+/// Counter: events mirrored onto the EHDB events feed (noetl/ai-meta#212 L1 T3).
+///
+/// Paired with [`record_event_published`], this is the shadow-parity signal: in
+/// `NOETL_EVENT_BUS=shadow` the two counters must track each other event-for-event
+/// and label-for-label.  A divergence by `event_type` localises which events are
+/// missing, which a single total would hide.
+fn ehdb_event_published_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_events_published_total",
+                "Total events published onto the EHDB events feed, by event type.",
+            ),
+            &["event_type"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+pub fn record_ehdb_event_published(event_type: &str) {
+    ehdb_event_published_total()
+        .with_label_values(&[event_type])
+        .inc();
+}
+
+/// Counter: EHDB event publishes that failed.
+///
+/// In `shadow` these are swallowed so the shadow path can never take down event
+/// ingest — which means this counter is the *only* place a failing shadow shows
+/// up.  A silent shadow that is quietly dropping events would otherwise read as
+/// perfect parity right up until the cutover.
+fn ehdb_event_publish_errors_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_events_publish_errors_total",
+                "Total EHDB events-feed publish failures, by event type.",
+            ),
+            &["event_type"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+pub fn record_ehdb_event_publish_error(event_type: &str) {
+    ehdb_event_publish_errors_total()
+        .with_label_values(&[event_type])
+        .inc();
+}
+
 /// Gauge: the tailer's current cursor (`noetl.event.id` last published).  Pair
 /// with the table's `MAX(id)` to read publish lag.  Single series (no labels) —
 /// one tailer per server.

--- a/src/state.rs
+++ b/src/state.rs
@@ -152,6 +152,16 @@ pub struct AppState {
     /// `Some` only when `command_bus_mode` publishes to EHDB and writers are
     /// configured; `None` keeps the NATS-only path with zero new state.
     pub ehdb_command_publisher: Option<Arc<crate::command_bus::EhdbCommandPublisher>>,
+
+    /// noetl/ai-meta#212 L1 T3 — the events-bus transport mode
+    /// (`NOETL_EVENT_BUS`; default `nats`). Selects whether `noetl.event`
+    /// payloads go to NATS, the EHDB events feed, or both (shadow).
+    pub event_bus_mode: crate::event_bus::EventBusMode,
+
+    /// noetl/ai-meta#212 L1 T3 — the lazily-connected EHDB events publisher.
+    /// `Some` only when `event_bus_mode` publishes to EHDB and writers are
+    /// configured; `None` keeps the NATS-only path with zero new state.
+    pub ehdb_event_publisher: Option<Arc<crate::event_bus::EhdbEventPublisher>>,
 }
 
 /// Cached orchestrator state for one execution, advanced incrementally.
@@ -834,6 +844,33 @@ impl AppState {
             None
         };
 
+        // noetl/ai-meta#212 L1 T3 — the events-bus transport. Same shape as the
+        // command bus above: default `nats` builds no EHDB state at all.
+        let event_bus_mode = crate::event_bus::EventBusMode::from_env_value(
+            &std::env::var("NOETL_EVENT_BUS").unwrap_or_default(),
+        );
+        let ehdb_event_publisher = if event_bus_mode.publishes_ehdb() {
+            let publisher = crate::event_bus::EhdbEventPublisher::from_env();
+            if publisher.is_configured() {
+                tracing::info!(
+                    ?event_bus_mode,
+                    "EHDB events bus enabled"
+                );
+                Some(Arc::new(publisher))
+            } else {
+                // Loud, because in `ehdb` mode this is the difference between
+                // publishing the durable event log and dropping it on the floor.
+                tracing::error!(
+                    ?event_bus_mode,
+                    "NOETL_EVENT_BUS selects EHDB but NOETL_EVENT_BUS_WRITER_ADDRS is empty; \
+                     EHDB event publishes will be skipped"
+                );
+                None
+            }
+        } else {
+            None
+        };
+
         Self {
             db,
             pools,
@@ -842,6 +879,8 @@ impl AppState {
             snowflake: Arc::new(snowflake),
             command_bus_mode,
             ehdb_command_publisher,
+            event_bus_mode,
+            ehdb_event_publisher,
             shard,
             affinity,
             start_time: std::time::Instant::now(),


### PR DESCRIPTION
Refs https://github.com/noetl/ai-meta/issues/212
Refs https://github.com/noetl/ai-meta/issues/194

Third slice of T3 — the publish half. Consumes noetl/ehdb#306
(`GroupCoordinator`) and pairs with noetl/worker#199 (the events writer host).

## What this adds

`NOETL_EVENT_BUS` (`nats` | `shadow` | `ehdb`), the events sibling of
`NOETL_COMMAND_BUS`. Default `nats` leaves today's path untouched and builds no
EHDB state at all.

| Mode | Publishes to | Authoritative |
|---|---|---|
| `nats` (default, and any unrecognised value) | NATS only | NATS |
| `shadow` | **both** | NATS |
| `ehdb` | EHDB only | EHDB |

## What is at stake

The server runs `NOETL_EVENT_INGEST_PUBLISH_ONLY=true`, so it writes **zero**
`noetl.event` rows — every event publishes to the stream, and the worker-side
`noetl_materializer` draining it is the **sole writer** of the durable event
log. This bus carries the write path of the platform's append-only source of
truth, not just the SPA's live updates.

## Design notes

**`EhdbEventPublisher` wraps `EhdbCommandPublisher`** rather than re-deriving
it. That type is not command-specific in any way that matters here — it is a
lazily-connected, shard-routing publisher of `EventRecord`s — so the events path
inherits the #208 retry window (sized to span a writer *pod restart*, not just a
broken socket) and the #205 no-mutex-across-the-round-trip fix for free.

**Failure semantics differ by mode, deliberately.** In `shadow` a failed EHDB
publish is counted and logged but does **not** fail the request: NATS is
authoritative, and a shadow path that can take down event ingest is a bigger
risk than the one it is measuring. In `ehdb` it is the only path the durable log
has, so a failure is returned and the caller retries.

**The chokepoint's transport gating is restructured, not patched.** It
previously required the NATS publisher to exist before publishing anything. In
`ehdb` mode there is no NATS publisher to build, so the batch would have fallen
through to `insert_rows` — silently resuming server-side event writes and
double-writing against the materializer. It now resolves each transport
independently and publishes when either is live.

## Metrics

`noetl_ehdb_events_published_total{event_type}` — paired with
`noetl_event_ingest_published_total`, this is the shadow-parity signal. Per
`event_type` on purpose: a divergence localises *which* events are missing,
where a single total would hide it.

`noetl_ehdb_events_publish_errors_total{event_type}` matters more than it looks.
In `shadow` those failures are swallowed by design, so this counter is the
**only** place a silently-failing shadow surfaces. Without it, a shadow dropping
every event reads as perfect parity right up until the cutover.

## Validation

3 new unit tests (mode parsing incl. the typo-falls-back-to-NATS case; the
publishes_* matrix; configured/unconfigured detection). Full lib suite green —
**694 passed, 0 failed**.

Formatting applied to the new file only — note that running `rustfmt` on
`src/lib.rs` follows every `mod` declaration and reflows the whole crate.

## Not in this PR

The materializer `ehdb` source and the gateway SSE client (the consume half).
Until those land, `shadow` mirrors events onto a feed nothing reads — which is
exactly the intended first prod step.