### PR TITLE
docs(command_bus): the header presents NATS as the current default path

### DIFF
--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -1,22 +1,34 @@
 //! **L1 T4 — the EHDB command bus (flag-gated).**
 //!
 //! Selects the transport that carries command notifications to workers, behind
-//! [`NOETL_COMMAND_BUS`](CommandBusMode). Default `nats` leaves today's path
-//! untouched. `ehdb` publishes each command to the per-shard EHDB writer (the
-//! cutover). `shadow` publishes to **both** — NATS stays authoritative and
-//! workers keep consuming it, while the same command is mirrored onto the EHDB
-//! bus so a shadow consumer can verify parity before any flip.
+//! [`NOETL_COMMAND_BUS`](CommandBusMode).
+//!
+//! ⚠ **The cutover is done and NATS is deleted** (noetl/ai-meta#194 T5). Every
+//! prod workload — server, user pool, and both system-pool shards — sets
+//! `NOETL_COMMAND_BUS=ehdb` explicitly.
+//!
+//! ⚠ **The code default is still `Nats`**, which is now a transport that does
+//! not exist. That is safe only because every deployment sets the variable. A
+//! new workload rolled without it would default to a dead transport, and
+//! "unset the flag" is no longer a rollback — it is an outage. Changing the
+//! default is a behaviour change and is tracked separately rather than done
+//! in passing.
+//!
+//! `shadow` mode published to both so a shadow consumer could verify parity
+//! before the flip. It has no meaning now: there is no second bus to mirror
+//! onto and nothing consuming NATS.
 //!
 //! A command notification maps to a D1 [`EventRecord`]: `event_id` is the sort
 //! key (monotonic → the single-writer ascending contract holds per shard),
 //! `execution_id` is the shard key (`shard_for_execution` is byte-identical to
 //! the server/worker `shard_for`), and the notification JSON is the payload —
-//! the worker decodes it back and fetches full command details from the API,
-//! exactly as it does off NATS today.
+//! the worker decodes it back and fetches full command details from the API —
+//! the same shape it used off NATS before the cutover.
 //!
 //! The publisher is **lazy-connected**: it dials the writers on first publish
 //! (and drops + redials on error), so the stateless server never hard-depends on
-//! the writers being up at boot — matching how it tolerates NATS being absent.
+//! the writers being up at boot. That tolerance was inherited from the NATS
+//! client and matters more now, not less: the writer is the only bus.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -28,7 +40,11 @@ use tokio::sync::Mutex;
 /// Which transport carries command notifications (env `NOETL_COMMAND_BUS`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CommandBusMode {
-    /// Publish to NATS only — today's path (default).
+    /// Publish to NATS only.
+    ///
+    /// ⚠ Still the `Default`, but NATS was deleted at T5 — selecting this, or
+    /// leaving `NOETL_COMMAND_BUS` unset, points at a transport that is not
+    /// there. See the module header.
     #[default]
     Nats,
     /// Publish to the per-shard EHDB writer only — the cutover.


### PR DESCRIPTION
`src/command_bus.rs`'s module header presents NATS as the current, default path. It states:

> Default `nats` leaves today's path untouched. … `shadow` publishes to **both** — NATS stays authoritative and workers keep consuming it …
>
> the worker decodes it back and fetches full command details from the API, exactly as it does off NATS today.
>
> … matching how it tolerates NATS being absent.

T5 deleted NATS (`noetl/ai-meta#194`). Verified against `shastaratech-noetl-prod`: **server, user pool, and both system-pool shards all set `NOETL_COMMAND_BUS=ehdb` explicitly.**

## The part that is more than a stale comment

**The code default is still `Nats`.**

```rust
/// Publish to NATS only — today's path (default).
#[default]
Nats,
```

Prod is safe *only* because every workload sets the variable. Two consequences that the old header actively obscured:

- A **new workload rolled without `NOETL_COMMAND_BUS`** defaults to a transport that does not exist.
- **"Unset the flag" is no longer a rollback.** The header framed the default as the untouched safe path; today it is an outage.

There is also a test named `mode_parses_like_the_command_bus_and_defaults_safe`. It passes — it asserts the parse defaults to `Nats` — but "defaults safe" is no longer a true description of that outcome.

## What this PR does and does not do

**Does:** corrects the module header and the `Nats` variant doc so both state that NATS is gone, that prod sets the flag explicitly, and that the default now points at nothing.

**Does not:** flip the default to `Ehdb`. That is a behaviour change — it alters what an unconfigured deployment does — and it deserves to be a visible decision rather than something folded into a docs commit. Filed as `noetl/ai-meta#243`.

Also drops `shadow` mode's description as a live option: there is no second bus to mirror onto and nothing consuming NATS.

## Verification

- `cargo check --all-targets` — clean.
- `cargo test --lib command_bus` — **4 passed, 0 failed.**

Documentation only. `docs:` subject, so semantic-release cuts nothing.

Refs noetl/ai-meta#194
