### PR TITLE
fix(catalog): a delete blocked by execution history is 409, not 500

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2660,7 +2660,7 @@ pub fn catalog_delete_total() -> &'static IntCounterVec {
 }
 
 /// Every `outcome` value `catalog_delete_total` can take.
-pub const CATALOG_DELETE_OUTCOMES: [&str; 2] = ["deleted", "no_match"];
+pub const CATALOG_DELETE_OUTCOMES: [&str; 3] = ["deleted", "no_match", "has_history"];
 
 /// Materialise both [`CATALOG_DELETE_OUTCOMES`] series at 0.
 ///
@@ -3364,6 +3364,45 @@ mod tests {
                 "{outcome} series must exist before any sweep; got {lines:?}"
             );
         }
+    }
+
+    /// noetl/ai-meta#237 — a foreign-key violation is a 409, not a 500.
+    ///
+    /// `noetl.event` carries an FK onto `noetl.catalog`, so any entry that has
+    /// ever been EXECUTED is pinned by its event rows, and the event log is
+    /// append-only so those rows are never removed to release it. Attempting to
+    /// hard-delete such an entry is therefore a well-formed request with a
+    /// legitimate refusal — not a server fault.
+    ///
+    /// Before this, prod returned a bare 500 whose only explanation was in the
+    /// server log. The condition was found exactly that way: the kind
+    /// validation passed because the probe entry had never been executed and so
+    /// had no FK reference — the one case that CAN be deleted.
+    ///
+    /// Asserts the mapping exists at the call site; the sqlx error type cannot
+    /// be constructed in a unit test without a live database.
+    #[test]
+    fn catalog_delete_maps_fk_violation_to_conflict() {
+        let full = include_str!("services/catalog.rs");
+        let src = full.split_once("\n#[cfg(test)]").map_or(full, |(b, _)| b);
+        assert!(
+            src.contains("Some(\"23503\")"),
+            "the FK violation SQLSTATE must be matched explicitly"
+        );
+        assert!(
+            src.contains("AppError::Conflict"),
+            "a foreign-key violation must map to Conflict (409), not fall through to 500"
+        );
+        assert!(
+            src.contains("has_history"),
+            "the refusal must be counted under its own outcome"
+        );
+        // The message has to name WHY, or a 409 is only marginally better than
+        // a 500 — the caller still cannot tell what to do about it.
+        assert!(
+            src.contains("append-only"),
+            "the 409 message must explain the append-only event FK"
+        );
     }
 
     /// noetl/ai-meta#237 — both catalog-delete outcomes must be SERVED at 0.

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -127,8 +127,37 @@ impl CatalogService {
             ));
         }
 
-        let removed =
-            queries::delete_catalog_entries(&self.pool, &path, request.version).await?;
+        let removed = match queries::delete_catalog_entries(&self.pool, &path, request.version)
+            .await
+        {
+            Ok(rows) => rows,
+            // Postgres 23503 = foreign_key_violation. `noetl.event` carries an FK
+            // onto `noetl.catalog`, so any entry that has ever been EXECUTED is
+            // pinned by its event rows — and `noetl.event` is append-only, so
+            // those rows are never removed to release it.
+            //
+            // That is a legitimate, expected outcome of a well-formed request,
+            // not a server fault: 409, naming the constraint, rather than a bare
+            // 500 that tells the caller nothing about why.
+            Err(AppError::Database(sqlx::Error::Database(db)))
+                if db.code().as_deref() == Some("23503") =>
+            {
+                crate::metrics::record_catalog_delete("has_history");
+                tracing::info!(
+                    path = %path,
+                    version = ?request.version,
+                    constraint = ?db.constraint(),
+                    "catalog delete refused: entry has execution history"
+                );
+                return Err(AppError::Conflict(format!(
+                    "Catalog entry '{path}' has execution history and cannot be hard-deleted: \
+                     noetl.event holds a foreign key onto noetl.catalog, and the event log is \
+                     append-only. Only an entry that has never been executed can be removed. \
+                     Retiring an executed entry needs a soft delete (noetl/ai-meta#237)."
+                )));
+            }
+            Err(e) => return Err(e),
+        };
 
         let deleted: Vec<DeletedCatalogEntry> = removed
             .iter()


### PR DESCRIPTION
## Why

`noetl.event` carries a **foreign key onto `noetl.catalog`**, so any catalog entry that has ever been *executed* is pinned by its event rows — and the event log is append-only, so those rows are never removed to release it. Such an entry is permanently un-hard-deletable **by design**.

Attempting it is a well-formed request with a legitimate refusal, but the endpoint surfaced it as a bare **500** whose only explanation lived in the server log:

```
update or delete on table "catalog" violates foreign key constraint
"event_catalog_id_fkey" on table "event"
```

## What

**409 Conflict**, naming the constraint and saying what would actually be needed (a soft delete, noetl/ai-meta#237). Counted under its own `has_history` outcome, pinned like the others.

Diagnostic only — no control flow, no schema, no semantics change. A never-executed entry still deletes, and the endpoint is still idempotent.

## ⚠ How this was found

**The kind validation passed.** The throwaway probe there had been registered but never *executed*, so it had no FK reference — the one case that can be deleted. The constraint only appeared against real production data.

A green pre-production check does not establish that a destructive endpoint behaves correctly on rows with history. Worth carrying: for a destructive surface, the pre-prod fixture has to include the *encumbered* case, not just the clean one.

## Testing

Guard asserts the SQLSTATE match, the `Conflict` mapping, the dedicated outcome, and that the message explains the append-only FK — a 409 that doesn't say why is only marginally better than a 500. Mutation-checked: swapping `Conflict` for another variant fails it, and un-pinning `has_history` fails the both-directions pin check.

`cargo test --lib`: 740 passed, 0 failed. Clippy: 0 errors, 4 warnings — the `origin/main` baseline.

Refs noetl/ai-meta#237