### PR TITLE
feat(ehdb): the cross-store verdict names the store it compared

### DIFF
--- a/src/handlers/ehdb_parity.rs
+++ b/src/handlers/ehdb_parity.rs
@@ -858,6 +858,23 @@ pub struct ComparisonResult {
     pub outcome: ParityOutcome,
     pub report: Option<CrossStoreReport>,
     pub detail: Option<String>,
+    /// Which store on the far side of the relay actually answered — the worker's
+    /// own pod-local log (`local`), or the writer-fronted tier service
+    /// (`service`). Read out of the tier reply's `tier_query_source` field
+    /// (noetl/ai-meta#257 PR 4).
+    ///
+    /// **A verdict without this is not attributable.** The tier store is
+    /// pod-local, so with more than one worker replica a `local` read answers
+    /// from whichever replica the relay's Service happened to route to — a
+    /// fragment of the tier, in a body shaped exactly like the whole of it. A
+    /// full-set match read that way is a fact about one pod, not about the tier,
+    /// and there is no way to tell the two apart after the fact.
+    ///
+    /// `None` means the reply carried no such field, which is what a worker
+    /// older than PR 4 answers. That is reported as itself, not defaulted to
+    /// `local`: guessing here would put a confident wrong label on the exact
+    /// question this field exists to answer.
+    pub tier_query_source: Option<String>,
 }
 
 /// Parse the tier's `read_execution` body into records.
@@ -985,7 +1002,7 @@ async fn fetch_tier(
     http: &reqwest::Client,
     base: &str,
     execution_id: i64,
-) -> Result<Vec<MirroredRecord>, (ParityOutcome, String)> {
+) -> Result<(Vec<MirroredRecord>, Option<String>), (ParityOutcome, String)> {
     let url = format!("{}/ehdb/tiers/eventlog", base.trim_end_matches('/'));
     let resp = http
         .get(&url)
@@ -1018,16 +1035,37 @@ async fn fetch_tier(
         ));
     }
 
-    parse_tier_body(&body).map_err(|o| {
-        (
-            o,
-            format!(
-                "tier reply carried no comparable records (http {}, body {})",
-                status.as_u16(),
-                truncate(&body.to_string(), 400)
-            ),
-        )
-    })
+    // Read the label BEFORE the parse, so a body that fails to parse still says
+    // which store produced it. Attribution is most useful exactly when the
+    // answer is wrong.
+    let source = tier_source_of(&body);
+
+    parse_tier_body(&body)
+        .map(|recs| (recs, source))
+        .map_err(|o| {
+            (
+                o,
+                format!(
+                    "tier reply carried no comparable records (http {}, body {})",
+                    status.as_u16(),
+                    truncate(&body.to_string(), 400)
+                ),
+            )
+        })
+}
+
+/// Which store the worker says answered — `tier_query_source` off the tier
+/// reply (noetl/ai-meta#257 PR 4).
+///
+/// `None` is a real answer, not a default: a worker older than PR 4 sends no
+/// such field, and labelling that `local` would be a guess printed with the
+/// same confidence as a measurement. The comparator reports the absence.
+fn tier_source_of(body: &serde_json::Value) -> Option<String> {
+    body.get("tier_query_source")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
 }
 
 fn truncate(s: &str, n: usize) -> String {
@@ -1064,6 +1102,7 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
                 "NOETL_EHDB_WORKER_QUERY_URL is unset; the server cannot read the tier"
                     .to_string(),
             ),
+            tier_query_source: None,
         };
     };
 
@@ -1077,6 +1116,7 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
                 outcome: ParityOutcome::Error,
                 report: None,
                 detail: Some(format!("authoritative read failed: {e}")),
+            tier_query_source: None,
             };
         }
     };
@@ -1088,6 +1128,7 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
             detail: Some(format!(
                 "execution has more than {MAX_COMPARE_EVENTS} authoritative events; a truncated comparison is not a comparison"
             )),
+            tier_query_source: None,
         };
     }
     if authoritative.is_empty() {
@@ -1099,11 +1140,12 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
             outcome: ParityOutcome::AuthoritativeEmpty,
             report: None,
             detail: Some("no authoritative events for this execution".to_string()),
+        tier_query_source: None,
         };
     }
 
     // Tier side.
-    let mirrored = match fetch_tier(relay_client(), &base, execution_id).await {
+    let (mirrored, tier_query_source) = match fetch_tier(relay_client(), &base, execution_id).await {
         Ok(m) => m,
         Err((outcome, detail)) => {
             crate::metrics::record_ehdb_crossstore_parity(TIER, outcome.as_str());
@@ -1118,6 +1160,7 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
                 outcome,
                 report: None,
                 detail: Some(detail),
+                tier_query_source: None,
             };
         }
     };
@@ -1129,6 +1172,7 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
             detail: Some(format!(
                 "tier returned {MAX_COMPARE_EVENTS} records — the page cap; a truncated comparison is not a comparison"
             )),
+            tier_query_source,
         };
     }
 
@@ -1158,6 +1202,7 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
         outcome,
         report: Some(report),
         detail: None,
+        tier_query_source,
     }
 }
 
@@ -1226,6 +1271,10 @@ pub async fn compare_execution_endpoint(
         "outcome": result.outcome.as_str(),
         "detail": result.detail,
         "report": result.report,
+        // Which store this verdict is ABOUT (noetl/ai-meta#257 PR 4). Beside the
+        // verdict rather than inside `report`, because `report` comes out of the
+        // pure comparator the controls also drive, and a control has no store.
+        "tier_query_source": result.tier_query_source,
         "controls_ok": controls_ok,
     });
     if q.controls.unwrap_or(true) {
@@ -1554,6 +1603,28 @@ mod tests {
     /// wrapped one as zero records — a fabricated divergence, and one that would
     /// have looked like a genuine finding.
     #[test]
+    /// ai-meta#257 PR 4. The verdict must be attributable to a store, and the
+    /// absence of a label must read as absence — not as `local`.
+    #[test]
+    fn the_store_that_answered_is_read_off_the_reply() {
+        assert_eq!(
+            tier_source_of(&json!({"records": [], "tier_query_source": "service"})).as_deref(),
+            Some("service")
+        );
+        assert_eq!(
+            tier_source_of(&json!({"result": {"records": []}, "tier_query_source": "local"}))
+                .as_deref(),
+            Some("local")
+        );
+        // A worker older than PR 4 sends no label. Reporting that as `local`
+        // would put a guess where the whole point is a measurement — and `local`
+        // is precisely the answer that would be wrong to assume, because it is
+        // the one that is only a fragment under multiple replicas.
+        assert_eq!(tier_source_of(&json!({"records": []})), None);
+        assert_eq!(tier_source_of(&json!({"tier_query_source": "   "})), None);
+        assert_eq!(tier_source_of(&json!({"tier_query_source": 7})), None);
+    }
+
     fn both_real_reply_shapes_parse() {
         let bare = json!({
             "action": "eventlog-read-execution",


### PR DESCRIPTION
## What this changes — the verdict names the store it compared

`GET /api/ehdb/parity/executions/{id}` returned a verdict without saying **which
store it was computed against**. The reply now carries `tier_query_source`
(`local` | `service`), echoed from the worker tier-route reply the relay hop
returned.

This matters because a `match` verdict is only as meaningful as the store behind
it. With workers on the default `NOETL_EHDB_TIER_QUERY_SOURCE=local` and more
than one replica, the relay resolves the pool's ClusterIP Service and the
comparator reads whichever pod it reached. Measured at three replicas, the same
execution returned:

| relay pinned at | outcome | ehdb / auth |
| :-- | :-- | --: |
| replica A | **divergent** | 0 / 13 |
| replica B | **match** | 13 / 13 |
| replica C | **divergent** | 0 / 13 |

Without this field those three are **indistinguishable in the response body**,
and a soak that sampled one replica would report a clean tier that is two-thirds
empty.

⚠ **Attribution, not proof.** A defect can keep `tier_query_source: service`
truthful-looking while the pod serves from its local store — one mutation did
exactly that, passing the label check and failing only the data checks. Read it
to know *what was compared*; read `matched` / `authoritative_count` /
`divergences` to know *whether it agreed*. A soak that produced no `divergent`
verdict **and** no `match` verdict has measured nothing.

## Gate

`playbooks/261-tier-query-service/RESULTS.md` — `service` arm **22/0** at three
replicas, `match` with `13 / 13` from each, `holds: true`, in-binary comparator
controls clean before and after (`controls_ok=true`, `unexpected=0`,
`expected=8`).

## Wiki

[server deployment-specification → *`GET /api/ehdb/parity/executions/{id}` — the `tier_query_source` reply field*](https://github.com/noetl/server/wiki/deployment-specification#environment-variables)
— landed in server.wiki@`9673f45`, directly under the
`NOETL_EHDB_CROSSSTORE_PARITY_*` rows.

Sibling page: [worker deployment-specification → `NOETL_EHDB_TIER_QUERY_SOURCE`](https://github.com/noetl/worker/wiki/deployment-specification#environment-variables)
(worker.wiki@`2acfd0f`) — the worker-side variable this field reports on.

## Issues

Closes #345
Refs [noetl/ai-meta#257](https://github.com/noetl/ai-meta/issues/257)

## Release

Subject is `feat(ehdb): …` ⇒ **minor**. Merge with `--merge`.

---

## The full go-live stack (both repos)

Merge **bottom-up**. Every PR is opened against its real base, so each reads as
one isolated diff — opening any of them against `main` would fold the
comparator's 1,944 lines into the change.

| # | repo | PR | base | diff | tracks |
| :-- | :-- | :-- | :-- | --: | :-- |
| 1 | worker | [#265](https://github.com/noetl/worker/pull/265) give the mirror the server-assigned `event_id` | `main` | +301 | — |
| 2 | server | [#343](https://github.com/noetl/server/pull/343) compare the tier against the authoritative log | `main` | +1944 | [ai-meta#258](https://github.com/noetl/ai-meta/issues/258) |
| 3 | worker | [#270](https://github.com/noetl/worker/pull/270) the tier service's server half is observable | `main` | +795 | [ai-meta#260](https://github.com/noetl/ai-meta/issues/260) |
| 4 | server | [#346](https://github.com/noetl/server/pull/346) mirror the full authoritative set | [#343](https://github.com/noetl/server/pull/343) | +432 | [ai-meta#258](https://github.com/noetl/ai-meta/issues/258) |
| 5 | worker | [#271](https://github.com/noetl/worker/pull/271) accept server-authored appends, disarm | [#265](https://github.com/noetl/worker/pull/265) | +375 | [ai-meta#258](https://github.com/noetl/ai-meta/issues/258) |
| 6 | server | [#347](https://github.com/noetl/server/pull/347) the verdict names the store it compared | [#346](https://github.com/noetl/server/pull/346) | +83 | [ai-meta#257](https://github.com/noetl/ai-meta/issues/257) |
| 7 | worker | [#272](https://github.com/noetl/worker/pull/272) tier reads resolve through the writer | [#271](https://github.com/noetl/worker/pull/271) | +414 | [ai-meta#257](https://github.com/noetl/ai-meta/issues/257) |
| 8 | worker | [#273](https://github.com/noetl/worker/pull/273) **the serve decision's third call site (the P0)** | [#272](https://github.com/noetl/worker/pull/272) | +803 | [ai-meta#257](https://github.com/noetl/ai-meta/issues/257) |
| 9 | worker | [#263](https://github.com/noetl/worker/pull/263) the flip-time signal describes its tier | `main` | — | [ai-meta#259](https://github.com/noetl/ai-meta/issues/259) |

Steps 1–2 are independent of each other. **Step 3 must precede step 8** — #273
carries a cherry-pick of #270's commit; merging #270 first drops it on rebase and
keeps the P0 diff at 803 lines instead of 1,598. Steps 4–8 are strictly ordered.
Step 9 can land any time.

**Cross-repo pairs.** #271 ↔ #346 are the two halves of one variable
(`NOETL_EHDB_EVENTLOG_MIRROR_SOURCE`) and must be deployed with the **same
value** on both sides — one side only means either the tier gets nothing or every
event lands twice. #272 ↔ #347 are the worker and server halves of the tier-read
resolution.

All rebases verified clean against a simulated merged `main` in scratch
worktrees — zero conflicts at every layer.

**Plan and evidence:**
[`playbooks/257-serve-readiness/MERGE-ORDER.md`](https://github.com/noetl/ai-meta/blob/main/playbooks/257-serve-readiness/MERGE-ORDER.md)
·
[`GO-LIVE.md`](https://github.com/noetl/ai-meta/blob/main/playbooks/257-serve-readiness/GO-LIVE.md)
·
[`RUNBOOK.md`](https://github.com/noetl/ai-meta/blob/main/playbooks/257-serve-readiness/RUNBOOK.md)

⚠ **Nothing here promotes a tier.** Prod stays on `NOETL_EHDB_EVENTLOG=shadow`
with no `NOETL_EHDB_TIER_*` set. The first flip is gated on P5–P9 and an explicit
per-tier go.
