### PR TITLE
fix: fail loudly on removed-NATS config, + operator notes

### DIFF
--- a/NATS-REMOVAL.md
+++ b/NATS-REMOVAL.md
@@ -1,0 +1,12 @@
+# NATS removal — operator notes (server)
+
+The NATS code is gone (noetl/ai-meta#212). Two things an operator should know:
+
+- **`NOETL_COMMAND_BUS` / `NOETL_EVENT_BUS` must be `ehdb`.** Selecting `nats`
+  no longer publishes anywhere. It is logged loudly ("command not delivered" /
+  "no transport") rather than silently doing nothing, but it will not work.
+- **`GET /api/health` reports `"nats":"removed"`** — a constant, kept so an
+  existing scraper does not break on a missing key.
+
+Removed env vars: `NOETL_NATS_URL`, `NOETL_REPLICA_COHERENCE=nats_kv`.
+Cross-replica coherence is local-only; the seam remains in `src/coherence.rs`.


### PR DESCRIPTION
Follow-up to the NATS dead-code removal (https://github.com/noetl/ai-meta/issues/212).

The removal PRs were `chore:`-prefixed so semantic-release cut no version. These changes are genuinely `fix:`-shaped: config that used to degrade silently now fails loudly, which is the behavioural change an operator needs a released build for.

Adds `NATS-REMOVAL.md` operator notes naming the now-required env vars.