### PR TITLE
feat(ehdb): mirror the full authoritative event set from the server

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -1,0 +1,348 @@
+//! Mirror the **complete** authoritative event set into the EHDB event-log tier.
+//!
+//! # Why this exists
+//!
+//! The event-log tier's mirror hook sits on the worker's emit chokepoint
+//! (`ControlPlaneClient::emit_event`), and that placement caps what the tier can
+//! ever hold. The server authors events itself — `playbook_started`,
+//! `command.issued`, `step.enter`, `playbook.completed`, and `command.claimed`
+//! inside the claim transaction — and not one of them passes through a worker.
+//!
+//! The cross-store comparator (`handlers::ehdb_parity`, noetl/server#343)
+//! measured it rather than inferring it: one `tests/gate_fast_probe` execution
+//! writes **13** authoritative events and the tier receives **6**. The comparator
+//! reports the other 7 as `unmirrored_by_design`, and it is right to — they are
+//! not divergence, they are absence by construction.
+//!
+//! But a tier holding 6 of 13 events cannot be the source of truth for replay.
+//! Flipping the event-log tier to `primary` on that basis would serve an
+//! incomplete log (noetl/ai-meta#257 §3.4, noetl/ai-meta#258). This module is the
+//! closure.
+//!
+//! # The design decision: move the mirror, do not extend it
+//!
+//! The obvious shape is "keep the worker mirror and add server-authored events
+//! beside it". That shape is wrong, and it fails on ordering.
+//!
+//! The comparator checks that the tier's records sit in the same relative order
+//! as the authoritative log. With two independent producers appending — a worker
+//! after its emit returns, the server after its own write — nothing orders their
+//! appends against each other. The server can assign `event_id` 100 and the
+//! worker's earlier `event_id` 99 can still land second. That is a real race with
+//! no fix available from either side, and it would surface as an intermittent
+//! `order` divergence indistinguishable from a genuine one.
+//!
+//! So the mirror **moves** instead. `handlers::event_write::emit_events` is the
+//! one chokepoint every authoritative event passes through — including the
+//! worker's own, because a worker event only reaches `noetl.event` by way of
+//! `POST /api/events`, which lands in `handle_event` and calls this same
+//! chokepoint. Mirroring there gives, in one place:
+//!
+//! * **completeness** — it is the code that produces the authoritative set, so
+//!   the mirrored set is that set. 13 of 13, not 6 plus a patch.
+//! * **ordering** — one producer, appending in the order the chain head already
+//!   serialises per execution. No cross-producer race exists to lose.
+//! * **identity** — the server assigns `event_id`, so the mirrored record
+//!   carries it with nothing to reconcile. The worker's
+//!   `NOETL_EHDB_AUTHORITATIVE_ID_STAMP` reconciliation stays for `worker` mode
+//!   and is simply not needed here.
+//! * **payload identity** — the mirrored projection is built from the very row
+//!   about to become authoritative.
+//!
+//! # The data-access boundary is not crossed
+//!
+//! Per `data-access-boundary.md` the server owns `noetl.event`, and per
+//! noetl/ai-meta#257 §3.5 the server is the component that resolves through the
+//! tier service when the event-log tier eventually goes primary. Mirroring from
+//! the server is that boundary, not an exception to it.
+//!
+//! The control-plane guard is equally untouched: the server does **not** open
+//! tier storage. It POSTs to the worker's tier surface — the same
+//! `NOETL_EHDB_WORKER_QUERY_URL` hop it already makes to read, on the same route,
+//! so the append resolves to whichever store the read resolves to. Writing where
+//! the comparator reads is thereby true by construction rather than by two env
+//! vars agreeing.
+//!
+//! # Failure posture
+//!
+//! Best-effort and isolated, exactly like the worker's mirror. This is an
+//! auxiliary verification path; it must never be able to fail an event write the
+//! platform has already committed to. Every failure is metered and logged and
+//! then dropped. The consequence of a dropped append is a `missing_event` on the
+//! comparator — loud, attributable, and exactly what the comparator is for.
+//!
+//! Default-off behind `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE=server`.
+
+use std::time::Duration;
+
+use serde_json::json;
+use tracing::warn;
+
+use crate::handlers::event_write::EventRow;
+use crate::state::AppState;
+
+/// `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE` — read by the server AND the worker.
+///
+/// One variable rather than two so the halves cannot disagree about who is
+/// mirroring. They still *can* disagree if only one component is rolled, and
+/// that shows up as a doubled record count on the comparator rather than as
+/// silence — the direction to be wrong in.
+pub const MIRROR_SOURCE_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_SOURCE";
+
+/// How long to wait on the relay before giving up on a batch.
+///
+/// Short on purpose. This sits inline on the event-write path, so the cost of a
+/// hung worker is bounded latency on event emission, not an unbounded stall.
+const APPEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Which component mirrors into the event-log tier. Mirror of the worker's
+/// `ehdb::mirror_source::MirrorSource`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MirrorSource {
+    Worker,
+    Server,
+}
+
+impl MirrorSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Worker => "worker",
+            Self::Server => "server",
+        }
+    }
+
+    /// Anything unrecognised is `Worker` — the pre-change behaviour. A typo must
+    /// leave the old mirror running, never disarm both halves and leave the tier
+    /// silently empty while `NOETL_EHDB_EVENTLOG` still reads `shadow`.
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+            Some("server") => Self::Server,
+            _ => Self::Worker,
+        }
+    }
+
+    pub fn from_process_env() -> Self {
+        Self::parse(std::env::var(MIRROR_SOURCE_ENV).ok().as_deref())
+    }
+}
+
+/// Is the server the mirror producer for this process?
+pub fn server_mirrors() -> bool {
+    MirrorSource::from_process_env() == MirrorSource::Server
+}
+
+/// The tier record for one authoritative row.
+///
+/// Two constraints meet here.
+///
+/// The comparator parses a mirrored record's identity out of `event_id`,
+/// `event_type`, `step` and `status` — the field names an `ExecutorEvent`
+/// serialises to, because until now every mirrored record was one. A
+/// server-authored record has to answer to the same names or the comparator
+/// cannot identify it, so `step` is emitted alongside `node_name` carrying the
+/// same value.
+///
+/// The tier is also meant to *become* the log, so a record that carried only
+/// those four fields would be a record you could verify and not one you could
+/// serve from. The full row shape goes in as well.
+pub fn mirror_payload(row: &EventRow) -> serde_json::Value {
+    json!({
+        // --- the comparator's identifying projection -------------------------
+        "event_id": row.event_id,
+        "event_type": row.event_type,
+        // Same value under both names: `step` is what the worker's ExecutorEvent
+        // calls it and what the comparator reads; `node_name` is what the
+        // authoritative column is called.
+        "step": row.node_name,
+        "status": row.status,
+        // --- the rest of the authoritative row -------------------------------
+        "execution_id": row.execution_id,
+        "catalog_id": row.catalog_id,
+        "node_id": row.node_id,
+        "node_name": row.node_name,
+        "node_type": row.node_type,
+        "parent_event_id": row.parent_event_id,
+        "prev_event_id": row.prev_event_id,
+        "parent_execution_id": row.parent_execution_id,
+        "result": row.result,
+        "meta": row.meta,
+        "error": row.error,
+        "worker_id": row.worker_id,
+        "created_at": row.created_at,
+        // Provenance. A record in the tier should say which mirror wrote it —
+        // without this, "the server mirror was rolled but the worker was not"
+        // and "both mirrored" are the same evidence after the fact.
+        "mirror_source": MirrorSource::Server.as_str(),
+    })
+}
+
+/// One HTTP client for the relay, shared across calls.
+fn relay_client() -> &'static reqwest::Client {
+    static C: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    C.get_or_init(reqwest::Client::new)
+}
+
+/// Mirror a batch of authoritative rows into the event-log tier.
+///
+/// Called from the `emit_events` chokepoint with the rows that are about to
+/// become authoritative — after terminal dedup and after chain stamping, so the
+/// mirrored set is exactly the set that lands in `noetl.event` and no row is
+/// mirrored that gets suppressed.
+///
+/// Never returns an error. See the module note on failure posture.
+pub async fn mirror_rows(state: &AppState, rows: &[EventRow]) {
+    if rows.is_empty() || !server_mirrors() {
+        return;
+    }
+    let Some(base) = std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        // Asked to mirror server-side with nowhere to mirror to. This is a
+        // misconfiguration, not a quiet no-op: without it the tier stays empty
+        // while the worker's mirror is also disarmed, and the comparator would
+        // report a missing_execution whose cause is two hops away.
+        crate::metrics::record_ehdb_eventlog_mirror("unconfigured", rows.len());
+        warn!(
+            target: "noetl_server::ehdb_eventlog_mirror",
+            "{MIRROR_SOURCE_ENV}=server but {} is unset — {} authoritative event(s) were not \
+             mirrored into the event-log tier",
+            crate::handlers::ehdb::WORKER_QUERY_URL_ENV,
+            rows.len()
+        );
+        return;
+    };
+    let _ = state; // reserved: per-execution routing when the tier shards.
+
+    // One request per batch, records in the order the chokepoint wrote them.
+    // N concurrent single-record requests would not preserve that order, and
+    // order is one of the properties the comparator checks.
+    let execution_id = rows[0].execution_id;
+    let records: Vec<String> = rows
+        .iter()
+        .map(|r| mirror_payload(r).to_string())
+        .collect();
+    let count = records.len();
+
+    let url = format!("{}/ehdb/tiers/eventlog", base.trim_end_matches('/'));
+    let body = json!({ "execution_id": execution_id.to_string(), "records": records });
+
+    let resp = relay_client()
+        .post(&url)
+        .json(&body)
+        .timeout(APPEND_TIMEOUT)
+        .send()
+        .await;
+
+    match resp {
+        Err(e) => {
+            crate::metrics::record_ehdb_eventlog_mirror("unavailable", count);
+            warn!(
+                target: "noetl_server::ehdb_eventlog_mirror",
+                execution_id, events = count, error = %e,
+                "event-log tier mirror relay failed"
+            );
+        }
+        Ok(r) => {
+            let status = r.status();
+            if status == reqwest::StatusCode::NOT_IMPLEMENTED
+                || status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+            {
+                // Two distinct causes, one meaning: this worker cannot accept
+                // server-authored appends, and the fix is a rollout rather than
+                // an outage.
+                //
+                //   501 — rolled, but still in `worker` mode.
+                //   405 — NOT rolled. The GET route exists on every worker back
+                //         to the query interface, so axum answers a POST to it
+                //         with "method not allowed" rather than 404. Counting
+                //         that as `degraded` would file the single most likely
+                //         operational state — server rolled ahead of worker —
+                //         under a label meaning "the append was refused", and
+                //         send an operator looking at the tier instead of at
+                //         the rollout.
+                crate::metrics::record_ehdb_eventlog_mirror("unconfigured", count);
+                warn!(
+                    target: "noetl_server::ehdb_eventlog_mirror",
+                    execution_id, events = count, status = status.as_u16(),
+                    "worker cannot accept server-authored appends — is it rolled, and is \
+                     {MIRROR_SOURCE_ENV}=server set on it?"
+                );
+            } else if status.is_success() {
+                crate::metrics::record_ehdb_eventlog_mirror("mirrored", count);
+            } else {
+                let detail = r.text().await.unwrap_or_default();
+                crate::metrics::record_ehdb_eventlog_mirror("degraded", count);
+                warn!(
+                    target: "noetl_server::ehdb_eventlog_mirror",
+                    execution_id, events = count, status = status.as_u16(),
+                    detail = %detail.chars().take(400).collect::<String>(),
+                    "event-log tier mirror was refused"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    fn row() -> EventRow {
+        EventRow::new(
+            991,
+            7,
+            3,
+            "command.completed",
+            "success",
+            DateTime::parse_from_rfc3339("2026-08-11T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .with_node("step1")
+    }
+
+    #[test]
+    fn unrecognised_source_stays_on_the_worker_mirror() {
+        assert_eq!(MirrorSource::parse(None), MirrorSource::Worker);
+        assert_eq!(MirrorSource::parse(Some("")), MirrorSource::Worker);
+        assert_eq!(MirrorSource::parse(Some("srever")), MirrorSource::Worker);
+        assert_eq!(MirrorSource::parse(Some("worker")), MirrorSource::Worker);
+    }
+
+    #[test]
+    fn server_is_recognised_case_and_space_insensitively() {
+        for v in ["server", "SERVER", " Server "] {
+            assert_eq!(MirrorSource::parse(Some(v)), MirrorSource::Server, "{v:?}");
+        }
+    }
+
+    #[test]
+    fn the_payload_answers_to_the_comparators_field_names() {
+        // The comparator reads `event_id`, `event_type`, `step`, `status` — the
+        // ExecutorEvent names. A server-authored record that omitted `step`
+        // would be reported as a payload divergence on every event, so this is
+        // the contract between the two halves, asserted on the value the wire
+        // carries rather than on the code that builds it.
+        let p = mirror_payload(&row());
+        assert_eq!(p["event_id"], 991);
+        assert_eq!(p["event_type"], "command.completed");
+        assert_eq!(p["step"], "step1");
+        assert_eq!(p["status"], "success");
+        // and the full row is there too, so the tier could serve from it.
+        assert_eq!(p["node_name"], "step1");
+        assert_eq!(p["execution_id"], 7);
+        assert_eq!(p["mirror_source"], "server");
+    }
+
+    #[test]
+    fn step_and_node_name_never_disagree() {
+        // They carry one value under two names; if a later edit sourced them
+        // separately the comparator would see a payload divergence the row
+        // itself does not have.
+        let p = mirror_payload(&row());
+        assert_eq!(p["step"], p["node_name"]);
+    }
+}

--- a/src/handlers/ehdb_parity.rs
+++ b/src/handlers/ehdb_parity.rs
@@ -932,6 +932,19 @@ async fn fetch_authoritative(
     state: &AppState,
     execution_id: i64,
 ) -> Result<Vec<AuthoritativeEvent>, sqlx::Error> {
+    // noetl/ai-meta#258 — the scope depends on WHO mirrors.
+    //
+    // With the worker mirroring (the default), only worker-emitted events can
+    // have a tier copy and the marker below is the boundary. With the server
+    // mirroring, the mirror sits on the chokepoint that writes `noetl.event`
+    // itself, so **every** authoritative event is expected in the tier and the
+    // marker would under-scope the comparison — it would pass while silently
+    // ignoring the seven events the whole exercise exists to capture.
+    //
+    // Derived from the same variable both mirrors read, so the comparator cannot
+    // hold a different opinion about the boundary than the producer does.
+    let server_mirrors = crate::handlers::ehdb_eventlog_mirror::server_mirrors();
+
     let rows = sqlx::query_as::<_, (i64, String, Option<String>, Option<String>, bool)>(
         r#"
         SELECT
@@ -939,8 +952,8 @@ async fn fetch_authoritative(
             event_type,
             node_name,
             status,
-            ((meta->>'worker_id') IS NOT NULL
-             AND event_type <> 'command.claimed') AS mirror_expected
+            ($3 OR ((meta->>'worker_id') IS NOT NULL
+                    AND event_type <> 'command.claimed')) AS mirror_expected
         FROM noetl.event
         WHERE execution_id = $1
         ORDER BY event_id ASC
@@ -949,6 +962,7 @@ async fn fetch_authoritative(
     )
     .bind(execution_id)
     .bind(MAX_COMPARE_EVENTS as i64 + 1)
+    .bind(server_mirrors)
     .fetch_all(state.pools.pool_for(execution_id))
     .await?;
 

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -384,6 +384,23 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     }
     let rows = rows.as_slice();
 
+    // noetl/ai-meta#258 — mirror the COMPLETE authoritative set into the EHDB
+    // event-log tier.
+    //
+    // Placed here, and the position is the whole point. It is after terminal
+    // dedup and after chain stamping, so `rows` is exactly the set that becomes
+    // authoritative: a suppressed duplicate terminal is not mirrored, and a
+    // mirrored record carries the same `prev_event_id` the log will carry.
+    //
+    // It is also *before* the publish/insert fork, so both branches are covered
+    // by one call site. Mirroring inside the branches would have meant two
+    // implementations of the same guarantee, and the gate-off branch is the one
+    // nobody exercises in prod — the classic place for the second copy to rot.
+    //
+    // No-op unless `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE=server`; best-effort and
+    // isolated, so no failure here can affect the authoritative write below.
+    crate::handlers::ehdb_eventlog_mirror::mirror_rows(state, rows).await;
+
     // All rows in a batch share the same execution + catalog, so one decision
     // covers the batch.
     if should_publish(state, rows[0].catalog_id).await {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod cross_region;
 pub mod dashboard;
 pub mod database;
 pub mod ehdb;
+pub mod ehdb_eventlog_mirror;
 pub mod ehdb_parity;
 pub mod event_write;
 pub mod events;

--- a/src/main.rs
+++ b/src/main.rs
@@ -785,6 +785,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_catalog_delete_series();
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_ehdb_crossstore_series();
+    noetl_server::metrics::init_ehdb_eventlog_mirror_series();
     noetl_server::metrics::init_result_tier_gc_series();
     noetl_server::metrics::init_credential_seal_series();
     noetl_server::metrics::init_system_plugin_seed_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3018,6 +3018,55 @@ pub fn record_ehdb_crossstore_control(control: &str, result: &str) {
 /// ([`crate::handlers::ehdb_parity::PARITY_OUTCOMES`], `DIVERGENCE_KINDS`,
 /// `CONTROL_NAMES`), not from a hand-maintained list in prose; the test below
 /// asserts the enums and the pinned set cannot drift apart.
+/// Counter: authoritative events the server mirrored into the event-log tier.
+///
+/// Labelled by outcome over a closed set, and counted in **events** rather than
+/// batches: the number an operator needs is "did the tier receive everything the
+/// log received", and a batch count cannot answer it.
+pub fn ehdb_eventlog_mirror_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_eventlog_mirror_total",
+                "Authoritative events the SERVER mirrored into the EHDB event-log tier, by \
+                 outcome (noetl/ai-meta#258).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Every outcome label the server-side mirror can emit. Closed set, pinned at 0.
+pub const EHDB_EVENTLOG_MIRROR_OUTCOMES: [&str; 4] =
+    ["mirrored", "unconfigured", "unavailable", "degraded"];
+
+pub fn record_ehdb_eventlog_mirror(outcome: &str, events: usize) {
+    ehdb_eventlog_mirror_total()
+        .with_label_values(&[outcome])
+        .inc_by(events as u64);
+}
+
+/// Pin the server-side mirror's label set at 0.
+///
+/// `Registry::gather` prunes metric families with no children, so without this a
+/// server that has mirrored nothing and a server that cannot mirror at all
+/// produce byte-identical `/metrics` output. Pinned unconditionally — a pin
+/// placed behind the mirror-source check would be absent on exactly the
+/// configuration whose `unconfigured` count someone would be reading.
+pub fn init_ehdb_eventlog_mirror_series() {
+    for outcome in EHDB_EVENTLOG_MIRROR_OUTCOMES {
+        ehdb_eventlog_mirror_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+}
+
 pub fn init_ehdb_crossstore_series() {
     use crate::handlers::ehdb_parity::{
         CONTROL_NAMES, DIVERGENCE_KINDS, PARITY_OUTCOMES, TIER,


### PR DESCRIPTION
## What this changes — the server half of the full-set mirror

The event-log tier held **6 of 13** events per execution, because the worker's
emit chokepoint mirrors only what the worker emits. The server authors
`playbook_started`, `command.issued`, `step.enter`, `playbook.completed` and
the in-transaction `command.claimed` — structurally absent from the tier, and
reported by the comparator as `unmirrored_by_design`.

`NOETL_EHDB_EVENTLOG_MIRROR_SOURCE=server` moves the mirror to
`handlers::event_write::emit_events` — the one chokepoint **every** authoritative
event passes through, worker events included (they reach `noetl.event` via
`POST /api/events`, so the server writes them). The tier then receives the
complete set in one ordered pass, and the comparator's `mirror_expected` scope
widens to every event.

**The server does not open tier storage.** It POSTs to the same
`NOETL_EHDB_WORKER_QUERY_URL` relay route it already reads through, so the
append lands in whatever store the read resolves to. That property is what the
PR-4 pair then makes deterministic.

Metrics: `noetl_ehdb_eventlog_mirror_total{outcome}` over a closed set
(`mirrored` / `unconfigured` / `unavailable` / `degraded`), pinned at 0
unconditionally — so "off" is legible rather than absent.

**Must be set to the same value on the worker**, which disarms its own mirror
when it reads `server`. See the sibling PR below.

## Gate

`playbooks/258-full-set-mirror/RESULTS.md` — **13 == 13**, `match`, 21/0.
Flag-off arm on the same images: tier holds **6 of 12**,
`unmirrored_by_design = 6`, server mirror counter **0**. Mutation (dropping
`command.issued` from `mirror_rows`): tier **11**, **2 divergences**,
`divergent`, 15/0.

⚠ Ran at **one** worker replica; the multi-replica hole is closed by the PR-4
pair below.

## Wiki

[server deployment-specification → `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE`](https://github.com/noetl/server/wiki/deployment-specification#environment-variables)
— Rule 2a, landed in server.wiki@`0f11841`.

Sibling page: [worker deployment-specification → *Authoritative event identity*](https://github.com/noetl/worker/wiki/deployment-specification#environment-variables)
(worker.wiki@`6bff4d9`).

## Issues

Closes #344
Refs [noetl/ai-meta#258](https://github.com/noetl/ai-meta/issues/258)

## Release

Subject is `feat(ehdb): …` ⇒ **minor**. Merge with `--merge`.

---

## The full go-live stack (both repos)

Merge **bottom-up**. Every PR is opened against its real base, so each reads as
one isolated diff — opening any of them against `main` would fold the
comparator's 1,944 lines into the change.

| # | repo | PR | base | diff | tracks |
| :-- | :-- | :-- | :-- | --: | :-- |
| 1 | worker | [#265](https://github.com/noetl/worker/pull/265) give the mirror the server-assigned `event_id` | `main` | +301 | — |
| 2 | server | [#343](https://github.com/noetl/server/pull/343) compare the tier against the authoritative log | `main` | +1944 | [ai-meta#258](https://github.com/noetl/ai-meta/issues/258) |
| 3 | worker | [#270](https://github.com/noetl/worker/pull/270) the tier service's server half is observable | `main` | +795 | [ai-meta#260](https://github.com/noetl/ai-meta/issues/260) |
| 4 | server | [#346](https://github.com/noetl/server/pull/346) mirror the full authoritative set | [#343](https://github.com/noetl/server/pull/343) | +432 | [ai-meta#258](https://github.com/noetl/ai-meta/issues/258) |
| 5 | worker | [#271](https://github.com/noetl/worker/pull/271) accept server-authored appends, disarm | [#265](https://github.com/noetl/worker/pull/265) | +375 | [ai-meta#258](https://github.com/noetl/ai-meta/issues/258) |
| 6 | server | [#347](https://github.com/noetl/server/pull/347) the verdict names the store it compared | [#346](https://github.com/noetl/server/pull/346) | +83 | [ai-meta#257](https://github.com/noetl/ai-meta/issues/257) |
| 7 | worker | [#272](https://github.com/noetl/worker/pull/272) tier reads resolve through the writer | [#271](https://github.com/noetl/worker/pull/271) | +414 | [ai-meta#257](https://github.com/noetl/ai-meta/issues/257) |
| 8 | worker | [#273](https://github.com/noetl/worker/pull/273) **the serve decision's third call site (the P0)** | [#272](https://github.com/noetl/worker/pull/272) | +803 | [ai-meta#257](https://github.com/noetl/ai-meta/issues/257) |
| 9 | worker | [#263](https://github.com/noetl/worker/pull/263) the flip-time signal describes its tier | `main` | — | [ai-meta#259](https://github.com/noetl/ai-meta/issues/259) |

Steps 1–2 are independent of each other. **Step 3 must precede step 8** — #273
carries a cherry-pick of #270's commit; merging #270 first drops it on rebase and
keeps the P0 diff at 803 lines instead of 1,598. Steps 4–8 are strictly ordered.
Step 9 can land any time.

**Cross-repo pairs.** #271 ↔ #346 are the two halves of one variable
(`NOETL_EHDB_EVENTLOG_MIRROR_SOURCE`) and must be deployed with the **same
value** on both sides — one side only means either the tier gets nothing or every
event lands twice. #272 ↔ #347 are the worker and server halves of the tier-read
resolution.

All rebases verified clean against a simulated merged `main` in scratch
worktrees — zero conflicts at every layer.

**Plan and evidence:**
[`playbooks/257-serve-readiness/MERGE-ORDER.md`](https://github.com/noetl/ai-meta/blob/main/playbooks/257-serve-readiness/MERGE-ORDER.md)
·
[`GO-LIVE.md`](https://github.com/noetl/ai-meta/blob/main/playbooks/257-serve-readiness/GO-LIVE.md)
·
[`RUNBOOK.md`](https://github.com/noetl/ai-meta/blob/main/playbooks/257-serve-readiness/RUNBOOK.md)

⚠ **Nothing here promotes a tier.** Prod stays on `NOETL_EHDB_EVENTLOG=shadow`
with no `NOETL_EHDB_TIER_*` set. The first flip is gated on P5–P9 and an explicit
per-tier go.
