### PR TITLE
feat(metrics): count the two ways an EHDB command is never delivered

### DIFF
--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1717,15 +1717,18 @@ async fn publish_command_notification(
                     if matches!(mode, crate::command_bus::CommandBusMode::Ehdb) {
                         return Err(AppError::Internal(format!("EHDB command publish: {e}")));
                     }
+                    crate::metrics::record_ehdb_command_publish_failed("shadow_failed");
                     tracing::warn!(
                         execution_id,
                         event_id,
                         error = %e,
-                        "EHDB shadow command publish failed (NATS authoritative)"
+                        "EHDB shadow command publish failed; the authoritative path is unaffected \
+                         (this said \"NATS authoritative\" until noetl/ai-meta#212 removed NATS)"
                     );
                 }
             },
             None if matches!(mode, crate::command_bus::CommandBusMode::Ehdb) => {
+                crate::metrics::record_ehdb_command_publish_failed("no_writers");
                 tracing::warn!(
                     execution_id,
                     event_id,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -471,11 +471,20 @@ pub fn ehdb_command_publish_failed_total() -> &'static IntCounterVec {
 /// the metric was removed, or the binary predates it.  Verified on kind against
 /// a released image — the gauge showed up and this counter did not.
 ///
-/// `reason` has exactly two known values, so both can be pinned at 0 and the
-/// absence question disappears: a scrape either shows 0 (healthy, current
-/// binary) or nothing (not this binary).
+/// The `reason` values are pinned at 0 so the absence question disappears: a
+/// scrape either shows 0 (healthy, current binary) or nothing (not this
+/// binary).
+///
+/// `no_writers` and `shadow_failed` were added when the P2 dispatch triage
+/// found two more ways a command fails to reach the bus, neither of which had
+/// any signal.  `no_writers` is the severe one: with `NOETL_COMMAND_BUS=ehdb`
+/// and no writer routes resolved, EVERY command is silently not delivered and
+/// every execution stalls — previously visible only as a `tracing::warn!`.
+pub const EHDB_COMMAND_PUBLISH_FAILED_REASONS: [&str; 4] =
+    ["gave_up", "attempt", "no_writers", "shadow_failed"];
+
 pub fn init_ehdb_command_publish_failed_series() {
-    for reason in ["gave_up", "attempt"] {
+    for reason in EHDB_COMMAND_PUBLISH_FAILED_REASONS {
         ehdb_command_publish_failed_total()
             .with_label_values(&[reason])
             .inc_by(0);
@@ -2820,6 +2829,42 @@ mod tests {
                 "{reason} series must exist before any skip; got {lines:?}"
             );
         }
+    }
+
+    /// Every way a command fails to reach the EHDB bus must be counted, and all
+    /// four reasons readable at 0.
+    ///
+    /// `no_writers` is the severe one: with `NOETL_COMMAND_BUS=ehdb` and no
+    /// writer routes resolved, every command is silently not delivered and
+    /// every execution stalls.  Before this it was a `tracing::warn!` and
+    /// nothing else, on a path where nothing else errors.
+    #[test]
+    fn ehdb_publish_failure_reasons_cover_every_undelivered_path() {
+        init_ehdb_command_publish_failed_series();
+        let text = gather_text().expect("gather metrics text");
+        for reason in EHDB_COMMAND_PUBLISH_FAILED_REASONS {
+            assert!(
+                text.lines().any(|l| l
+                    .starts_with("noetl_ehdb_command_publish_failed_total{")
+                    && l.contains(&format!("reason=\"{reason}\""))),
+                "{reason} must be pinned at 0"
+            );
+        }
+        // Both dispatch-side sites in execute.rs must record.
+        let src = include_str!("handlers/execute.rs");
+        for reason in ["no_writers", "shadow_failed"] {
+            assert!(
+                src.contains(&format!("record_ehdb_command_publish_failed(\"{reason}\")")),
+                "{reason} must be recorded at its dispatch site"
+            );
+        }
+        // The stale claim must not come back: NATS stopped being authoritative
+        // at T5, so a message saying it is would mislead exactly when someone
+        // is debugging an undelivered command.
+        assert!(
+            !src.contains("EHDB shadow command publish failed (NATS authoritative)"),
+            "the pre-T5 'NATS authoritative' wording must stay corrected"
+        );
     }
 
     /// Both P1 server sets must be readable at 0, and every plug-in outcome


### PR DESCRIPTION
First of the P2 dispatch tier.  Both sites are in the command-publish path in
`handlers/execute.rs`, and neither had any signal.

no_writers — the severe one
---------------------------
With `NOETL_COMMAND_BUS=ehdb` and no writer routes resolved, the publish is not
attempted at all: the command is silently not delivered and the execution
stalls.  Nothing errors, nothing retries, and the only trace was a
`tracing::warn!`.  Production runs `NOETL_COMMAND_BUS=ehdb`, so a
misconfiguration of `NOETL_COMMAND_BUS_WRITER_ADDRS` would stall every execution
with no metric moving anywhere.

shadow_failed
-------------
A failed shadow publish, which does not affect the authoritative path but was
previously indistinguishable from a healthy shadow.

Both join the existing `noetl_ehdb_command_publish_failed_total{reason}` rather
than getting new metrics, so "a command did not reach the bus" stays one number
with reasons.  The inline `["gave_up", "attempt"]` pin becomes
`EHDB_COMMAND_PUBLISH_FAILED_REASONS` so the set is verifiable by
`playbooks/lib/pinned_sets.py` rather than only by reading.

Also corrects a stale message
-----------------------------
The shadow warning said "(NATS authoritative)".  NATS stopped being
authoritative at T5 (noetl/ai-meta#212) and no longer exists, so that
parenthetical would mislead exactly when someone is debugging an undelivered
command — it points at a fallback that is not there.  The test asserts the old
wording does not come back.

728 tests pass; clippy clean.

Refs noetl/ai-meta#238, noetl/ai-meta#212