### PR TITLE
feat(metrics): pin the orphan-guardrail outcome series

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -761,6 +761,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_ehdb_command_publish_failed_series();
     noetl_server::metrics::init_event_ingest_publish_skipped_series();
     noetl_server::metrics::init_nonconvergence_sweep_series();
+    noetl_server::metrics::init_orphan_sweep_series();
 
     // Load configuration
     let app_config = AppConfig::from_env().unwrap_or_else(|e| {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -181,6 +181,34 @@ pub fn record_orphan_sweep(outcome: &str) {
     orphan_sweep_total().with_label_values(&[outcome]).inc();
 }
 
+/// The five `outcome` values, kept in sync with the `record_orphan_sweep`
+/// call sites in [`crate::handlers::orphan_sweep`] (all string literals).
+pub const ORPHAN_SWEEP_OUTCOMES: [&str; 5] = [
+    "candidate",
+    "terminated",
+    "skipped_live",
+    "capped",
+    "error",
+];
+
+/// Materialise every [`ORPHAN_SWEEP_OUTCOMES`] series at 0.
+///
+/// Same reasoning as [`init_nonconvergence_sweep_series`], and it lands on the
+/// same operational question.  This guardrail also emits `playbook.failed`, and
+/// noetl/ai-meta#227 describes it re-issuing against permanently stalled
+/// executions on an otherwise idle cluster — a loop that was detected only by
+/// watching `ehdb_feed_shard_committed` climb, because these counters were
+/// absent rather than zero.  "Is the guardrail doing anything, and is it
+/// terminating things?" should be one scrape, not an inference from a shard
+/// cursor.
+pub fn init_orphan_sweep_series() {
+    for outcome in ORPHAN_SWEEP_OUTCOMES {
+        orphan_sweep_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+}
+
 // ── Systemic non-convergence sweep (noetl/ai-meta#227 part B) ────────────────
 
 /// `noetl_nonconvergence_sweep_total{outcome}` — outcomes of the systemic
@@ -2618,6 +2646,27 @@ mod tests {
             assert!(
                 lines.iter().any(|l| l.contains(&format!("reason=\"{reason}\""))),
                 "{reason} series must exist before any skip; got {lines:?}"
+            );
+        }
+    }
+
+    /// The orphan guardrail also emits `playbook.failed`, and noetl/ai-meta#227
+    /// describes it looping against stalled executions while these counters were
+    /// absent — so the loop was found by watching a shard cursor climb.
+    #[test]
+    fn orphan_sweep_outcome_series_exist_at_zero() {
+        init_orphan_sweep_series();
+        let text = gather_text().expect("gather metrics text");
+        let lines: Vec<&str> = text
+            .lines()
+            .filter(|l| l.starts_with("noetl_orphan_sweep_total{"))
+            .collect();
+        for outcome in ORPHAN_SWEEP_OUTCOMES {
+            assert!(
+                lines
+                    .iter()
+                    .any(|l| l.contains(&format!("outcome=\"{outcome}\""))),
+                "{outcome} series must exist before any sweep; got {lines:?}"
             );
         }
     }


### PR DESCRIPTION
The orphaned-command guardrail emits `playbook.failed`, and noetl/ai-meta#227
describes it re-issuing against permanently stalled executions on an otherwise
idle cluster — roughly 2 records/s indefinitely.  That loop was found by
watching `ehdb_feed_shard_committed` climb, because `noetl_orphan_sweep_total`
was ABSENT rather than zero: an unincremented labelled counter has no series,
and `Registry::gather` prunes empty families.  Confirmed absent on the live prod
server, which exposes 10 metric families of the 136 defined.

"Is the guardrail running, and is it terminating anything?" should be one
scrape, not an inference from a shard cursor.  All five outcomes are pinned at
0, so a healthy quiet cluster reads five zeros and only absence means "not this
binary".

The label set is taken from the `record_orphan_sweep` call sites, all of which
pass string literals — not from the metric's doc comment.  That distinction is
not academic: the same exercise on the non-convergence sweep one commit earlier
found its doc listing six of seven outcomes, and pinning from it would have left
one permanently unreadable.  Here the doc and the code agree, checked rather
than assumed.

This is observability only.  #227's suggestion 2 — bounding the guardrail so a
repeatedly-failing re-issue ends in a terminal FAILED rather than looping — is a
behaviour change on a live prod path and is deliberately not included here.  It
does become measurable with this in place, which is the prerequisite: you cannot
bound attempts you do not count.

721 tests pass; clippy clean.

Refs noetl/ai-meta#238, noetl/ai-meta#227