### PR TITLE
fix(orchestrate-core): read the parked-callback marker from the wire shape

### DIFF
--- a/orchestrate-core/src/state.rs
+++ b/orchestrate-core/src/state.rs
@@ -365,11 +365,22 @@ pub struct WorkflowState {
 /// "parked", so an old event or a tool that does not set it behaves exactly as
 /// before.
 pub fn is_parked_on_callback(event: &Event) -> bool {
-    event
-        .context
-        .as_ref()
-        .and_then(|c| c.get("pending_callback"))
-        .and_then(|v| v.as_bool())
+    fn marker(v: Option<&serde_json::Value>) -> Option<bool> {
+        v.and_then(|c| c.get("pending_callback"))
+            .and_then(|v| v.as_bool())
+    }
+
+    // The worker stamps the marker into the TOOL RESULT's context, so on the
+    // wire it arrives at `result.context.pending_callback` and the event's own
+    // `context` is null.  Reading only `event.context` — which is what this did
+    // — returned false for every real event, so no step ever parked and the DAG
+    // advanced on the dispatch (noetl/ai-meta#186 Bug 1, caught by kind
+    // validation after the unit tests passed against a hand-built event).
+    //
+    // `event.context` is still checked so a caller that inlines the marker
+    // there keeps working.
+    marker(event.result.as_ref().and_then(|r| r.get("context")))
+        .or_else(|| marker(event.context.as_ref()))
         .unwrap_or(false)
 }
 
@@ -2306,6 +2317,62 @@ mod pending_callback_tests {
     ///
     /// A `command.completed` carrying `pending_callback` must NOT complete the
     /// step, or nothing can stop a dependent step from dispatching.
+    /// The shape the WORKER actually emits: the marker is nested in the tool
+    /// result's context and the event's own `context` is null.
+    ///
+    /// Every other test in this module hand-builds `context: Some(...)` with
+    /// `result: None`, which is the inverse of the wire format — so they passed
+    /// while the DAG advanced in production.  Kind validation on released images
+    /// caught it: three container Jobs created inside the same second while the
+    /// first took ~4s to finish.
+    fn ev_wire(id: i64, ty: &str, step: &str) -> Event {
+        Event {
+            event_id: id,
+            execution_id: 1,
+            catalog_id: 1,
+            event_type: ty.to_string(),
+            node_name: Some(step.to_string()),
+            status: "success".to_string(),
+            context: None,
+            result: Some(serde_json::json!({
+                "context": {
+                    "command_id": "e:s:1",
+                    "pending_callback": true,
+                    "status": "success"
+                },
+                "status": "success"
+            })),
+            meta: None,
+            timestamp: DateTime::from_timestamp(id, 0).expect("fixed epoch"),
+            parent_execution_id: None,
+            attempt: None,
+        }
+    }
+
+    #[test]
+    fn the_marker_is_read_from_the_wire_shape_result_context() {
+        let e = ev_wire(2, "command.completed", "run_schema");
+        assert!(
+            is_parked_on_callback(&e),
+            "the worker stamps pending_callback into result.context; reading only \
+             event.context misses every real event"
+        );
+    }
+
+    #[test]
+    fn a_wire_shaped_parked_completion_does_not_complete_the_step() {
+        let mut st = WorkflowState::new(1, 1);
+        st.apply_event(&ev(1, "command.started", "run_schema", None));
+        st.apply_event(&ev_wire(2, "command.completed", "run_schema"));
+        let step = st.steps.get("run_schema").expect("step present");
+        assert!(step.pending_callback, "the step must park on the wire shape");
+        assert!(step.uses_callback, "and be marked a callback user");
+        assert!(
+            step.completed_at.is_none(),
+            "a parked step must NOT be complete — this is what let the DAG advance"
+        );
+    }
+
     #[test]
     fn a_parked_command_completed_does_not_complete_the_step() {
         let mut st = WorkflowState::new(1, 1);


### PR DESCRIPTION
`noetl/ai-meta#186` Bug 1 was fixed in `37296d1` and **did not hold end-to-end**. Kind validation on released images (server `3.64.0` / worker `5.97.0`) reproduced it exactly as originally reported:

```
11:52:17.094  command.completed  run_schema_creation
11:52:17.191  step.enter         run_table_creation   ← 97ms later
```

All three container Jobs were created **inside the same second** while the first took ~4s to finish. In one run two Jobs reported `succeeded=0` and the execution still reported `COMPLETED`.

## Root cause: a shape mismatch, not missing logic

| | |
| :-- | :-- |
| `is_parked_on_callback` read | `event.context.pending_callback` |
| the worker emits | `event.result.context.pending_callback`, with `event.context` **null** |

Confirmed against the stored event:

```
context       : null
result.context: {"command_id": "…", "pending_callback": true, "status": "success"}
```

So the predicate returned `false` for **every real event**. No step ever parked, and the DAG advanced on the dispatch. The gating added in `37296d1` was correct and simply never reached.

## Why the tests passed

Every test in `pending_callback_tests` hand-builds `context: Some(…)` with `result: None` — the **inverse** of the wire format. They proved the function against an event shape the platform does not produce.

That is precisely what "unit-proven" was hiding, and why this needed kind validation on real images to surface.

## What this adds

`ev_wire()`, constructing the real shape, plus two tests:

- `the_marker_is_read_from_the_wire_shape_result_context`
- `a_wire_shaped_parked_completion_does_not_complete_the_step`

**Verified they fail pre-fix**: reverting the lookup with the tests in place gives **2 failed, 5 passed**; with the fix, **7 passed**.

`event.context` is still checked, so a caller that inlines the marker keeps working.

## Suites

- `cargo test --lib` — **713 passed, 0 failed**
- `cargo test -p noetl-orchestrate-core` — **145 passed, 0 failed**

## Still to prove

This PR fixes the predicate. **End-to-end proof comes next**: once this releases, I will pull the released image into kind and re-run the same fixture, and the pass condition is that `run_table_creation`'s Job is created *after* `run_schema_creation`'s Job completes — not that the unit tests are green. The whole point of this issue is that those are different claims.

Refs noetl/ai-meta#186
