### PR TITLE
fix(catalog): the archived_at DDL must not crash-loop the server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -927,7 +927,27 @@ async fn main() -> anyhow::Result<()> {
     // with execution history be retired without violating the append-only
     // event FK that makes a hard delete impossible.  Additive, nullable,
     // defaults NULL, so it is a no-op for every existing row.
-    noetl_server::db::queries::catalog::ensure_archived_column(&db_pool).await?;
+    //
+    // ⚠ NON-FATAL by design.  `noetl.catalog` is NOT owned by the role the
+    // server connects as (kind: owner `demo`, connection `noetl`), and Postgres
+    // requires ownership to ALTER a table.  Making this fatal crash-looped the
+    // server on first boot — caught in kind before it reached production.
+    //
+    // A server that cannot add an OPTIONAL column must still start: the column
+    // only enables soft delete, and every other code path is unaffected by its
+    // absence.  Same shape as `seed_system_plugins` below, which is non-fatal
+    // for the same reason.
+    //
+    // When the column is missing, the archive path reports a clear, actionable
+    // error rather than a 500 (see `services::catalog::archive`).  Adding it
+    // needs a privileged role and is an operator action.
+    if let Err(e) = noetl_server::db::queries::catalog::ensure_archived_column(&db_pool).await {
+        tracing::warn!(
+            error = %e,
+            "could not ensure noetl.catalog.archived_at (needs table ownership); \
+             soft delete will report it is unavailable until an operator adds the column"
+        );
+    }
     // Seed built-in system plug-ins (noetl/ai-meta#108 slice 3) — the
     // server-owned `system/orchestrate` (+ future built-ins) compiled to wasm32
     // and baked into the image are registered into noetl.plugin_module on boot,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2660,12 +2660,13 @@ pub fn catalog_delete_total() -> &'static IntCounterVec {
 }
 
 /// Every `outcome` value `catalog_delete_total` can take.
-pub const CATALOG_DELETE_OUTCOMES: [&str; 5] = [
+pub const CATALOG_DELETE_OUTCOMES: [&str; 6] = [
     "deleted",
     "no_match",
     "archived",
     "already_archived",
     "restored",
+    "archive_unavailable",
 ];
 
 /// Materialise both [`CATALOG_DELETE_OUTCOMES`] series at 0.
@@ -3398,15 +3399,76 @@ mod tests {
             src.contains("archive_catalog_entries"),
             "an FK violation must fall back to archiving, not error out"
         );
+        // What the FK branch must DO, stated positively. An earlier version of
+        // this guard asserted "no AppError::Conflict in the branch", which was a
+        // proxy for the same idea — and it became wrong the moment the archive
+        // path grew a legitimate nested Conflict for the missing-column case.
+        // Assert the behaviour, not the absence of a symbol.
+        let fk = src.find("Some(\"23503\")").expect("the FK branch exists");
+        let fk_branch = &src[fk..];
+        let archive_at = fk_branch
+            .find("archive_catalog_entries")
+            .expect("the FK branch must archive");
+        let ok_at = fk_branch
+            .find("return Ok(CatalogDeleteResponse")
+            .expect("the FK branch must return success once archived");
         assert!(
-            !src.contains("AppError::Conflict"),
-            "the 409 path was replaced by the archive fallback; a Conflict here \
-             would mean the caller's request is refused again"
+            archive_at < ok_at,
+            "the FK branch must archive BEFORE reporting success"
         );
+
         // Retirement must be undoable, or soft delete is just a slower hard delete.
         assert!(
             src.contains("restore_catalog_entries"),
             "restore must exist for archive to be reversible"
+        );
+    }
+
+    /// noetl/ai-meta#237 — startup DDL that can fail on a PERMISSIONS boundary
+    /// must not be fatal.
+    ///
+    /// `noetl.catalog` is not owned by the role the server connects as (kind:
+    /// owner `demo`, connection `noetl`), and Postgres requires ownership to
+    /// ALTER. The first cut used `?`, so the server exited on boot and
+    /// crash-looped — caught in kind against the released image, before it
+    /// reached production, where it would have taken the control plane down.
+    ///
+    /// The column is OPTIONAL: it only enables soft delete, and nothing else
+    /// depends on it. A server that cannot add it must still start.
+    #[test]
+    fn optional_startup_ddl_is_not_fatal() {
+        let m = include_str!("main.rs");
+        let src = m.split_once("\n#[cfg(test)]").map_or(m, |(b, _)| b);
+        let i = src
+            .find("ensure_archived_column")
+            .expect("the archived_at DDL runs at startup");
+        // Look at the statement around the call, not the whole file.
+        let start = src[..i].rfind('\n').unwrap_or(0);
+        let end = src[i..].find(";\n").map(|j| i + j).unwrap_or(src.len());
+        let stmt = &src[start..end];
+        assert!(
+            !stmt.contains(".await?"),
+            "the archived_at DDL must not use `?` — a permissions failure would \
+             crash-loop the server on boot; statement was:\n{stmt}"
+        );
+        assert!(
+            src[start..].starts_with("\n    if let Err(") || stmt.contains("if let Err("),
+            "the DDL failure must be handled and logged, not propagated"
+        );
+    }
+
+    /// A missing `archived_at` must produce an ACTIONABLE error, not a 500.
+    #[test]
+    fn missing_archived_column_reports_the_operator_action() {
+        let full = include_str!("services/catalog.rs");
+        let src = full.split_once("\n#[cfg(test)]").map_or(full, |(b, _)| b);
+        assert!(
+            src.contains("Some(\"42703\")"),
+            "undefined_column must be matched so the message can be specific"
+        );
+        assert!(
+            src.contains("ALTER TABLE noetl.catalog ADD COLUMN"),
+            "the error must name the exact statement an operator has to run"
         );
     }
 

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -151,8 +151,35 @@ impl CatalogService {
                 // Falling back rather than erroring is the point of this
                 // endpoint: the caller asked for the entry to go away, and it
                 // does — reversibly, via `restore`.
-                let archived =
-                    queries::archive_catalog_entries(&self.pool, &path, request.version).await?;
+                let archived = match queries::archive_catalog_entries(
+                    &self.pool,
+                    &path,
+                    request.version,
+                )
+                .await
+                {
+                    Ok(rows) => rows,
+                    // 42703 = undefined_column. The `archived_at` column could not
+                    // be added at startup because the server's role does not own
+                    // `noetl.catalog` (it is owned by a different role in every
+                    // deployment checked). Say so precisely — the alternative is a
+                    // 500 that looks like a server fault when it is a one-line
+                    // operator action.
+                    Err(AppError::Database(sqlx::Error::Database(d)))
+                        if d.code().as_deref() == Some("42703") =>
+                    {
+                        crate::metrics::record_catalog_delete("archive_unavailable");
+                        return Err(AppError::Conflict(format!(
+                            "Catalog entry '{path}' has execution history so it cannot be \
+                             hard-deleted, and soft delete is unavailable: the \
+                             noetl.catalog.archived_at column does not exist. The server \
+                             cannot add it because it does not own the table. An operator \
+                             with ownership must run: ALTER TABLE noetl.catalog ADD COLUMN \
+                             IF NOT EXISTS archived_at TIMESTAMPTZ NULL; (noetl/ai-meta#237)"
+                        )));
+                    }
+                    Err(e) => return Err(e),
+                };
                 let entries: Vec<DeletedCatalogEntry> = archived
                     .iter()
                     .map(|(id, v)| DeletedCatalogEntry {


### PR DESCRIPTION
## What happened

v3.79.0 added `ALTER TABLE noetl.catalog ADD COLUMN IF NOT EXISTS archived_at` as startup DDL and propagated the error with `?`.

`noetl.catalog` is **not owned by the role the server connects as** — in kind it is owned by `demo` while the server connects as `noetl` — and Postgres requires ownership to `ALTER`. So the statement fails and the server exits:

```
Error: Database error: must be owner of table catalog
back-off 5m0s restarting failed container, restartCount 6
```

**Caught in kind against the released image before any production deploy.** v3.79.0 must not be rolled to prod; this supersedes it.

## Changes

1. **The DDL is non-fatal.** The column is *optional* — it enables soft delete and nothing else depends on it — so a server that cannot add it must still start. Same shape as `seed_system_plugins`, already non-fatal for the same class of reason.

2. **A missing column produces an actionable error.** SQLSTATE `42703` is matched and the response names the exact statement an operator with ownership must run, instead of surfacing as a 500 that looks like a server fault.

## The general lesson

**Startup DDL that can fail on a permissions boundary must never be fatal.** Ownership is not something the application controls, and treating it as an invariant turns a degraded feature into an outage. That is why this ships with a guard rather than just a fix.

## Testing

- Guard asserts the DDL call site does not use `?` — **mutation-checked**: restoring `?` fails it.
- Guard asserts the missing-column path names the `ALTER` statement.

⚠ Also **relaxed an over-broad assertion** from the previous change. It forbade `AppError::Conflict` anywhere in the delete service, as a proxy for "the FK branch must not refuse". That became wrong the moment the archive path grew a legitimate nested Conflict for the missing-column case. Restated positively: the FK branch must call archive, then return success. Asserting a behaviour beats asserting the absence of a symbol.

`cargo test --lib`: 743 passed, 0 failed. Clippy: 0 errors, 4 warnings — baseline.

Refs noetl/ai-meta#237