### PR TITLE
ci(release): publish multi-arch server images (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,28 @@ jobs:
         if: ${{ env.CRATES_IO_TOKEN == '' }}
         run: echo "CRATES_IO_TOKEN is not set; skipping crate publish."
 
+  # Multi-arch, mirroring noetl/worker's release.yml (noetl/ai-meta#236).
+  #
+  # WHY: every server release before this was amd64-only, while the worker has
+  # always published a manifest list.  The dev/validation kind cluster is arm64
+  # (Apple Silicon + podman), so a released server image could never run there —
+  # which meant validating any server change required building the image
+  # LOCALLY, on the same 6-CPU VM as the live kind control plane.  That is the
+  # operation that has corrupted etcd on that box, so in practice server changes
+  # shipped unit-proven and kind ran hand-built images no release produced.
+  # `deployment-validation.md` mandates kind validation before GKE; this is what
+  # makes that satisfiable with the artifact that actually ships.
   publish-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch_tag: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch_tag: arm64
+    runs-on: ${{ matrix.runner }}
     needs: verify-version
     if: ${{ needs.verify-version.outputs.has_dockerfile == 'true' }}
     steps:
@@ -111,14 +131,42 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Per-arch image under an arch-suffixed tag; publish-manifest stitches the
+      # version + latest manifest list from the pair.  Native runners, so no
+      # QEMU emulation (an emulated arm64 Rust build is prohibitively slow).
       - uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: |
-            ghcr.io/noetl/server:${{ needs.verify-version.outputs.version }}
-            ghcr.io/noetl/server:latest
+          platforms: ${{ matrix.platform }}
+          tags: ghcr.io/noetl/server:${{ needs.verify-version.outputs.version }}-${{ matrix.arch_tag }}
+
+  # Metadata only — combines the two per-arch images into the manifest list the
+  # version and `latest` tags point at.  Same shape as the worker's job.
+  publish-manifest:
+    runs-on: ubuntu-latest
+    needs: [verify-version, publish-image]
+    if: ${{ needs.verify-version.outputs.has_dockerfile == 'true' }}
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create + push multi-arch manifest list
+        env:
+          VERSION: ${{ needs.verify-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t ghcr.io/noetl/server:${VERSION} \
+            -t ghcr.io/noetl/server:latest \
+            ghcr.io/noetl/server:${VERSION}-amd64 \
+            ghcr.io/noetl/server:${VERSION}-arm64
+          echo "=== manifest list ==="
+          docker buildx imagetools inspect ghcr.io/noetl/server:${VERSION}
 
   # Additive Artifact Registry path.  Builds the SAME release version
   # on Cloud Build (native amd64, in us-central1 next to the GKE
@@ -172,7 +220,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [verify-version, publish-image]
+    needs: [verify-version, publish-image, publish-manifest]
     if: ${{ always() && needs.verify-version.result == 'success' && (needs.publish-image.result == 'success' || needs.publish-image.result == 'skipped') }}
     steps:
       - uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Closes noetl/ai-meta#236.

Every server release before this was **amd64-only**, while `noetl/worker` has always published a manifest list:

```
ghcr.io/noetl/server:3.62.1  -> [amd64]        (and every prior tag)
ghcr.io/noetl/worker:5.96.0  -> [amd64, arm64]
kind node architecture       -> arm64
```

## Why this is structural, not cosmetic

The dev/validation kind cluster is arm64 (Apple Silicon + podman), so a **released** server image could never run there. Validating any server change therefore required building the image **locally, on the same 6-CPU VM as the live kind control plane** — the operation that has corrupted etcd on that box.

The practical result: server changes shipped unit-proven, and kind ran hand-built images (`localhost/noetl-server-rust:v3620`) that no release produced. What was validated was **not the artifact that ships**. `agents/rules/deployment-validation.md` mandates kind validation before GKE; this is what makes that satisfiable with the real artifact.

## Shape

Mirrors the worker's proven job exactly — a 2-entry matrix on **native** runners (`ubuntu-latest` / `ubuntu-24.04-arm`; no QEMU, since an emulated arm64 Rust build is prohibitively slow), each pushing an arch-suffixed tag, then a metadata-only `publish-manifest` stitching the version + `latest` list.

## One ordering fix included

`github-release` now also needs `publish-manifest`. Without it, it would fire after the per-arch builds but **before the manifest list exists**, publishing a release that names `ghcr.io/noetl/server:<version>` — a tag only `publish-manifest` creates. The worker already has this dependency; the server never needed it while single-arch, so adding the matrix without it would have introduced a real defect.

`publish-ar` is untouched and still `needs: [verify-version]` only, so the known noetl/ai-meta#211 failure still cannot block a release.

## Cost

Roughly doubles server release wall-clock. The server has no `libduckdb-sys`, so this is an ordinary Rust build — nothing like the worker's ~40-minute DuckDB tail.

## Verification

YAML parses; job graph now matches the worker's:

```
verify-version   -> (none)
publish-crate    -> verify-version
publish-image    -> verify-version                      [matrix: amd64, arm64]
publish-manifest -> verify-version, publish-image
publish-ar       -> verify-version                      (decoupled, unchanged)
github-release   -> verify-version, publish-image, publish-manifest
```

The first release after merge should be checked with `crane manifest ghcr.io/noetl/server:<version>` reporting both platforms.