### PR TITLE
fix(ci): pin the Cloud Build quota project so publish-ar can stage source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,11 @@ jobs:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID || 'shastaratech-noetl-prod' }}
         run: |
           set -euo pipefail
+          # The WIF credential is an external account; gcloud checks
+          # serviceusage.services.use against the QUOTA project, which is unset
+          # by default.  The build SA holds roles/serviceusage.serviceUsageConsumer
+          # on PROJECT_ID, so pin the quota project to it.  See noetl/ai-meta#211.
+          gcloud config set billing/quota_project "${PROJECT_ID}"
           gcloud builds submit \
             --project="${PROJECT_ID}" \
             --region=us-central1 \


### PR DESCRIPTION
## What

One line in `publish-ar`: `gcloud config set billing/quota_project "${PROJECT_ID}"` before `gcloud builds submit`.

## Why

`publish-ar` has failed on **every** release since the OIDC hop landed, forcing the `crane` GHCR→AR workaround. The error is misleading:

> `The user is forbidden from accessing the bucket [shastaratech-noetl-prod_cloudbuild]. Please check your organization's policy or if the user has the **"serviceusage.services.use"** permission.`

It reads as a storage problem and is not one. The build SA already holds **`roles/storage.objectAdmin`** and **`roles/storage.bucketViewer`** on that bucket — both verified, and adding `bucketViewer` changed nothing.

`google-github-actions/auth` produces an **external account (WIF)** credential. For external accounts, gcloud resolves `serviceusage.services.use` against the **quota project**, which is unset by default — so the `roles/serviceusage.serviceUsageConsumer` the SA *does* hold on `PROJECT_ID` is never presented.

Pinning the quota project makes the existing grant effective. **No new IAM required.**

## Fallback

If this doesn't fix it, the alternative is an IAM grant to the federated principal itself (the project policy currently has **zero** `principalSet://` bindings).

## Risk

Confined to the `publish-ar` job, which already fails 100% of the time, so it cannot regress anything — `publish-image`, `publish-crate`, `publish-manifest` and `github-release` are untouched. Revert is a one-line revert.

Refs noetl/ai-meta#211