### PR TITLE
fix(ci): pass an explicit staging dir so publish-ar skips bucket discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,22 +216,12 @@ jobs:
           # by default.  The build SA holds roles/serviceusage.serviceUsageConsumer
           # on PROJECT_ID, so pin the quota project to it.  See noetl/ai-meta#211.
           gcloud config set billing/quota_project "${PROJECT_ID}"
-          # --- noetl/ai-meta#211 diagnostics -------------------------------
-          # Five IAM/policy theories are dead (storage roles, serviceUsageConsumer
-          # on the SA, quota project, the WIF principalSet, and an org policy --
-          # storage.restrictAuthTypes is effectively ALLOW).  Probe the exact call
-          # that 403s instead of guessing a sixth time.
-          echo "::group::211 probe"
-          gcloud auth list 2>&1 | head -5 || true
-          echo "-- bucket metadata (storage.buckets.get) --"
-          gcloud storage buckets describe "gs://${PROJECT_ID}_cloudbuild" \
-            --format="value(name,location,location_type)" 2>&1 | head -5 || true
-          echo "-- bucket listing (storage.objects.list) --"
-          gcloud storage ls "gs://${PROJECT_ID}_cloudbuild" 2>&1 | head -5 || true
-          echo "::endgroup::"
-          # ----------------------------------------------------------------
+          # An explicit staging dir skips gcloud's bucket-DISCOVERY call
+          # (GET /storage/v1/b?prefix=...), which needs project-level
+          # storage.buckets.list.  The SA has bucket-scoped objectAdmin, so
+          # buckets.get returns 200 and the list 403s.  See noetl/ai-meta#211.
           gcloud builds submit \
-            --verbosity=debug \
+            --gcs-source-staging-dir="gs://${PROJECT_ID}_cloudbuild/source" \
             --project="${PROJECT_ID}" \
             --region=us-central1 \
             --config=cloudbuild.yaml \


### PR DESCRIPTION
Fixes the `publish-ar` failure that has forced the `crane` GHCR→AR workaround on every release. **No IAM change.**

## The diagnosed cause

The instrumented run from #338 pinned it exactly:

```
GET /storage/v1/b/shastaratech-noetl-prod_cloudbuild   → 200   ← buckets.get WORKS
GET /storage/v1/b?prefix=…&project=…                   → 403   ← buckets.LIST
→ submit_util.py:423 SetSource → BucketForbiddenError
```

`gcloud builds submit` **lists** buckets to discover the staging bucket, and `storage.buckets.list` is a **project-level** permission. Every role granted for this was **bucket-scoped** (`storage.objectAdmin`, `storage.bucketViewer`) — hence `buckets.get` → 200, a manual `gcloud storage ls gs://…` → success, and the list → 403. Right resource, wrong scope, across five separate attempts.

## The fix

`--gcs-source-staging-dir` skips discovery — gcloud uses the given location directly. The SA already holds `objectAdmin` on that bucket, so the upload needs no new permission.

## Also disproves

The regional/multi-region staging theory. The bucket *is* US multi-region against a `us-central1` build, but the failure occurs in `SetSource` at discovery, **before** staging or region is consulted — creating a regional bucket would have changed nothing.

## Cleanup

Removes the #338 diagnostics; they did their job.

Refs noetl/ai-meta#211