### PR TITLE
fix(catalog): the archived filter must be conditional on the column existing

### DIFF
--- a/src/db/queries/catalog.rs
+++ b/src/db/queries/catalog.rs
@@ -118,35 +118,29 @@ pub async fn get_catalog_by_path_version(
     path: &str,
     version: i16,
 ) -> AppResult<Option<CatalogEntry>> {
-    let entry = sqlx::query_as::<_, CatalogEntry>(
-        r#"
-        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
-        FROM noetl.catalog
-        WHERE path = $1 AND version = $2 AND archived_at IS NULL
-        "#,
-    )
-    .bind(path)
-    .bind(version)
-    .fetch_optional(pool)
-    .await?;
+    let sql = format!(
+        "SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at FROM noetl.catalog WHERE path = $1 AND version = $2{archived}",
+        archived = archived_filter()
+    );
+    let entry = sqlx::query_as::<_, CatalogEntry>(&sql)
+        .bind(path)
+        .bind(version)
+        .fetch_optional(pool)
+        .await?;
 
     Ok(entry)
 }
 
 /// Get the latest catalog entry by path.
 pub async fn get_catalog_latest(pool: &DbPool, path: &str) -> AppResult<Option<CatalogEntry>> {
-    let entry = sqlx::query_as::<_, CatalogEntry>(
-        r#"
-        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
-        FROM noetl.catalog
-        WHERE path = $1 AND archived_at IS NULL
-        ORDER BY version DESC
-        LIMIT 1
-        "#,
-    )
-    .bind(path)
-    .fetch_optional(pool)
-    .await?;
+    let sql = format!(
+        "SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at FROM noetl.catalog WHERE path = $1{archived} ORDER BY version DESC LIMIT 1",
+        archived = archived_filter()
+    );
+    let entry = sqlx::query_as::<_, CatalogEntry>(&sql)
+        .bind(path)
+        .fetch_optional(pool)
+        .await?;
 
     Ok(entry)
 }
@@ -163,7 +157,9 @@ pub async fn list_catalog_entries(
     include_archived: bool,
 ) -> AppResult<Vec<CatalogEntry>> {
     const COLS: &str = "catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at";
-    let archived = if include_archived { "" } else { " AND archived_at IS NULL" };
+    // Absent column => no predicate at all, regardless of `include_archived`:
+    // there is nothing to filter and referencing it would break the query.
+    let archived = if include_archived { "" } else { archived_filter() };
     let entries = if let Some(k) = kind {
         let sql = format!("SELECT {COLS} FROM noetl.catalog WHERE kind = $1{archived} ORDER BY created_at DESC");
         sqlx::query_as::<_, CatalogEntry>(&sql)
@@ -182,17 +178,14 @@ pub async fn list_catalog_entries(
 
 /// Get all versions of a catalog entry by path.
 pub async fn get_catalog_all_versions(pool: &DbPool, path: &str) -> AppResult<Vec<CatalogEntry>> {
-    let entries = sqlx::query_as::<_, CatalogEntry>(
-        r#"
-        SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at
-        FROM noetl.catalog
-        WHERE path = $1 AND archived_at IS NULL
-        ORDER BY version DESC
-        "#,
-    )
-    .bind(path)
-    .fetch_all(pool)
-    .await?;
+    let sql = format!(
+        "SELECT catalog_id AS id, path, kind, version, content, layout, payload, meta, created_at AT TIME ZONE 'UTC' as created_at FROM noetl.catalog WHERE path = $1{archived} ORDER BY version DESC",
+        archived = archived_filter()
+    );
+    let entries = sqlx::query_as::<_, CatalogEntry>(&sql)
+        .bind(path)
+        .fetch_all(pool)
+        .await?;
 
     Ok(entries)
 }
@@ -245,20 +238,91 @@ pub async fn delete_catalog_entries(
     Ok(rows)
 }
 
-/// Add the soft-delete column if it is not already there (noetl/ai-meta#237).
+/// Whether `noetl.catalog.archived_at` exists in this database.
 ///
-/// Idempotent startup DDL, the same shape `secret_audit` / `result_store` /
-/// `plugin_module` use, so first boot lands the schema without an out-of-band
-/// migration step.
+/// Resolved once at startup by [`ensure_archived_column`] and read by every
+/// query that would otherwise reference the column.
 ///
-/// Purely additive: nullable, defaults NULL, and every existing row reads NULL
-/// (= not archived). A binary that predates this column is unaffected by its
-/// presence, so the rollout and rollback are both safe.
+/// This exists because the column is genuinely OPTIONAL: the server cannot
+/// create it (the table is owned by a different role in every deployment
+/// checked), so it may or may not be there, and **every read path must behave
+/// exactly as it did before soft delete when it is absent**.
+///
+/// Getting this wrong took production down for ~90 seconds: a predicate
+/// referencing a non-existent column made `resolve_catalog` return 500 on every
+/// execute-by-path.  The feature degrading is fine; resolution breaking is not.
+static ARCHIVED_COLUMN_PRESENT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// `" AND archived_at IS NULL"` when the column exists, `""` when it does not.
+///
+/// Every query that filters archived rows must interpolate this rather than
+/// hard-coding the predicate.
+pub fn archived_filter() -> &'static str {
+    if ARCHIVED_COLUMN_PRESENT.load(std::sync::atomic::Ordering::Relaxed) {
+        " AND archived_at IS NULL"
+    } else {
+        ""
+    }
+}
+
+/// True when soft delete is available in this database.
+pub fn archived_column_present() -> bool {
+    ARCHIVED_COLUMN_PRESENT.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Best-effort add of the soft-delete column, then DETECT whether it is there
+/// (noetl/ai-meta#237).
+///
+/// The detection is deliberately independent of whether the `ALTER` succeeded.
+/// `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` fails with "must be owner of
+/// table" for a non-owner **even when the column already exists**, so the
+/// statement's result says nothing about the column's presence. Only
+/// `information_schema` does.
+///
+/// That also means an operator adding the column out of band turns the feature
+/// on at the next restart, with no code change.
 pub async fn ensure_archived_column(pool: &DbPool) -> AppResult<()> {
-    sqlx::query("ALTER TABLE noetl.catalog ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ NULL")
-        .execute(pool)
-        .await?;
+    // Best effort — a non-owner cannot ALTER, and that is expected.
+    let alter = sqlx::query(
+        "ALTER TABLE noetl.catalog ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ NULL",
+    )
+    .execute(pool)
+    .await;
+
+    let present: Option<(i32,)> = sqlx::query_as(
+        r#"
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'noetl' AND table_name = 'catalog'
+          AND column_name = 'archived_at'
+        "#,
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    let found = present.is_some();
+    ARCHIVED_COLUMN_PRESENT.store(found, std::sync::atomic::Ordering::Relaxed);
+
+    match (alter, found) {
+        (Ok(_), _) => tracing::info!("noetl.catalog.archived_at present; soft delete enabled"),
+        (Err(_), true) => tracing::info!(
+            "noetl.catalog.archived_at already present (added out of band); soft delete enabled"
+        ),
+        (Err(e), false) => tracing::warn!(
+            error = %e,
+            "noetl.catalog.archived_at is ABSENT and cannot be added (table owned by another \
+             role). Soft delete is unavailable; every other catalog path behaves exactly as \
+             before. An owner can enable it with: ALTER TABLE noetl.catalog ADD COLUMN IF NOT \
+             EXISTS archived_at TIMESTAMPTZ NULL;"
+        ),
+    }
     Ok(())
+}
+
+/// Test-only override so the conditional behaviour can be exercised both ways.
+#[cfg(test)]
+pub fn set_archived_column_present_for_test(v: bool) {
+    ARCHIVED_COLUMN_PRESENT.store(v, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Mark catalog entries archived (noetl/ai-meta#237).

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -575,11 +575,19 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
             // noetl/ai-meta#237 — an archived entry is retired: it must not
                 // resolve by PATH, which is how everything normally runs.
                 // Resolution by explicit `catalog_id` (above) deliberately still
-                // works, so a historical version can be re-run on purpose; that
-                // is the escape hatch, and it requires naming the row.
-                "SELECT catalog_id, path FROM noetl.catalog \
-                 WHERE path = $1 AND archived_at IS NULL \
-                 ORDER BY version DESC LIMIT 1",
+                // works, so a historical version can be re-run on purpose.
+                //
+                // ⚠ The predicate is CONDITIONAL on the column existing. Hard-coding
+                // it took production down: the server cannot create the column
+                // (the table is owned by another role), so on a database without
+                // it every execute-by-path returned 500. When absent this is the
+                // empty string and the query is byte-identical to pre-soft-delete.
+                &format!(
+                    "SELECT catalog_id, path FROM noetl.catalog \
+                     WHERE path = $1{archived} \
+                     ORDER BY version DESC LIMIT 1",
+                    archived = crate::db::queries::catalog::archived_filter()
+                ),
         )
         .bind(path)
         .fetch_optional(state.pools.cluster())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3472,46 +3472,94 @@ mod tests {
         );
     }
 
-    /// Archiving must actually RETIRE the entry, not merely label it.
+    /// noetl/ai-meta#237 — the archived predicate must be CONDITIONAL, never
+    /// hard-coded.
     ///
-    /// The whole point is that an archived playbook stops being reachable. If
-    /// path resolution still found it, `delete` would report success while the
-    /// entry kept executing — worse than not archiving at all, because it would
-    /// look done.
+    /// The server cannot create `archived_at` (the table is owned by another
+    /// role), so a database may legitimately not have it. Hard-coding
+    /// `archived_at IS NULL` into resolution took **production** down for ~90
+    /// seconds: every execute-by-path returned 500 with
+    /// `column "archived_at" does not exist`.
     ///
-    /// Deliberately does NOT require the filter on `get_next_version` (archived
-    /// versions must still count, or a re-register would reuse a version number
-    /// and collide), on `get_catalog_by_id` (explicit id is the documented
-    /// escape hatch), or on the delete itself (an archived never-executed row
-    /// must remain hard-deletable).
+    /// Feature degrading is fine. Resolution breaking is not. Every read path
+    /// that filters archived rows must interpolate `archived_filter()`, which is
+    /// the empty string when the column is absent — making the query
+    /// byte-identical to pre-soft-delete.
     #[test]
-    fn archived_entries_stop_resolving_by_path() {
-        let q = include_str!("db/queries/catalog.rs");
-        let src = q.split_once("\n#[cfg(test)]").map_or(q, |(b, _)| b);
+    fn archived_predicate_is_conditional_on_every_read_path() {
+        fn non_test(src: &str) -> &str {
+            src.split_once("\n#[cfg(test)]").map_or(src, |(b, _)| b)
+        }
+        let q = non_test(include_str!("db/queries/catalog.rs"));
+        let ex = non_test(include_str!("handlers/execute.rs"));
+
+        // The execute path is the one that broke prod.
+        assert!(
+            ex.contains("archived_filter()"),
+            "resolve_catalog must interpolate archived_filter(), not hard-code the predicate"
+        );
+        assert!(
+            !ex.contains("AND archived_at IS NULL \\"),
+            "resolve_catalog must not hard-code the predicate"
+        );
+
+        // Every SELECT in the queries module must go through the helper.  The
+        // remaining literal uses are the UPDATEs in archive/restore, which only
+        // run once the column exists.
         fn body<'a>(src: &'a str, name: &str) -> &'a str {
-            let s = src
-                .find(&format!("pub async fn {name}("))
-                .unwrap_or_else(|| panic!("{name} exists"));
+            let s = src.find(&format!("pub async fn {name}(")).unwrap_or_else(|| panic!("{name}"));
             let e = src[s..].find("\n}").map(|i| s + i).unwrap_or(src.len());
             &src[s..e]
         }
-        for name in ["get_catalog_latest", "get_catalog_by_path_version"] {
+        for name in [
+            "get_catalog_latest",
+            "get_catalog_by_path_version",
+            "get_catalog_all_versions",
+            "list_catalog_entries",
+        ] {
+            let b = body(q, name);
             assert!(
-                body(src, name).contains("archived_at IS NULL"),
-                "{name} resolves a playbook for use and must skip archived rows"
+                b.contains("archived_filter()"),
+                "{name} must use archived_filter(); a hard-coded predicate breaks it on a \
+                 database without the column"
+            );
+            assert!(
+                !b.contains("AND archived_at IS NULL"),
+                "{name} still hard-codes the predicate"
             );
         }
+
+        // And the invariant that survives from before: version numbering must
+        // still COUNT archived rows, so it must not filter at all.
         assert!(
-            !body(src, "get_next_version").contains("archived_at IS NULL"),
-            "get_next_version must COUNT archived versions, or re-registering an \
-             archived path reuses a version number"
+            !body(q, "get_next_version").contains("archived"),
+            "get_next_version must count archived versions, or re-registering reuses a version"
         );
-        // And the execute path itself, which resolves by path directly.
-        let ex = include_str!("handlers/execute.rs");
-        let ex_src = ex.split_once("\n#[cfg(test)]").map_or(ex, |(b, _)| b);
+    }
+
+    /// Detection must not depend on the ALTER succeeding.
+    ///
+    /// `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` fails with "must be owner" for
+    /// a non-owner **even when the column already exists**, so its result says
+    /// nothing about presence. If detection keyed off the ALTER, an operator
+    /// adding the column out of band would never turn the feature on.
+    #[test]
+    fn archived_column_detection_is_independent_of_the_alter() {
+        let q = include_str!("db/queries/catalog.rs");
+        let src = q.split_once("\n#[cfg(test)]").map_or(q, |(b, _)| b);
+        let f = src
+            .find("pub async fn ensure_archived_column")
+            .expect("ensure_archived_column exists");
+        let body = &src[f..];
         assert!(
-            ex_src.contains("archived_at IS NULL"),
-            "resolve_catalog's by-path lookup must skip archived entries"
+            body.contains("information_schema.columns"),
+            "presence must be detected from information_schema, not inferred from the ALTER"
+        );
+        let alter_at = body.find("ALTER TABLE").expect("attempts the ALTER");
+        let detect_at = body.find("information_schema").expect("detects");
+        assert!(
+            alter_at < detect_at,
+            "detect AFTER attempting the ALTER, so a successful add is seen too"
         );
     }
 


### PR DESCRIPTION
## What broke

v3.79.1 made the startup DDL non-fatal, so the server starts without `archived_at` — but left every read path referencing the column unconditionally. Deploying it **broke production for ~90 seconds**: every execute-by-path returned

```
column "archived_at" does not exist  ->  HTTP 500
```

Note which failure was worse. v3.79.0 crash-looped **loudly** and kind caught it. v3.79.1 started cleanly and then failed on the hot path **only under real traffic**. Making the DDL non-fatal without making its *readers* tolerant converted a loud failure into a quiet one.

## Fix

`archived_filter()` returns `" AND archived_at IS NULL"` when the column exists and `""` when it does not — so on a database without it, every query is **byte-identical to pre-soft-delete**. Applied to all five read paths the diff touches:

| path | |
| :-- | :-- |
| `resolve_catalog` (handlers/execute.rs) | **the one that broke prod** |
| `get_catalog_latest` | |
| `get_catalog_by_path_version` | |
| `get_catalog_all_versions` | |
| `list_catalog_entries` | |

`get_next_version` still counts archived rows — untouched, as before.

## Detection is independent of the ALTER

Presence is read from `information_schema`, **not** inferred from whether the `ALTER` succeeded. `ADD COLUMN IF NOT EXISTS` fails with "must be owner" for a non-owner *even when the column already exists*, so the statement's result says nothing about presence.

Consequence: an operator adding the column out of band enables soft delete at the next restart, with no code change.

## Testing

Two guards, both mutation-checked:

| mutation | caught |
| :-- | :-- |
| hard-code the predicate back into `resolve_catalog` | ✅ |
| infer presence from the ALTER instead of `information_schema` | ✅ |

`cargo test --lib`: 744 passed, 0 failed. Clippy: 0 errors, 4 warnings — baseline.

## The generalisable lesson

When a change makes a schema object **optional**, every reader of that object is part of the change's surface. Validating the new feature's degraded path is not sufficient — the pre-existing hot paths the diff touches must be validated against the same database state. This is going into the regression harness as a first-class case.

Refs noetl/ai-meta#237