### PR TITLE
fix(result-tier-gc): a truncated sink feed must fail closed, not open

### DIFF
--- a/src/db/queries/sink_pending.rs
+++ b/src/db/queries/sink_pending.rs
@@ -80,4 +80,31 @@ pub async fn list_pending(pool: &DbPool, limit: i64) -> AppResult<Vec<i64>> {
 }
 
 /// Default safety cap for [`list_pending`].
+///
+/// noetl/ai-meta#199 — a cap on a SAFETY gate has to be observable, because
+/// hitting it makes the gate fail OPEN.  `list_pending` is `ORDER BY marked_at
+/// LIMIT n`, so truncation silently drops the **newest** marks — precisely the
+/// executions whose business context is most likely still live — and the
+/// Feather GC then reclaims them.
+///
+/// That contradicts the sweep's own documented invariant, which says the gate
+/// "can only ever retain more, never delete more".  With a silent cap it can
+/// delete more.  See [`list_pending_checked`].
 pub const DEFAULT_LIST_LIMIT: i64 = 100_000;
+
+/// [`list_pending`] plus whether the result was truncated by the cap.
+///
+/// Returns `(ids, complete)`. `complete == false` means the feed hit
+/// `DEFAULT_LIST_LIMIT` and the caller is holding an INCOMPLETE view of what is
+/// un-sunk.
+///
+/// A caller gating deletion on this set must fail CLOSED when `complete` is
+/// false: retaining objects it might have reclaimed costs storage, whereas
+/// reclaiming business context that was never sunk to the customer's system of
+/// record is unrecoverable. Those are not symmetric, so the tie does not go to
+/// the sweep.
+pub async fn list_pending_checked(pool: &DbPool, limit: i64) -> AppResult<(Vec<i64>, bool)> {
+    let ids = list_pending(pool, limit).await?;
+    let complete = (ids.len() as i64) < limit;
+    Ok((ids, complete))
+}

--- a/src/handlers/result_tier.rs
+++ b/src/handlers/result_tier.rs
@@ -43,19 +43,31 @@ pub async fn gc(
     // cross-process from the worker's in-process sink gate); the sweep then retains
     // any object whose execution is still pending-sink. Gate off ⇒ empty set + no
     // DB read, so the sweep is byte-identical to the pre-#199 behavior.
-    let pending_sink: std::collections::HashSet<i64> = if result_tier_gc::sink_gate_enabled() {
-        crate::metrics::record_sink_state("gc_consult");
-        crate::db::queries::sink_pending::list_pending(
-            &deps.pool,
-            crate::db::queries::sink_pending::DEFAULT_LIST_LIMIT,
-        )
-        .await?
-        .into_iter()
-        .collect()
-    } else {
-        std::collections::HashSet::new()
-    };
-    let report = result_tier_gc::sweep(&deps.pool, &deps.backend, &req, &pending_sink).await?;
+    let (pending_sink, pending_sink_complete): (std::collections::HashSet<i64>, bool) =
+        if result_tier_gc::sink_gate_enabled() {
+            crate::metrics::record_sink_state("gc_consult");
+            // `_checked` reports whether the cap truncated the feed. A truncated
+            // feed makes the gate fail OPEN, so the sweep needs to know
+            // (noetl/ai-meta#199).
+            let (ids, complete) = crate::db::queries::sink_pending::list_pending_checked(
+                &deps.pool,
+                crate::db::queries::sink_pending::DEFAULT_LIST_LIMIT,
+            )
+            .await?;
+            (ids.into_iter().collect(), complete)
+        } else {
+            // Gate off ⇒ empty set, no DB read, and `complete` is vacuously true:
+            // there is nothing to be incomplete about.
+            (std::collections::HashSet::new(), true)
+        };
+    let report = result_tier_gc::sweep(
+        &deps.pool,
+        &deps.backend,
+        &req,
+        &pending_sink,
+        pending_sink_complete,
+    )
+    .await?;
 
     // Observability: one counter, deltas tell the story (no_op when the gate is
     // off, scanned/deleted/skipped_live/errors otherwise).

--- a/src/services/result_tier_gc.rs
+++ b/src/services/result_tier_gc.rs
@@ -312,6 +312,34 @@ pub fn state_shard_gc_enabled() -> bool {
 /// (the set of pending-sink executions). Absent a feed the source is empty, so
 /// enabling the flag alone is still behavior-neutral — the gate can only ever
 /// make the sweep *more* conservative, never less.
+/// Should this object be held back as un-sunk? (noetl/ai-meta#199)
+///
+/// Pure so the sweep and its tests exercise the SAME decision — a test that
+/// re-implements the rule passes whether or not the shipped code still follows
+/// it, which is how a gate ends up asserted-but-not-enforced.
+///
+/// `feed_complete == false` means the sink feed hit its cap and this process is
+/// holding an incomplete view of what is un-sunk. Every object then reads as
+/// un-sunk: the safe interpretation of "I cannot see the whole set". Retaining
+/// costs storage; reclaiming business context that never reached the customer's
+/// system of record is unrecoverable, so the tie does not go to the sweep.
+pub(crate) fn is_unsunk(
+    sink_gate: bool,
+    feed_complete: bool,
+    pending_sink: &std::collections::HashSet<i64>,
+    execution_id: Option<i64>,
+) -> bool {
+    if !sink_gate {
+        return false;
+    }
+    if !feed_complete {
+        return true;
+    }
+    execution_id
+        .map(|id| pending_sink.contains(&id))
+        .unwrap_or(false)
+}
+
 pub fn sink_gate_enabled() -> bool {
     matches!(
         std::env::var("NOETL_RESULT_TIER_GC_SINK_GATE")
@@ -444,6 +472,7 @@ pub async fn sweep(
     backend: &ObjectBackend,
     req: &GcRequest,
     pending_sink: &std::collections::HashSet<i64>,
+    pending_sink_complete: bool,
 ) -> AppResult<GcReport> {
     if !gc_enabled() {
         return Ok(GcReport::disabled());
@@ -458,6 +487,25 @@ pub async fn sweep(
     // noetl/ai-meta#199 Slice B: opt-in write-behind-cache guard. Off (or an empty
     // sink-state source) → no object is ever retained for un-sunk context.
     let sink_gate = sink_gate_enabled();
+    // noetl/ai-meta#199 — the sink feed is capped (`DEFAULT_LIST_LIMIT`), and
+    // `ORDER BY marked_at` means truncation drops the NEWEST marks: the
+    // executions whose business context is most likely still live.  With an
+    // incomplete feed this sweep cannot tell un-sunk from sunk, so it must not
+    // delete anything.
+    //
+    // Fail closed, deliberately asymmetric: retaining objects costs storage,
+    // reclaiming un-sunk business context is unrecoverable.
+    let sink_feed_incomplete = sink_gate && !pending_sink_complete;
+    if sink_feed_incomplete {
+        tracing::error!(
+            pending = pending_sink.len(),
+            "result-tier GC: the sink feed is TRUNCATED — refusing to reclaim. \
+             The gate cannot see every un-sunk execution, so a sweep would delete \
+             business context that never reached the customer's system of record. \
+             Raise the list limit or drain noetl.sink_pending (noetl/ai-meta#199)."
+        );
+        crate::metrics::record_sink_state("gc_feed_truncated");
+    }
 
     let mut report = GcReport {
         enabled: true,
@@ -491,7 +539,9 @@ pub async fn sweep(
         let age = eid.and_then(|id| age_seconds(id, now));
         // Write-behind-cache: is this execution's business context still un-sunk?
         // Only consulted when the sink gate is on; an empty source ⇒ always false.
-        let has_unsunk = sink_gate && eid.map(|id| pending_sink.contains(&id)).unwrap_or(false);
+        // An incomplete feed makes EVERY object un-sunk as far as this sweep is
+        // concerned — the safe reading of "I cannot see the whole set".
+        let has_unsunk = is_unsunk(sink_gate, !sink_feed_incomplete, pending_sink, eid);
 
         // Whether the open-shard guard *would* have deleted this object under the
         // base policy — used to count objects the guard specifically protected.
@@ -844,5 +894,74 @@ mod tests {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod sink_feed_truncation_tests {
+    use super::*;
+
+    fn pending(ids: &[i64]) -> std::collections::HashSet<i64> {
+        ids.iter().copied().collect()
+    }
+
+    /// noetl/ai-meta#199 — the sink feed is capped at `DEFAULT_LIST_LIMIT` and
+    /// ordered by `marked_at`, so truncation drops the **newest** marks: exactly
+    /// the executions whose business context is most likely still live.
+    ///
+    /// The sweep's own doc comment claims the gate "can only ever retain more,
+    /// never delete more". A silent cap breaks that — the gate stops seeing
+    /// un-sunk executions and the sweep reclaims them, failing OPEN.
+    #[test]
+    fn a_truncated_feed_holds_back_an_execution_it_cannot_see() {
+        let p = pending(&[1, 2]);
+        // Complete feed: an unlisted execution is reclaimable.
+        assert!(!is_unsunk(true, true, &p, Some(9)));
+        // Truncated feed: the same execution must be retained — its mark may
+        // simply be past the cap.
+        assert!(
+            is_unsunk(true, false, &p, Some(9)),
+            "a truncated feed must retain an execution it cannot see; this is the \
+             fail-open the cap introduced"
+        );
+    }
+
+    /// The gate must still discriminate when the feed IS complete, or it
+    /// degenerates into "retain everything" and the retention means nothing.
+    #[test]
+    fn a_complete_feed_still_discriminates() {
+        let p = pending(&[1, 2]);
+        assert!(is_unsunk(true, true, &p, Some(1)), "a marked execution is un-sunk");
+        assert!(!is_unsunk(true, true, &p, Some(9)), "an unmarked one is reclaimable");
+        assert!(
+            !is_unsunk(true, true, &p, None),
+            "an unparseable key is not un-sunk — it is handled by skipped_unparseable"
+        );
+    }
+
+    /// Gate OFF must be byte-identical to pre-#199 behaviour, including when the
+    /// feed is nominally incomplete: with the gate off there is no feed to be
+    /// incomplete about, and no DB read happens at all.
+    #[test]
+    fn the_gate_off_path_is_untouched() {
+        let p = pending(&[1, 2]);
+        for complete in [true, false] {
+            for eid in [Some(1), Some(9), None] {
+                assert!(
+                    !is_unsunk(false, complete, &p, eid),
+                    "gate off must never retain (complete={complete}, eid={eid:?})"
+                );
+            }
+        }
+    }
+
+    /// Exactly-at-limit is indistinguishable from "there were more", so it must
+    /// read as truncated. Guessing complete is what fails the gate open.
+    #[test]
+    fn exactly_at_the_cap_reads_as_truncated() {
+        let complete = |n: usize, limit: i64| (n as i64) < limit;
+        assert!(complete(0, 100));
+        assert!(complete(99, 100));
+        assert!(!complete(100, 100), "at the cap must read as TRUNCATED");
     }
 }


### PR DESCRIPTION
noetl/ai-meta#199.

The Feather result-tier GC reads `noetl.sink_pending` to decide which objects still hold business context that has not reached the customer's system of record. **That read is capped, and the cap is invisible:**

```sql
SELECT execution_id FROM noetl.sink_pending ORDER BY marked_at LIMIT $1
-- DEFAULT_LIST_LIMIT = 100_000, with no truncation detection anywhere
```

Two things make this worse than a plain cap:

- **`ORDER BY marked_at` drops the *newest* marks on truncation** — the executions whose business context is most likely still live.
- The gate then stops seeing them and the sweep **reclaims** them. It fails **open**, silently, in the one direction that is unrecoverable.

It also contradicts the sweep's own documented invariant:

> the gate "can only ever retain more, never delete more"

With a silent cap, it can delete more.

## The fix

`list_pending_checked` reports whether the cap truncated the result. An incomplete feed makes **every** object read as un-sunk — the safe reading of *"I cannot see the whole set"*.

Deliberately asymmetric: retaining objects costs **storage**; reclaiming context that never reached the customer's system of record **cannot be undone**. The tie does not go to the sweep. Logged at ERROR with a `gc_feed_truncated` counter, because a gate that silently stops discriminating is the exact failure this slice exists to prevent.

**Exactly-at-the-cap counts as truncated** — it is indistinguishable from a larger set, and guessing "complete" is what fails it open.

## On the tests

The first version re-implemented the decision inline in the test. It passed — and **would have passed against the unfixed sweep**, because it asserted a rule nothing enforced. That is the same shape as a gate nobody reaches, and this session has already found six of those.

So the decision moved into a pure `is_unsunk` that the sweep and the tests **share**.

| test | pre-fix | post-fix |
| :-- | :-- | :-- |
| `a_truncated_feed_holds_back_an_execution_it_cannot_see` | **FAILS** | passes |
| `a_complete_feed_still_discriminates` | passes | passes |
| `the_gate_off_path_is_untouched` | passes | passes |
| `exactly_at_the_cap_reads_as_truncated` | passes | passes |

The controls matter: if a complete feed stopped discriminating, the gate would degenerate to "retain everything" and the retention would mean nothing.

## Blast radius

**Behaviour-neutral while `NOETL_RESULT_TIER_GC_SINK_GATE` is off — which is everywhere today.** With the gate off there is no DB read and `complete` is vacuously true, so the sweep is byte-identical to before.

## Gate

712 server lib tests pass; clippy unchanged at 3 pre-existing warnings (verified by stashing).

Refs noetl/ai-meta#199