### PR TITLE
feat(orchestrate): make a ref-not-found drive miss distinguishable from a decode error

### DIFF
--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -3581,6 +3581,8 @@ async fn apply_worker_orchestration(
     // (`NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES`, default 100KB) and rides the
     // `call.done` payload as an `output_b64` string.
     let mut decoded = decode_orchestration_result(find_output_b64(payload));
+    // noetl/ai-meta#154 Leg A — set when the miss was specifically an absent ref.
+    let mut orchestrate_ref_missing = false;
 
     // Offloaded path (noetl/ai-meta#113): a large drive result (≈ the full
     // execution context — e.g. http_to_postgres, save_edge_cases) exceeds the
@@ -3620,10 +3622,22 @@ async fn apply_worker_orchestration(
                             );
                         }
                     }
-                    Ok(None) => warn!(
-                        execution_id,
-                        ref_uri, "worker-driven: orchestrate result ref not found in store"
-                    ),
+                    Ok(None) => {
+                        // noetl/ai-meta#154 Leg A. A ref that is ABSENT from the
+                        // store is a different failure from a payload that will
+                        // not decode, and until now both landed on the same
+                        // `decode_error` label. That mattered: the fall-through
+                        // below returns Ok(0) — no commands, no terminal event —
+                        // so the execution stays RUNNING and the 8s reconciler
+                        // re-drives it forever. A loop that is indistinguishable
+                        // in metrics from a one-off decode failure is a loop
+                        // nobody can see.
+                        orchestrate_ref_missing = true;
+                        warn!(
+                            execution_id,
+                            ref_uri, "worker-driven: orchestrate result ref not found in store"
+                        )
+                    }
                     Err(e) => warn!(
                         execution_id,
                         ref_uri, %e,
@@ -3678,7 +3692,16 @@ async fn apply_worker_orchestration(
             "worker-driven: could not decode OrchestrationResult from orchestrate completion \
              (missing output_b64, bad base64, or an error envelope)"
         );
-        crate::metrics::record_orchestrate_drive("decode_error");
+        // noetl/ai-meta#154 Leg A: separate the two causes. `ref_not_found`
+        // means the drive result was offloaded and its object is gone — which
+        // re-drives forever because this returns Ok(0) with no terminal event.
+        // `decode_error` is a malformed payload. Same outcome today, different
+        // cause, and only one of them loops.
+        crate::metrics::record_orchestrate_drive(if orchestrate_ref_missing {
+            "ref_not_found"
+        } else {
+            "decode_error"
+        });
         return Ok(0);
     };
 


### PR DESCRIPTION
noetl/ai-meta#154 **Leg A, partial** — the observability half.

## The loop

When the off-server drive's orchestrate result is offloaded to a reference and that object is **absent** from the store:

```rust
Ok(None) => warn!(... "orchestrate result ref not found in store"),
...
crate::metrics::record_orchestrate_drive("decode_error");
return Ok(0);          // no commands, NO terminal event
```

`Ok(0)` with no terminal leaves the execution `RUNNING`, and the 8-second reconciler re-drives it. Forever. That is the loop this issue is about.

## Why the label matters

Until now this shared the `decode_error` label with a genuinely malformed payload. Those are different failures with different remedies — and **only one of them loops**. A decode error is a one-off; a missing ref re-drives every 8 seconds indefinitely.

Sharing a label made the loop *invisible*: an operator sees a counter tick and cannot tell one bad payload from an execution spinning. Adds `ref_not_found` alongside the existing 15 outcome labels.

## Scope — deliberately half

**Behaviour is unchanged**: same `Ok(0)`, same warn, same absent terminal event.

The rest of Leg A — bounded retry then `playbook.failed` — is a real behaviour change and wants its own validation. It also depends on this: you cannot bound a retry you cannot count, and today there is no signal that separates the looping case from the non-looping one. This is the prerequisite, shipped on its own so the loop becomes measurable before anything starts terminating executions on the strength of it.

The two `Err` arms (resolution failed, unparseable ref) stay on `decode_error` — both are transient-or-malformed rather than "the object is gone", which is the distinction being drawn.

## Gate

712 server lib tests pass; clippy unchanged at 3 pre-existing warnings (verified by stashing).

Refs noetl/ai-meta#154