### PR TITLE
feat(catalog): add an auth-gated delete endpoint

### DIFF
--- a/src/db/models/catalog.rs
+++ b/src/db/models/catalog.rs
@@ -169,3 +169,35 @@ pub struct CatalogEntryRequest {
     #[serde(default)]
     pub version: Option<String>,
 }
+
+/// `POST /api/catalog/delete` body (noetl/ai-meta#237).
+#[derive(Debug, Clone, Deserialize)]
+pub struct CatalogDeleteRequest {
+    /// Catalog path to remove.
+    pub path: String,
+    /// When present, remove only this version; when absent, remove every
+    /// version of `path`. Required to be explicit — there is deliberately no
+    /// "delete the latest" shorthand, because the latest version is the one
+    /// executions resolve to.
+    #[serde(default)]
+    pub version: Option<i16>,
+}
+
+/// One removed row, echoed back so the caller can audit what went.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeletedCatalogEntry {
+    pub catalog_id: String,
+    pub version: i16,
+}
+
+/// `POST /api/catalog/delete` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct CatalogDeleteResponse {
+    pub status: String,
+    pub message: String,
+    pub path: String,
+    /// Every row removed. Empty when nothing matched — deleting an absent
+    /// entry is a no-op, not an error.
+    pub deleted: Vec<DeletedCatalogEntry>,
+    pub count: usize,
+}

--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -199,3 +199,51 @@ pub async fn get_catalog_all_versions(pool: &DbPool, path: &str) -> AppResult<Ve
 
     Ok(entries)
 }
+
+/// Delete catalog entries for `path`, optionally narrowed to one `version`.
+///
+/// Returns the `(catalog_id, version)` of every row removed, so the caller can
+/// report exactly what went — a delete that reports only a count cannot be
+/// audited afterwards, and this table has no replay to reconstruct from.
+///
+/// `RETURNING` makes the read and the delete one statement: a
+/// select-then-delete would race a concurrent `register`, which mints a new
+/// version for the same path (`get_next_version`), and could report a row it
+/// did not remove.
+///
+/// Idempotent: deleting an absent path or version removes nothing and returns
+/// an empty vector rather than erroring.
+pub async fn delete_catalog_entries(
+    pool: &DbPool,
+    path: &str,
+    version: Option<i16>,
+) -> AppResult<Vec<(i64, i16)>> {
+    let rows: Vec<(i64, i16)> = match version {
+        Some(v) => {
+            sqlx::query_as(
+                r#"
+                DELETE FROM noetl.catalog
+                WHERE path = $1 AND version = $2
+                RETURNING catalog_id, version
+                "#,
+            )
+            .bind(path)
+            .bind(v)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_as(
+                r#"
+                DELETE FROM noetl.catalog
+                WHERE path = $1
+                RETURNING catalog_id, version
+                "#,
+            )
+            .bind(path)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+    Ok(rows)
+}

--- a/src/handlers/catalog.rs
+++ b/src/handlers/catalog.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use crate::db::models::{
     CatalogEntries, CatalogEntriesRequest, CatalogEntryRequest, CatalogEntryResponse,
     CatalogRegisterRequest, CatalogRegisterResponse,
+    CatalogDeleteRequest, CatalogDeleteResponse,
 };
 use crate::error::{AppError, AppResult};
 use crate::services::ui_schema::{infer_ui_schema, UiSchemaResponse};
@@ -64,6 +65,71 @@ async fn register_inner(
     Json(request): Json<CatalogRegisterRequest>,
 ) -> AppResult<(StatusCode, Json<CatalogRegisterResponse>)> {
     let response = service.register(request).await?;
+    Ok((StatusCode::OK, Json(response)))
+}
+
+/// Delete catalog entries.
+///
+/// `POST /api/catalog/delete`
+///
+/// # Auth
+///
+/// Gated by [`RequireInternalApiToken`] — the same bearer the other privileged
+/// mutating surfaces use, which fails **closed**: 503 when
+/// `NOETL_INTERNAL_API_TOKEN` is unset on the server, 403 on a missing or
+/// mismatched token.
+///
+/// Deliberately stricter than `register` on the same router, which is
+/// currently ungated. Registering is additive and reversible; deleting is
+/// neither, and `noetl.catalog` has no replay to reconstruct a removed row
+/// from. Matching `register`'s posture here would have made an unauthenticated
+/// caller able to destroy catalog content.
+///
+/// # Request Body
+///
+/// ```json
+/// { "path": "tests/fixtures/foo", "version": 3 }
+/// ```
+///
+/// `version` is optional; omitting it removes **every** version of the path.
+/// There is no "delete the latest" shorthand — the latest version is the one
+/// executions resolve to, so removing it must be spelled out.
+///
+/// # Response
+///
+/// ```json
+/// {
+///   "status": "success",
+///   "message": "Removed 2 version(s) of catalog entry 'tests/fixtures/foo'.",
+///   "path": "tests/fixtures/foo",
+///   "deleted": [{"catalog_id": "123", "version": 2}, {"catalog_id": "122", "version": 1}],
+///   "count": 2
+/// }
+/// ```
+///
+/// Idempotent: deleting an absent path or version returns 200 with
+/// `count: 0` rather than 404, so a cleanup run is safe to repeat.
+pub async fn delete(
+    service: State<CatalogService>,
+    _token: crate::handlers::internal::RequireInternalApiToken,
+    request: Json<CatalogDeleteRequest>,
+) -> AppResult<(StatusCode, Json<CatalogDeleteResponse>)> {
+    let started_at = std::time::Instant::now();
+    let result = delete_inner(service, request).await;
+    let status_label = if result.is_ok() { "ok" } else { "error" };
+    crate::metrics::record_write_request(
+        crate::metrics::endpoint::CATALOG_DELETE,
+        status_label,
+        started_at.elapsed().as_secs_f64(),
+    );
+    result
+}
+
+async fn delete_inner(
+    State(service): State<CatalogService>,
+    Json(request): Json<CatalogDeleteRequest>,
+) -> AppResult<(StatusCode, Json<CatalogDeleteResponse>)> {
+    let response = service.delete(request).await?;
     Ok((StatusCode::OK, Json(response)))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ fn build_router(
     // Catalog routes
     let catalog_routes = Router::new()
         .route("/api/catalog/register", post(handlers::catalog::register))
+            .route("/api/catalog/delete", post(handlers::catalog::delete))
         .route("/api/catalog/list", post(handlers::catalog::list))
         .route(
             "/api/catalog/resource",
@@ -767,6 +768,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_nonconvergence_sweep_series();
     noetl_server::metrics::init_orphan_sweep_series();
     noetl_server::metrics::init_sink_state_series();
+    noetl_server::metrics::init_catalog_delete_series();
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_result_tier_gc_series();
     noetl_server::metrics::init_credential_seal_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1465,6 +1465,7 @@ pub fn record_permanent_log_slimmed(count: u64, bytes: u64) {
 /// (and only here) when instrumenting future write endpoints.
 pub mod endpoint {
     pub const CATALOG_REGISTER: &str = "catalog_register";
+    pub const CATALOG_DELETE: &str = "catalog_delete";
     pub const CREDENTIALS_UPSERT: &str = "credentials_upsert";
     pub const KEYCHAIN_SET: &str = "keychain_set";
     pub const RUNTIME_REGISTER: &str = "runtime_register";
@@ -2634,6 +2635,49 @@ pub fn init_sink_state_series() {
     }
 }
 
+/// `noetl_catalog_delete_total{outcome}` — catalog rows removed via
+/// `POST /api/catalog/delete` (noetl/ai-meta#237).
+///
+/// `noetl.catalog` is not event-sourced and has no replay, so a delete leaves
+/// no trace anywhere else.  This counter plus the INFO log at the call site are
+/// the audit trail.
+pub fn catalog_delete_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_catalog_delete_total",
+                "Catalog delete operations by outcome (noetl/ai-meta#237).",
+            ),
+            &["outcome"],
+        )
+        .expect("catalog_delete_total metric");
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register catalog_delete_total");
+        m
+    })
+}
+
+/// Every `outcome` value `catalog_delete_total` can take.
+pub const CATALOG_DELETE_OUTCOMES: [&str; 2] = ["deleted", "no_match"];
+
+/// Materialise both [`CATALOG_DELETE_OUTCOMES`] series at 0.
+///
+/// A destructive endpoint whose counter is absent until the first delete cannot
+/// answer "has anything been removed from the catalog?" — the question an
+/// operator asks first, and the one where absent must not read as zero.
+pub fn init_catalog_delete_series() {
+    for outcome in CATALOG_DELETE_OUTCOMES {
+        catalog_delete_total().with_label_values(&[outcome]).inc_by(0);
+    }
+}
+
+/// Record one catalog delete outcome.
+pub fn record_catalog_delete(outcome: &str) {
+    catalog_delete_total().with_label_values(&[outcome]).inc();
+}
+
 pub fn record_sink_state(op: &str) {
     sink_state_total().with_label_values(&[op]).inc();
 }
@@ -3320,6 +3364,127 @@ mod tests {
                 "{outcome} series must exist before any sweep; got {lines:?}"
             );
         }
+    }
+
+    /// noetl/ai-meta#237 — both catalog-delete outcomes must be SERVED at 0.
+    ///
+    /// A destructive endpoint whose counter appears only after the first delete
+    /// cannot answer "has anything been removed from the catalog?", and
+    /// `noetl.catalog` has no replay, so that counter plus the INFO log are the
+    /// entire audit trail. Absent must not read as zero here.
+    ///
+    /// Touches no recorder — calling one would create the series and mask the
+    /// defect.
+    #[test]
+    fn catalog_delete_outcomes_are_served_at_zero() {
+        init_catalog_delete_series();
+        let text = gather_text().expect("gather metrics text");
+        for outcome in CATALOG_DELETE_OUTCOMES {
+            let want = format!("noetl_catalog_delete_total{{outcome=\"{outcome}\"}}");
+            let line = text
+                .lines()
+                .find(|l| l.starts_with(&want))
+                .unwrap_or_else(|| panic!("{want} must be pinned"));
+            assert!(
+                line.trim_end().ends_with(" 0"),
+                "{want} must read 0 before any delete; got {line:?}"
+            );
+        }
+    }
+
+    /// The pinned set must cover the outcomes the service actually records.
+    #[test]
+    fn catalog_delete_pinned_outcomes_match_the_call_site() {
+        let full = include_str!("services/catalog.rs");
+        let src = full.split_once("\n#[cfg(test)]").map_or(full, |(b, _)| b);
+
+        // Direction 1: everything pinned is actually recorded.
+        for outcome in CATALOG_DELETE_OUTCOMES {
+            assert!(
+                src.contains(&format!("\"{outcome}\"")),
+                "{outcome} is pinned but the service never records it"
+            );
+        }
+
+        // Direction 2 — the one that matters, and the one a set-iterating test
+        // cannot check: every literal the service passes to
+        // `record_catalog_delete` must be pinned. Shrinking the pinned array
+        // also shrinks a test that loops over it, so without this a dropped
+        // outcome reintroduces the absent-series bug for that value alone while
+        // the rest read 0 and look complete.
+        let call = src
+            .find("record_catalog_delete(")
+            .expect("the service must record a delete outcome");
+        let region = &src[call..call + 200];
+        let recorded: Vec<&str> = region
+            .match_indices('"')
+            .collect::<Vec<_>>()
+            .chunks(2)
+            .filter_map(|c| match c {
+                [(a, _), (b, _)] => Some(&region[a + 1..*b]),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !recorded.is_empty(),
+            "could not extract the recorded outcome literals from {region:?}"
+        );
+        for r in &recorded {
+            assert!(
+                CATALOG_DELETE_OUTCOMES.contains(r),
+                "the service records {r:?} but it is not in CATALOG_DELETE_OUTCOMES, \
+                 so that series is absent from /metrics until it first fires"
+            );
+        }
+    }
+
+    /// noetl/ai-meta#237 — the delete endpoint must be auth-gated.
+    ///
+    /// `register` on the same router is ungated, so "match the neighbours" would
+    /// have shipped an unauthenticated destructive endpoint. This asserts the
+    /// handler takes the internal-token extractor, which fails closed (503 when
+    /// the server has no token, 403 on a bad one).
+    ///
+    /// Fails on any refactor that drops the extractor — which would compile
+    /// perfectly well and silently open the surface.
+    #[test]
+    fn catalog_delete_handler_requires_the_internal_token() {
+        let full = include_str!("handlers/catalog.rs");
+        let src = full.split_once("\n#[cfg(test)]").map_or(full, |(b, _)| b);
+        let start = src.find("pub async fn delete(").expect("delete handler exists");
+        let sig = &src[start..start + 400];
+        assert!(
+            sig.contains("RequireInternalApiToken"),
+            "the delete handler must take the internal-token extractor; signature was:\n{sig}"
+        );
+    }
+
+    /// The only `DELETE FROM noetl.catalog` in the crate must be the one the
+    /// service calls — the data-access boundary this endpoint exists to honour.
+    ///
+    /// If a second raw delete appears anywhere, the endpoint stops being the
+    /// single supported removal path and the audit trail has a hole.
+    #[test]
+    fn catalog_delete_has_exactly_one_raw_sql_site() {
+        let q = include_str!("db/queries/catalog.rs");
+        // Two statements live inside `delete_catalog_entries` — the
+        // version-scoped delete and the whole-path delete. What matters is that
+        // NONE live outside it: everything before that function must be free of
+        // raw catalog deletes, or the endpoint is no longer the single removal
+        // path and the audit trail has a hole.
+        let before = q
+            .split_once("pub async fn delete_catalog_entries")
+            .map(|(b, _)| b)
+            .expect("delete_catalog_entries exists");
+        assert_eq!(
+            before.matches("DELETE FROM noetl.catalog").count(),
+            0,
+            "a raw catalog DELETE exists outside delete_catalog_entries"
+        );
+        assert!(
+            q.matches("DELETE FROM noetl.catalog").count() >= 1,
+            "delete_catalog_entries must actually delete"
+        );
     }
 
     /// noetl/ai-meta#248 — every `op` the code actually records must be pinned.

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -5,6 +5,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use crate::db::models::{
     CatalogEntries, CatalogEntry, CatalogEntryRequest, CatalogEntryResponse,
     CatalogRegisterRequest, CatalogRegisterResponse,
+    CatalogDeleteRequest, CatalogDeleteResponse, DeletedCatalogEntry,
 };
 use crate::db::queries::catalog as queries;
 use crate::db::DbPool;
@@ -102,6 +103,73 @@ impl CatalogService {
     }
 
     /// List catalog entries.
+    /// Delete catalog entries for a path (noetl/ai-meta#237).
+    ///
+    /// Routed through the service like every other catalog mutation so the
+    /// data-access boundary holds: `noetl.catalog` is server-owned, and the
+    /// only supported way to remove a row is this API. Before it existed the
+    /// alternative was a raw `DELETE FROM noetl.catalog`, which bypasses the
+    /// boundary and leaves no audit trail.
+    ///
+    /// `version: None` removes every version of the path.
+    ///
+    /// Returns what was removed rather than a bare count: `noetl.catalog` is
+    /// not event-sourced and has no replay, so the response is the only record
+    /// of what a delete actually took.
+    pub async fn delete(
+        &self,
+        request: CatalogDeleteRequest,
+    ) -> AppResult<CatalogDeleteResponse> {
+        let path = request.path.trim().to_string();
+        if path.is_empty() {
+            return Err(AppError::Validation(
+                "catalog delete requires a non-empty 'path'".to_string(),
+            ));
+        }
+
+        let removed =
+            queries::delete_catalog_entries(&self.pool, &path, request.version).await?;
+
+        let deleted: Vec<DeletedCatalogEntry> = removed
+            .iter()
+            .map(|(id, v)| DeletedCatalogEntry {
+                catalog_id: id.to_string(),
+                version: *v,
+            })
+            .collect();
+
+        crate::metrics::record_catalog_delete(if deleted.is_empty() {
+            "no_match"
+        } else {
+            "deleted"
+        });
+
+        // Deliberately INFO, not debug: this is a destructive operation on a
+        // table with no replay, and the log line is part of the audit trail.
+        tracing::info!(
+            path = %path,
+            version = ?request.version,
+            removed = deleted.len(),
+            catalog_ids = ?deleted.iter().map(|d| d.catalog_id.as_str()).collect::<Vec<_>>(),
+            "catalog delete"
+        );
+
+        let message = match (deleted.len(), request.version) {
+            (0, Some(v)) => format!("No catalog entry '{path}' version {v}; nothing removed."),
+            (0, None) => format!("No catalog entries for '{path}'; nothing removed."),
+            (n, Some(v)) => format!("Removed catalog entry '{path}' version {v} ({n} row)."),
+            (n, None) => format!("Removed {n} version(s) of catalog entry '{path}'."),
+        };
+
+        Ok(CatalogDeleteResponse {
+            status: "success".to_string(),
+            message,
+            path,
+            count: deleted.len(),
+            deleted,
+        })
+    }
+
     pub async fn list(&self, resource_type: Option<&str>) -> AppResult<CatalogEntries> {
         let entries = queries::list_catalog_entries(&self.pool, resource_type).await?;
 


### PR DESCRIPTION
## Why

`noetl.catalog` has **no removal path**. The only way to drop a stale entry was a raw `DELETE FROM noetl.catalog`, which bypasses the data-access boundary (the table is server-owned; everything else reaches it through this API) and leaves no audit trail. That is why the noetl/ai-meta#237 cleanup has been deferred rather than done.

## What

`POST /api/catalog/delete` with `{path, version?}`. Omitting `version` removes every version of the path. There is deliberately **no "delete the latest" shorthand** — the latest version is the one executions resolve to, so removing it should be spelled out.

### Auth — stricter than its neighbours, on purpose

Gated by `RequireInternalApiToken`, which fails **closed**: 503 when the server has no token configured, 403 on a missing or mismatched one.

`register` on the same router is currently **ungated**, so "match the neighbouring mutating endpoint" would have shipped an unauthenticated destructive endpoint. Registering is additive and reversible; deleting is neither, and this table has no replay to reconstruct a removed row from.

### Auditability

Returns every `(catalog_id, version)` removed, not a bare count — with no replay, the response and the INFO log are the only record of what a delete took. `DELETE ... RETURNING` keeps read and delete in one statement, so a concurrent `register` (which mints a new version for the same path) cannot make it report a row it did not remove.

**Idempotent:** an absent path or version returns 200 with `count: 0`, so a cleanup run is safe to repeat.

**Observability:** `noetl_catalog_delete_total{outcome}`, both outcomes pinned at 0 at startup, plus an INFO line with path, version and removed ids.

## Testing

Four guards, **all mutation-checked**:

| guard | mutation that breaks it |
| :-- | :-- |
| both outcomes served at 0 (touching no recorder) | unregistering the metric |
| pinned set ↔ recorded literals, **both directions** | shrinking the pinned array |
| handler takes the auth extractor | deleting the extractor from the signature |
| no raw catalog `DELETE` outside the query fn | adding a stray one |

⚠ The both-directions check earned its place: my first version looped over the pinned array, so **shrinking the array shrank the test** and a dropped outcome passed. Same self-referential weakness as the guard in noetl/worker#246 — caught only by running the mutation.

`cargo test --lib`: 739 passed, 0 failed. Clippy: 0 errors, 4 warnings — identical to the `origin/main` baseline.

Refs noetl/ai-meta#237