### PR TITLE
docs: rustdoc links that can never resolve

### DIFF
--- a/src/handlers/sink_state.rs
+++ b/src/handlers/sink_state.rs
@@ -10,7 +10,7 @@
 //!
 //! Internal-only surface, gated by `RequireInternalApiToken` like the sibling
 //! `/api/internal/result-tier/gc` route — workers write through the API, never
-//! directly to `noetl.*` ([`data-access-boundary.md`]). Both endpoints are
+//! directly to `noetl.*` ([`data-access-boundary.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/data-access-boundary.md)). Both endpoints are
 //! idempotent, so a worker retry / redelivery never corrupts the set.
 //!
 //! - `POST /api/internal/sink-state/mark` — record an execution pending-sink.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1382,7 +1382,7 @@ pub fn record_jwks_event(event: &str) {
 ///   label (`provider_build_error`, `provider_fetch_error`, `template_error`).
 ///
 /// `execution_id` is NOT a label (cardinality) — it lives on the matching
-/// span per [`agents/rules/observability.md`].  Region IS a label by design:
+/// span per [`agents/rules/observability.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/observability.md).  Region IS a label by design:
 /// the cardinality is bounded (operators don't deploy into hundreds of
 /// regions in practice), and per-region breakdown is exactly what an
 /// operator queries when troubleshooting a residency-related outage.
@@ -1458,7 +1458,7 @@ pub fn record_secret_provider_build(provider: &str, region: &str, status: &str) 
 /// where cloud secret managers and Vault clusters actually live.
 ///
 /// `execution_id` is NOT a label — it lives on the matching `secret.resolve`
-/// span per [`agents/rules/observability.md`] Principle 4.
+/// span per [`agents/rules/observability.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/observability.md) Principle 4.
 pub fn secret_resolve_duration_seconds() -> &'static HistogramVec {
     static M: OnceLock<HistogramVec> = OnceLock::new();
     M.get_or_init(|| {
@@ -1806,7 +1806,7 @@ pub fn record_secret_refresh(outcome: &str) {
 /// `status` ∈ { `ok`, `error` }.
 /// `execution_id` is NOT a label (cardinality) — it lives on the
 /// `result_store.put` tracing span per
-/// [`agents/rules/observability.md`] Principle 4.
+/// [`agents/rules/observability.md`](https://github.com/noetl/ai-meta/blob/main/agents/rules/observability.md) Principle 4.
 pub fn result_store_put_total() -> &'static IntCounterVec {
     static M: OnceLock<IntCounterVec> = OnceLock::new();
     M.get_or_init(|| {

--- a/src/state.rs
+++ b/src/state.rs
@@ -135,7 +135,9 @@ pub struct AppState {
     pub finalized_guard: Arc<FinalizedGuard>,
 
     /// CQRS write-path publisher (noetl/ai-meta#103 phase 2d-3).  Lazily built
-    /// on first use from [`Self::nats`] so the `emit_event` chokepoint can
+    /// on first use from the NATS client field, which was removed with the
+    /// rest of the NATS path at T5 (noetl/ai-meta#194), so the `emit_event`
+    /// chokepoint can
     /// publish to the `noetl_events` stream when
     /// `config.event_ingest_publish_only` is on.  `OnceCell` so the gate-off
     /// (default) path never builds it and the gate-on path ensures the stream


### PR DESCRIPTION
Five rustdoc links that can never resolve, in three classes.

## A markdown path inside intra-doc brackets

`metrics.rs` referenced ``[`agents/rules/observability.md`]`` three times and `handlers/sink_state.rs` ``[`data-access-boundary.md`]`` once, with **no URL**. rustdoc treats the brackets as an item path and tries to resolve a filename as a Rust item.

This repo already links both documents correctly elsewhere — `handlers/events.rs:464` and `handlers/health.rs:169` use `[`text`](url)`. The fix matches the form that already works here rather than inventing one.

## A link to a field that no longer exists

`state.rs` documented the CQRS write-path publisher as *"lazily built on first use from ``[`Self::nats`]``"*. That field went with the NATS path at T5 (`noetl/ai-meta#194`). Reworded to say what happened to it, since "built from the NATS client" is still the useful history — it just needs to not be a link to a thing that is gone.

## Verification

**Unresolved-link warnings 19 → 14**, measured before and after **in the same checkout**.

That qualifier is load-bearing: measuring "before" in one worktree and "after" in another gives the same number both times, because cargo caches builds per directory. I hit exactly that earlier today on `noetl/worker` and reported an unchanged count that had in fact changed.

`cargo test --lib`: **712 passed, 0 failed.** `cargo check --all-targets` clean.

## Left alone

The remaining 14 are genuine item-path problems — `KeychainDef`, `ShardingConfig`, `ShardingConfig::from_env`, `DbPoolMap`, `CallDoneStatus`, `AppConfig::permanent_log_lean`, `record_async`, `record_strict` and others. Each needs the correct module path, which is a per-item judgement rather than a mechanical rewrite, so they are not swept in with these.

Documentation only; no behaviour change. `docs:` subject, so semantic-release cuts nothing.
