### PR TITLE
test(template): a #231 scalar-contract test has never run

### DIFF
--- a/orchestrate-core/src/template.rs
+++ b/orchestrate-core/src/template.rs
@@ -140,8 +140,9 @@ impl TemplateRenderer {
         // Python-style, so a JSON `true` in the context came back out as
         // `"True"`, matched nothing here, and fell through to a plain String.
         // `test_issue_89_scalar_renders_unaffected` asserts the intended
-        // contract ("a number stays a number, a bool stays a bool") and has been
-        // RED on main for exactly that reason.
+        // contract ("a number stays a number, a bool stays a bool").  That test
+        // carried no `#[test]` attribute and so never ran; it is enabled and
+        // green as of the fix above.
         if let Some(b) = parse_engine_bool(trimmed) {
             return Ok(serde_json::Value::Bool(b));
         }
@@ -1084,7 +1085,6 @@ mod tests {
         assert!(out["next_cursor"].is_null());
     }
 
-    #[test]
     /// noetl/ai-meta#231. The FALSE direction is the one that matters: a
     /// `String("False")` is a non-empty string, so anything doing a bare
     /// truthiness check on it reads it as YES — silently running work that
@@ -1130,6 +1130,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn test_issue_89_scalar_renders_unaffected() {
         // The retry only fires for container-shaped output; scalars keep
         // their existing typed parsing (number stays a number, etc.).


### PR DESCRIPTION
`test_issue_89_scalar_renders_unaffected` has no `#[test]` attribute, so it compiles as dead code and never executes.

Same shape as noetl/worker#226, found in the same sweep. The attribute exists but is attached to the wrong function — a later test (`a_python_style_bool_types_back_to_a_json_bool`, #231) was inserted between this test's doc comment + `#[test]` and its own `fn`, absorbing it. That is why one carried two attributes and this one none.

## Production code cited it as the guarantee

`orchestrate-core/src/template.rs:142`, in the middle of the scalar-parsing branch:

> `test_issue_89_scalar_renders_unaffected` asserts the intended contract ("a number stays a number, a bool stays a bool") **and has been RED on main** for exactly that reason.

Both halves of that are now wrong. #231's `parse_engine_bool` fix landed (it handles `"True"`/`"False"`), and the test **passes** once enabled. So the file documented a red test that was not running at all — and had not been for as long as the attribute was misplaced. Comment corrected to state what is true.

This is the wasm-compiled drive core, so the contract it guards ("a bool stays a bool") is the one whose FALSE direction the neighbouring test calls out: `String("False")` is non-empty, so a bare truthiness check reads it as YES and silently runs work that should have been skipped.

## Verification — and a note on how not to measure this

Verified **statically**, by parsing the attribute preceding each `fn`:

```
main collects 22 tests in this file
this branch collects 23  —  gains exactly test_issue_89_scalar_renders_unaffected, loses none
```

Full suite: **143 passed, 0 failed.**

I first tried to measure it with `cargo test -- --list` across a `git stash` cycle. That reported the same total for both states and appeared to show one test being swapped for another — a stale binary, because `stash`/`touch` races cargo's fingerprinting. The static check has no such failure mode; it is the one to trust here.

## Why nothing caught it

`noetl/server` runs no PR-level CI — only `release.yml` and `semantic-release.yml`. `cargo check --all-targets` reports both halves (`duplicate_macro_attributes` and `dead_code`) and nothing runs it on a PR.

No production behavior change. Typed `test` so it produces no release.

Refs noetl/ai-meta#231