### PR TITLE
fix(ehdb): system-pool events bypassed the mirror, so the serving tier was short

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -32,11 +32,11 @@
 //! no fix available from either side, and it would surface as an intermittent
 //! `order` divergence indistinguishable from a genuine one.
 //!
-//! So the mirror **moves** instead. `handlers::event_write::emit_events` is the
-//! one chokepoint every authoritative event passes through — including the
-//! worker's own, because a worker event only reaches `noetl.event` by way of
-//! `POST /api/events`, which lands in `handle_event` and calls this same
-//! chokepoint. Mirroring there gives, in one place:
+//! So the mirror **moves** instead. `handlers::event_write::emit_events` is
+//! *almost* the one chokepoint every authoritative event passes through —
+//! including the worker's own, because a worker event only reaches `noetl.event`
+//! by way of `POST /api/events`, which lands in `handle_event` and calls this
+//! same chokepoint. Mirroring there gives, in one place:
 //!
 //! * **completeness** — it is the code that produces the authoritative set, so
 //!   the mirrored set is that set. 13 of 13, not 6 plus a patch.
@@ -48,6 +48,32 @@
 //!   and is simply not needed here.
 //! * **payload identity** — the mirrored projection is built from the very row
 //!   about to become authoritative.
+//!
+//! # "Almost" — the two in-transaction writers (noetl/ai-meta#263)
+//!
+//! `emit_events` is where events go when the server has already decided to write
+//! them *outside* a transaction. Two sites in `handlers::events` — the command
+//! claim and the batch ingest — write `noetl.event` **inside** the same
+//! transaction that claims the command, and reach `emit_events` only on the
+//! branch where `should_publish` is true.
+//!
+//! `should_publish` is false for every **system-pool** execution by construction:
+//! `system/*` playbooks drain the event stream, so they cannot also be fed by it.
+//! That made the bypass exactly coextensive with the system pool. User-pool
+//! executions took the publish branch and mirrored completely — `test/simple_loop`
+//! at 29 of 29 — while every hourly `system/scheduled_cleanup` mirrored 11 of 13,
+//! missing precisely its two `command.claimed` events. The comparator called all
+//! 13 mirror-expected, which in server-mirror mode is correct, so it reported the
+//! two as `missing_event` with `unmirrored_by_design = 0`. It was right; the tier
+//! was incomplete, and `primary`.
+//!
+//! Both sites now call [`mirror_rows`] after their commit. That is three call
+//! sites rather than one, which is worth being uncomfortable about — but the
+//! ordering hazard that moved the mirror here does not apply: it was a race
+//! between two independent *processes*, and these are the same process appending
+//! before it answers the request that would let the next event exist.
+//! `tests::every_in_tx_event_insert_is_mirrored` counts INSERT sites against
+//! mirror sites so a fourth writer cannot be added silently.
 //!
 //! # The data-access boundary is not crossed
 //!
@@ -344,5 +370,60 @@ mod tests {
         // itself does not have.
         let p = mirror_payload(&row());
         assert_eq!(p["step"], p["node_name"]);
+    }
+
+    /// Every place the server writes `noetl.event` outside the chokepoint must
+    /// also mirror — the guard for noetl/ai-meta#263.
+    ///
+    /// The mirror lives in `event_write::emit_events`, described there as "the
+    /// one chokepoint every authoritative event passes through". It is not: two
+    /// sites in `handlers::events` write the table directly, in-transaction, on
+    /// the branch `should_publish` takes when it returns false. That branch is
+    /// the ONLY branch a **system-pool** execution can take (`is_system_execution`
+    /// is one of `should_publish`'s three false conditions), so `system/*`
+    /// playbooks mirrored every event except the ones written there — 11 of 13 on
+    /// every hourly `system/scheduled_cleanup`, on a tier that is `primary`.
+    ///
+    /// Counting `INSERT INTO noetl.event` rather than naming the two known sites:
+    /// a third one added later is the failure this is here to catch, and a test
+    /// that lists the sites it already knows about cannot catch it.
+    #[test]
+    fn every_in_tx_event_insert_is_mirrored() {
+        let events_rs = include_str!("events.rs");
+        let inserts = events_rs.matches("INSERT INTO noetl.event").count();
+        let mirrors = events_rs.matches("ehdb_eventlog_mirror::mirror_rows").count();
+        assert_eq!(
+            inserts, mirrors,
+            "handlers/events.rs has {inserts} direct `noetl.event` INSERT site(s) but \
+             {mirrors} mirror call(s). Every in-tx INSERT bypasses \
+             `event_write::emit_events` and therefore bypasses the mirror on it; \
+             each one owes the event-log tier a post-commit `mirror_rows` or the \
+             tier serves an incomplete log (noetl/ai-meta#263)."
+        );
+        assert!(
+            inserts >= 2,
+            "expected the claim + batch in-tx INSERT sites to still exist; if they \
+             were routed through `emit_events` instead, delete this test and say so"
+        );
+    }
+
+    /// The chokepoint still mirrors, and mirrors before the publish/insert fork.
+    ///
+    /// The #263 fix adds mirror call sites; it must not have moved or removed the
+    /// one that covers everything else.
+    #[test]
+    fn the_chokepoint_mirrors_before_it_forks() {
+        let ew = include_str!("event_write.rs");
+        let mirror_at = ew
+            .find("ehdb_eventlog_mirror::mirror_rows")
+            .expect("event_write::emit_events must still mirror");
+        let fork_at = ew
+            .find("if should_publish(state, rows[0].catalog_id)")
+            .expect("the publish/insert fork must still be here");
+        assert!(
+            mirror_at < fork_at,
+            "the mirror must sit BEFORE the publish/insert fork so one call site \
+             covers both branches"
+        );
     }
 }

--- a/src/handlers/ehdb_parity.rs
+++ b/src/handlers/ehdb_parity.rs
@@ -1595,14 +1595,6 @@ mod tests {
         }
     }
 
-    /// Both real reply shapes, verbatim from the two sources.
-    ///
-    /// The wrapped one is what the worker's `run_query` returns and what the
-    /// server sees by default; the bare one is the tier service's reply relayed
-    /// through untouched. A parser that handles only the bare shape reads the
-    /// wrapped one as zero records — a fabricated divergence, and one that would
-    /// have looked like a genuine finding.
-    #[test]
     /// ai-meta#257 PR 4. The verdict must be attributable to a store, and the
     /// absence of a label must read as absence — not as `local`.
     #[test]
@@ -1625,6 +1617,20 @@ mod tests {
         assert_eq!(tier_source_of(&json!({"tier_query_source": 7})), None);
     }
 
+    /// Both real reply shapes, verbatim from the two sources.
+    ///
+    /// The wrapped one is what the worker's `run_query` returns and what the
+    /// server sees by default; the bare one is the tier service's reply relayed
+    /// through untouched. A parser that handles only the bare shape reads the
+    /// wrapped one as zero records — a fabricated divergence, and one that would
+    /// have looked like a genuine finding.
+    ///
+    /// It had no `#[test]`: a doc comment landed between this function's
+    /// attribute and the function, so the attribute bound to the *next* item and
+    /// this one silently never ran. `cargo build --all-targets` said so twice —
+    /// `duplicated attribute` here and `never used` there — and both warnings
+    /// name the symptom rather than the cause (noetl/ai-meta#263 drive-by).
+    #[test]
     fn both_real_reply_shapes_parse() {
         let bare = json!({
             "action": "eventlog-read-execution",

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1133,23 +1133,31 @@ pub async fn claim_command(
     // claim audit isn't lost.
     let publish_claim =
         crate::handlers::event_write::should_publish(&state, catalog_id.unwrap_or(0)).await;
+    let claim_created_at = chrono::Utc::now();
+    // Built once and used by BOTH branches, so the row the mirror sends and the
+    // row the INSERT binds cannot describe different events (noetl/ai-meta#263).
+    let claim_row = crate::handlers::event_write::EventRow::new(
+        claim_event_id,
+        execution_id,
+        catalog_id.unwrap_or(0),
+        "command.claimed",
+        "RUNNING",
+        claim_created_at,
+    )
+    .with_node(step.clone())
+    .with_result(claim_result)
+    .with_meta(claim_meta)
+    .with_worker_id(Some(request.worker_id.clone()));
     let mut claim_event_to_publish: Option<crate::handlers::event_write::EventRow> = None;
+    // noetl/ai-meta#263 — the gate-off branch below writes `noetl.event` itself,
+    // so it never reaches `event_write::emit_events` and therefore never reached
+    // the event-log-tier mirror that lives on that chokepoint.  Carried out of
+    // the transaction and mirrored after the commit, exactly like the gate-on
+    // branch's post-commit `emit_event`.
+    let mut claim_event_to_mirror: Option<crate::handlers::event_write::EventRow> = None;
     if step != noetl_orchestrate_core::state::WorkflowState::ORCHESTRATE_META_STEP {
         if publish_claim {
-            claim_event_to_publish = Some(
-                crate::handlers::event_write::EventRow::new(
-                    claim_event_id,
-                    execution_id,
-                    catalog_id.unwrap_or(0),
-                    "command.claimed",
-                    "RUNNING",
-                    chrono::Utc::now(),
-                )
-                .with_node(step.clone())
-                .with_result(claim_result.clone())
-                .with_meta(claim_meta.clone())
-                .with_worker_id(Some(request.worker_id.clone())),
-            );
+            claim_event_to_publish = Some(claim_row);
         } else {
             // One-level event chain (RFC #115 Phase 2): stamp `prev_event_id`
             // from the per-execution chain head + advance the head, EXACTLY as
@@ -1177,6 +1185,7 @@ pub async fn claim_command(
                 .into_iter()
                 .next()
                 .flatten();
+            let claim_row = claim_row.with_prev_event_id(prev_event_id);
             sqlx::query(
                 r#"
                 INSERT INTO noetl.event (
@@ -1190,20 +1199,25 @@ pub async fn claim_command(
                 )
                 "#,
             )
-            .bind(claim_event_id)
-            .bind(execution_id)
+            .bind(claim_row.event_id)
+            .bind(claim_row.execution_id)
+            // The original `Option<i64>` rather than the row's `unwrap_or(0)`:
+            // this column is NOT NULL in practice (`playbook_started` wrote one
+            // first) and binding the Option keeps the SQL byte-identical to what
+            // this site has always sent.
             .bind(catalog_id)
-            .bind("command.claimed")
-            .bind(&step)
-            .bind(&step)
-            .bind("RUNNING")
-            .bind(claim_result)
-            .bind(claim_meta)
-            .bind(&request.worker_id)
-            .bind(prev_event_id)
-            .bind(chrono::Utc::now())
+            .bind(&claim_row.event_type)
+            .bind(&claim_row.node_id)
+            .bind(&claim_row.node_name)
+            .bind(&claim_row.status)
+            .bind(&claim_row.result)
+            .bind(&claim_row.meta)
+            .bind(&claim_row.worker_id)
+            .bind(claim_row.prev_event_id)
+            .bind(claim_row.created_at)
             .execute(&mut *tx)
             .await?;
+            claim_event_to_mirror = Some(claim_row);
         }
     }
 
@@ -1212,6 +1226,28 @@ pub async fn claim_command(
     if let Some(ev) = claim_event_to_publish {
         crate::handlers::event_write::emit_event(&state, state.pools.pool_for(execution_id), ev)
             .await?;
+    }
+    // noetl/ai-meta#263 — the second mirror call site, and the only other place
+    // the server writes `noetl.event` for a live execution.
+    //
+    // `emit_events` mirrors before its publish/insert fork, which covers every
+    // event that reaches it.  This one does not reach it: `should_publish` is
+    // false for every **system-pool** execution by construction
+    // (`is_system_execution` — they drain the stream, so they cannot be fed by
+    // it), so `system/*` playbooks always took the in-tx branch and their
+    // `command.claimed` events were never mirrored.  The comparator called them
+    // `mirror_expected` — correctly, in server-mirror mode every authoritative
+    // event is — and reported two `missing_event`s per hourly
+    // `system/scheduled_cleanup` run, on a tier that is `primary` and serving.
+    //
+    // This does NOT reintroduce the two-producer ordering race that moved the
+    // mirror off the worker in the first place.  That race was between two
+    // *processes* appending independently; this is the same server process, and
+    // the append happens after the claim's commit and before the claim response
+    // returns — so the worker's next event for this execution cannot be emitted,
+    // let alone mirrored, until this record is already in the tier.
+    if let Some(ev) = claim_event_to_mirror {
+        crate::handlers::ehdb_eventlog_mirror::mirror_rows(&state, std::slice::from_ref(&ev)).await;
     }
 
     Ok(Json(ClaimResponse {
@@ -1313,24 +1349,26 @@ pub async fn handle_batch_events(
     // relocates to the materializer endpoint.
     let publish_batch =
         crate::handlers::event_write::should_publish(&state, catalog_id.unwrap_or(0)).await;
+    // Built once for both branches so the gate-off INSERT and the mirror send the
+    // same events (noetl/ai-meta#263).
+    let event_rows: Vec<crate::handlers::event_write::EventRow> = rows
+        .iter()
+        .map(|r| {
+            crate::handlers::event_write::EventRow::new(
+                r.event_id,
+                execution_id,
+                catalog_id.unwrap_or(0),
+                r.event_type.clone(),
+                r.status.clone(),
+                now,
+            )
+            .with_node(r.step.clone())
+            .with_result(r.result_obj.clone())
+            .with_meta(r.meta_obj.clone())
+            .with_worker_id(request.worker_id.clone())
+        })
+        .collect();
     if publish_batch {
-        let event_rows: Vec<crate::handlers::event_write::EventRow> = rows
-            .iter()
-            .map(|r| {
-                crate::handlers::event_write::EventRow::new(
-                    r.event_id,
-                    execution_id,
-                    catalog_id.unwrap_or(0),
-                    r.event_type.clone(),
-                    r.status.clone(),
-                    now,
-                )
-                .with_node(r.step.clone())
-                .with_result(r.result_obj.clone())
-                .with_meta(r.meta_obj.clone())
-                .with_worker_id(request.worker_id.clone())
-            })
-            .collect();
         // Commit the (possibly empty) claim tx first, then publish.
         tx.commit().await?;
         crate::handlers::event_write::emit_events(
@@ -1348,26 +1386,41 @@ pub async fn handle_batch_events(
         // a batch share one execution.
         let ids: Vec<i64> = rows.iter().map(|r| r.event_id).collect();
         let prevs = state.chain_heads.link_batch(execution_id, &ids).await;
+        let event_rows: Vec<crate::handlers::event_write::EventRow> = event_rows
+            .into_iter()
+            .zip(prevs.iter())
+            .map(|(r, prev)| r.with_prev_event_id(*prev))
+            .collect();
         let mut qb = sqlx::QueryBuilder::new(
             "INSERT INTO noetl.event (event_id, execution_id, catalog_id, event_type, \
              node_id, node_name, status, result, meta, worker_id, prev_event_id, created_at) ",
         );
-        qb.push_values(rows.iter().zip(prevs.iter()), |mut b, (r, prev)| {
+        qb.push_values(event_rows.iter(), |mut b, r| {
             b.push_bind(r.event_id)
-                .push_bind(execution_id)
+                .push_bind(r.execution_id)
+                // The original `Option<i64>`, not the row's `unwrap_or(0)` — same
+                // reason as the claim site above: keeps the SQL byte-identical.
                 .push_bind(catalog_id)
                 .push_bind(&r.event_type)
-                .push_bind(&r.step)
-                .push_bind(&r.step)
+                .push_bind(&r.node_id)
+                .push_bind(&r.node_name)
                 .push_bind(&r.status)
-                .push_bind(&r.result_obj)
-                .push_bind(&r.meta_obj)
-                .push_bind(&request.worker_id)
-                .push_bind(*prev)
-                .push_bind(now);
+                .push_bind(&r.result)
+                .push_bind(&r.meta)
+                .push_bind(&r.worker_id)
+                .push_bind(r.prev_event_id)
+                .push_bind(r.created_at);
         });
         qb.build().execute(&mut *tx).await?;
         tx.commit().await?;
+        // noetl/ai-meta#263 — same gap as the claim site: this in-tx batch INSERT
+        // bypasses `emit_events`, so without this the tier would silently miss
+        // every batched event on a system-pool execution.  `scheduled_cleanup`
+        // does not batch today, which is why the reported gap was exactly the two
+        // `command.claimed` rows — but the bypass is the same one and closing only
+        // half of it would leave the tier's completeness dependent on which
+        // ingest route a future system playbook happens to use.
+        crate::handlers::ehdb_eventlog_mirror::mirror_rows(&state, &event_rows).await;
     }
 
     // Trigger orchestrator for any command.completed in the batch,


### PR DESCRIPTION
## The defect

The EHDB event-log tier is `primary` and **serving**. For every hourly
`system/scheduled_cleanup` execution it held **11 of 13** events while reporting
`unmirrored_by_design = 0` — a claim of completeness it did not have. Both absent
events were `command.claimed`.

It is not a `command.claimed` problem. `test/simple_loop` on the user pool carries
5 of them and mirrors 29/29. The difference is **which branch writes the row**.

## Root cause

`claim_command` forks on `should_publish`:

| branch | what writes `noetl.event` | mirrored? |
| :-- | :-- | :-- |
| `should_publish == true` | `EventRow` → `emit_event` after commit → `event_write::emit_events` | yes — the mirror sits on that chokepoint (#348) |
| `should_publish == false` | raw `INSERT`, **inside the claim transaction** | **no** |

`should_publish` is false for every **system-pool** execution by construction:
`is_system_execution` is one of its three false conditions, because `system/*`
playbooks drain the event stream and so cannot also be fed by it. That made the
bypass exactly coextensive with the system pool — which is why it presented as an
event-type problem and was not.

Prod confirms all three preconditions: `NOETL_EVENT_INGEST_PUBLISH_ONLY=true`,
`NOETL_EVENT_BUS=ehdb`, `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE=server`.

`handle_batch_events` has the same shape and the same gap. `scheduled_cleanup`
does not batch, so it contributed nothing to the reported numbers — but left
alone, the tier's completeness would depend on which ingest route a future system
playbook happened to use.

## The fix

Both in-tx sites build the `EventRow` once (the INSERT binds from it, so the SQL
is unchanged) and call `mirror_rows` after the commit.

Preserved: in-tx atomicity with the `noetl.command` claim, the #121 chain link,
event identity, and ordering — the append happens before the claim response
returns, so the worker's next event for that execution cannot exist yet, let
alone race it. This does **not** reintroduce the hazard that moved the mirror off
the worker: that was two independent *processes*; this is one.

Default-safe — `mirror_rows` is a no-op unless `MIRROR_SOURCE=server`. The serve
path is untouched; the tier stays `primary` throughout.

Three mirror call sites instead of one is worth being uncomfortable about, so
`every_in_tx_event_insert_is_mirrored` counts direct `noetl.event` INSERT sites
against mirror calls rather than naming the two it knows about — a fourth writer
added later is the failure it exists to catch.

## Kind gate

Server **3.81.0** (the exact build prod is running) and worker **5.118.1**
(likewise), with prod's env copied. The issue's prod numbers reproduce
digit-for-digit.

| arm | `system/scheduled_cleanup` | `test/simple_loop` |
| :-- | :-- | :-- |
| **before** | auth=13 **ehdb=11**, `unmirrored_by_design=0`, missing = the 2 `command.claimed` | 29/29 match |
| **after** | auth=13 **ehdb=13** matched=13 `holds=true` `outcome=match` | 29/29 match |
| **mutation** — claim-site call reverted, image rebuilt | back to **11/13**, same 2 missing | — |

Not vacuous: the comparator's own positive controls report `controls_ok=true` in
every run, and the gate independently asserts a non-trivial event count, at least
one `command.claimed`, and `unmirrored_by_design == 0`.

`cargo test --lib`: 766 pass. Clippy clean (4 pre-existing warnings, none in the
touched regions).

## Drive-by

`both_real_reply_shapes_parse` in `ehdb_parity.rs` carried **no `#[test]`** — a
doc comment had landed between the attribute and its function, so the attribute
bound to the next item and the test silently never ran. `cargo build
--all-targets` reported it as `duplicated attribute` here and `never used` there;
both name the symptom rather than the cause.

Closes noetl/ai-meta#263

🤖 Generated with [Claude Code](https://claude.com/claude-code)