### PR TITLE
feat(metrics): count why events skip the publish path, by reason

### DIFF
--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -224,10 +224,27 @@ fn is_system_path(path: &str) -> bool {
 /// the gate is on, NATS is connected, AND the execution is not a system-pool
 /// playbook (those drain the stream — see [`is_system_execution`]).  This is the
 /// single decision the chokepoint and the relocated trigger both consult.
+///
+/// Every `false` also records **which** condition produced it
+/// (`noetl_event_ingest_publish_skipped_total{reason}`).  The publish counter
+/// alone cannot express this: it has no series until the first publish, so a
+/// server that publishes nothing looks identical whether the gate is off, the
+/// transport is missing (noetl/ai-meta#212), or it is simply carrying only
+/// system traffic — and only the middle one is a fault.
 pub async fn should_publish(state: &AppState, catalog_id: i64) -> bool {
-    state.config.event_ingest_publish_only
-        && has_event_transport(state)
-        && !is_system_execution(state, catalog_id).await
+    if !state.config.event_ingest_publish_only {
+        crate::metrics::record_event_ingest_publish_skipped("gate_off");
+        return false;
+    }
+    if !has_event_transport(state) {
+        crate::metrics::record_event_ingest_publish_skipped("no_transport");
+        return false;
+    }
+    if is_system_execution(state, catalog_id).await {
+        crate::metrics::record_event_ingest_publish_skipped("system_execution");
+        return false;
+    }
+    true
 }
 
 /// Is *some* event transport available to publish on?

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -351,6 +351,70 @@ pub fn record_ehdb_command_publish_failed(reason: &str) {
         .inc();
 }
 
+/// `noetl_event_ingest_publish_skipped_total{reason}` — events that took the
+/// INSERT path instead of the publish path, and which of `should_publish`'s
+/// three conditions sent them there.
+///
+/// `noetl_event_ingest_published_total` counts only the publish side, so a
+/// server that publishes nothing exposes no series at all — and post-T5 the
+/// EHDB events feed is the sole writer of the durable log, which makes "zero
+/// publishes" the single most consequential state to be unable to read.
+///
+/// Absent, that zero has three very different causes and no way to tell them
+/// apart from `/metrics`:
+///
+/// - `gate_off` — `NOETL_EVENT_INGEST_PUBLISH_ONLY` is unset. Expected.
+/// - `no_transport` — the gate is on but there is no usable publisher, which
+///   is the noetl/ai-meta#212 shape: nothing errors, executions still
+///   complete, and the events feed sits at a flat cursor.
+/// - `system_execution` — system-pool playbooks are deliberately exempt
+///   (see [`is_system_execution`]), so a server carrying only system traffic
+///   publishes nothing and is perfectly healthy.
+///
+/// Reading which of the three applies on production took a source dive, three
+/// env lookups and a label inspection; it is one scrape with this counter.
+///
+/// [`is_system_execution`]: crate::handlers::event_write
+pub fn event_ingest_publish_skipped_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_event_ingest_publish_skipped_total",
+                "Events routed to INSERT instead of publish, by which should_publish condition failed (noetl/ai-meta#238)",
+            ),
+            &["reason"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Materialise all three `reason` series at 0 so they exist before the first skip.
+///
+/// Same argument as [`init_ehdb_command_publish_failed_series`]: a labelled
+/// counter is ABSENT until incremented, and absent cannot be distinguished
+/// from "the binary predates this metric". `reason` has exactly three known
+/// values, so all three can be pinned and the absence question disappears.
+pub fn init_event_ingest_publish_skipped_series() {
+    for reason in ["gate_off", "no_transport", "system_execution"] {
+        event_ingest_publish_skipped_total()
+            .with_label_values(&[reason])
+            .inc_by(0);
+    }
+}
+
+/// Record one event that skipped the publish path
+/// (see [`event_ingest_publish_skipped_total`]).
+pub fn record_event_ingest_publish_skipped(reason: &str) {
+    event_ingest_publish_skipped_total()
+        .with_label_values(&[reason])
+        .inc();
+}
+
 /// `noetl_ehdb_event_publisher_configured` — 1 when the server has a usable
 /// EHDB events publisher, 0 when `NOETL_EVENT_BUS` selects EHDB but
 /// `NOETL_EVENT_BUS_WRITER_ADDRS` resolved to no routes.
@@ -2506,5 +2570,51 @@ mod tests {
                 "{reason} series must exist before any failure; got {lines:?}"
             );
         }
+    }
+
+    /// The publish-skip reasons carry the same absent-until-fired problem, and
+    /// on this path the zero is the *normal* reading: a server carrying only
+    /// system-pool traffic never publishes, and must be distinguishable from
+    /// one whose transport is missing.
+    #[test]
+    fn publish_skip_series_exist_at_zero_before_any_skip() {
+        init_event_ingest_publish_skipped_series();
+        let text = gather_text().expect("gather metrics text");
+        let lines: Vec<&str> = text
+            .lines()
+            .filter(|l| l.starts_with("noetl_event_ingest_publish_skipped_total{"))
+            .collect();
+        for reason in ["gate_off", "no_transport", "system_execution"] {
+            assert!(
+                lines.iter().any(|l| l.contains(&format!("reason=\"{reason}\""))),
+                "{reason} series must exist before any skip; got {lines:?}"
+            );
+        }
+    }
+
+    /// A recorded skip must land on its own `reason` series, not merge into a
+    /// neighbouring one — the three are only useful because they separate a
+    /// fault (`no_transport`) from two healthy states.
+    #[test]
+    fn recorded_skip_increments_only_its_own_reason() {
+        init_event_ingest_publish_skipped_series();
+        let before = event_ingest_publish_skipped_total()
+            .with_label_values(&["no_transport"])
+            .get();
+        record_event_ingest_publish_skipped("system_execution");
+        assert_eq!(
+            event_ingest_publish_skipped_total()
+                .with_label_values(&["no_transport"])
+                .get(),
+            before,
+            "recording one reason must not move another"
+        );
+        assert!(
+            event_ingest_publish_skipped_total()
+                .with_label_values(&["system_execution"])
+                .get()
+                > 0,
+            "the recorded reason must have moved"
+        );
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -850,6 +850,7 @@ impl AppState {
             // than being absent — absent cannot be told apart from "metric gone"
             // or "older binary" (noetl/ai-meta#238).
             crate::metrics::init_ehdb_command_publish_failed_series();
+            crate::metrics::init_event_ingest_publish_skipped_series();
             if publisher.is_configured() {
                 tracing::info!(
                     ?event_bus_mode,


### PR DESCRIPTION
`noetl_event_ingest_published_total` counts only the publish side, so a
server that publishes nothing exposes no series at all.  Post-T5 the EHDB
events feed is the sole writer of the durable log, which makes "zero
publishes" the most consequential state on this path to be unable to read.

Found on production today: the counter is absent with the gate
`NOETL_EVENT_INGEST_PUBLISH_ONLY=true` ON, `NOETL_EVENT_BUS=ehdb`, and a
writer address configured — which looks exactly like the noetl/ai-meta#212
failure the `has_event_transport` comment describes.  It is not: every
label on that pod is `pool="system"`, so `is_system_execution` exempts
every event and the server is healthy.  Establishing that took a source
dive, three env lookups and a label inspection.

`should_publish` now records which of its three conditions produced each
`false`:

  gate_off          NOETL_EVENT_INGEST_PUBLISH_ONLY unset — expected
  no_transport      gate on, no usable publisher — the #212 fault
  system_execution  system-pool playbook, deliberately exempt — healthy

All three series are pinned at 0 at startup, same argument as #314: a
labelled counter is absent until fired, and absent cannot be told apart
from "the binary predates this metric".  Here the zero is the *normal*
reading, so pinning matters more than it did there.

Two tests: the series exist before any skip, and recording one reason does
not move another.

Refs noetl/ai-meta#238