### PR TITLE
ci(211): probe the exact GCS call that publish-ar 403s on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,22 @@ jobs:
           # by default.  The build SA holds roles/serviceusage.serviceUsageConsumer
           # on PROJECT_ID, so pin the quota project to it.  See noetl/ai-meta#211.
           gcloud config set billing/quota_project "${PROJECT_ID}"
+          # --- noetl/ai-meta#211 diagnostics -------------------------------
+          # Five IAM/policy theories are dead (storage roles, serviceUsageConsumer
+          # on the SA, quota project, the WIF principalSet, and an org policy --
+          # storage.restrictAuthTypes is effectively ALLOW).  Probe the exact call
+          # that 403s instead of guessing a sixth time.
+          echo "::group::211 probe"
+          gcloud auth list 2>&1 | head -5 || true
+          echo "-- bucket metadata (storage.buckets.get) --"
+          gcloud storage buckets describe "gs://${PROJECT_ID}_cloudbuild" \
+            --format="value(name,location,location_type)" 2>&1 | head -5 || true
+          echo "-- bucket listing (storage.objects.list) --"
+          gcloud storage ls "gs://${PROJECT_ID}_cloudbuild" 2>&1 | head -5 || true
+          echo "::endgroup::"
+          # ----------------------------------------------------------------
           gcloud builds submit \
+            --verbosity=debug \
             --project="${PROJECT_ID}" \
             --region=us-central1 \
             --config=cloudbuild.yaml \


### PR DESCRIPTION
Diagnostic-only. Adds a probe group before `gcloud builds submit` and turns on `--verbosity=debug`.

## Why

Five IAM/policy theories are dead, each verified:

| theory | evidence |
| :-- | :-- |
| storage roles | SA holds `storage.objectAdmin` **and** `storage.bucketViewer` on the bucket |
| `serviceUsageConsumer` on the SA | held at project level |
| quota project unset | pinned in #337; log shows `Updated property [billing/quota_project]` |
| federated principal ungranted | `principalSet://…/github/*` granted |
| org policy blocking auth type | `storage.restrictAuthTypes` → effective **`allValues: ALLOW`** |

gcloud's message names the *bucket* and suggests *serviceusage*, and that phrasing has misdirected three investigations. This probes which call actually 403s — `buckets.get`, `objects.list`, or the source upload itself.

## Leading concrete lead

The build runs `--region=us-central1` but `shastaratech-noetl-prod_cloudbuild` is **US multi-region**. A regional build with multi-region staging is a known mismatch, and would explain why no amount of IAM helped.

## Risk

None to the outcome: every probe is `|| true`, and `publish-ar` already fails 100% of the time. Removed once the cause is found.

Refs noetl/ai-meta#211