### PR TITLE
fix(metrics): the lean-log counter shipped ABSENT — and the test that missed it

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -768,6 +768,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_system_plugin_seed_series();
     noetl_server::metrics::init_secret_refresh_series();
     noetl_server::metrics::init_command_row_insert_series();
+    noetl_server::metrics::init_unlabelled_series();
     noetl_server::handlers::auth_verify::init_verify_series();
 
     // Load configuration

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1611,6 +1611,24 @@ pub fn permanent_log_lean_stage_failed_total() -> &'static IntCounter {
     })
 }
 
+/// Register the unlabelled metrics that nothing touches at startup.
+///
+/// On this crate every metric is behind a `OnceLock` and is registered when its
+/// ACCESSOR is first called — so "unlabelled, therefore always present at 0" is
+/// false here.  It is true on the worker, whose metrics are built eagerly in
+/// `WorkerMetrics::new`; assuming it transferred is how
+/// `noetl_permanent_log_lean_stage_failed_total` shipped absent from a released
+/// image while its unit test passed, because the test called the accessor and
+/// the binary never does.
+///
+/// `ehdb_event_publisher_configured` and `sharding_config_parse_failed` are
+/// already registered as a side effect of being SET at startup.  This covers
+/// the ones with no such setter.
+pub fn init_unlabelled_series() {
+    // Touching the accessor is what registers it.
+    let _ = permanent_log_lean_stage_failed_total();
+}
+
 /// Record one failed command-context stage.
 pub fn record_permanent_log_lean_stage_failed() {
     permanent_log_lean_stage_failed_total().inc();
@@ -2937,6 +2955,46 @@ mod tests {
         }
     }
 
+    /// Calling ONLY the startup inits must register every unlabelled metric.
+    ///
+    /// This is the test that was missing.  The previous one called
+    /// `permanent_log_lean_stage_failed_total()` directly to "touch its
+    /// registration" — which registered it, so the assertion passed while the
+    /// released binary served a `/metrics` without it.  Every metric here is
+    /// behind a `OnceLock` and registers when its ACCESSOR runs; nothing in the
+    /// binary called that one.  Caught by scraping a released image on kind, not
+    /// by any test.
+    ///
+    /// So this test deliberately touches no accessor: it runs what `main` runs
+    /// and then asks what a scrape would show.
+    #[test]
+    fn startup_inits_alone_register_every_unlabelled_metric() {
+        init_unlabelled_series();
+        set_sharding_config_parse_failed(false);
+        set_ehdb_event_publisher_configured(false);
+
+        let text = gather_text().expect("gather metrics text");
+        for name in [
+            "noetl_permanent_log_lean_stage_failed_total",
+            "noetl_sharding_config_parse_failed",
+            "noetl_ehdb_event_publisher_configured",
+        ] {
+            assert!(
+                text.lines().any(|l| l.starts_with(&format!("{name} "))),
+                "{name} must be registered by startup alone — a metric only \
+                 registers when its accessor runs, and the binary must be the \
+                 thing that runs it"
+            );
+        }
+
+        // main must call it; wiring the init and forgetting the call is the
+        // same bug one level up.
+        assert!(
+            include_str!("main.rs").contains("init_unlabelled_series()"),
+            "main must invoke init_unlabelled_series"
+        );
+    }
+
     /// The remaining P2 server signals must all be readable with no activity.
     ///
     /// Two are unlabelled on purpose.  `sharding_config_parse_failed` is set on
@@ -2947,8 +3005,6 @@ mod tests {
     fn p2_server_signals_are_present_at_zero() {
         init_command_row_insert_series();
         set_sharding_config_parse_failed(false);
-        // Touch the counter's registration without incrementing it.
-        permanent_log_lean_stage_failed_total();
         let text = gather_text().expect("gather metrics text");
 
         for mode in COMMAND_ROW_INSERT_MODES {
@@ -2964,11 +3020,6 @@ mod tests {
             .find(|l| l.starts_with("noetl_sharding_config_parse_failed "))
             .expect("the sharding gauge must be present even when parsing succeeded");
         assert!(g.ends_with(" 0"), "healthy startup must read 0; got {g:?}");
-        assert!(
-            text.lines()
-                .any(|l| l.starts_with("noetl_permanent_log_lean_stage_failed_total ")),
-            "the unlabelled lean-log counter must be present at 0"
-        );
 
         // Both startup arms must set the gauge, or the healthy path leaves it
         // absent and the fallback stays as invisible as it was.


### PR DESCRIPTION
Validating server v3.77.0 on kind against the RELEASED image found
`noetl_permanent_log_lean_stage_failed_total` missing from /metrics, one commit
after I added it claiming "an unlabelled IntCounter is always present at 0".

That claim is true on the WORKER, whose metrics are built eagerly in
`WorkerMetrics::new`.  It is false here: every metric in this crate sits behind
a `OnceLock` and is registered when its ACCESSOR first runs.  Nothing in the
binary called that accessor, so the family never existed to be gathered.  Of the
three unlabelled lazy metrics, the other two are registered as a side effect of
being SET at startup; this one had no setter.

`init_unlabelled_series()` registers it, called from `main` beside the other
inits.

The test is the more important half
-----------------------------------
The old assertion called `permanent_log_lean_stage_failed_total()` first — with
a comment saying it was "touching its registration without incrementing it".
That call IS the registration, so the test created the very condition it then
verified and passed against a binary that served /metrics without the metric.

`startup_inits_alone_register_every_unlabelled_metric` touches no accessor: it
runs what `main` runs, then asks what a scrape would show.  It also asserts
`main` actually calls the init, since wiring an init and forgetting to call it
is the same bug one level up.

Checked it can fail rather than assuming: emptying the init body makes it report
`noetl_permanent_log_lean_stage_failed_total must be registered by startup
alone`, and restoring it goes green.

This is the third time today an end-to-end check on a released image found
something no unit test could — and the first where the unit test actively masked
it.

730 tests pass; clippy clean.

Refs noetl/ai-meta#238