### PR TITLE
feat(metrics): expose whether the EHDB events publisher is configured

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -332,6 +332,41 @@ pub fn record_ehdb_command_publish_failed(reason: &str) {
         .inc();
 }
 
+/// `noetl_ehdb_event_publisher_configured` — 1 when the server has a usable
+/// EHDB events publisher, 0 when `NOETL_EVENT_BUS` selects EHDB but
+/// `NOETL_EVENT_BUS_WRITER_ADDRS` resolved to no routes.
+///
+/// The zero case is not a degraded mode: post-T5 the events feed is the sole
+/// writer of the durable log, so every event publish is skipped and the log
+/// simply stops growing.  Until now the only signal was one `tracing::error!`
+/// at startup — a line that scrolls away, on a workload nothing scrapes
+/// (noetl/ai-meta#238).  A gauge is alertable and survives the boot it
+/// describes.
+///
+/// Deliberately a gauge rather than a counter: this is boot-time state, and the
+/// question an operator asks is "is it configured right now", not "how often did
+/// it fail".
+pub fn ehdb_event_publisher_configured() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_event_publisher_configured",
+            "1 when the EHDB events publisher has writer routes, 0 when EHDB is selected but none resolved (noetl/ai-meta#238).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Record whether the EHDB events publisher is usable (see
+/// [`ehdb_event_publisher_configured`]).
+pub fn set_ehdb_event_publisher_configured(configured: bool) {
+    ehdb_event_publisher_configured().set(i64::from(configured));
+}
+
 // ── Off-server tail-attach accelerator (noetl/ai-meta#156) ───────────────────
 
 /// `noetl_offserver_tail_attached_total{outcome}` — off-server drive dispatches
@@ -2410,5 +2445,28 @@ mod tests {
             lines.iter().any(|l| l.contains("reason=\"attempt\"")),
             "attempt series missing; got {lines:?}"
         );
+    }
+
+    /// noetl/ai-meta#238 — "the durable log is being dropped on the floor" must
+    /// be a metric, not only a startup log line.  A gauge because the operator
+    /// question is "is it configured now", and because a boot-time error scrolls
+    /// away while a gauge survives.
+    #[test]
+    fn the_event_publisher_configured_gauge_tracks_both_states() {
+        set_ehdb_event_publisher_configured(false);
+        let text = gather_text().expect("gather metrics text");
+        let line = text
+            .lines()
+            .find(|l| l.starts_with("noetl_ehdb_event_publisher_configured "))
+            .expect("gauge must appear in /metrics");
+        assert!(line.ends_with(" 0"), "unconfigured must read 0; got {line:?}");
+
+        set_ehdb_event_publisher_configured(true);
+        let text = gather_text().expect("gather metrics text");
+        let line = text
+            .lines()
+            .find(|l| l.starts_with("noetl_ehdb_event_publisher_configured "))
+            .expect("gauge must appear in /metrics");
+        assert!(line.ends_with(" 1"), "configured must read 1; got {line:?}");
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -845,6 +845,7 @@ impl AppState {
         );
         let ehdb_event_publisher = if event_bus_mode.publishes_ehdb() {
             let publisher = crate::event_bus::EhdbEventPublisher::from_env();
+            crate::metrics::set_ehdb_event_publisher_configured(publisher.is_configured());
             if publisher.is_configured() {
                 tracing::info!(
                     ?event_bus_mode,


### PR DESCRIPTION
When `NOETL_EVENT_BUS` selects EHDB but `NOETL_EVENT_BUS_WRITER_ADDRS` resolves to no routes, the server builds no publisher and **skips every event publish**.

The code already knows how bad that is:

```rust
// Loud, because in `ehdb` mode this is the difference between
// publishing the durable event log and dropping it on the floor.
tracing::error!(…);
```

…and then that single startup line is the entire signal.

## Why a log line is not enough here

- It scrolls away. The condition persists; the evidence does not.
- The server is **not scraped at all** today (`noetl/ai-meta#238`), so nothing aggregates it either.
- Post-T5 the events feed is the **sole writer** of the durable log. A cluster silently not writing its log looks exactly like a quiet one — there is no second symptom.

## What it adds

`noetl_ehdb_event_publisher_configured` (1/0), set at the construction site.

**A gauge rather than a counter, deliberately.** This is boot-time state and the operator question is *"is it configured right now"*, not *"how often did it fail"*. A gauge also survives the boot it describes, which the log line does not.

## Test

Asserts **both** states resolve in the rendered `/metrics` text. A one-directional test would pass on a gauge that never leaves its default — which is the failure mode worth guarding, given how many guards audited today turned out unable to fail.

`cargo test --lib`: **714 passed, 0 failed**, and 8/8 consecutive runs clean.

Refs noetl/ai-meta#238
