### PR TITLE
feat(metrics): the three server P1 data-loss paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -765,6 +765,8 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_result_tier_gc_series();
     noetl_server::metrics::init_credential_seal_series();
+    noetl_server::metrics::init_system_plugin_seed_series();
+    noetl_server::metrics::init_secret_refresh_series();
     noetl_server::handlers::auth_verify::init_verify_series();
 
     // Load configuration

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1551,6 +1551,79 @@ pub fn credentials_sealed_total() -> &'static IntCounterVec {
     })
 }
 
+/// `noetl_system_plugin_seed_total{outcome}` — built-in wasm plug-ins seeded
+/// into the catalog at startup, and the ones that were skipped.
+///
+/// A `.wasm` file with a non-UTF8 name or that cannot be read is skipped with a
+/// `tracing::warn!` and startup continues.  The plug-in is simply not in the
+/// catalog, and the failure surfaces much later as a drive that cannot route to
+/// `system/<name>` — far from the cause.  The startup log line reports only the
+/// count that succeeded, so a run that seeded 3 of 4 is indistinguishable from
+/// one that seeded 3 of 3.
+pub fn system_plugin_seed_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_system_plugin_seed_total",
+                "Built-in wasm plug-ins seeded at startup, by outcome (noetl/ai-meta#238).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Every outcome [`system_plugin_seed_total`] records.
+pub const SYSTEM_PLUGIN_SEED_OUTCOMES: [&str; 3] =
+    ["seeded", "skipped_non_utf8", "skipped_unreadable"];
+
+/// Materialise every [`SYSTEM_PLUGIN_SEED_OUTCOMES`] series at 0.
+pub fn init_system_plugin_seed_series() {
+    for outcome in SYSTEM_PLUGIN_SEED_OUTCOMES {
+        system_plugin_seed_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+}
+
+/// Record one plug-in seed outcome.
+pub fn record_system_plugin_seed(outcome: &str) {
+    system_plugin_seed_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
+/// Every `outcome` [`secret_refresh_total`] records.
+///
+/// NOT derivable by scanning call-site literals: two of the five
+/// (`succeeded`, `failed`) are assigned to a local in a `match` and passed as a
+/// variable, so a literal scan finds three and would pin a set that is short by
+/// two — with the missing ones absent from `/metrics` while the rest read 0.
+/// Enumerated by reading `services/credential.rs` and `services/keychain.rs`,
+/// and deliberately excluded from the scan-based check in
+/// `playbooks/lib/pinned_sets.py` for the same reason.
+pub const SECRET_REFRESH_OUTCOMES: [&str; 5] = [
+    "triggered",
+    "stampede_collapsed",
+    "succeeded",
+    "failed",
+    "decision_failed",
+];
+
+/// Materialise every [`SECRET_REFRESH_OUTCOMES`] series at 0.
+pub fn init_secret_refresh_series() {
+    for outcome in SECRET_REFRESH_OUTCOMES {
+        secret_refresh_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+}
+
 /// Every `status` the sealed-credential endpoint records, taken from the call
 /// sites in [`crate::handlers::credentials`].
 ///
@@ -2747,6 +2820,49 @@ mod tests {
                 "{reason} series must exist before any skip; got {lines:?}"
             );
         }
+    }
+
+    /// Both P1 server sets must be readable at 0, and every plug-in outcome
+    /// must be instrumented.
+    ///
+    /// The plug-in one matters because the startup log reports only the count
+    /// that succeeded: seeding 3 of 4 and 3 of 3 look identical there.  The
+    /// secret-refresh one is checked for COMPLETENESS here rather than by the
+    /// scan in `pinned_sets.py`, because two of its five outcomes are passed as
+    /// a variable and a literal scan under-reports it by exactly those two.
+    #[test]
+    fn plugin_seed_and_secret_refresh_series_exist() {
+        init_system_plugin_seed_series();
+        init_secret_refresh_series();
+        let text = gather_text().expect("gather metrics text");
+        for outcome in SYSTEM_PLUGIN_SEED_OUTCOMES {
+            assert!(
+                text.lines().any(|l| l.starts_with("noetl_system_plugin_seed_total{")
+                    && l.contains(&format!("outcome=\"{outcome}\""))),
+                "{outcome} must be pinned"
+            );
+        }
+        for outcome in SECRET_REFRESH_OUTCOMES {
+            assert!(
+                text.lines().any(|l| l.starts_with("noetl_secret_refresh_total{")
+                    && l.contains(&format!("outcome=\"{outcome}\""))),
+                "{outcome} must be pinned"
+            );
+        }
+
+        // Every skip path in the seeder must record, or a missing plug-in stays
+        // as silent as it was before.
+        let src = include_str!("system_plugins.rs");
+        assert_eq!(
+            src.matches("record_system_plugin_seed(").count(),
+            3,
+            "all three seed outcomes must be instrumented"
+        );
+        assert_eq!(
+            src.matches("tracing::warn!").count(),
+            src.matches("record_system_plugin_seed(\"skipped").count(),
+            "every warn! in the seeder must have a matching skipped_* counter"
+        );
     }
 
     /// Same guard as the GC one, on the security-relevant path.  Reuses the

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -415,6 +415,7 @@ impl CredentialService {
                 // Don't fail the credential lookup on a refresh-decision
                 // read error — log + skip; the cached value already
                 // returned to the caller.
+                crate::metrics::record_secret_refresh("decision_failed");
                 tracing::warn!(
                     execution_id,
                     alias = %alias,

--- a/src/system_plugins.rs
+++ b/src/system_plugins.rs
@@ -73,17 +73,20 @@ pub fn scan_system_plugins(dir: &Path) -> Vec<SeedEntry> {
             continue;
         }
         let Some(stem) = file.file_stem().and_then(|s| s.to_str()) else {
+            crate::metrics::record_system_plugin_seed("skipped_non_utf8");
             tracing::warn!(file = %file.display(), "skipping plug-in with non-UTF8 name");
             continue;
         };
         let bytes = match std::fs::read(&file) {
             Ok(b) => b,
             Err(e) => {
+                crate::metrics::record_system_plugin_seed("skipped_unreadable");
                 tracing::warn!(file = %file.display(), error = %e, "skipping unreadable plug-in");
                 continue;
             }
         };
         let digest = hex::encode(Sha256::digest(&bytes));
+        crate::metrics::record_system_plugin_seed("seeded");
         entries.push(SeedEntry {
             path: format!("system/{stem}"),
             version: SEED_VERSION,


### PR DESCRIPTION
Completes the P1 tier of the warn/error-without-metric triage (5 sites; the two
worker ones landed in noetl/worker#238).

system_plugins.rs — a plug-in that is never seeded
--------------------------------------------------
A `.wasm` file with a non-UTF8 name, or one that cannot be read, is skipped with
a warn and startup continues.  The plug-in is simply absent from the catalog,
and the failure surfaces much later as a drive that cannot route to
`system/<name>` — far from its cause.  The startup log reports only the count
that SUCCEEDED, so seeding 3 of 4 and 3 of 3 are indistinguishable.

`noetl_system_plugin_seed_total{outcome}` records seeded / skipped_non_utf8 /
skipped_unreadable, all pinned at 0, so the ratio is readable from one scrape.

credential.rs — a background refresh silently not taken
-------------------------------------------------------
A failed refresh-decision read returns early: the cached credential is still
served, so nothing fails now, but the refresh does not happen and the credential
can go stale into a later auth failure.  Added `decision_failed` to the existing
`noetl_secret_refresh_total{outcome}` rather than a new metric, so all five
refresh outcomes live on one counter.

A subtlety worth recording
--------------------------
`SECRET_REFRESH_OUTCOMES` is NOT derivable by scanning call-site literals: two
of the five (`succeeded`, `failed`) are assigned to a local in a `match` and
passed as a variable.  The extractor in `playbooks/lib/pinned_sets.py` correctly
SKIPS such sites — so scanning would have found three, and pinning from that
would have left two outcomes absent while the other three read 0.  The set is
enumerated by reading both files, and explicitly excluded from the scan-based
check with that reason, rather than being silently under-reported.

The guard asserts all three plug-in outcomes are instrumented AND that every
`warn!` in the seeder has a matching `skipped_*` counter, so a new skip path
cannot be added without a counter.

727 tests pass; clippy clean.

Refs noetl/ai-meta#238