### PR TITLE
feat(metrics): pin the publish-failure series at 0 so they exist before firing

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -325,6 +325,25 @@ pub fn ehdb_command_publish_failed_total() -> &'static IntCounterVec {
     })
 }
 
+/// Materialise both `reason` series at 0 so they exist before the first failure.
+///
+/// A labelled counter has no series until it is incremented, so an unfired
+/// `noetl_ehdb_command_publish_failed_total` is simply ABSENT from `/metrics`.
+/// Absent is indistinguishable from three different things: nothing has failed,
+/// the metric was removed, or the binary predates it.  Verified on kind against
+/// a released image — the gauge showed up and this counter did not.
+///
+/// `reason` has exactly two known values, so both can be pinned at 0 and the
+/// absence question disappears: a scrape either shows 0 (healthy, current
+/// binary) or nothing (not this binary).
+pub fn init_ehdb_command_publish_failed_series() {
+    for reason in ["gave_up", "attempt"] {
+        ehdb_command_publish_failed_total()
+            .with_label_values(&[reason])
+            .inc_by(0);
+    }
+}
+
 /// Record a failed EHDB command publish (see [`ehdb_command_publish_failed_total`]).
 pub fn record_ehdb_command_publish_failed(reason: &str) {
     ehdb_command_publish_failed_total()
@@ -2468,5 +2487,24 @@ mod tests {
             .find(|l| l.starts_with("noetl_ehdb_event_publisher_configured "))
             .expect("gauge must appear in /metrics");
         assert!(line.ends_with(" 1"), "configured must read 1; got {line:?}");
+    }
+
+    /// A labelled counter is ABSENT from /metrics until first incremented, so an
+    /// unfired failure counter cannot be told apart from a removed metric or an
+    /// older binary.  Verified on kind: the gauge appeared, this counter did not.
+    #[test]
+    fn publish_failure_series_exist_at_zero_before_any_failure() {
+        init_ehdb_command_publish_failed_series();
+        let text = gather_text().expect("gather metrics text");
+        let lines: Vec<&str> = text
+            .lines()
+            .filter(|l| l.starts_with("noetl_ehdb_command_publish_failed_total{"))
+            .collect();
+        for reason in ["gave_up", "attempt"] {
+            assert!(
+                lines.iter().any(|l| l.contains(&format!("reason=\"{reason}\""))),
+                "{reason} series must exist before any failure; got {lines:?}"
+            );
+        }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -846,6 +846,10 @@ impl AppState {
         let ehdb_event_publisher = if event_bus_mode.publishes_ehdb() {
             let publisher = crate::event_bus::EhdbEventPublisher::from_env();
             crate::metrics::set_ehdb_event_publisher_configured(publisher.is_configured());
+            // Pin both failure series at 0 so an unfired counter reads 0 rather
+            // than being absent — absent cannot be told apart from "metric gone"
+            // or "older binary" (noetl/ai-meta#238).
+            crate::metrics::init_ehdb_command_publish_failed_series();
             if publisher.is_configured() {
                 tracing::info!(
                     ?event_bus_mode,


### PR DESCRIPTION
A labelled counter has **no series until it is incremented**, so an unfired `noetl_ehdb_command_publish_failed_total` is simply **absent** from `/metrics`.

## Found by validating my own work end-to-end

Rather than trusting the unit test, I rolled the released **v3.65.0** image onto kind and scraped it:

```
noetl_ehdb_event_publisher_configured        PRESENT  (value 1)
noetl_ehdb_command_publish_failed_total      absent
```

Both are "working". Only one is **observable before it fires**.

## Why absent is not good enough

Absent is indistinguishable from three different things:

- nothing has failed,
- the metric was removed,
- the binary predates it.

That is the ambiguous-zero problem one level up — and on this path it is the difference between *"dispatch is healthy"* and *"we are not measuring dispatch"*. Given the whole point of `noetl/server#309` was that a give-up existed only in a log line, shipping a counter you cannot confirm is wired would have reproduced the same blind spot in a new shape.

## Fix

`reason` has exactly two known values, so both are pinned at 0 at startup. A scrape now shows either `0` (healthy, current binary) or nothing (not this binary) — and those mean different things.

## Deliberately not done for the worker counter

`noetl_worker_event_emit_failed_total` is labelled by `event_type`, which is unbounded — there is no fixed set to pin. Alerting on it stays correct (`increase()` over an absent series does not fire), but the *"is it wired?"* question there still needs the code rather than the scrape. Noted rather than papered over with a placeholder label.

`cargo test --lib`: **715 passed, 0 failed.** `cargo check --all-targets` clean.

Refs noetl/ai-meta#238
