### PR TITLE
feat(metrics): count EHDB command-publish failures

### DIFF
--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -232,6 +232,7 @@ impl EhdbCommandPublisher {
                 }
                 Err(e) => {
                     last_err = format!("EHDB publish failed: {e}");
+                    crate::metrics::record_ehdb_command_publish_failed("attempt");
                     // Drop the router so the next attempt redials (writer
                     // restarted, rolled, or a shard moved) — but only if it is
                     // still the one that failed, so a redial another task already
@@ -255,6 +256,10 @@ impl EhdbCommandPublisher {
                 }
             }
         }
+        // Countable, not just loggable: this is the dispatch path, and a command
+        // that is never published is never claimed — the execution stops with no
+        // terminal event to notice it (noetl/ai-meta#208).
+        crate::metrics::record_ehdb_command_publish_failed("gave_up");
         tracing::error!(
             execution_id,
             event_id,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -292,6 +292,46 @@ pub fn record_command_publish(route: &str, pool: &str) {
         .inc();
 }
 
+/// `noetl_ehdb_command_publish_failed_total{reason}` — command notifications the
+/// server **gave up** publishing to the EHDB writer after exhausting its retry
+/// window, and per-attempt failures that were retried.
+///
+/// `noetl_command_publish_total` counts only successes, so before this there was
+/// no failure rate and a total give-up was visible in the log and nowhere else.
+/// That matters on this path specifically: post-T5 the EHDB writer is the only
+/// transport carrying command notifications, and a command that is never
+/// published is never claimed — the execution simply stops, with no terminal
+/// event to notice. noetl/ai-meta#208 was exactly that shape and ran unnoticed
+/// in production for ~2.4 days.
+///
+/// `reason` is `gave_up` (retry window exhausted; the dispatch is lost) or
+/// `attempt` (one publish attempt failed and will be retried — expected during
+/// a writer restart, and only interesting as a rate).
+pub fn ehdb_command_publish_failed_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_command_publish_failed_total",
+                "Command notifications the server failed to publish to the EHDB writer, by reason (noetl/ai-meta#208).",
+            ),
+            &["reason"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Record a failed EHDB command publish (see [`ehdb_command_publish_failed_total`]).
+pub fn record_ehdb_command_publish_failed(reason: &str) {
+    ehdb_command_publish_failed_total()
+        .with_label_values(&[reason])
+        .inc();
+}
+
 // ── Off-server tail-attach accelerator (noetl/ai-meta#156) ───────────────────
 
 /// `noetl_offserver_tail_attached_total{outcome}` — off-server drive dispatches
@@ -2339,5 +2379,36 @@ mod tests {
             names.len()
         );
         assert!(names.iter().all(|n| !n.is_empty()));
+    }
+
+    /// noetl/ai-meta#208 — a publish that gives up must be COUNTABLE, not only
+    /// loggable.  `noetl_command_publish_total` counts successes, so without
+    /// this counter there is no failure rate and a total give-up is invisible
+    /// outside the log.
+    #[test]
+    fn ehdb_publish_failures_are_counted_by_reason() {
+        record_ehdb_command_publish_failed("gave_up");
+        record_ehdb_command_publish_failed("attempt");
+        record_ehdb_command_publish_failed("attempt");
+
+        let text = gather_text().expect("gather metrics text");
+        assert!(
+            text.contains("noetl_ehdb_command_publish_failed_total"),
+            "the counter must appear in /metrics output"
+        );
+        // Scoped to this metric's own lines so the assertion cannot pass on
+        // some other metric that happens to carry the same label.
+        let lines: Vec<&str> = text
+            .lines()
+            .filter(|l| l.starts_with("noetl_ehdb_command_publish_failed_total{"))
+            .collect();
+        assert!(
+            lines.iter().any(|l| l.contains("reason=\"gave_up\"")),
+            "gave_up series missing; got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("reason=\"attempt\"")),
+            "attempt series missing; got {lines:?}"
+        );
     }
 }


### PR DESCRIPTION
`noetl_command_publish_total` counts **successes only**. When the server gave up publishing a command notification after exhausting its retry window, the sole record was a `tracing::error!` — no counter, so no failure rate and nothing to alert on.

That gap sits on the most consequential path in the system. Post-T5 the EHDB writer is the only transport carrying command notifications; a command that is never published is never claimed, and the execution simply stops with **no terminal event to notice it**. `noetl/ai-meta#208` was exactly that shape and ran unnoticed in production for ~2.4 days.

## What it adds

`noetl_ehdb_command_publish_failed_total{reason}`:

| reason | meaning |
| :-- | :-- |
| `gave_up` | the retry window is exhausted and the dispatch is lost |
| `attempt` | one attempt failed and will be retried — expected during a writer restart |

Both call sites instrumented. The pair is what makes them useful together: a writer restart shows as an `attempt` burst that resolves, which is exactly what distinguishes it from a `gave_up` that does not.

## Test

Asserts both series appear in the rendered `/metrics` text, **scoped to this metric's own lines** so it cannot pass on some other metric that happens to carry a `reason` label. It cannot compile without the recorder, so it fails pre-fix by construction.

`cargo test --lib`: **713 passed, 0 failed.** `cargo check --all-targets` clean.

Refs noetl/ai-meta#208, noetl/ai-meta#238