### PR TITLE
fix: add the sink-state release endpoint, pin its ops, deflake the gauge test

### DIFF
--- a/src/handlers/sink_state.rs
+++ b/src/handlers/sink_state.rs
@@ -15,6 +15,8 @@
 //!
 //! - `POST /api/internal/sink-state/mark` — record an execution pending-sink.
 //! - `POST /api/internal/sink-state/confirm` — clear it (context sunk).
+//! - `POST /api/internal/sink-state/release` — clear it WITHOUT claiming the
+//!   context was sunk (the sink attempt failed or moved to an async callback).
 
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
@@ -45,7 +47,18 @@ pub struct SinkConfirmRequest {
     pub execution_id: i64,
 }
 
-/// Response for both endpoints.
+/// `POST /api/internal/sink-state/release` body (noetl/ai-meta#248).
+#[derive(Debug, Clone, Deserialize)]
+pub struct SinkReleaseRequest {
+    pub execution_id: i64,
+    /// Why the mark is being cleared without a sink having happened —
+    /// `released_failed` / `released_pending_callback` / `released_error`.
+    /// Diagnostic only; the row is cleared either way.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Response for these endpoints.
 #[derive(Debug, Clone, Serialize)]
 pub struct SinkStateResponse {
     pub execution_id: i64,
@@ -80,6 +93,45 @@ pub async fn confirm(
 ) -> AppResult<Json<SinkStateResponse>> {
     let changed = sink_pending::confirm(&deps.pool, req.execution_id).await?;
     crate::metrics::record_sink_state("confirm");
+    Ok(Json(SinkStateResponse {
+        execution_id: req.execution_id,
+        changed,
+    }))
+}
+
+/// `POST /api/internal/sink-state/release` — clear an execution's pending-sink
+/// state WITHOUT asserting its context was sunk (noetl/ai-meta#248).
+///
+/// The worker marks an execution for the duration of a sink attempt. When that
+/// attempt ends any way other than clean success — a non-success result, an
+/// error, or a hand-off to an async callback the reporting process never
+/// observes — the mark must still be cleared on this feed, or the row is
+/// retained forever and the result-tier GC never reclaims that execution's
+/// objects.
+///
+/// Deliberately a separate endpoint rather than reusing `confirm`. The DB effect
+/// is identical (the row goes away), but `confirm` is a claim that the
+/// customer's system of record has the data, and a failed sink has not earned
+/// that claim. Keeping them distinct means `noetl_sink_state_total{op}`
+/// distinguishes "sunk" from "gave up", which is the difference an operator
+/// actually needs.
+///
+/// Idempotent: releasing an absent row is a no-op.
+#[tracing::instrument(skip(deps, _token, req), fields(execution_id = req.execution_id))]
+pub async fn release(
+    State(deps): State<SinkStateDeps>,
+    _token: RequireInternalApiToken,
+    Json(req): Json<SinkReleaseRequest>,
+) -> AppResult<Json<SinkStateResponse>> {
+    let changed = sink_pending::confirm(&deps.pool, req.execution_id).await?;
+    crate::metrics::record_sink_state("release");
+    if changed {
+        tracing::debug!(
+            execution_id = req.execution_id,
+            reason = req.reason.as_deref().unwrap_or("unspecified"),
+            "sink-state released without a sink confirmation"
+        );
+    }
     Ok(Json(SinkStateResponse {
         execution_id: req.execution_id,
         changed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -590,6 +590,10 @@ fn build_router(
             "/api/internal/sink-state/confirm",
             post(handlers::sink_state::confirm),
         )
+        .route(
+            "/api/internal/sink-state/release",
+            post(handlers::sink_state::release),
+        )
         .with_state(handlers::sink_state::SinkStateDeps {
             pool: db_pool.clone(),
         });
@@ -762,6 +766,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_event_ingest_publish_skipped_series();
     noetl_server::metrics::init_nonconvergence_sweep_series();
     noetl_server::metrics::init_orphan_sweep_series();
+    noetl_server::metrics::init_sink_state_series();
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_result_tier_gc_series();
     noetl_server::metrics::init_credential_seal_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2612,6 +2612,28 @@ pub fn sink_state_total() -> &'static IntCounterVec {
 }
 
 /// Record one sink-state feed operation (`mark` / `confirm` / `gc_consult`).
+/// Every `op` value `noetl_sink_state_total` can take (noetl/ai-meta#248).
+///
+/// `release` was added with the endpoint that clears a mark WITHOUT claiming the
+/// context was sunk.  Pinning matters more than usual here: the whole point of
+/// the feed is that a *retained* execution is visible, so an operator asking
+/// "did anything give up on a sink?" must be able to read a 0 rather than an
+/// absent series.
+pub const SINK_STATE_OPS: [&str; 5] = [
+    "mark",
+    "confirm",
+    "release",
+    "gc_consult",
+    "gc_feed_truncated",
+];
+
+/// Materialise every [`SINK_STATE_OPS`] series at 0.
+pub fn init_sink_state_series() {
+    for op in SINK_STATE_OPS {
+        sink_state_total().with_label_values(&[op]).inc_by(0);
+    }
+}
+
 pub fn record_sink_state(op: &str) {
     sink_state_total().with_label_values(&[op]).inc();
 }
@@ -2782,6 +2804,23 @@ pub fn record_container_callback_stale(state: &str) {
 
 #[cfg(test)]
 mod tests {
+
+    /// Serialises the tests that mutate PROCESS-GLOBAL gauges.
+    ///
+    /// `cargo test` runs tests on a thread pool and does **not** serialise them,
+    /// so two tests that both `set_ehdb_event_publisher_configured` race: one
+    /// sets it false while the other is asserting it reads 1. That produced a
+    /// flake on roughly one run in three — green often enough to look like noise
+    /// and to survive review, which is the worst frequency for a failing test.
+    ///
+    /// The lock is poison-tolerant: a panic in one test must fail that test, not
+    /// cascade into every other test that takes this lock.
+    static GLOBAL_GAUGE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_global_gauges() -> std::sync::MutexGuard<'static, ()> {
+        GLOBAL_GAUGE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     use super::*;
     // The registry is process-global, so all tests share state.
     // We assert on the rendered text after at least one observation
@@ -2936,6 +2975,7 @@ mod tests {
     /// away while a gauge survives.
     #[test]
     fn the_event_publisher_configured_gauge_tracks_both_states() {
+        let _guard = lock_global_gauges();
         set_ehdb_event_publisher_configured(false);
         let text = gather_text().expect("gather metrics text");
         let line = text
@@ -3006,6 +3046,7 @@ mod tests {
     /// and then asks what a scrape would show.
     #[test]
     fn startup_inits_alone_register_every_unlabelled_metric() {
+        let _guard = lock_global_gauges();
         init_unlabelled_series();
         set_sharding_config_parse_failed(false);
         set_ehdb_event_publisher_configured(false);
@@ -3277,6 +3318,66 @@ mod tests {
                     .iter()
                     .any(|l| l.contains(&format!("outcome=\"{outcome}\""))),
                 "{outcome} series must exist before any sweep; got {lines:?}"
+            );
+        }
+    }
+
+    /// noetl/ai-meta#248 — every `op` the code actually records must be pinned.
+    ///
+    /// An op that is recorded but not pinned is absent from `/metrics` until it
+    /// first fires, so "nothing has given up on a sink" and "this build cannot
+    /// tell you" look identical. Scans the non-test source of every call site so
+    /// the guard cannot match its own literals.
+    #[test]
+    fn sink_state_pinned_ops_cover_every_call_site() {
+        fn non_test(src: &str) -> &str {
+            src.split_once("\n#[cfg(test)]").map_or(src, |(b, _)| b)
+        }
+        let sources = [
+            non_test(include_str!("handlers/sink_state.rs")),
+            non_test(include_str!("handlers/result_tier.rs")),
+            non_test(include_str!("services/result_tier_gc.rs")),
+        ];
+        let mut found = std::collections::BTreeSet::new();
+        for src in sources {
+            let mut rest = src;
+            while let Some(k) = rest.find("record_sink_state(\"") {
+                rest = &rest[k + "record_sink_state(\"".len()..];
+                if let Some(end) = rest.find('"') {
+                    found.insert(rest[..end].to_string());
+                }
+            }
+        }
+        assert!(!found.is_empty(), "the scan found no call sites at all");
+        for op in &found {
+            assert!(
+                SINK_STATE_OPS.contains(&op.as_str()),
+                "op {op:?} is recorded but not in SINK_STATE_OPS, so it is absent \
+                 from /metrics until it first fires"
+            );
+        }
+        for pinned in SINK_STATE_OPS {
+            assert!(
+                found.contains(pinned),
+                "op {pinned:?} is pinned but nothing records it"
+            );
+        }
+    }
+
+    /// The pinned ops must be SERVED at 0 without touching a recorder.
+    #[test]
+    fn sink_state_ops_are_served_at_zero() {
+        init_sink_state_series();
+        let text = gather_text().expect("gather metrics text");
+        for op in SINK_STATE_OPS {
+            let want = format!("noetl_sink_state_total{{op=\"{op}\"}}");
+            let line = text
+                .lines()
+                .find(|l| l.starts_with(&want))
+                .unwrap_or_else(|| panic!("{want} must be pinned"));
+            assert!(
+                line.trim_end().ends_with(" 0"),
+                "{want} must read 0 before anything happens; got {line:?}"
             );
         }
     }


### PR DESCRIPTION
Three related additive fixes. **Nothing is enabled by any of them.**

## 1. `POST /api/internal/sink-state/release`

The worker marks an execution on the `noetl.sink_pending` feed for the duration of a sink attempt and clears it on success. There was **no way to clear it any other way**, so a sink that failed, errored, or handed off to an async callback left the row forever and the result-tier GC never reclaimed that execution's objects.

noetl/worker#244 closed the same leak on the worker's in-process index. This closes it on the server-visible feed — the half I explicitly listed as *not covered* there, because a release must not be posted as a `confirm`.

**Why a separate endpoint rather than reusing `confirm`:** the DB effect is identical (the row goes away), but `confirm` is a claim that the customer's system of record has the data, and a failed sink has not earned that claim. Keeping them distinct makes `noetl_sink_state_total{op}` distinguish *sunk* from *gave up* — the difference an operator actually needs. The optional `reason` rides on the debug line.

## 2. Pin `noetl_sink_state_total{op}`

All five ops (`mark` / `confirm` / `release` / `gc_consult` / `gc_feed_truncated`) materialised at 0 at startup. The entire point of this feed is that a *retained* execution is visible, so "did anything give up on a sink?" must be answerable with a 0 rather than an absent series.

A guard test scans the **non-test** source of every call site and asserts the pinned set and the recorded ops agree **in both directions** — a recorded-but-unpinned op reintroduces the absent-series bug for that value alone while the rest read 0 and look complete. Mutation-checked: un-pinning `release` fails it.

## 3. Deflake `the_event_publisher_configured_gauge_tracks_both_states`

Two tests mutate the same process-global gauge, and `cargo test` does **not** serialise tests — so one set it false while the other asserted it read 1.

Measured on **unmodified `origin/main`: 1 failure in 3 runs.** Green often enough to read as noise, which is the worst possible frequency for a failing test. Both tests now take a shared poison-tolerant mutex (a panic in one must fail that test, not cascade). **6/6 green** after.

Same class as the `EnvGuard` race in noetl/ai-meta#232 — and that issue records that **no `cargo test` runs in CI on any Rust repo**, so a flake here is caught by a human running the suite or not at all.

## Validation

`cargo test --lib`: 735 passed, 0 failed, stable across 6 consecutive runs. `cargo clippy --all-targets`: 0 errors, 4 warnings — identical to the `origin/main` baseline.

Refs noetl/ai-meta#248