### PR TITLE
feat(metrics): pin the sealed-credential statuses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -764,6 +764,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_orphan_sweep_series();
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_result_tier_gc_series();
+    noetl_server::metrics::init_credential_seal_series();
     noetl_server::handlers::auth_verify::init_verify_series();
 
     // Load configuration

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1551,6 +1551,41 @@ pub fn credentials_sealed_total() -> &'static IntCounterVec {
     })
 }
 
+/// Every `status` the sealed-credential endpoint records, taken from the call
+/// sites in [`crate::handlers::credentials`].
+///
+/// This endpoint hands a worker an X25519-sealed credential (Secrets Wallet
+/// Phase 5b, noetl/ai-meta#61), so its failure modes are security-relevant:
+/// `residency_violation` is a policy denial, `no_pubkey` and `worker_not_found`
+/// are callers that could not be addressed, and `seal_error` is the crypto
+/// path failing.  A healthy deployment that has simply not sealed anything yet
+/// and a deployment where the endpoint is not reachable both rendered as an
+/// empty scrape, because a labelled counter has no series until incremented.
+///
+/// Note the name mismatch that hid this: the metric is
+/// `noetl_credentials_sealed_total` and the recorder is
+/// `record_credential_seal` — singular, and not a prefix of the metric.  A
+/// search keyed on the metric name finds nothing outside `metrics.rs` and
+/// reads as a dead recorder.
+pub const CREDENTIAL_SEAL_STATUSES: [&str; 7] = [
+    "ok",
+    "ok_via_broker",
+    "no_pubkey",
+    "worker_not_found",
+    "residency_violation",
+    "credential_error",
+    "seal_error",
+];
+
+/// Materialise every [`CREDENTIAL_SEAL_STATUSES`] series at 0.
+pub fn init_credential_seal_series() {
+    for status in CREDENTIAL_SEAL_STATUSES {
+        credentials_sealed_total()
+            .with_label_values(&[status])
+            .inc_by(0);
+    }
+}
+
 /// Increment [`credentials_sealed_total`] by 1 for the given outcome.
 pub fn record_credential_seal(status: &str) {
     credentials_sealed_total()
@@ -2712,6 +2747,42 @@ mod tests {
                 "{reason} series must exist before any skip; got {lines:?}"
             );
         }
+    }
+
+    /// Same guard as the GC one, on the security-relevant path.  Reuses the
+    /// after-the-call extraction rather than same-line matching, because that
+    /// is the variant that has already been caught missing a literal.
+    #[test]
+    fn credential_seal_literals_are_all_pinned() {
+        let src = include_str!("handlers/credentials.rs");
+        let call = "record_credential_seal(";
+        let mut found: Vec<&str> = Vec::new();
+        let mut rest = src;
+        while let Some(i) = rest.find(call) {
+            rest = &rest[i + call.len()..];
+            if let Some(q1) = rest.find('"') {
+                let after = &rest[q1 + 1..];
+                if let Some(q2) = after.find('"') {
+                    found.push(&after[..q2]);
+                }
+            }
+        }
+        assert!(
+            found.len() >= 8,
+            "extraction found only {} call site(s) — must fail loudly, not vacuously; got {found:?}",
+            found.len()
+        );
+        for lit in &found {
+            assert!(
+                CREDENTIAL_SEAL_STATUSES.contains(lit),
+                "record_credential_seal(\"{lit}\") is recorded but not pinned"
+            );
+        }
+        // The security-relevant denial must never quietly drop out of the set.
+        assert!(
+            CREDENTIAL_SEAL_STATUSES.contains(&"residency_violation"),
+            "residency_violation is a policy denial and must stay pinned"
+        );
     }
 
     /// Every outcome literal at a call site must be pinned.


### PR DESCRIPTION
The sealed-credential endpoint hands a worker an X25519-sealed credential
(Secrets Wallet Phase 5b, noetl/ai-meta#61), so its failure modes are
security-relevant: `residency_violation` is a policy denial, `no_pubkey` and
`worker_not_found` are callers that could not be addressed, `seal_error` is the
crypto path failing.  A deployment that has simply not sealed anything yet and
one where the endpoint is unreachable both rendered as an empty scrape, because
a labelled counter has no series until it is incremented.

All seven statuses are pinned at 0, from the eight call sites in
`handlers/credentials.rs`.

**A naming mismatch hid this.**  The metric is `noetl_credentials_sealed_total`
and the recorder is `record_credential_seal` — singular, and not a prefix of
the metric name.  Searching on the metric name finds nothing outside
`metrics.rs`, which reads exactly like a dead recorder.  That is the third
instance today of a recorder whose name is not derivable from its metric
(`record_jwt_verify` / `noetl_auth_jwt_verify_total`, `record_state_builder_drive`
/ `noetl_worker_state_builder_drive_builds_total`), so it is recorded in the
doc comment rather than left to be rediscovered.

`credential_seal_literals_are_all_pinned` uses the same after-the-call
extraction as the GC guard rather than same-line matching — that is the variant
already caught missing a literal — asserts at least 8 call sites were found so a
broken parser fails loudly, and asserts `residency_violation` specifically stays
pinned, since a policy denial silently dropping out of the set is the worst
version of this bug.

726 tests pass; clippy clean.

Refs noetl/ai-meta#238, noetl/ai-meta#61