### PR TITLE
feat(catalog): soft delete — retire an entry the append-only FK pins

### DIFF
--- a/src/db/models/catalog.rs
+++ b/src/db/models/catalog.rs
@@ -89,6 +89,14 @@ pub struct CatalogEntriesRequest {
     /// Filter by resource type
     #[serde(default)]
     pub resource_type: Option<String>,
+
+    /// Include soft-deleted (archived) entries (noetl/ai-meta#237).
+    ///
+    /// Defaults to false: an archived entry is retired, so the ordinary listing
+    /// hides it. Set true to see what has been retired — the view an operator
+    /// needs before restoring something.
+    #[serde(default)]
+    pub include_archived: bool,
 }
 
 /// Response containing list of catalog entries.

--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -122,7 +122,7 @@ pub async fn get_catalog_by_path_version(
         r#"
         SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
-        WHERE path = $1 AND version = $2
+        WHERE path = $1 AND version = $2 AND archived_at IS NULL
         "#,
     )
     .bind(path)
@@ -139,7 +139,7 @@ pub async fn get_catalog_latest(pool: &DbPool, path: &str) -> AppResult<Option<C
         r#"
         SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
-        WHERE path = $1
+        WHERE path = $1 AND archived_at IS NULL
         ORDER BY version DESC
         LIMIT 1
         "#,
@@ -152,32 +152,29 @@ pub async fn get_catalog_latest(pool: &DbPool, path: &str) -> AppResult<Option<C
 }
 
 /// List all catalog entries, optionally filtered by kind.
+/// `include_archived` opts in to soft-deleted rows (noetl/ai-meta#237).
+///
+/// The default hides them: an archived entry is retired, and a listing that
+/// still showed it would defeat the point. The opt-in exists so an operator can
+/// see what was retired and restore it.
 pub async fn list_catalog_entries(
     pool: &DbPool,
     kind: Option<&str>,
+    include_archived: bool,
 ) -> AppResult<Vec<CatalogEntry>> {
+    const COLS: &str = "catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at";
+    let archived = if include_archived { "" } else { " AND archived_at IS NULL" };
     let entries = if let Some(k) = kind {
-        sqlx::query_as::<_, CatalogEntry>(
-            r#"
-            SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
-            FROM noetl.catalog
-            WHERE kind = $1
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(k)
-        .fetch_all(pool)
-        .await?
+        let sql = format!("SELECT {COLS} FROM noetl.catalog WHERE kind = $1{archived} ORDER BY created_at DESC");
+        sqlx::query_as::<_, CatalogEntry>(&sql)
+            .bind(k)
+            .fetch_all(pool)
+            .await?
     } else {
-        sqlx::query_as::<_, CatalogEntry>(
-            r#"
-            SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
-            FROM noetl.catalog
-            ORDER BY created_at DESC
-            "#,
-        )
-        .fetch_all(pool)
-        .await?
+        let sql = format!("SELECT {COLS} FROM noetl.catalog WHERE 1 = 1{archived} ORDER BY created_at DESC");
+        sqlx::query_as::<_, CatalogEntry>(&sql)
+            .fetch_all(pool)
+            .await?
     };
 
     Ok(entries)
@@ -189,7 +186,7 @@ pub async fn get_catalog_all_versions(pool: &DbPool, path: &str) -> AppResult<Ve
         r#"
         SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
         FROM noetl.catalog
-        WHERE path = $1
+        WHERE path = $1 AND archived_at IS NULL
         ORDER BY version DESC
         "#,
     )
@@ -237,6 +234,106 @@ pub async fn delete_catalog_entries(
                 r#"
                 DELETE FROM noetl.catalog
                 WHERE path = $1
+                RETURNING catalog_id, version
+                "#,
+            )
+            .bind(path)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+    Ok(rows)
+}
+
+/// Add the soft-delete column if it is not already there (noetl/ai-meta#237).
+///
+/// Idempotent startup DDL, the same shape `secret_audit` / `result_store` /
+/// `plugin_module` use, so first boot lands the schema without an out-of-band
+/// migration step.
+///
+/// Purely additive: nullable, defaults NULL, and every existing row reads NULL
+/// (= not archived). A binary that predates this column is unaffected by its
+/// presence, so the rollout and rollback are both safe.
+pub async fn ensure_archived_column(pool: &DbPool) -> AppResult<()> {
+    sqlx::query("ALTER TABLE noetl.catalog ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ NULL")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Mark catalog entries archived (noetl/ai-meta#237).
+///
+/// The soft-delete counterpart of [`delete_catalog_entries`], and the only
+/// retirement available to an entry that has execution history: `noetl.event`
+/// holds a foreign key onto `noetl.catalog` and the event log is append-only,
+/// so those rows can never be removed to release it.
+///
+/// Idempotent by construction — `archived_at IS NULL` in the predicate means
+/// re-archiving an already-archived entry matches nothing and reports 0.
+pub async fn archive_catalog_entries(
+    pool: &DbPool,
+    path: &str,
+    version: Option<i16>,
+) -> AppResult<Vec<(i64, i16)>> {
+    let rows: Vec<(i64, i16)> = match version {
+        Some(v) => {
+            sqlx::query_as(
+                r#"
+                UPDATE noetl.catalog SET archived_at = now()
+                WHERE path = $1 AND version = $2 AND archived_at IS NULL
+                RETURNING catalog_id, version
+                "#,
+            )
+            .bind(path)
+            .bind(v)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_as(
+                r#"
+                UPDATE noetl.catalog SET archived_at = now()
+                WHERE path = $1 AND archived_at IS NULL
+                RETURNING catalog_id, version
+                "#,
+            )
+            .bind(path)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+    Ok(rows)
+}
+
+/// Un-archive catalog entries — the reverse of [`archive_catalog_entries`].
+///
+/// This is why soft delete is the right answer for #237: retirement is a plain
+/// `UPDATE`, so it is fully reversible and destroys nothing. Nothing else in
+/// this table has that property.
+pub async fn restore_catalog_entries(
+    pool: &DbPool,
+    path: &str,
+    version: Option<i16>,
+) -> AppResult<Vec<(i64, i16)>> {
+    let rows: Vec<(i64, i16)> = match version {
+        Some(v) => {
+            sqlx::query_as(
+                r#"
+                UPDATE noetl.catalog SET archived_at = NULL
+                WHERE path = $1 AND version = $2 AND archived_at IS NOT NULL
+                RETURNING catalog_id, version
+                "#,
+            )
+            .bind(path)
+            .bind(v)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_as(
+                r#"
+                UPDATE noetl.catalog SET archived_at = NULL
+                WHERE path = $1 AND archived_at IS NOT NULL
                 RETURNING catalog_id, version
                 "#,
             )

--- a/src/handlers/catalog.rs
+++ b/src/handlers/catalog.rs
@@ -133,6 +133,39 @@ async fn delete_inner(
     Ok((StatusCode::OK, Json(response)))
 }
 
+/// Restore (un-archive) catalog entries.
+///
+/// `POST /api/catalog/restore`
+///
+/// Auth-gated identically to `delete`. Takes the same `{path, version?}` body.
+/// Idempotent: restoring a non-archived entry returns 200 with `count: 0`.
+///
+/// This is what makes the archive path safe to use: retirement is reversible
+/// with one call, so nothing is ever destroyed.
+pub async fn restore(
+    service: State<CatalogService>,
+    _token: crate::handlers::internal::RequireInternalApiToken,
+    request: Json<CatalogDeleteRequest>,
+) -> AppResult<(StatusCode, Json<CatalogDeleteResponse>)> {
+    let started_at = std::time::Instant::now();
+    let result = restore_inner(service, request).await;
+    let status_label = if result.is_ok() { "ok" } else { "error" };
+    crate::metrics::record_write_request(
+        crate::metrics::endpoint::CATALOG_DELETE,
+        status_label,
+        started_at.elapsed().as_secs_f64(),
+    );
+    result
+}
+
+async fn restore_inner(
+    State(service): State<CatalogService>,
+    Json(request): Json<CatalogDeleteRequest>,
+) -> AppResult<(StatusCode, Json<CatalogDeleteResponse>)> {
+    let response = service.restore(request).await?;
+    Ok((StatusCode::OK, Json(response)))
+}
+
 /// List all catalog resources.
 ///
 /// `POST /api/catalog/list`
@@ -164,7 +197,9 @@ pub async fn list(
     State(service): State<CatalogService>,
     Json(request): Json<CatalogEntriesRequest>,
 ) -> AppResult<Json<CatalogEntries>> {
-    let entries = service.list(request.resource_type.as_deref()).await?;
+    let entries = service
+        .list(request.resource_type.as_deref(), request.include_archived)
+        .await?;
     Ok(Json(entries))
 }
 

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -572,7 +572,14 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
     } else if let Some(path) = &request.path {
         // Lookup by path (latest version; Phase F R4-3: cluster-wide)
         let entry = sqlx::query_as::<_, (i64, String)>(
-            "SELECT catalog_id, path FROM noetl.catalog WHERE path = $1 ORDER BY version DESC LIMIT 1",
+            // noetl/ai-meta#237 — an archived entry is retired: it must not
+                // resolve by PATH, which is how everything normally runs.
+                // Resolution by explicit `catalog_id` (above) deliberately still
+                // works, so a historical version can be re-run on purpose; that
+                // is the escape hatch, and it requires naming the row.
+                "SELECT catalog_id, path FROM noetl.catalog \
+                 WHERE path = $1 AND archived_at IS NULL \
+                 ORDER BY version DESC LIMIT 1",
         )
         .bind(path)
         .fetch_optional(state.pools.cluster())

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,10 @@ fn build_router(
         .route("/api/catalog/register", post(handlers::catalog::register))
             .route("/api/catalog/delete", post(handlers::catalog::delete))
         .route("/api/catalog/list", post(handlers::catalog::list))
+            .route(
+                "/api/catalog/restore",
+                post(handlers::catalog::restore),
+            )
         .route(
             "/api/catalog/resource",
             post(handlers::catalog::get_resource),
@@ -919,6 +923,11 @@ async fn main() -> anyhow::Result<()> {
     // for the system worker pool's wasmtime PluginSource.  Same idempotent
     // startup-DDL pattern; server-owned end-to-end.
     noetl_server::db::queries::plugin_module::ensure_table(&db_pool).await?;
+    // Catalog soft delete (noetl/ai-meta#237) — `archived_at` lets an entry
+    // with execution history be retired without violating the append-only
+    // event FK that makes a hard delete impossible.  Additive, nullable,
+    // defaults NULL, so it is a no-op for every existing row.
+    noetl_server::db::queries::catalog::ensure_archived_column(&db_pool).await?;
     // Seed built-in system plug-ins (noetl/ai-meta#108 slice 3) — the
     // server-owned `system/orchestrate` (+ future built-ins) compiled to wasm32
     // and baked into the image are registered into noetl.plugin_module on boot,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2660,7 +2660,13 @@ pub fn catalog_delete_total() -> &'static IntCounterVec {
 }
 
 /// Every `outcome` value `catalog_delete_total` can take.
-pub const CATALOG_DELETE_OUTCOMES: [&str; 3] = ["deleted", "no_match", "has_history"];
+pub const CATALOG_DELETE_OUTCOMES: [&str; 5] = [
+    "deleted",
+    "no_match",
+    "archived",
+    "already_archived",
+    "restored",
+];
 
 /// Materialise both [`CATALOG_DELETE_OUTCOMES`] series at 0.
 ///
@@ -3366,42 +3372,84 @@ mod tests {
         }
     }
 
-    /// noetl/ai-meta#237 — a foreign-key violation is a 409, not a 500.
+    /// noetl/ai-meta#237 — a foreign-key violation SOFT-DELETES; it does not error.
     ///
-    /// `noetl.event` carries an FK onto `noetl.catalog`, so any entry that has
-    /// ever been EXECUTED is pinned by its event rows, and the event log is
-    /// append-only so those rows are never removed to release it. Attempting to
-    /// hard-delete such an entry is therefore a well-formed request with a
-    /// legitimate refusal — not a server fault.
+    /// `noetl.event` holds an FK onto `noetl.catalog` and the event log is
+    /// append-only, so an entry with execution history can never be hard
+    /// deleted. It used to surface as a bare 500, then briefly as a 409.
+    /// Neither did what the caller asked.
     ///
-    /// Before this, prod returned a bare 500 whose only explanation was in the
-    /// server log. The condition was found exactly that way: the kind
-    /// validation passed because the probe entry had never been executed and so
-    /// had no FK reference — the one case that CAN be deleted.
+    /// Now the FK violation is the *signal* to archive instead: the entry is
+    /// marked `archived_at`, stops resolving by path, drops out of `list`, and
+    /// is restorable with one call. The caller's intent — make this go away —
+    /// is satisfied, reversibly, without destroying anything.
     ///
-    /// Asserts the mapping exists at the call site; the sqlx error type cannot
-    /// be constructed in a unit test without a live database.
+    /// Asserts the mapping at the call site; the sqlx error type cannot be
+    /// constructed in a unit test without a live database.
     #[test]
-    fn catalog_delete_maps_fk_violation_to_conflict() {
+    fn catalog_delete_falls_back_to_archive_on_fk_violation() {
         let full = include_str!("services/catalog.rs");
         let src = full.split_once("\n#[cfg(test)]").map_or(full, |(b, _)| b);
         assert!(
             src.contains("Some(\"23503\")"),
-            "the FK violation SQLSTATE must be matched explicitly"
+            "the FK violation SQLSTATE must still be matched explicitly"
         );
         assert!(
-            src.contains("AppError::Conflict"),
-            "a foreign-key violation must map to Conflict (409), not fall through to 500"
+            src.contains("archive_catalog_entries"),
+            "an FK violation must fall back to archiving, not error out"
         );
         assert!(
-            src.contains("has_history"),
-            "the refusal must be counted under its own outcome"
+            !src.contains("AppError::Conflict"),
+            "the 409 path was replaced by the archive fallback; a Conflict here \
+             would mean the caller's request is refused again"
         );
-        // The message has to name WHY, or a 409 is only marginally better than
-        // a 500 — the caller still cannot tell what to do about it.
+        // Retirement must be undoable, or soft delete is just a slower hard delete.
         assert!(
-            src.contains("append-only"),
-            "the 409 message must explain the append-only event FK"
+            src.contains("restore_catalog_entries"),
+            "restore must exist for archive to be reversible"
+        );
+    }
+
+    /// Archiving must actually RETIRE the entry, not merely label it.
+    ///
+    /// The whole point is that an archived playbook stops being reachable. If
+    /// path resolution still found it, `delete` would report success while the
+    /// entry kept executing — worse than not archiving at all, because it would
+    /// look done.
+    ///
+    /// Deliberately does NOT require the filter on `get_next_version` (archived
+    /// versions must still count, or a re-register would reuse a version number
+    /// and collide), on `get_catalog_by_id` (explicit id is the documented
+    /// escape hatch), or on the delete itself (an archived never-executed row
+    /// must remain hard-deletable).
+    #[test]
+    fn archived_entries_stop_resolving_by_path() {
+        let q = include_str!("db/queries/catalog.rs");
+        let src = q.split_once("\n#[cfg(test)]").map_or(q, |(b, _)| b);
+        fn body<'a>(src: &'a str, name: &str) -> &'a str {
+            let s = src
+                .find(&format!("pub async fn {name}("))
+                .unwrap_or_else(|| panic!("{name} exists"));
+            let e = src[s..].find("\n}").map(|i| s + i).unwrap_or(src.len());
+            &src[s..e]
+        }
+        for name in ["get_catalog_latest", "get_catalog_by_path_version"] {
+            assert!(
+                body(src, name).contains("archived_at IS NULL"),
+                "{name} resolves a playbook for use and must skip archived rows"
+            );
+        }
+        assert!(
+            !body(src, "get_next_version").contains("archived_at IS NULL"),
+            "get_next_version must COUNT archived versions, or re-registering an \
+             archived path reuses a version number"
+        );
+        // And the execute path itself, which resolves by path directly.
+        let ex = include_str!("handlers/execute.rs");
+        let ex_src = ex.split_once("\n#[cfg(test)]").map_or(ex, |(b, _)| b);
+        assert!(
+            ex_src.contains("archived_at IS NULL"),
+            "resolve_catalog's by-path lookup must skip archived entries"
         );
     }
 

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -142,19 +142,58 @@ impl CatalogService {
             Err(AppError::Database(sqlx::Error::Database(db)))
                 if db.code().as_deref() == Some("23503") =>
             {
-                crate::metrics::record_catalog_delete("has_history");
+                // noetl/ai-meta#237 — the entry has execution history, so a hard
+                // delete is impossible by construction. SOFT-delete instead:
+                // mark it archived, which retires it (it stops resolving by
+                // path and drops out of `list`) while destroying nothing and
+                // leaving the event FK intact.
+                //
+                // Falling back rather than erroring is the point of this
+                // endpoint: the caller asked for the entry to go away, and it
+                // does — reversibly, via `restore`.
+                let archived =
+                    queries::archive_catalog_entries(&self.pool, &path, request.version).await?;
+                let entries: Vec<DeletedCatalogEntry> = archived
+                    .iter()
+                    .map(|(id, v)| DeletedCatalogEntry {
+                        catalog_id: id.to_string(),
+                        version: *v,
+                    })
+                    .collect();
+                crate::metrics::record_catalog_delete(if entries.is_empty() {
+                    "already_archived"
+                } else {
+                    "archived"
+                });
                 tracing::info!(
                     path = %path,
                     version = ?request.version,
                     constraint = ?db.constraint(),
-                    "catalog delete refused: entry has execution history"
+                    archived = entries.len(),
+                    "catalog entry archived (has execution history; hard delete impossible)"
                 );
-                return Err(AppError::Conflict(format!(
-                    "Catalog entry '{path}' has execution history and cannot be hard-deleted: \
-                     noetl.event holds a foreign key onto noetl.catalog, and the event log is \
-                     append-only. Only an entry that has never been executed can be removed. \
-                     Retiring an executed entry needs a soft delete (noetl/ai-meta#237)."
-                )));
+                let message = if entries.is_empty() {
+                    format!(
+                        "Catalog entry '{path}' has execution history and is already archived; \
+                         nothing changed."
+                    )
+                } else {
+                    format!(
+                        "Catalog entry '{path}': archived {} version(s). It has execution \
+                         history, so it cannot be hard-deleted (noetl.event holds a foreign key \
+                         onto noetl.catalog and the event log is append-only). It no longer \
+                         resolves by path and is hidden from list; restore with \
+                         POST /api/catalog/restore.",
+                        entries.len()
+                    )
+                };
+                return Ok(CatalogDeleteResponse {
+                    status: "success".to_string(),
+                    message,
+                    path,
+                    count: entries.len(),
+                    deleted: entries,
+                });
             }
             Err(e) => return Err(e),
         };
@@ -199,8 +238,61 @@ impl CatalogService {
         })
     }
 
-    pub async fn list(&self, resource_type: Option<&str>) -> AppResult<CatalogEntries> {
-        let entries = queries::list_catalog_entries(&self.pool, resource_type).await?;
+    /// Un-archive catalog entries (noetl/ai-meta#237).
+    ///
+    /// The reverse of the archive path, and the reason soft delete is the right
+    /// resolution for #237: retirement is a plain `UPDATE`, so it destroys
+    /// nothing and is undone by another `UPDATE`. Nothing else available on
+    /// this table has that property.
+    ///
+    /// Idempotent: restoring an entry that is not archived matches nothing and
+    /// reports 0.
+    pub async fn restore(
+        &self,
+        request: CatalogDeleteRequest,
+    ) -> AppResult<CatalogDeleteResponse> {
+        let path = request.path.trim().to_string();
+        if path.is_empty() {
+            return Err(AppError::Validation(
+                "catalog restore requires a non-empty 'path'".to_string(),
+            ));
+        }
+        let rows = queries::restore_catalog_entries(&self.pool, &path, request.version).await?;
+        let restored: Vec<DeletedCatalogEntry> = rows
+            .iter()
+            .map(|(id, v)| DeletedCatalogEntry {
+                catalog_id: id.to_string(),
+                version: *v,
+            })
+            .collect();
+        crate::metrics::record_catalog_delete("restored");
+        tracing::info!(
+            path = %path,
+            version = ?request.version,
+            restored = restored.len(),
+            "catalog restore"
+        );
+        let message = if restored.is_empty() {
+            format!("No archived entries for '{path}'; nothing restored.")
+        } else {
+            format!("Restored {} archived version(s) of '{path}'.", restored.len())
+        };
+        Ok(CatalogDeleteResponse {
+            status: "success".to_string(),
+            message,
+            path,
+            count: restored.len(),
+            deleted: restored,
+        })
+    }
+
+    pub async fn list(
+        &self,
+        resource_type: Option<&str>,
+        include_archived: bool,
+    ) -> AppResult<CatalogEntries> {
+        let entries =
+            queries::list_catalog_entries(&self.pool, resource_type, include_archived).await?;
 
         let responses: Vec<CatalogEntryResponse> = entries.into_iter().map(|e| e.into()).collect();
 


### PR DESCRIPTION
## Why

noetl/ai-meta#237. `noetl.event` holds a foreign key onto `noetl.catalog`, and the event log is append-only, so **any entry that has ever been executed can never be hard deleted**. The hard-delete cleanup was never going to work; this is the resolution the constraint forces.

## Schema

`archived_at TIMESTAMPTZ NULL`, added by idempotent startup DDL (the pattern `secret_audit` / `result_store` / `plugin_module` already use). Purely additive — nullable, defaults NULL, every existing row reads "not archived", so rollout **and rollback** are no-ops for older binaries.

## Behaviour

| case | result |
| :-- | :-- |
| never-executed entry | **hard delete** (nothing is lost) |
| entry with execution history | **archived** — the FK violation is the *signal*, not an error |
| archived entry | stops resolving by path, hidden from `list` |
| `POST /api/catalog/restore` | un-archives — a plain `UPDATE` |

## Three read paths deliberately NOT filtered

This is the subtle part, and a blanket "filter everywhere" would have broken two of them:

- **`get_next_version` must still COUNT archived versions** — otherwise re-registering an archived path reuses a version number and collides.
- **`get_catalog_by_id`** is the documented escape hatch for deliberately re-running a retired version.
- **the delete itself** must stay able to hard-remove an archived *never-executed* row.

`list` hides archived by default, with `include_archived: true` to opt in — an operator needs to see what was retired before restoring it.

## Why this supersedes last release's 409

The 409 was honest but useless: it refused the caller's request and left them nothing to do. Archiving satisfies the intent, destroys nothing, and is undone with one call. The guard that asserted the 409 was **updated, not deleted**, and now asserts the archive fallback — the failing test was the design change announcing itself.

## Testing

Mutation-checked three ways, each failing its guard:

| mutation | caught by |
| :-- | :-- |
| un-filter `get_catalog_latest` | "resolves a playbook for use and must skip archived rows" |
| wrongly filter `get_next_version` | "must COUNT archived versions, or re-registering reuses a version number" |
| revert the fallback to `Conflict` | "an FK violation must fall back to archiving, not error out" |

`cargo test --lib`: 741 passed, 0 failed. Clippy: 0 errors, 4 warnings — the `origin/main` baseline.

Refs noetl/ai-meta#237