### PR TITLE
fix(orchestrator): re-drive on in-flight clear instead of waiting 8s (#155)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -86,6 +86,25 @@ pub struct AppConfig {
     #[serde(default = "default_true")]
     pub orchestrate_plugin_drive: bool,
 
+    /// Re-drive immediately when the orchestrate in-flight guard clears, if a
+    /// trigger was dropped while it was held (noetl/ai-meta#155).
+    ///
+    /// `NOETL_ORCH_RETRIGGER_ON_CLEAR`.  Default **false** — the existing
+    /// behaviour is unchanged and recovery stays with the 8s reconcile poller.
+    ///
+    /// Why it exists: a `command.completed` that lands while a
+    /// `system/orchestrate` is in flight is dropped by the serialisation guard
+    /// (`skipped_in_flight`) and nothing records that a re-drive is owed.  The
+    /// in-flight drive was computed against the older head, so it does not cover
+    /// the dropped trigger, and the execution stalls for a full
+    /// `RECONCILE_INTERVAL` (8s).  Measured on a 10-hop kind flow: 6 drops in 53
+    /// dispatches, one of which cost 8316ms on a turn whose other hops were
+    /// ~1.3s.
+    ///
+    /// **Revert:** set to `false` — per-deployment, immediate, no rebuild.
+    #[serde(default)]
+    pub orch_retrigger_on_clear: bool,
+
     /// CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3).  When true, every
     /// server-originated `noetl.event` write goes through the `emit_event`
     /// chokepoint as a **publish** to the `noetl_events` JetStream stream
@@ -1036,6 +1055,8 @@ impl Default for AppConfig {
             projector_owns_snapshot: false,
             // noetl/ai-meta#108 (c): worker-driven drive is the default.
             orchestrate_plugin_drive: true,
+            // noetl/ai-meta#155: opt-in; 8s-poller recovery stays the default.
+            orch_retrigger_on_clear: false,
             // noetl/ai-meta#103 2d-3: synchronous INSERT path by default.
             event_ingest_publish_only: false,
             auto_recreate_runtime: true,

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -2671,6 +2671,14 @@ async fn dispatch_offserver_stateless_drive(
     let mut cache = cache_slot.lock().await;
     if cache.orchestrate_in_flight {
         crate::metrics::record_orchestrate_drive("skipped_in_flight");
+        // noetl/ai-meta#155: the in-flight drive was computed against the head as
+        // it stood when it was dispatched, so it does not cover this trigger.
+        // Record that a re-drive is owed instead of dropping the wakeup and
+        // waiting out the 8s reconcile poller.
+        if state.config.orch_retrigger_on_clear {
+            cache.orchestrate_retrigger_pending = true;
+            crate::metrics::record_orchestrate_drive("retrigger_recorded");
+        }
         debug!(
             execution_id,
             "stateless drive: orchestrate already in flight; skip"
@@ -3221,6 +3229,11 @@ async fn trigger_orchestrator_inner(
         // would otherwise produce two orchestrate commands → duplicate work).
         if cache.orchestrate_in_flight {
             crate::metrics::record_orchestrate_drive("skipped_in_flight");
+            // noetl/ai-meta#155 — see the stateless site above.
+            if state.config.orch_retrigger_on_clear {
+                cache.orchestrate_retrigger_pending = true;
+                crate::metrics::record_orchestrate_drive("retrigger_recorded");
+            }
             debug!(
                 execution_id,
                 "worker-driven: orchestrate already in flight; skip"
@@ -3980,6 +3993,39 @@ async fn apply_worker_orchestration(
         state.chain_heads.evict(execution_id).await; // RFC #115 §4: drop the chain head too
         state.chain_tails.evict(execution_id); // noetl/ai-meta#156: drop the tail ring too
         state.exec_descriptors.evict(execution_id).await; // RFC #115 Phase 4 remainder
+        // Terminal: nothing left to re-drive, and the slot is gone.  Any pending
+        // flag dies with it.
+        return Ok(commands_generated);
+    }
+
+    // noetl/ai-meta#155 — a trigger was dropped while this drive held the
+    // in-flight guard.  The guard is now clear and this drive's result has been
+    // applied, so re-drive immediately rather than waiting out the 8s reconcile
+    // poller.  Taken (not just read) so one clear re-drives once; if the
+    // re-drive loses the guard race again it re-records the flag and the next
+    // clear picks it up, which terminates because each drive that wins the race
+    // advances the head.
+    let owed = state.config.orch_retrigger_on_clear
+        && std::mem::take(&mut cache.orchestrate_retrigger_pending);
+    drop(cache);
+    if owed {
+        crate::metrics::record_orchestrate_drive("retrigger_dispatched");
+        debug!(
+            execution_id,
+            "stateless drive: re-driving on in-flight clear (dropped trigger)"
+        );
+        // Spawned, not awaited: this runs on the `call.done` request path of the
+        // orchestrate command, and the re-drive must not extend that response.
+        // `i64::MAX` as the trigger id matches the reconcile poller — it keeps
+        // the immediate-straggler shortcut from firing on an already-applied
+        // event.  Not recursive: `trigger_orchestrator_inner` dispatches a
+        // command and returns; it never calls back into this function.
+        let st = state.clone();
+        tokio::spawn(async move {
+            if let Err(e) = trigger_orchestrator_inner(&st, execution_id, i64::MAX, false).await {
+                warn!(execution_id, %e, "re-drive on in-flight clear failed");
+            }
+        });
     }
     Ok(commands_generated)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -198,6 +198,22 @@ pub struct ExecOrchState {
     /// orchestrate commands → double-issue the same next commands.  In-memory
     /// only; a server restart re-derives the drive from the event log.
     pub orchestrate_in_flight: bool,
+    /// A trigger arrived while `orchestrate_in_flight` was set and was dropped
+    /// (noetl/ai-meta#155).
+    ///
+    /// The in-flight guard exists so two near-simultaneous triggers do not
+    /// double-issue a drive, and it returns `Ok(0)` on the loser.  But the
+    /// winning drive was computed against the head as it stood when it was
+    /// dispatched, so when the loser carried a *newer* head its work is simply
+    /// lost: no next command is issued, and no further real event fires a
+    /// trigger, so the execution sits until the 8s `RECONCILE_INTERVAL` poller
+    /// notices.  Measured: a single such drop cost 8316ms on an otherwise
+    /// ~1.3s/hop flow.
+    ///
+    /// Setting this on the drop, and re-driving when the guard clears, turns
+    /// that 8s wait into an immediate re-dispatch.  In-memory only, like the
+    /// guard it shadows; a server restart re-derives the drive from the log.
+    pub orchestrate_retrigger_pending: bool,
 }
 
 /// Per-execution chain head for the one-level event chain (RFC #115 Phase 2,


### PR DESCRIPTION
## The bug

A `command.completed` that lands while a `system/orchestrate` is in flight is dropped by the serialisation guard (`events.rs:2672`, `:3222` → `skipped_in_flight`) and **nothing records that a re-drive is owed**. The in-flight drive was computed against the older head, so it does not cover the dropped trigger — the execution sits until the 8s `RECONCILE_INTERVAL` poller. The comment at the clear site (`:3682`) says so outright. Measured: one drop cost **8316ms** on a flow whose other hops were ~1.3s.

## The fix

Record the owed re-drive at both skip sites; re-dispatch when the guard clears and this drive's result has been applied. Flag `NOETL_ORCH_RETRIGGER_ON_CLEAR`, **default false**.

Pending flag is *taken* so one clear re-drives once; a lost race re-records and terminates because each winning drive advances the head. Spawned, not awaited (must not extend the `call.done` response). Terminal executions return before it.

## Kind validation (10-hop probe, concurrency 5)

**Mechanism (decisive):** 5 drops → 5 re-drives, 1:1 on the same execution_id, each **637–1603ms** after the skip instead of up to 8s.

**Stalls:** flag OFF 3 / 40 runs (max gap 9006ms); flag ON **0 / 30 runs** (max gap 1825ms).

**Latency (interleaved A/B, removes a large monotonic drift confound):** OFF 42567ms (15 runs) vs ON 42875ms (10 runs) — **+0.7%, noise**. Latency-neutral. Non-interleaved arms had suggested a regression; the drift fully explains it.

**Safety:** 61 events/run (identical), 0 duplicate event_ids, exact lifecycle counts, **max 1 command.issued per (execution, step)** — no duplicate work.

**EHDB:** parity controls all `expected` / 0 `unexpected`. Mirror, serve config, tiers untouched.

**Note:** not every `skipped_in_flight` is a lost wakeup — a parallel fan-out produced 22 drops and zero stalls (one drive covers a loop's completions). The harmful variant is the linear one, where the dropped trigger carries a newer head.

## New metric labels

`noetl_orchestrate_drive_total{stage="retrigger_recorded"|"retrigger_dispatched"}`.

Refs noetl/ai-meta#155

🤖 Generated with [Claude Code](https://claude.com/claude-code)