### PR TITLE
feat(metrics): count noetl.event rows written by events/project

### DIFF
--- a/src/handlers/internal.rs
+++ b/src/handlers/internal.rs
@@ -344,6 +344,11 @@ pub async fn events_project(
 
     let (projected, duplicates) = svc::project_events(&state.db, &request.events).await?;
     info!(projected, duplicates, "events/project done");
+    // The durable-log write counter (noetl/ai-meta#212). This sink is the sole
+    // writer of `noetl.event` under NOETL_EVENT_INGEST_PUBLISH_ONLY, and until
+    // now it emitted only a log line — so "are rows still landing in the log"
+    // had no queryable answer, which is exactly the T3 cutover's gate.
+    crate::metrics::record_events_projected(projected as u64, duplicates as u64);
 
     // Relocated orchestrator trigger (gate-on only).  For each execution whose
     // just-materialized batch carried a triggering event, fire the drive with

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1029,6 +1029,58 @@ pub fn events_materialized_total() -> &'static prometheus::IntCounter {
     })
 }
 
+/// Counter: `noetl.event` rows written by `/api/internal/events/project` — the
+/// live durable-log write path.
+///
+/// [`events_materialized_total`] counts the *other* sink
+/// (`/api/internal/events/materialize`), which the deployed configuration does
+/// not use, so it reads 0 forever and is not a usable signal for "is the durable
+/// log still being written". This one tracks the path that actually runs under
+/// `NOETL_EVENT_INGEST_PUBLISH_ONLY`, where the worker-side `noetl_materializer`
+/// draining the events bus is the sole writer of `noetl.event`.
+///
+/// That makes it the ground-truth gate for the T3 events-bus cutover
+/// (noetl/ai-meta#212): publish counters prove the *publisher*, this proves rows
+/// are still landing in the log. `duplicates` is tracked separately because
+/// at-least-once redelivery makes a non-zero duplicate count normal — collapsing
+/// the two would hide a real drop behind retried writes.
+pub fn events_projected_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_events_projected_total",
+            "noetl.event rows written via /api/internal/events/project (the live materializer sink).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Counter: rows `/api/internal/events/project` skipped as already-present.
+pub fn events_projected_duplicates_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = prometheus::IntCounter::new(
+            "noetl_events_projected_duplicates_total",
+            "Rows /api/internal/events/project skipped as duplicates (at-least-once redelivery).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record the outcome of one `events/project` batch.
+pub fn record_events_projected(projected: u64, duplicates: u64) {
+    events_projected_total().inc_by(projected);
+    events_projected_duplicates_total().inc_by(duplicates);
+}
+
 /// Record a batch of materialized event rows.
 pub fn record_events_materialized(rows: u64) {
     events_materialized_total().inc_by(rows);


### PR DESCRIPTION
Refs https://github.com/noetl/ai-meta/issues/212

Surfaced while building the T3 shadow-parity check: the durable event log's
write path has no metric.

## The gap

`/api/internal/events/project` is the sink that actually writes `noetl.event`
under `NOETL_EVENT_INGEST_PUBLISH_ONLY` — the worker-side `noetl_materializer`
drains the events bus and posts here, making it the **sole writer** of the
durable event log. It emitted only an `info!` line.

`noetl_events_materialized_total` looks like it covers this, but it counts the
*other* sink (`/api/internal/events/materialize`), which the deployed
configuration does not use. Verified on shastaratech prod: the metric is absent
from `/metrics` entirely, because its `OnceLock` never registers — it has never
been incremented. A signal that reads 0 forever is worse than no signal.

## Why now

This is the ground-truth gate for the T3 events-bus cutover. Publish counters
prove the *publisher*; this proves rows are still landing in the log. Without
it, cutting `noetl_materializer` over to EHDB could only be verified by
inference.

## Notes

Duplicates are counted separately rather than folded into one number:
at-least-once redelivery makes a non-zero duplicate count normal, so a combined
counter would hide a real drop behind retried writes.

Full lib suite green.