### PR TITLE
feat(metrics): split POST /api/events into phases (#155)

### DIFF
--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -399,11 +399,17 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     //
     // No-op unless `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE=server`; best-effort and
     // isolated, so no failure here can affect the authoritative write below.
+    // noetl/ai-meta#155 — timing only.  The mirror itself is untouched.
+    let __t = std::time::Instant::now();
     crate::handlers::ehdb_eventlog_mirror::mirror_rows(state, rows).await;
+    crate::metrics::record_event_ingest_phase("emit_mirror", __t.elapsed().as_secs_f64());
 
     // All rows in a batch share the same execution + catalog, so one decision
     // covers the batch.
-    if should_publish(state, rows[0].catalog_id).await {
+    let __t = std::time::Instant::now();
+    let __should_publish = should_publish(state, rows[0].catalog_id).await;
+    crate::metrics::record_event_ingest_phase("emit_should_publish", __t.elapsed().as_secs_f64());
+    if __should_publish {
         // noetl/ai-meta#212 L1 T3 — which transports are live for this batch.
         //
         // EHDB is the only transport. Resolved here (rather than assumed) so a
@@ -429,6 +435,7 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
                 // The SAME bytes as NATS gets, so shadow parity is a straight
                 // comparison rather than a schema translation.
                 if ehdb_live {
+                    let __t = std::time::Instant::now();
                     publish_event_to_ehdb(
                         state,
                         rows[0].execution_id,
@@ -437,6 +444,10 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
                         &bytes,
                     )
                     .await?;
+                    crate::metrics::record_event_ingest_phase(
+                        "emit_publish",
+                        __t.elapsed().as_secs_f64(),
+                    );
                 }
                 crate::metrics::record_event_published(&row.event_type);
                 if state.config.offserver_attach_tail {
@@ -455,7 +466,10 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
         // No transport available → fall through to INSERT.
     }
 
-    insert_rows(pool, rows).await
+    let __t = std::time::Instant::now();
+    let __r = insert_rows(pool, rows).await;
+    crate::metrics::record_event_ingest_phase("emit_insert", __t.elapsed().as_secs_f64());
+    __r
 }
 
 /// The canonical full-column-superset INSERT.  Single multi-row statement.

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -568,7 +568,10 @@ pub(crate) async fn normalize_event_to_row(
         None => state.snowflake.generate()?,
     };
 
+    // noetl/ai-meta#155 — phase timing only; no behaviour change on this path.
+    let __t = std::time::Instant::now();
     let catalog_id = get_catalog_id(state, execution_id, "get_catalog_id_single").await?;
+    crate::metrics::record_event_ingest_phase("catalog_id", __t.elapsed().as_secs_f64());
 
     let mut meta = request
         .meta
@@ -630,7 +633,11 @@ async fn handle_event_inner(
     // For command.claimed, check if already claimed
     if request.event_type == "command.claimed" {
         if let Some(command_id) = get_command_id(&request) {
-            if check_already_claimed(&state, execution_id, &command_id, &request.worker_id).await? {
+            let __t = std::time::Instant::now();
+            let __already =
+                check_already_claimed(&state, execution_id, &command_id, &request.worker_id).await?;
+            crate::metrics::record_event_ingest_phase("claim_check", __t.elapsed().as_secs_f64());
+            if __already {
                 // Already claimed by same worker - idempotent success
                 return Ok(Json(EventResponse {
                     status: "ok".to_string(),
@@ -645,7 +652,9 @@ async fn handle_event_inner(
     // same one the CQRS materializer applies to native producer events,
     // #103 phase 2d) so the synchronous + materialized writes are
     // byte-identical.
+    let __t = std::time::Instant::now();
     let row = normalize_event_to_row(&state, &request).await?;
+    crate::metrics::record_event_ingest_phase("normalize", __t.elapsed().as_secs_f64());
     let event_id = row.event_id;
 
     // System meta-command events are NOT workflow events — they're the
@@ -676,8 +685,10 @@ async fn handle_event_inner(
         .with_node(row.node_name.clone())
         .with_result(row.result.clone())
         .with_meta(row.meta.clone());
+        let __t = std::time::Instant::now();
         crate::handlers::event_write::emit_event(&state, state.pools.pool_for(execution_id), ev)
             .await?;
+        crate::metrics::record_event_ingest_phase("emit", __t.elapsed().as_secs_f64());
     } else {
         crate::metrics::record_orchestrate_drive("event_suppressed");
     }
@@ -747,7 +758,10 @@ async fn handle_event_inner(
         // write endpoint (`handlers::internal::events_project`), which fires it AFTER
         // the row is durably inserted (read-your-writes). Gate off (default): trigger
         // inline exactly as today.
-        match trigger_orchestrator(&state, execution_id, event_id).await {
+        let __t = std::time::Instant::now();
+        let __trig = trigger_orchestrator(&state, execution_id, event_id).await;
+        crate::metrics::record_event_ingest_phase("trigger", __t.elapsed().as_secs_f64());
+        match __trig {
             Ok(cmds) => {
                 info!(
                     "Orchestrator generated {} commands for execution {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -779,6 +779,8 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_build_info();
     noetl_server::metrics::init_ehdb_command_publish_failed_series();
     noetl_server::metrics::init_event_ingest_publish_skipped_series();
+    // noetl/ai-meta#155 — pin the emit-path phase split.
+    noetl_server::metrics::init_event_ingest_phase_series();
     noetl_server::metrics::init_nonconvergence_sweep_series();
     noetl_server::metrics::init_orphan_sweep_series();
     noetl_server::metrics::init_sink_state_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1202,6 +1202,81 @@ pub fn event_ingest_duration_seconds() -> &'static HistogramVec {
     })
 }
 
+/// Histogram: one PHASE of `POST /api/events`, so the handler's total can be
+/// attributed rather than guessed (noetl/ai-meta#155).
+///
+/// The total (`event_ingest_duration_seconds`) reads ~336ms for
+/// `command.started` / `command.completed` and ~1021ms for `call.done` on prod,
+/// against ~40ms in kind — three emits per playbook hop, which is most of the
+/// uniform ~0.9-1.4s per-transition cadence users see. Nothing recorded WHERE
+/// inside the handler that goes, and the components differ between environments
+/// (prod runs the GCS object store, kind runs the Postgres one), so the split
+/// has to be measured on prod rather than inferred from a kind run.
+///
+/// `phase` values, in execution order:
+///
+/// - `catalog_id`     — the `get_catalog_id` lookup.
+/// - `claim_check`    — `check_already_claimed` (claim events only).
+/// - `normalize`      — `normalize_event_to_row`.
+/// - `emit`           — the whole `emit_event` chokepoint (sum of the four below).
+/// - `emit_mirror`    — the EHDB event-log tier mirror (`mirror_rows`).
+/// - `emit_should_publish` — the publish gate's catalog lookup.
+/// - `emit_publish`   — publishing onto the EHDB events feed.
+/// - `emit_insert`    — the authoritative Postgres INSERT.
+/// - `trigger`        — `trigger_orchestrator` (dispatches the drive).
+///
+/// Measurement only: recording a duration changes no behaviour on this path.
+pub fn event_ingest_phase_seconds() -> &'static HistogramVec {
+    static M: OnceLock<HistogramVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let hist = HistogramVec::new(
+            HistogramOpts::new(
+                "noetl_event_ingest_phase_seconds",
+                "Wall-clock time in one phase of POST /api/events.",
+            )
+            .buckets(vec![
+                0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5, 5.0, 10.0,
+            ]),
+            &["phase"],
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(hist.clone()))
+            .expect("histogram registration must succeed");
+        hist
+    })
+}
+
+/// Record one `POST /api/events` phase (see [`event_ingest_phase_seconds`]).
+pub fn record_event_ingest_phase(phase: &str, seconds: f64) {
+    event_ingest_phase_seconds()
+        .with_label_values(&[phase])
+        .observe(seconds);
+}
+
+/// Pin the closed `phase` label set so every series exists from process start.
+///
+/// `Registry::gather` prunes empty families, so an un-exercised phase would be
+/// absent and indistinguishable from a binary too old to have the metric — the
+/// distinction that matters when reading a prod scrape for the first time.
+pub fn init_event_ingest_phase_series() {
+    for phase in [
+        "catalog_id",
+        "claim_check",
+        "normalize",
+        "emit",
+        "emit_mirror",
+        "emit_should_publish",
+        "emit_publish",
+        "emit_insert",
+        "trigger",
+    ] {
+        event_ingest_phase_seconds()
+            .with_label_values(&[phase])
+            .observe(0.0);
+    }
+}
+
 /// Record a single `POST /api/events` outcome.
 ///
 /// `event_type` is the wire event_type from the request


### PR DESCRIPTION
## Why

The emit path is the real Muno turn cost and nothing attributed it. Prod `event_ingest_duration_seconds`:

| event_type | prod server-side | kind |
| --- | --- | --- |
| `call.done` | **1021ms** | ~40ms |
| `command.completed` | 350ms | ~40ms |
| `command.started` | 336ms | ~40ms |

Three emits per playbook hop — that is most of the uniform ~0.9–1.4s per-transition cadence users see on a ~89s turn.

**The components cannot be inferred from a kind run.** Prod runs `NOETL_OBJECT_STORE_BACKEND=gcs` + `NOETL_PERMANENT_LOG_LEAN=true` and mirrors the event log from the server (`MIRROR_SOURCE=server`); kind uses the Postgres object store. A kind measurement of this handler is structurally blind to prod's dominant term — which is how the previous round's index fix came to look 4.8× better in kind than the ~1% it is worth on prod.

## What

`noetl_event_ingest_phase_seconds{phase}`, in execution order:

`catalog_id` → `claim_check` → `normalize` → `emit` (the chokepoint total) → its four constituents `emit_mirror` / `emit_should_publish` / `emit_publish` / `emit_insert` → `trigger`.

One of the four suspected components was **ruled out by reading rather than instrumented**: the cross-store parity check is a background sampler (`spawn_crossstore_parity_sampler`) plus an endpoint — not on the emit path at all.

All label values are **pinned at startup**. `Registry::gather` prunes empty families, so an un-exercised phase would be absent and indistinguishable from a binary too old to have the metric — precisely the question a first prod scrape has to answer.

## Measurement only

Each site wraps an existing call in an `Instant` and records a duration. **No call is added, removed, reordered, or made conditional.** The EHDB mirror, serve config and tiers are untouched — the event-log tier is serving `primary` in prod.

Two call sites needed disambiguation rather than a blind replace: `emit_event` appears twice in `events.rs` (the handler path and the claim-publish path) and only the handler one is timed; an assertion caught that before it became a silent double-count.

`cargo check --all-targets` clean; clippy unchanged (the 3 warnings are pre-existing).

Refs noetl/ai-meta#155

🤖 Generated with [Claude Code](https://claude.com/claude-code)