### PR TITLE
feat(sweep): terminate systemically non-convergent executions, off by default

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -650,6 +650,86 @@ pub struct AppConfig {
     /// maps `NOETL_ORPHAN_SWEEP_LOOKBACK_SECS`.
     #[serde(default = "default_orphan_sweep_lookback_secs")]
     pub orphan_sweep_lookback_secs: u64,
+
+    // ---------------------------------------------------------------------
+    // Systemic non-convergence sweep (noetl/ai-meta#227 part B)
+    // ---------------------------------------------------------------------
+    /// Enable the systemic non-convergence sweep
+    /// ([`crate::handlers::nonconvergence_sweep`]).  Envy maps
+    /// `NOETL_NONCONVERGENCE_SWEEP_ENABLED`.
+    ///
+    /// The orphan sweep above handles exactly one shape: a command **claimed**
+    /// by a worker that then died.  It is deliberately blind to every other way
+    /// an execution can stop converging — an issued command that was never
+    /// claimed, a DAG whose branches all evaluated false so no successor was
+    /// ever issued, and history bulk-imported from another cluster (which has
+    /// no live command at all).  Those accumulate forever as permanent
+    /// `RUNNING` rows: 3359 of them on prod as of 2026-08-04, the oldest 160
+    /// days old, 1699 of which entered the database in a single migration
+    /// transaction and were never executed here.
+    ///
+    /// This sweep closes that gap with a **progress** predicate rather than a
+    /// shape predicate: an execution is eligible only when its newest event of
+    /// any kind is older than [`Self::nonconvergence_grace_secs`] — i.e. the
+    /// execution's own watermark has not moved — **and** nothing can still move
+    /// it.  See the module docs for the full conjunction and, more importantly,
+    /// for what is deliberately excluded.
+    ///
+    /// **Default false.**  The task spawns and returns immediately, scanning
+    /// nothing, so default behaviour is byte-identical.  Instant rollback =
+    /// flip back to false; no state is carried between ticks.
+    #[serde(default)]
+    pub nonconvergence_sweep_enabled: bool,
+
+    /// Seconds between non-convergence sweep ticks.  Envy maps
+    /// `NOETL_NONCONVERGENCE_SWEEP_INTERVAL_SECS`.  Default 300 — this sweep
+    /// chases a backlog measured in days, so it does not need the orphan
+    /// sweep's 60s cadence, and a longer interval keeps its (larger) candidate
+    /// query further off the database's back.
+    #[serde(default = "default_nonconvergence_sweep_interval_secs")]
+    pub nonconvergence_sweep_interval_secs: u64,
+
+    /// How long an execution's newest event must be in the past before the
+    /// execution is considered non-convergent, in seconds.  Envy maps
+    /// `NOETL_NONCONVERGENCE_GRACE_SECS`.
+    ///
+    /// **This is the entire safety margin of the sweep** and should be treated
+    /// as such.  Anything that legitimately runs longer than this without
+    /// emitting a single event would be terminated.  Default 86400 (24h),
+    /// which is ~430× the p99 wall-clock of a real execution on prod and
+    /// ~1700× the longest observed inter-event gap inside a healthy run.
+    #[serde(default = "default_nonconvergence_grace_secs")]
+    pub nonconvergence_grace_secs: u64,
+
+    /// Cap on executions terminated per non-convergence tick.  Envy maps
+    /// `NOETL_NONCONVERGENCE_SWEEP_MAX_PER_TICK`.  Default 20; a capped tick
+    /// logs the deferred backlog (no silent truncation).  With the prod backlog
+    /// of ~3.3k this drains over ~14 hours at the default interval, which is
+    /// the intended pace — a sweep that clears thousands of executions in one
+    /// tick is a sweep whose blast radius nobody can watch.
+    #[serde(default = "default_nonconvergence_sweep_max_per_tick")]
+    pub nonconvergence_sweep_max_per_tick: usize,
+
+    /// Per-shard `LIMIT` on the non-convergence candidate scan.  Envy maps
+    /// `NOETL_NONCONVERGENCE_SWEEP_SCAN_LIMIT`.  Default 500.
+    #[serde(default = "default_nonconvergence_sweep_scan_limit")]
+    pub nonconvergence_sweep_scan_limit: i64,
+
+    /// Opt-in escape hatch: also terminate an execution whose outstanding
+    /// `command.claimed` is held by a **live** worker, when that claim is older
+    /// than this many seconds.  Envy maps
+    /// `NOETL_NONCONVERGENCE_STUCK_CLAIM_SECS`.
+    ///
+    /// **Default 0 = disabled**, and it should stay disabled unless an operator
+    /// has a specific reason.  The Rust worker emits no per-command heartbeat
+    /// (`command.heartbeat` is a retired Python-worker event — the newest one on
+    /// prod is dated 2026-05-23), so there is no signal that distinguishes
+    /// "held by a live worker and grinding through a slow step" from "held by a
+    /// live worker and wedged".  Absent that signal this setting is a timeout,
+    /// not a proof, and it can terminate healthy work.  Reinstating a
+    /// per-command progress signal is the prerequisite for making this safe.
+    #[serde(default)]
+    pub nonconvergence_stuck_claim_secs: u64,
 }
 
 /// How the execution-lifecycle hot path reads `noetl.event` — see
@@ -766,6 +846,23 @@ fn default_orphan_sweep_lookback_secs() -> u64 {
     // so this only bounds the candidate scan; wide enough to catch anything a
     // couple of days old, narrow enough to keep the query off the full log.
     48 * 60 * 60
+}
+
+fn default_nonconvergence_sweep_interval_secs() -> u64 {
+    300
+}
+
+fn default_nonconvergence_grace_secs() -> u64 {
+    // 24h.  The safety margin, not a tuning knob — see the field docs.
+    24 * 60 * 60
+}
+
+fn default_nonconvergence_sweep_max_per_tick() -> usize {
+    20
+}
+
+fn default_nonconvergence_sweep_scan_limit() -> i64 {
+    500
 }
 
 fn default_offserver_tail_cap() -> usize {
@@ -901,6 +998,15 @@ impl Default for AppConfig {
             orphan_sweep_max_per_tick: default_orphan_sweep_max_per_tick(),
             orphan_sweep_scan_limit: default_orphan_sweep_scan_limit(),
             orphan_sweep_lookback_secs: default_orphan_sweep_lookback_secs(),
+            // noetl/ai-meta#227 part B — same discipline as the orphan sweep
+            // above: inert by default, so a permanently-stalled execution stays
+            // exactly as it is until an operator opts in.
+            nonconvergence_sweep_enabled: false,
+            nonconvergence_sweep_interval_secs: default_nonconvergence_sweep_interval_secs(),
+            nonconvergence_grace_secs: default_nonconvergence_grace_secs(),
+            nonconvergence_sweep_max_per_tick: default_nonconvergence_sweep_max_per_tick(),
+            nonconvergence_sweep_scan_limit: default_nonconvergence_sweep_scan_limit(),
+            nonconvergence_stuck_claim_secs: 0,
         }
     }
 }

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -862,20 +862,30 @@ fn default_nonconvergence_grace_secs() -> u64 {
 ///
 /// This exists because a short grace terminates work that was going to finish.
 ///
-/// Finalization is not instant.  Measured in kind on 2026-08-04, sweep OFF and
-/// no restarts, 40 `fixtures/playbooks/hello_world` executions: after the final
-/// step's `command.completed`, the orchestrator takes **p50 206s, p90 210s, max
-/// 393s** to emit `playbook.completed`.  All 40 finalized — nothing was lost,
-/// the tail is simply minutes long.
+/// Finalization is not instant, and — the part that matters for picking a
+/// number — **its tail scales with drive-queue depth**, so there is no single
+/// value to tune against.  Measured in kind on 2026-08-04, sweep OFF, no
+/// restarts, time from the final step's `command.completed` to
+/// `playbook.completed`:
 ///
-/// A validation run at `grace=120` therefore terminated 30 executions that had
-/// run every step successfully and were still inside that tail.  The predicate
-/// was right; the grace was wrong.  The negative control caught it, and this
-/// floor is what stops the same configuration reaching production.
+/// | load | p50 | max |
+/// | :-- | --: | --: |
+/// | light sustained (1 execution / 6s, 212 samples) | 49s | 138s |
+/// | after a burst, queue still draining (40 samples) | 206s | 393s |
 ///
-/// 3600s is a 9x margin over the observed maximum, and costs the real use case
-/// nothing: the prod backlog this sweep exists to clear is between 3.5 and 159
-/// **days** stale.  The 24h default is a 220x margin.
+/// Every execution finalized in both regimes — nothing is lost, the tail is
+/// simply minutes long and **8x longer under load than at rest**.  That spread
+/// is the argument for a floor rather than a tuned value: a grace chosen from a
+/// quiet cluster is wrong on a busy one, and busy is when it matters.
+///
+/// A validation run at `grace=120` duly terminated 30 executions that had run
+/// every step successfully and were still inside that tail.  The predicate was
+/// right; the grace was wrong.  The negative control caught it, and this floor
+/// is what stops the same configuration reaching production.
+///
+/// 3600s is 9x the worst observed tail (26x the light-load one), and costs the
+/// real use case nothing: the prod backlog this sweep exists to clear is
+/// between 3.5 and 159 **days** stale.  The 24h default is 220x.
 pub const MIN_NONCONVERGENCE_GRACE_SECS: u64 = 3600;
 
 fn default_nonconvergence_sweep_max_per_tick() -> usize {

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -31,7 +31,6 @@ pub struct AppConfig {
     #[serde(default = "default_server_name")]
     pub server_name: String,
 
-
     /// Enable GCP token API endpoint
     #[serde(default = "default_true")]
     pub enable_gcp_token_api: bool,
@@ -695,9 +694,11 @@ pub struct AppConfig {
     ///
     /// **This is the entire safety margin of the sweep** and should be treated
     /// as such.  Anything that legitimately runs longer than this without
-    /// emitting a single event would be terminated.  Default 86400 (24h),
-    /// which is ~430× the p99 wall-clock of a real execution on prod and
-    /// ~1700× the longest observed inter-event gap inside a healthy run.
+    /// emitting a single event would be terminated.
+    ///
+    /// Default 86400 (24h).  Values below
+    /// [`MIN_NONCONVERGENCE_GRACE_SECS`] are raised to it at startup, loudly —
+    /// see that constant for the measurement that produced the floor.
     #[serde(default = "default_nonconvergence_grace_secs")]
     pub nonconvergence_grace_secs: u64,
 
@@ -856,6 +857,26 @@ fn default_nonconvergence_grace_secs() -> u64 {
     // 24h.  The safety margin, not a tuning knob — see the field docs.
     24 * 60 * 60
 }
+
+/// Hard floor on [`AppConfig::nonconvergence_grace_secs`], enforced at startup.
+///
+/// This exists because a short grace terminates work that was going to finish.
+///
+/// Finalization is not instant.  Measured in kind on 2026-08-04, sweep OFF and
+/// no restarts, 40 `fixtures/playbooks/hello_world` executions: after the final
+/// step's `command.completed`, the orchestrator takes **p50 206s, p90 210s, max
+/// 393s** to emit `playbook.completed`.  All 40 finalized — nothing was lost,
+/// the tail is simply minutes long.
+///
+/// A validation run at `grace=120` therefore terminated 30 executions that had
+/// run every step successfully and were still inside that tail.  The predicate
+/// was right; the grace was wrong.  The negative control caught it, and this
+/// floor is what stops the same configuration reaching production.
+///
+/// 3600s is a 9x margin over the observed maximum, and costs the real use case
+/// nothing: the prod backlog this sweep exists to clear is between 3.5 and 159
+/// **days** stale.  The 24h default is a 220x margin.
+pub const MIN_NONCONVERGENCE_GRACE_SECS: u64 = 3600;
 
 fn default_nonconvergence_sweep_max_per_tick() -> usize {
     20

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,5 +6,8 @@
 mod app;
 pub mod database;
 
-pub use app::{AppConfig, EventReadPath, ReplicaCoherence, StateBuildMode, StateBuilder};
+pub use app::{
+    AppConfig, EventReadPath, ReplicaCoherence, StateBuildMode, StateBuilder,
+    MIN_NONCONVERGENCE_GRACE_SECS,
+};
 pub use database::{DatabaseConfig, ShardConnection, ShardConnectionError, ShardingConfig};

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -22,6 +22,7 @@ pub mod internal;
 pub mod keychain;
 pub mod plugins;
 pub mod objects;
+pub mod nonconvergence_sweep;
 pub mod orphan_sweep;
 pub mod registry;
 pub mod replay;

--- a/src/handlers/nonconvergence_sweep.rs
+++ b/src/handlers/nonconvergence_sweep.rs
@@ -848,9 +848,11 @@ mod tests {
 
     /// SAFETY: a grace below the floor is raised, not honoured.  A validation
     /// run at grace=120 terminated 30 executions that had run every step
-    /// successfully and were still inside the finalization tail (measured p50
-    /// 206s, max 393s); this is the guard that stops that configuration
-    /// reaching production.
+    /// successfully and were still inside the finalization tail — which scales
+    /// with drive-queue depth (p50 49s / max 138s at light load, p50 206s / max
+    /// 393s behind a burst), so it cannot be tuned against a single
+    /// measurement.  This is the guard that stops that configuration reaching
+    /// production.
     #[test]
     fn grace_below_the_floor_is_raised() {
         use crate::config::MIN_NONCONVERGENCE_GRACE_SECS;

--- a/src/handlers/nonconvergence_sweep.rs
+++ b/src/handlers/nonconvergence_sweep.rs
@@ -1,0 +1,739 @@
+//! Systemic non-convergence sweep (refs
+//! [#227](https://github.com/noetl/ai-meta/issues/227) part B).
+//!
+//! ## What this is for, and why the orphan sweep is not enough
+//!
+//! [`crate::handlers::orphan_sweep`] (#171) terminates exactly one shape: a
+//! command that was **claimed** by a worker which then died.  That is the
+//! zombie it was built for, and it handles it correctly.  It is blind to every
+//! other way an execution stops converging, for two structural reasons:
+//!
+//! 1. its predicate requires an outstanding `command.claimed`, and
+//! 2. its candidate scan is bounded to a 48h lookback.
+//!
+//! A census of `shastaratech-noetl-prod` on 2026-08-04 found **3359**
+//! executions with a start event and no terminal event, the oldest 160 days
+//! old.  Sampling them turns up four unrelated causes, only one of which the
+//! orphan sweep can even see:
+//!
+//! | shape | last event | orphan sweep sees it? |
+//! | :-- | :-- | :-- |
+//! | all branches evaluated false, no successor issued | `step.skipped` | no — no claim |
+//! | command issued, never claimed | `command.issued` | no — no claim |
+//! | already cancelled, mis-projected as RUNNING | `execution.cancelled` | no — and must not |
+//! | history bulk-imported from another cluster | anything | no — and never will |
+//!
+//! That last row is the largest cohort: 1699 of the 3359 share a single
+//! `ingest_time` to the microsecond (2026-05-18 04:31:47.130085), the
+//! `noetl-demo-19700101` → `shastaratech-noetl-prod` migration loading 570,623
+//! events in one transaction.  Those executions were already non-terminal in
+//! the *source* cluster.  Importing an event log cannot resurrect an in-flight
+//! execution — there is no command, no worker, no bus entry, only history — so
+//! they are non-convergent by construction and no runtime repair will ever move
+//! them.
+//!
+//! ## The predicate: progress, not shape
+//!
+//! Because the causes are unrelated, keying on any one of them would clear
+//! almost none of the backlog.  This sweep keys on the one thing they share:
+//! **the execution's watermark has stopped moving and nothing can move it.**
+//!
+//! An execution is eligible only when **all** of the following hold.  Each is a
+//! separate `AND`; there is no scoring, no heuristic weighting, no "two out of
+//! three".
+//!
+//! 1. **It has started and has no terminal event** — no `playbook.completed`,
+//!    `playbook.failed`, `playbook.cancelled` (or their legacy `playbook_*`
+//!    spellings).
+//! 2. **Its watermark is stale** — the newest event of *any* type on the
+//!    execution is older than `nonconvergence_grace_secs` (default 24h).  This
+//!    is the forward-progress signal: an execution that emitted anything at all
+//!    recently is, by definition, converging.
+//! 3. **No live worker holds it** — if the execution has an outstanding
+//!    `command.claimed` (no matching `command.completed` / `command.failed`)
+//!    whose owner is in the live set, it is skipped unconditionally.  This is
+//!    #171's "never fail live work" guard, reused verbatim and *not* relaxed.
+//! 4. **It is not parked awaiting an external callback** — see §Callbacks.
+//! 5. **It was not already cancelled** — an execution carrying
+//!    `execution.cancelled` is left alone; it needs the status projection
+//!    fixed, not a `playbook.failed` written over the top of a deliberate
+//!    cancellation.
+//!
+//! ## Callbacks: the case that would otherwise be terminated wrongly
+//!
+//! The execution model explicitly allows a step to park indefinitely while an
+//! external system works (`agents/rules/execution-model.md`, "Callback / hook
+//! rule").  On that path the worker returns and frees its slot *without*
+//! emitting `call.done`; the terminal arrives later from
+//! `POST /api/internal/container-callback/…`.
+//!
+//! From the event log alone, a healthy execution parked on a 6-hour callback is
+//! **indistinguishable** from one whose DAG ran out of successors: both have a
+//! `command.completed`, no outstanding claim, and an arbitrarily old watermark.
+//! Condition 3 does not save it, because there is no claim to check.  A naive
+//! staleness predicate would terminate healthy work here — this is the sweep's
+//! sharpest edge.
+//!
+//! So the worker now stamps `pending_callback: true` into the `command.completed`
+//! it emits on that path (`repos/worker/src/executor/command.rs`), and condition
+//! 4 excludes any execution whose newest `command.completed` carries the marker
+//! with no `call.done` after it.  A positive signal, not an inference.
+//!
+//! Executions that predate the marker cannot carry it.  That is acceptable
+//! today and the reason is measurable, not hopeful: prod contains **zero**
+//! events mentioning `pending_callback` and one mentioning a container job
+//! handle, because `Tool::Container` is the only producer and it is effectively
+//! unused (see [#186](https://github.com/noetl/ai-meta/issues/186)).  Should
+//! that change, the marker is already in place for everything emitted from now
+//! on.
+//!
+//! ## What this sweep deliberately does NOT do
+//!
+//! * It does not terminate an execution held by a live worker.  The user-facing
+//!   ask was to distinguish "held by a live worker but provably stuck" from
+//!   "held by a live worker and progressing".  **That is not provable today.**
+//!   The only per-command progress signal that ever existed,
+//!   `command.heartbeat`, was emitted by the retired Python worker; the newest
+//!   one on prod is dated 2026-05-23 and the Rust worker emits none.  Worker
+//!   liveness in `noetl.runtime` is pool-level, not command-level, so it cannot
+//!   answer the question either.  Rather than approximate a proof with a
+//!   timeout, the timeout is exposed as `nonconvergence_stuck_claim_secs`,
+//!   **default 0 = off**, and documented as a timeout.  Reinstating a
+//!   per-command progress signal is the honest prerequisite.
+//! * It does not re-queue anything.  Like #171 it terminates, so no
+//!   side-effecting step is ever re-executed.
+//! * It does not delete or update a single row.  `noetl.event` is append-only;
+//!   the sweep appends one `playbook.failed` and nothing else.
+//!
+//! ## Performance
+//!
+//! The hard requirement is **zero added synchronous cost on the hot path**.
+//! Nothing here touches publish, append, claim, ack or dispatch: it is a
+//! background task on its own interval (default 300s), exactly like #171.
+//!
+//! The candidate query is written candidate-first, the shape #62 established:
+//! stage `starts` picks executions from the `event_type` index (~11k start
+//! events, not the 966k-row table), the terminal-existence check rides
+//! `idx_event_exec_type (execution_id, event_type, event_id DESC)`, and the
+//! per-execution watermark / claim / callback lookups are `LATERAL` probes over
+//! `idx_event_execution_id` on an already-bounded candidate set.  There is no
+//! aggregate over the full table.
+//!
+//! ## Safety posture
+//!
+//! Flag-gated, **default off** (`NOETL_NONCONVERGENCE_SWEEP_ENABLED`); the task
+//! spawns, logs once and returns, so default behaviour is byte-identical.
+//! Rate-limited per tick.  Affinity-filtered so only the owning replica acts.
+//! Terminates through [`crate::handlers::event_write::emit_event`], so #103
+//! sole-writer ordering and #118 idempotent-terminal dedup both hold and two
+//! replicas racing the same execution collapse to one terminal.  No state is
+//! carried between ticks, so rollback is flipping the flag.
+
+use std::collections::HashSet;
+
+use tracing::{info, warn};
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::state::AppState;
+
+/// One execution whose watermark has stopped moving, with everything the
+/// disposition decision needs.  Assembled by [`query_nonconvergence_candidates`];
+/// judged by [`plan_dispositions`], which is pure.
+#[derive(Debug, Clone)]
+pub(crate) struct StalledExecution {
+    pub execution_id: i64,
+    pub catalog_id: i64,
+    /// Newest event on the execution — the causal parent of the terminal
+    /// `playbook.failed`, so the chain stays intact.
+    pub last_event_id: i64,
+    /// Type of that newest event, purely for the operator-facing reason string.
+    pub last_event_type: String,
+    /// Age of that newest event in seconds at query time.
+    pub stalled_secs: i64,
+    /// Owner of an outstanding (unfinished) `command.claimed`, if any.
+    pub claim_worker_id: Option<String>,
+    /// Age of that outstanding claim in seconds, if any.
+    pub claim_age_secs: Option<i64>,
+    /// The execution's newest `command.completed` carries `pending_callback`
+    /// and no `call.done` follows it — parked by design, not stalled.
+    pub awaiting_callback: bool,
+}
+
+/// Fate of one candidate this tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Disposition {
+    /// Nothing can move it → emit `playbook.failed`.
+    Terminate,
+    /// An outstanding command is held by a live worker → in-flight work.
+    SkippedLive,
+    /// Parked on an external callback by design → not stalled.
+    SkippedAwaitingCallback,
+    /// Eligible, but this tick's termination budget is spent.
+    Capped,
+}
+
+impl Disposition {
+    fn metric_label(self) -> &'static str {
+        match self {
+            Disposition::Terminate => "terminated",
+            Disposition::SkippedLive => "skipped_live",
+            Disposition::SkippedAwaitingCallback => "skipped_awaiting_callback",
+            Disposition::Capped => "capped",
+        }
+    }
+}
+
+/// Spawn the background non-convergence sweep.  Safe to spawn unconditionally:
+/// while the flag is off the task logs once and returns, scanning nothing.
+pub fn spawn_nonconvergence_sweep(state: AppState) {
+    tokio::spawn(async move {
+        if !state.config.nonconvergence_sweep_enabled {
+            info!(
+                target: "noetl_server::nonconvergence_sweep",
+                "non-convergence sweep: disabled (NOETL_NONCONVERGENCE_SWEEP_ENABLED=false) — not scanning"
+            );
+            return;
+        }
+        let interval =
+            std::time::Duration::from_secs(state.config.nonconvergence_sweep_interval_secs.max(1));
+        warn!(
+            target: "noetl_server::nonconvergence_sweep",
+            interval_secs = state.config.nonconvergence_sweep_interval_secs,
+            grace_secs = state.config.nonconvergence_grace_secs,
+            max_per_tick = state.config.nonconvergence_sweep_max_per_tick,
+            stuck_claim_secs = state.config.nonconvergence_stuck_claim_secs,
+            "non-convergence sweep: ENABLED — executions whose watermark has not moved for the grace period will be terminated append-only (playbook.failed)"
+        );
+        loop {
+            tokio::time::sleep(interval).await;
+            if let Err(e) = run_nonconvergence_sweep(&state).await {
+                warn!(target: "noetl_server::nonconvergence_sweep", error = %e, "non-convergence sweep: tick failed");
+                crate::metrics::record_nonconvergence_sweep("error");
+            }
+        }
+    });
+}
+
+/// Run one sweep tick.
+async fn run_nonconvergence_sweep(state: &AppState) -> AppResult<()> {
+    let cfg = &state.config;
+    let grace = cfg.nonconvergence_grace_secs as i64;
+    let scan_limit = cfg.nonconvergence_sweep_scan_limit;
+    let max_per_tick = cfg.nonconvergence_sweep_max_per_tick;
+    let stuck_claim = cfg.nonconvergence_stuck_claim_secs as i64;
+
+    // Live-worker set — the same `noetl.runtime` question the orphan sweep asks,
+    // and the same answer, so the two sweeps can never disagree about whether a
+    // worker is alive.
+    let live: HashSet<String> = sqlx::query_as::<_, (String,)>(
+        r#"
+        SELECT name FROM noetl.runtime
+        WHERE kind = 'worker_pool'
+          AND heartbeat >= NOW() - INTERVAL '1 second' * $1
+        "#,
+    )
+    .bind(cfg.orphan_worker_ttl_secs as i64)
+    .fetch_all(state.pools.cluster())
+    .await?
+    .into_iter()
+    .map(|(name,)| name)
+    .collect();
+
+    let per_shard = state
+        .pools
+        .for_each_shard(|_idx, pool| async move {
+            query_nonconvergence_candidates(&pool, grace, scan_limit).await
+        })
+        .await?;
+
+    let mut candidates: Vec<StalledExecution> =
+        per_shard.into_iter().flat_map(|(_, v)| v).collect();
+
+    // Execution affinity (RFC #116): only the owner replica acts, so the
+    // per-tick cap counts this replica's work and two replicas never double-plan
+    // the same backlog.  Inert with a single replica / affinity off.
+    if state.affinity.active() {
+        candidates.retain(|c| state.affinity.owns(c.execution_id));
+    }
+    // Longest-stalled first, so the per-tick cap always makes progress on the
+    // oldest end of the backlog instead of oscillating.
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.stalled_secs));
+
+    let plan = plan_dispositions(&candidates, &live, max_per_tick, stuck_claim);
+    let mut deferred = 0usize;
+    for (cand, disp) in candidates.iter().zip(plan.iter()) {
+        crate::metrics::record_nonconvergence_sweep("candidate");
+        crate::metrics::record_nonconvergence_sweep(disp.metric_label());
+        match disp {
+            Disposition::SkippedLive | Disposition::SkippedAwaitingCallback => {}
+            Disposition::Capped => deferred += 1,
+            Disposition::Terminate => match emit_nonconvergent_failed(state, cand).await {
+                Ok(()) => info!(
+                    target: "noetl_server::nonconvergence_sweep",
+                    execution_id = cand.execution_id,
+                    stalled_secs = cand.stalled_secs,
+                    last_event_type = %cand.last_event_type,
+                    "non-convergence sweep: terminated permanently-stalled execution (playbook.failed)"
+                ),
+                Err(e) => {
+                    warn!(
+                        target: "noetl_server::nonconvergence_sweep",
+                        execution_id = cand.execution_id,
+                        error = %e,
+                        "non-convergence sweep: emit playbook.failed failed"
+                    );
+                    crate::metrics::record_nonconvergence_sweep("error");
+                }
+            },
+        }
+    }
+
+    if deferred > 0 {
+        warn!(
+            target: "noetl_server::nonconvergence_sweep",
+            deferred,
+            max_per_tick,
+            "non-convergence sweep: per-tick cap hit; deferred to the next tick"
+        );
+    }
+    Ok(())
+}
+
+/// Pure decision core — the safety-critical part, kept free of I/O so it can be
+/// exhaustively tested.
+///
+/// Invariants, in precedence order:
+///
+/// 1. A candidate parked on an external callback is **always**
+///    `SkippedAwaitingCallback`.  Checked first, because a parked execution
+///    whose worker also happens to be dead is still parked, not stalled.
+/// 2. A candidate whose outstanding claim is held by a **live** worker is
+///    `SkippedLive`, unless `stuck_claim_secs > 0` (opt-in, default off) and the
+///    claim is older than it.
+/// 3. Otherwise the first `max_per_tick` candidates `Terminate`; the rest are
+///    `Capped`.
+///
+/// Skipped candidates never consume the termination budget.
+pub(crate) fn plan_dispositions(
+    candidates: &[StalledExecution],
+    live: &HashSet<String>,
+    max_per_tick: usize,
+    stuck_claim_secs: i64,
+) -> Vec<Disposition> {
+    let mut terminated = 0usize;
+    candidates
+        .iter()
+        .map(|c| {
+            if c.awaiting_callback {
+                return Disposition::SkippedAwaitingCallback;
+            }
+            let held_by_live = c.claim_worker_id.as_ref().is_some_and(|w| live.contains(w));
+            if held_by_live {
+                // Opt-in override: a live-held claim older than the configured
+                // ceiling.  Default 0 disables this entirely — see the config
+                // docs for why this is a timeout and not a proof.
+                let overridden =
+                    stuck_claim_secs > 0 && c.claim_age_secs.is_some_and(|a| a > stuck_claim_secs);
+                if !overridden {
+                    return Disposition::SkippedLive;
+                }
+            }
+            if terminated < max_per_tick {
+                terminated += 1;
+                Disposition::Terminate
+            } else {
+                Disposition::Capped
+            }
+        })
+        .collect()
+}
+
+/// Candidate query for one shard.
+///
+/// Candidate-first (the #62 shape), so nothing here aggregates over the full
+/// event table:
+///
+/// * `starts` selects from the `event_type` index — ~11k start events on prod,
+///   already narrowed by `created_at`, since an execution cannot have a
+///   watermark older than `grace` unless it also *started* before then.  That
+///   prefilter is necessary-but-not-sufficient and is only there to shrink the
+///   scan; condition 2 is enforced for real on the watermark below.
+/// * the terminal-existence check rides
+///   `idx_event_exec_type (execution_id, event_type, event_id DESC)`.
+/// * `watermark`, `claim` and `callback` are `LATERAL` probes over
+///   `idx_event_execution_id`, evaluated only for the already-bounded candidate
+///   set.
+async fn query_nonconvergence_candidates(
+    pool: &DbPool,
+    grace_secs: i64,
+    scan_limit: i64,
+) -> AppResult<Vec<StalledExecution>> {
+    type Row = (
+        i64,
+        i64,
+        i64,
+        String,
+        i64,
+        Option<String>,
+        Option<i64>,
+        bool,
+    );
+    let rows = sqlx::query_as::<_, Row>(
+        r#"
+        WITH starts AS (
+            SELECT s.execution_id, MIN(s.created_at) AS started_at
+            FROM noetl.event s
+            WHERE s.event_type IN ('playbook.initialized', 'playbook_started', 'playbook.started')
+              AND s.created_at < NOW() - INTERVAL '1 second' * $1
+            GROUP BY s.execution_id
+        ),
+        open AS (
+            SELECT st.execution_id, st.started_at
+            FROM starts st
+            WHERE NOT EXISTS (
+                SELECT 1 FROM noetl.event t
+                WHERE t.execution_id = st.execution_id
+                  AND t.event_type IN (
+                      'playbook.completed', 'playbook_completed',
+                      'playbook.failed',    'playbook_failed',
+                      'playbook.cancelled', 'playbook_cancelled',
+                      -- An execution cancelled through the API carries
+                      -- `execution.cancelled`.  It is excluded here rather than
+                      -- terminated: writing playbook.failed over a deliberate
+                      -- cancellation would turn a clean CANCELLED into a
+                      -- misleading FAILED.  The projection gap that leaves it
+                      -- reading RUNNING is fixed in ExecutionService::list.
+                      'execution.cancelled'
+                  )
+            )
+            -- Match the status projection exactly.  `ExecutionService::list`
+            -- reports an execution FAILED as soon as ANY of its events carries
+            -- status='FAILED', even with no terminal event present — 78 prod
+            -- executions are in that state.  Terminating one would append a
+            -- redundant terminal to something operators already see as failed,
+            -- so the sweep leaves them alone and the two views stay consistent.
+            AND NOT EXISTS (
+                SELECT 1 FROM noetl.event f
+                WHERE f.execution_id = st.execution_id
+                  AND f.status = 'FAILED'
+            )
+            ORDER BY st.started_at ASC
+            LIMIT $2
+        )
+        SELECT
+            o.execution_id,
+            COALESCE(
+                (SELECT e2.catalog_id FROM noetl.event e2
+                  WHERE e2.execution_id = o.execution_id AND e2.catalog_id <> 0
+                  ORDER BY e2.event_id ASC LIMIT 1),
+                0
+            ) AS catalog_id,
+            w.event_id                                        AS last_event_id,
+            w.event_type                                      AS last_event_type,
+            FLOOR(EXTRACT(EPOCH FROM (NOW() - w.created_at)))::BIGINT AS stalled_secs,
+            claim.worker_id                                   AS claim_worker_id,
+            FLOOR(EXTRACT(EPOCH FROM (NOW() - claim.created_at)))::BIGINT AS claim_age_secs,
+            (cb.execution_id IS NOT NULL)                     AS awaiting_callback
+        FROM open o
+        CROSS JOIN LATERAL (
+            SELECT e.event_id, e.event_type, e.created_at
+            FROM noetl.event e
+            WHERE e.execution_id = o.execution_id
+            ORDER BY e.created_at DESC, e.event_id DESC
+            LIMIT 1
+        ) w
+        LEFT JOIN LATERAL (
+            SELECT COALESCE(c.worker_id, c.meta->>'worker_id') AS worker_id, c.created_at
+            FROM noetl.event c
+            WHERE c.execution_id = o.execution_id
+              AND c.event_type = 'command.claimed'
+              AND COALESCE(c.worker_id, c.meta->>'worker_id') IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM noetl.event t
+                  WHERE t.execution_id = c.execution_id
+                    AND t.node_name = c.node_name
+                    AND t.event_type IN ('command.completed', 'command.failed')
+                    AND t.created_at >= c.created_at
+              )
+            ORDER BY c.created_at DESC
+            LIMIT 1
+        ) claim ON TRUE
+        LEFT JOIN LATERAL (
+            -- Parked on an external callback: the newest `command.completed`
+            -- carries the worker's `pending_callback` marker and no `call.done`
+            -- has landed for that step since.  A positive signal — absence of
+            -- the marker is never read as "parked".
+            SELECT cc.execution_id
+            FROM noetl.event cc
+            WHERE cc.execution_id = o.execution_id
+              AND cc.event_type = 'command.completed'
+              -- Where the marker actually lands, verified against prod rows
+              -- rather than assumed: the worker hands `emit_event_via` a
+              -- `context` JSON which the control plane stores under
+              -- **`result.context`** — the `context` column itself is NULL on
+              -- every `command.completed` on prod.  The other two spellings are
+              -- accepted so a future storage-path change cannot silently turn
+              -- the exclusion off.
+              --
+              -- Text comparison rather than ::boolean on purpose: a cast would
+              -- raise on any unexpected value and take the whole sweep tick
+              -- down with it.  A malformed marker must read as "not parked
+              -- (unknown)", never as a crash — and it is the *presence* of a
+              -- literal true that grants the exclusion, so an unparseable value
+              -- simply fails to match.
+              AND (
+                    cc.result->'context'->>'pending_callback' = 'true'
+                 OR cc.context->>'pending_callback' = 'true'
+                 OR cc.meta->>'pending_callback' = 'true'
+                  )
+              AND NOT EXISTS (
+                  SELECT 1 FROM noetl.event d
+                  WHERE d.execution_id = cc.execution_id
+                    AND d.node_name = cc.node_name
+                    AND d.event_type = 'call.done'
+                    AND d.created_at >= cc.created_at
+              )
+            ORDER BY cc.created_at DESC
+            LIMIT 1
+        ) cb ON TRUE
+        WHERE w.created_at < NOW() - INTERVAL '1 second' * $1
+        "#,
+    )
+    .bind(grace_secs)
+    .bind(scan_limit)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(
+                execution_id,
+                catalog_id,
+                last_event_id,
+                last_event_type,
+                stalled_secs,
+                claim_worker_id,
+                claim_age_secs,
+                awaiting_callback,
+            )| StalledExecution {
+                execution_id,
+                catalog_id,
+                last_event_id,
+                last_event_type,
+                stalled_secs,
+                claim_worker_id,
+                claim_age_secs,
+                awaiting_callback,
+            },
+        )
+        .collect())
+}
+
+/// Emit the terminal `playbook.failed`, append-only, through the emit
+/// chokepoint (so #103 sole-writer + #118 idempotent-terminal hold).  Parented
+/// on the execution's newest event so the causal chain stays intact.
+///
+/// The reason is machine-readable (`meta.reason`) as well as human-readable, so
+/// an operator can tell these apart from orphan-sweep terminals and from real
+/// application failures without parsing prose.
+async fn emit_nonconvergent_failed(state: &AppState, cand: &StalledExecution) -> AppResult<()> {
+    let event_id = state.snowflake.generate()?;
+    let error = format!(
+        "execution did not converge: no event has been emitted for {}s (newest event '{}'), \
+         no live worker holds an outstanding command, and no callback is pending — \
+         terminated by the non-convergence sweep",
+        cand.stalled_secs, cand.last_event_type
+    );
+    let ev = crate::handlers::event_write::EventRow::new(
+        event_id,
+        cand.execution_id,
+        cand.catalog_id,
+        "playbook.failed",
+        "FAILED",
+        chrono::Utc::now(),
+    )
+    .with_node("playbook")
+    .with_result(serde_json::json!({"status": "FAILED", "context": {"error": error}}))
+    .with_meta(serde_json::json!({
+        "emitted_by": "nonconvergence_sweep",
+        "reason": "watermark_stalled_beyond_grace",
+        "stalled_secs": cand.stalled_secs,
+        "last_event_type": cand.last_event_type,
+        "last_event_id": cand.last_event_id,
+        "commands_generated": 0,
+        "error": error,
+    }))
+    .with_parent_event_id(cand.last_event_id);
+    crate::handlers::event_write::emit_event(state, state.pools.pool_for(cand.execution_id), ev)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stalled(execution_id: i64) -> StalledExecution {
+        StalledExecution {
+            execution_id,
+            catalog_id: 42,
+            last_event_id: execution_id + 1,
+            last_event_type: "step.skipped".to_string(),
+            stalled_secs: 3_456_000,
+            claim_worker_id: None,
+            claim_age_secs: None,
+            awaiting_callback: false,
+        }
+    }
+
+    fn held_by(execution_id: i64, worker: &str, claim_age_secs: i64) -> StalledExecution {
+        StalledExecution {
+            claim_worker_id: Some(worker.to_string()),
+            claim_age_secs: Some(claim_age_secs),
+            last_event_type: "command.claimed".to_string(),
+            ..stalled(execution_id)
+        }
+    }
+
+    fn live_set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The base case: an execution nothing holds, stalled far beyond grace.
+    #[test]
+    fn unheld_stalled_execution_is_terminated() {
+        let c = vec![stalled(100)];
+        let plan = plan_dispositions(&c, &live_set(&[]), 20, 0);
+        assert_eq!(plan, vec![Disposition::Terminate]);
+    }
+
+    /// SAFETY: an outstanding claim held by a LIVE worker is never terminated,
+    /// no matter how long it has been stalled or how large the cap.  This is
+    /// #171's guard and it is not relaxed here.
+    #[test]
+    fn live_held_execution_is_never_terminated() {
+        let c = vec![held_by(100, "noetl-worker-rust-abc-1", 999_999)];
+        let plan = plan_dispositions(&c, &live_set(&["noetl-worker-rust-abc-1"]), 9999, 0);
+        assert_eq!(plan, vec![Disposition::SkippedLive]);
+    }
+
+    /// A claim whose owner is gone is fair game — that is the orphan shape,
+    /// reachable here when it is older than the orphan sweep's 48h lookback.
+    #[test]
+    fn dead_held_execution_is_terminated() {
+        let c = vec![held_by(100, "noetl-worker-rust-dead-9", 999_999)];
+        let plan = plan_dispositions(&c, &live_set(&["noetl-worker-rust-abc-1"]), 20, 0);
+        assert_eq!(plan, vec![Disposition::Terminate]);
+    }
+
+    /// SAFETY: an execution parked on an external callback is never terminated,
+    /// however old.  Time in the external system is free (execution-model
+    /// "Callback / hook rule") and the watermark is meaningless there.
+    #[test]
+    fn callback_parked_execution_is_never_terminated() {
+        let mut c = stalled(100);
+        c.awaiting_callback = true;
+        c.stalled_secs = 90 * 24 * 3600;
+        let plan = plan_dispositions(&[c], &live_set(&[]), 9999, 0);
+        assert_eq!(plan, vec![Disposition::SkippedAwaitingCallback]);
+    }
+
+    /// SAFETY: the callback check has precedence over every other rule — a
+    /// parked execution whose worker also died is still parked.  The callback
+    /// path frees the worker slot by design, so a rolled pod is expected there
+    /// and must not turn a park into a termination.
+    #[test]
+    fn callback_check_outranks_dead_worker() {
+        let mut c = held_by(100, "noetl-worker-rust-dead-9", 999_999);
+        c.awaiting_callback = true;
+        let plan = plan_dispositions(&[c], &live_set(&[]), 20, 0);
+        assert_eq!(plan, vec![Disposition::SkippedAwaitingCallback]);
+    }
+
+    /// The opt-in live-held override stays inert at its default of 0 even when
+    /// the claim is ancient.  Default-off has to mean off.
+    #[test]
+    fn stuck_claim_override_is_inert_at_zero() {
+        let c = vec![held_by(100, "live-worker", i64::MAX / 2)];
+        let plan = plan_dispositions(&c, &live_set(&["live-worker"]), 20, 0);
+        assert_eq!(plan, vec![Disposition::SkippedLive]);
+    }
+
+    /// When an operator opts in, a live-held claim older than the ceiling is
+    /// terminated — and one younger than it still is not.
+    #[test]
+    fn stuck_claim_override_respects_its_threshold() {
+        let c = vec![
+            held_by(100, "live-worker", 7200),
+            held_by(200, "live-worker", 60),
+        ];
+        let plan = plan_dispositions(&c, &live_set(&["live-worker"]), 20, 3600);
+        assert_eq!(plan, vec![Disposition::Terminate, Disposition::SkippedLive]);
+    }
+
+    /// Skipped candidates must not consume the termination budget, or one live
+    /// worker holding many executions would starve the sweep.
+    #[test]
+    fn skipped_candidates_do_not_consume_the_budget() {
+        let c = vec![
+            held_by(1, "live-worker", 100),
+            held_by(2, "live-worker", 100),
+            held_by(3, "live-worker", 100),
+            stalled(4),
+            stalled(5),
+        ];
+        let plan = plan_dispositions(&c, &live_set(&["live-worker"]), 2, 0);
+        assert_eq!(
+            plan,
+            vec![
+                Disposition::SkippedLive,
+                Disposition::SkippedLive,
+                Disposition::SkippedLive,
+                Disposition::Terminate,
+                Disposition::Terminate,
+            ]
+        );
+    }
+
+    /// The per-tick cap bounds terminations and defers the rest.
+    #[test]
+    fn cap_bounds_terminations_per_tick() {
+        let c: Vec<_> = (1..=5).map(stalled).collect();
+        let plan = plan_dispositions(&c, &live_set(&[]), 2, 0);
+        assert_eq!(
+            plan,
+            vec![
+                Disposition::Terminate,
+                Disposition::Terminate,
+                Disposition::Capped,
+                Disposition::Capped,
+                Disposition::Capped,
+            ]
+        );
+    }
+
+    /// A zero cap terminates nothing — a usable kill switch that still lets the
+    /// sweep report what it *would* have done.
+    #[test]
+    fn zero_cap_terminates_nothing() {
+        let c: Vec<_> = (1..=3).map(stalled).collect();
+        let plan = plan_dispositions(&c, &live_set(&[]), 0, 0);
+        assert!(plan.iter().all(|d| *d == Disposition::Capped));
+    }
+
+    /// Every disposition maps to a distinct metric label, so a dashboard can
+    /// separate "we skipped live work" from "we ran out of budget".
+    #[test]
+    fn disposition_metric_labels_are_distinct() {
+        let all = [
+            Disposition::Terminate,
+            Disposition::SkippedLive,
+            Disposition::SkippedAwaitingCallback,
+            Disposition::Capped,
+        ];
+        let labels: HashSet<&str> = all.iter().map(|d| d.metric_label()).collect();
+        assert_eq!(labels.len(), all.len());
+    }
+}

--- a/src/handlers/nonconvergence_sweep.rs
+++ b/src/handlers/nonconvergence_sweep.rs
@@ -58,6 +58,11 @@
 //!    `execution.cancelled` is left alone; it needs the status projection
 //!    fixed, not a `playbook.failed` written over the top of a deliberate
 //!    cancellation.
+//! 6. **Its parent is not still progressing** — a child execution whose parent
+//!    has emitted an event inside the grace period is left alone. 2919 of the
+//!    3258 executions eligible on prod are children, so this is the common
+//!    shape; a parent mid-flight may still drive the child it is waiting on,
+//!    and terminating it would be failing work another live execution owns.
 //!
 //! ## Callbacks: the case that would otherwise be terminated wrongly
 //!
@@ -158,6 +163,9 @@ pub(crate) struct StalledExecution {
     /// The execution's newest `command.completed` carries `pending_callback`
     /// and no `call.done` follows it — parked by design, not stalled.
     pub awaiting_callback: bool,
+    /// This is a child execution whose **parent** has emitted an event inside
+    /// the grace period — the parent is still moving and may yet drive it.
+    pub parent_active: bool,
 }
 
 /// The grace period actually used, never below
@@ -178,6 +186,9 @@ pub(crate) enum Disposition {
     SkippedLive,
     /// Parked on an external callback by design → not stalled.
     SkippedAwaitingCallback,
+    /// A child whose parent is still progressing → the parent may still drive
+    /// it, so this is not ours to terminate.
+    SkippedParentActive,
     /// Eligible, but this tick's termination budget is spent.
     Capped,
 }
@@ -188,6 +199,7 @@ impl Disposition {
             Disposition::Terminate => "terminated",
             Disposition::SkippedLive => "skipped_live",
             Disposition::SkippedAwaitingCallback => "skipped_awaiting_callback",
+            Disposition::SkippedParentActive => "skipped_parent_active",
             Disposition::Capped => "capped",
         }
     }
@@ -289,7 +301,9 @@ async fn run_nonconvergence_sweep(state: &AppState) -> AppResult<()> {
         crate::metrics::record_nonconvergence_sweep("candidate");
         crate::metrics::record_nonconvergence_sweep(disp.metric_label());
         match disp {
-            Disposition::SkippedLive | Disposition::SkippedAwaitingCallback => {}
+            Disposition::SkippedLive
+            | Disposition::SkippedAwaitingCallback
+            | Disposition::SkippedParentActive => {}
             Disposition::Capped => deferred += 1,
             Disposition::Terminate => match emit_nonconvergent_failed(state, cand).await {
                 Ok(()) => info!(
@@ -351,6 +365,15 @@ pub(crate) fn plan_dispositions(
             if c.awaiting_callback {
                 return Disposition::SkippedAwaitingCallback;
             }
+            // A child of a parent that is still emitting events. 2919 of the
+            // 3258 executions eligible on prod are children, so this is the
+            // common shape, not an edge case — and a parent mid-flight may
+            // still drive the child it is waiting on. Terminating it would be
+            // failing work another live execution owns, which is the same
+            // mistake the live-claim guard exists to prevent, one level up.
+            if c.parent_active {
+                return Disposition::SkippedParentActive;
+            }
             let held_by_live = c.claim_worker_id.as_ref().is_some_and(|w| live.contains(w));
             if held_by_live {
                 // Opt-in override: a live-held claim older than the configured
@@ -400,6 +423,7 @@ async fn query_nonconvergence_candidates(
         i64,
         Option<String>,
         Option<i64>,
+        bool,
         bool,
     );
     let rows = sqlx::query_as::<_, Row>(
@@ -457,7 +481,8 @@ async fn query_nonconvergence_candidates(
             FLOOR(EXTRACT(EPOCH FROM (NOW() - w.created_at)))::BIGINT AS stalled_secs,
             claim.worker_id                                   AS claim_worker_id,
             FLOOR(EXTRACT(EPOCH FROM (NOW() - claim.created_at)))::BIGINT AS claim_age_secs,
-            (cb.execution_id IS NOT NULL)                     AS awaiting_callback
+            (cb.execution_id IS NOT NULL)                     AS awaiting_callback,
+            COALESCE(pa.active, false)                        AS parent_active
         FROM open o
         CROSS JOIN LATERAL (
             SELECT e.event_id, e.event_type, e.created_at
@@ -520,6 +545,25 @@ async fn query_nonconvergence_candidates(
             ORDER BY cc.created_at DESC
             LIMIT 1
         ) cb ON TRUE
+        LEFT JOIN LATERAL (
+            -- Is this a child whose parent is still moving?  `parent_execution_id`
+            -- is carried on the child's own events, so the parent id comes from
+            -- there; "moving" is the same watermark test applied one level up.
+            SELECT EXISTS (
+                SELECT 1
+                FROM noetl.event pe
+                WHERE pe.execution_id = (
+                        SELECT ce.parent_execution_id
+                        FROM noetl.event ce
+                        WHERE ce.execution_id = o.execution_id
+                          AND ce.parent_execution_id IS NOT NULL
+                          AND ce.parent_execution_id <> 0
+                        ORDER BY ce.event_id ASC
+                        LIMIT 1
+                    )
+                  AND pe.created_at >= NOW() - INTERVAL '1 second' * $1
+            ) AS active
+        ) pa ON TRUE
         WHERE w.created_at < NOW() - INTERVAL '1 second' * $1
         "#,
     )
@@ -540,6 +584,7 @@ async fn query_nonconvergence_candidates(
                 claim_worker_id,
                 claim_age_secs,
                 awaiting_callback,
+                parent_active,
             )| StalledExecution {
                 execution_id,
                 catalog_id,
@@ -549,6 +594,7 @@ async fn query_nonconvergence_candidates(
                 claim_worker_id,
                 claim_age_secs,
                 awaiting_callback,
+                parent_active,
             },
         )
         .collect())
@@ -608,6 +654,7 @@ mod tests {
             claim_worker_id: None,
             claim_age_secs: None,
             awaiting_callback: false,
+            parent_active: false,
         }
     }
 
@@ -744,6 +791,59 @@ mod tests {
         let c: Vec<_> = (1..=3).map(stalled).collect();
         let plan = plan_dispositions(&c, &live_set(&[]), 0, 0);
         assert!(plan.iter().all(|d| *d == Disposition::Capped));
+    }
+
+    /// SAFETY: a child whose parent is still emitting events is never
+    /// terminated. 2919 of the 3258 executions eligible on prod are children,
+    /// so this is the common shape — and a parent mid-flight may still drive
+    /// the child it is waiting on.
+    #[test]
+    fn child_of_an_active_parent_is_never_terminated() {
+        let mut c = stalled(100);
+        c.parent_active = true;
+        c.stalled_secs = 90 * 24 * 3600;
+        let plan = plan_dispositions(&[c], &live_set(&[]), 9999, 0);
+        assert_eq!(plan, vec![Disposition::SkippedParentActive]);
+    }
+
+    /// A child whose parent has gone quiet too is fair game — otherwise a whole
+    /// dead tree would be permanently unreachable, which is most of the prod
+    /// backlog.
+    #[test]
+    fn child_of_a_quiet_parent_is_terminated() {
+        let c = stalled(100);
+        assert!(!c.parent_active);
+        let plan = plan_dispositions(&[c], &live_set(&[]), 20, 0);
+        assert_eq!(plan, vec![Disposition::Terminate]);
+    }
+
+    /// The callback exclusion still outranks the parent check — a parked child
+    /// is parked whatever its parent is doing.
+    #[test]
+    fn callback_check_outranks_parent_active() {
+        let mut c = stalled(100);
+        c.awaiting_callback = true;
+        c.parent_active = true;
+        let plan = plan_dispositions(&[c], &live_set(&[]), 20, 0);
+        assert_eq!(plan, vec![Disposition::SkippedAwaitingCallback]);
+    }
+
+    /// A skipped-for-parent candidate must not consume the termination budget
+    /// either.
+    #[test]
+    fn parent_active_skips_do_not_consume_the_budget() {
+        let mut a = stalled(1);
+        a.parent_active = true;
+        let c = vec![a, stalled(2), stalled(3)];
+        let plan = plan_dispositions(&c, &live_set(&[]), 2, 0);
+        assert_eq!(
+            plan,
+            vec![
+                Disposition::SkippedParentActive,
+                Disposition::Terminate,
+                Disposition::Terminate,
+            ]
+        );
     }
 
     /// SAFETY: a grace below the floor is raised, not honoured.  A validation

--- a/src/handlers/nonconvergence_sweep.rs
+++ b/src/handlers/nonconvergence_sweep.rs
@@ -160,6 +160,15 @@ pub(crate) struct StalledExecution {
     pub awaiting_callback: bool,
 }
 
+/// The grace period actually used, never below
+/// [`crate::config::MIN_NONCONVERGENCE_GRACE_SECS`].
+///
+/// Applied at both the log site and the query site so the number an operator
+/// reads in the startup line is the number the predicate uses.
+fn effective_grace_secs(configured: u64) -> u64 {
+    configured.max(crate::config::MIN_NONCONVERGENCE_GRACE_SECS)
+}
+
 /// Fate of one candidate this tick.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Disposition {
@@ -197,10 +206,24 @@ pub fn spawn_nonconvergence_sweep(state: AppState) {
         }
         let interval =
             std::time::Duration::from_secs(state.config.nonconvergence_sweep_interval_secs.max(1));
+        // Enforce the grace floor here rather than trusting the deployment.  A
+        // grace shorter than the orchestrator's finalization tail terminates
+        // executions that ran every step successfully and were merely waiting to
+        // be finalized — measured, not theorised: see
+        // `MIN_NONCONVERGENCE_GRACE_SECS`.
+        let grace = effective_grace_secs(state.config.nonconvergence_grace_secs);
+        if grace != state.config.nonconvergence_grace_secs {
+            warn!(
+                target: "noetl_server::nonconvergence_sweep",
+                configured = state.config.nonconvergence_grace_secs,
+                effective = grace,
+                "non-convergence sweep: NOETL_NONCONVERGENCE_GRACE_SECS is below the safe floor and has been RAISED — a shorter grace terminates executions that are merely awaiting finalization"
+            );
+        }
         warn!(
             target: "noetl_server::nonconvergence_sweep",
             interval_secs = state.config.nonconvergence_sweep_interval_secs,
-            grace_secs = state.config.nonconvergence_grace_secs,
+            grace_secs = grace,
             max_per_tick = state.config.nonconvergence_sweep_max_per_tick,
             stuck_claim_secs = state.config.nonconvergence_stuck_claim_secs,
             "non-convergence sweep: ENABLED — executions whose watermark has not moved for the grace period will be terminated append-only (playbook.failed)"
@@ -218,7 +241,7 @@ pub fn spawn_nonconvergence_sweep(state: AppState) {
 /// Run one sweep tick.
 async fn run_nonconvergence_sweep(state: &AppState) -> AppResult<()> {
     let cfg = &state.config;
-    let grace = cfg.nonconvergence_grace_secs as i64;
+    let grace = effective_grace_secs(cfg.nonconvergence_grace_secs) as i64;
     let scan_limit = cfg.nonconvergence_sweep_scan_limit;
     let max_per_tick = cfg.nonconvergence_sweep_max_per_tick;
     let stuck_claim = cfg.nonconvergence_stuck_claim_secs as i64;
@@ -721,6 +744,41 @@ mod tests {
         let c: Vec<_> = (1..=3).map(stalled).collect();
         let plan = plan_dispositions(&c, &live_set(&[]), 0, 0);
         assert!(plan.iter().all(|d| *d == Disposition::Capped));
+    }
+
+    /// SAFETY: a grace below the floor is raised, not honoured.  A validation
+    /// run at grace=120 terminated 30 executions that had run every step
+    /// successfully and were still inside the finalization tail (measured p50
+    /// 206s, max 393s); this is the guard that stops that configuration
+    /// reaching production.
+    #[test]
+    fn grace_below_the_floor_is_raised() {
+        use crate::config::MIN_NONCONVERGENCE_GRACE_SECS;
+        assert_eq!(effective_grace_secs(0), MIN_NONCONVERGENCE_GRACE_SECS);
+        assert_eq!(effective_grace_secs(120), MIN_NONCONVERGENCE_GRACE_SECS);
+        assert_eq!(
+            effective_grace_secs(MIN_NONCONVERGENCE_GRACE_SECS - 1),
+            MIN_NONCONVERGENCE_GRACE_SECS
+        );
+    }
+
+    /// A grace at or above the floor is passed through untouched — the floor is
+    /// a floor, not an override.
+    #[test]
+    fn grace_at_or_above_the_floor_is_honoured() {
+        use crate::config::MIN_NONCONVERGENCE_GRACE_SECS;
+        assert_eq!(
+            effective_grace_secs(MIN_NONCONVERGENCE_GRACE_SECS),
+            MIN_NONCONVERGENCE_GRACE_SECS
+        );
+        assert_eq!(effective_grace_secs(86_400), 86_400);
+    }
+
+    /// The default must satisfy its own floor.
+    #[test]
+    fn default_grace_clears_the_floor() {
+        let cfg = crate::config::AppConfig::default();
+        assert!(cfg.nonconvergence_grace_secs >= crate::config::MIN_NONCONVERGENCE_GRACE_SECS);
     }
 
     /// Every disposition maps to a distinct metric label, so a dashboard can

--- a/src/main.rs
+++ b/src/main.rs
@@ -806,6 +806,16 @@ async fn main() -> anyhow::Result<()> {
     // flips it on, so this is behavior-neutral until enabled.
     handlers::orphan_sweep::spawn_orphan_command_sweep(state.clone());
 
+    // Systemic non-convergence sweep (noetl/ai-meta#227 part B): terminates
+    // append-only (playbook.failed) any execution whose watermark — its newest
+    // event of any type — has not moved for the grace period, while no live
+    // worker holds an outstanding command and no external callback is pending.
+    // Covers the shapes the orphan sweep above is structurally blind to (never
+    // claimed, no successor issued, imported history), which is most of them.
+    // Default OFF (NOETL_NONCONVERGENCE_SWEEP_ENABLED); behavior-neutral until
+    // ops flips it on.
+    handlers::nonconvergence_sweep::spawn_nonconvergence_sweep(state.clone());
+
 
     // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when
     // `NOETL_EVENT_INGEST_PUBLISH_ONLY` is on, server-originated events publish to

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -181,6 +181,47 @@ pub fn record_orphan_sweep(outcome: &str) {
     orphan_sweep_total().with_label_values(&[outcome]).inc();
 }
 
+// ── Systemic non-convergence sweep (noetl/ai-meta#227 part B) ────────────────
+
+/// `noetl_nonconvergence_sweep_total{outcome}` — outcomes of the systemic
+/// non-convergence sweep ([`crate::handlers::nonconvergence_sweep`]).  `outcome`
+/// is one of: `candidate` (an execution whose watermark has not moved for the
+/// grace period was examined), `terminated` (`playbook.failed` emitted),
+/// `skipped_live` (an outstanding command is held by a live worker — never
+/// failed), `skipped_awaiting_callback` (parked on an external callback by
+/// design — never failed), `capped` (eligible but deferred to a later tick by
+/// the rate limit), `error` (scan / emit failure).  Zero increments while the
+/// sweep is off (`NOETL_NONCONVERGENCE_SWEEP_ENABLED=false`).
+///
+/// `skipped_live` and `skipped_awaiting_callback` are the negative-control
+/// signals: during a drain they should account for every healthy execution the
+/// sweep looked at, and any drift in `terminated` against a known target list is
+/// the alarm.
+pub fn nonconvergence_sweep_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_nonconvergence_sweep_total",
+                "Systemic non-convergence sweep outcomes, by outcome.",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record one non-convergence sweep outcome (see [`nonconvergence_sweep_total`]).
+pub fn record_nonconvergence_sweep(outcome: &str) {
+    nonconvergence_sweep_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
 // ── Result/state tier GC (noetl/ai-meta#104 Phase F + #166 Phase 5) ──────────
 
 /// `noetl_result_tier_gc_objects_total{class,action}` — objects a tier-GC sweep

--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -301,7 +301,13 @@ impl ExecutionService {
                                 CASE
                                     WHEN bool_or(e.event_type IN ('playbook.completed', 'playbook_completed')) THEN 'COMPLETED'
                                     WHEN bool_or(e.event_type IN ('playbook.failed', 'playbook_failed') OR e.status = 'FAILED') THEN 'FAILED'
-                                    WHEN bool_or(e.event_type IN ('playbook.cancelled', 'playbook_cancelled')) THEN 'CANCELLED'
+                                    -- noetl/ai-meta#227: `execution.cancelled` is the
+                                    -- cancellation terminal the Python engine emits (it is in
+                                    -- that engine's own _EXECUTION_TERMINAL_EVENT_TYPES, and
+                                    -- auto_resume maps it to "cancelled").  This projection
+                                    -- never learned about it, so 234 deliberately-cancelled
+                                    -- executions on prod report RUNNING for ever.
+                                    WHEN bool_or(e.event_type IN ('playbook.cancelled', 'playbook_cancelled', 'execution.cancelled')) THEN 'CANCELLED'
                                     ELSE 'RUNNING'
                                 END as status
                             FROM noetl.event e
@@ -505,6 +511,8 @@ impl ExecutionService {
                         | "playbook_failed"
                         | "playbook.cancelled"
                         | "playbook_cancelled"
+                        // noetl/ai-meta#227 — see determine_status.
+                        | "execution.cancelled"
                 )
             })
             .map(|e| e.created_at)
@@ -734,7 +742,7 @@ impl ExecutionService {
             SELECT EXISTS(
                 SELECT 1 FROM noetl.event
                 WHERE execution_id = $1
-                  AND event_type IN ('playbook.cancelled', 'playbook_cancelled')
+                  AND event_type IN ('playbook.cancelled', 'playbook_cancelled', 'execution.cancelled')
             )
             "#,
         )
@@ -865,7 +873,7 @@ impl ExecutionService {
             SELECT EXISTS(
                 SELECT 1 FROM noetl.event
                 WHERE execution_id = $1
-                  AND event_type IN ('playbook.cancelled', 'playbook_cancelled')
+                  AND event_type IN ('playbook.cancelled', 'playbook_cancelled', 'execution.cancelled')
             )
             "#,
         )
@@ -936,7 +944,12 @@ impl ExecutionService {
             match event.event_type.as_str() {
                 "playbook.completed" | "playbook_completed" => return "COMPLETED".to_string(),
                 "playbook.failed" | "playbook_failed" => return "FAILED".to_string(),
-                "playbook.cancelled" | "playbook_cancelled" => return "CANCELLED".to_string(),
+                // noetl/ai-meta#227 — `execution.cancelled` is a cancellation
+                // terminal too (the Python engine's own terminal set includes it);
+                // without it a cancelled execution reads RUNNING for ever.
+                "playbook.cancelled" | "playbook_cancelled" | "execution.cancelled" => {
+                    return "CANCELLED".to_string()
+                }
                 _ => {}
             }
             if event.status == "FAILED" {


### PR DESCRIPTION
Part B of [noetl/ai-meta#227](https://github.com/noetl/ai-meta/issues/227). **Default off.**

## Why the orphan sweep is not enough

#171 terminates exactly one shape — a command **claimed** by a worker that then died — and is structurally blind to every other way an execution stops converging: its predicate requires an outstanding `command.claimed`, and its candidate scan is capped at a 48h lookback.

A census of prod on 2026-08-04 found **3359** executions with a start event and no terminal event, the oldest 160 days old. (`GET /api/executions?status=RUNNING` reports ~70 — it is a paginated-recent semantic capped at ~1000 candidates, so it cannot see the backlog.) Four unrelated causes, none visible to #171:

| shape | last event |
| :-- | :-- |
| all branches evaluated false, no successor issued | `step.skipped` |
| command issued, never claimed | `command.issued` |
| already cancelled, mis-projected RUNNING | `execution.cancelled` |
| history bulk-imported from another cluster | anything |

The last is the largest cohort — **1699** share one `ingest_time` to the microsecond: the 2026-05-18 migration loading 570,623 events in one transaction. Those were already non-terminal in the *source* cluster; no runtime repair will ever move them.

## The predicate: progress, not shape

Six conjunctive conditions, no scoring: started with no terminal; watermark (newest event of any type) older than grace; no **live** worker holding an outstanding claim (#171's guard, reused, not relaxed); not parked on a callback; not already `execution.cancelled`; no event with `status='FAILED'` (which the list projection already reports as FAILED — 78 on prod — so terminating one would make the two views disagree).

Terminal via `emit_event` → `playbook.failed` through the #103 chokepoint, so #118 idempotent-terminal holds and two replicas racing one execution collapse to a single terminal. Append-only; nothing re-queued, no row updated or deleted.

## ⚠ The negative control failed on the first run — that is the useful part

At `grace=120s` under load: 6/6 positive controls terminated, 5/5 pre-existing terminals untouched, and **30 of 344 healthy load executions terminated**. Their chains were complete through `command.completed end success`; the sweep failed them 126s later.

They were inside the orchestrator's finalization tail. Measured with the sweep off and no restarts, 40 `hello_world` executions: last `command.completed` → `playbook.completed` is **p50 206s, p90 210s, max 393s, and 40/40 finalize**. Reliable, just slow.

The predicate was right; the grace was wrong. So `MIN_NONCONVERGENCE_GRACE_SECS = 3600` now raises any lower configured value at startup, loudly, applied at both the log site and the query site so the number an operator reads is the number the predicate uses. 9× margin over the observed max; the 86400s default is 220×. Verified live: `configured=120 effective=3600`.

## Callbacks — the case that would otherwise be killed

On the `pending_callback` path the worker skips `call.done` and returns, freeing the slot. From the event log a healthy execution parked on a six-hour callback is **indistinguishable** from one whose DAG ran out of successors, and the live-claim guard does not help because there is no claim. Paired with noetl/worker#`feat/227-pending-callback-marker`, which stamps the marker; the sweep excludes on that positive signal, never on an inference. Textual comparison, so a malformed value cannot take a tick down with a cast error. Location verified against prod rows: the payload lands in `result.context`, not the `context` column.

## What it deliberately does not do

Terminate an execution held by a live worker. Distinguishing "held and stuck" from "held and grinding" is **not provable today** — `command.heartbeat` was the Python worker's (newest on prod: 2026-05-23) and the Rust worker emits none; `noetl.runtime` liveness is pool-level. Rather than dress a timeout as a proof, it is exposed as `NOETL_NONCONVERGENCE_STUCK_CLAIM_SECS`, **default 0 = off**, documented as a timeout.

## Perf

Nothing added to publish, append, claim, ack or dispatch. Background task, 300s default interval. Candidate query is candidate-first in the #62 shape; measured against the **real prod table** (966,493 rows), read-only: **408ms warm**, 30ms planning, no seq scan on any large partition — a 0.13% duty cycle.

## Also fixed

`execution.cancelled` is a cancellation terminal in the Python engine's own terminal set and `auto_resume` maps it to "cancelled", but `ExecutionService` never recognised it — **234 deliberately-cancelled prod executions report RUNNING for ever.**

## Status

701/701 lib tests, clippy clean. Default-off; rollback is the flag, no state carried between ticks. Not in prod.

Refs noetl/ai-meta#227