### PR TITLE
fix(orchestrate-core): accept the parked marker from meta, as the sweep does

### DIFF
--- a/orchestrate-core/src/state.rs
+++ b/orchestrate-core/src/state.rs
@@ -379,8 +379,15 @@ pub fn is_parked_on_callback(event: &Event) -> bool {
     //
     // `event.context` is still checked so a caller that inlines the marker
     // there keeps working.
+    // Three locations, matching the sweep's SQL exactly
+    // (`handlers/nonconvergence_sweep.rs`, which checks
+    // `result->'context'`, `context` and `meta`).  Both predicates answer the
+    // same question — "is this execution parked by design?" — and they must not
+    // disagree: the sweep skipping an execution the orchestrator advanced past,
+    // or vice versa, is worse than either being wrong alone.
     marker(event.result.as_ref().and_then(|r| r.get("context")))
         .or_else(|| marker(event.context.as_ref()))
+        .or_else(|| marker(event.meta.as_ref()))
         .unwrap_or(false)
 }
 
@@ -2347,6 +2354,15 @@ mod pending_callback_tests {
             parent_execution_id: None,
             attempt: None,
         }
+    }
+
+    #[test]
+    fn the_marker_is_read_from_meta_like_the_sweep_sql() {
+        // The sweep's SQL accepts the marker in meta; this predicate must agree,
+        // or the sweep skips an execution the orchestrator already advanced past.
+        let mut e = ev(2, "command.completed", "run_schema", None);
+        e.meta = Some(serde_json::json!({"pending_callback": true}));
+        assert!(is_parked_on_callback(&e), "meta must be accepted, as the SQL does");
     }
 
     #[test]


### PR DESCRIPTION
Two predicates answer the same question — *is this execution parked by design?* — and they disagreed about where the marker lives.

| | locations checked |
| :-- | :-- |
| `nonconvergence_sweep.rs` SQL | `result->'context'`, `context`, `meta` |
| `is_parked_on_callback` | `result.context`, `context` |

The SQL author knew the marker could arrive in any of three places. The Rust predicate originally checked only `context` — which *is* `noetl/ai-meta#186` Bug 1 — and that fix added `result.context` and stopped there.

## Why close a gap nothing has hit

The divergence matters in a specific way: the sweep skipping an execution the orchestrator has already advanced past, or the reverse, is worse than either being wrong alone — the two then disagree about whether work is healthy, and the sweep's job is deciding what to terminate.

Nothing stamps into `meta` today, so this closes the gap before it opens rather than fixing an observed failure.

## Incidentally, good news on the sweep

Checking this was prompted by #186: if the sweep read the marker the same narrow way the orchestrator did, it would have failed to exclude parked executions and terminated healthy work. **It does not** — its SQL checks `result->'context'` first, which is the wire shape. The 3,183-execution drain run earlier today was safe on that axis.

Adds a parity test that names the SQL as the thing it must agree with, so a future edit to either side has something to fail against.

`cargo test -p noetl-orchestrate-core pending_callback`: **8 passed.** `cargo test --lib`: **713 passed, 0 failed.**

Refs noetl/ai-meta#186, noetl/ai-meta#227