### PR TITLE
perf(ehdb): async event-log mirror behind a bounded queue + a comparator lag window (#155)

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -810,6 +810,29 @@ pub struct AppConfig {
     /// something.
     #[serde(default = "default_ehdb_crossstore_parity_lookback_secs")]
     pub ehdb_crossstore_parity_lookback_secs: u64,
+
+    /// How recent an authoritative event may be before the comparator stops
+    /// counting its absence from the tier as divergence, in seconds.  Envy maps
+    /// `NOETL_EHDB_CROSSSTORE_PARITY_LAG_TOLERANCE_SECS`.  **Default 0 —
+    /// no tolerance, which is the pre-noetl/ai-meta#155 behaviour exactly.**
+    ///
+    /// Required by, and only by, the **async mirror**
+    /// (`NOETL_EHDB_EVENTLOG_MIRROR_ASYNC`).  With the mirror inline an event is
+    /// in the tier before `emit_events` returns, so an immediate comparison is
+    /// sound.  With it queued, an execution sampled mid-flight has a tier copy
+    /// that is legitimately behind — and this comparator is what demotes a
+    /// `primary`-serving tier, so without a window it would demote healthy
+    /// tiers on their own liveness.
+    ///
+    /// This is a **latency** concession, not a coverage one: a genuinely lost
+    /// event is invisible for the window and then reports `missing_event`
+    /// forever.  Set it above the mirror's observed
+    /// `noetl_ehdb_eventlog_mirror_lag_seconds` tail and no higher — a window
+    /// wider than the real lag buys nothing and blinds the comparator for
+    /// longer.  The `EhdbMirrorLagExceedsParityWindow` alert in noetl/ops is
+    /// what proves the two agree in production rather than on paper.
+    #[serde(default)]
+    pub ehdb_crossstore_parity_lag_tolerance_secs: u64,
 }
 
 /// How the execution-lifecycle hot path reads `noetl.event` — see
@@ -1143,6 +1166,7 @@ impl Default for AppConfig {
             ehdb_crossstore_parity_sample_size: default_ehdb_crossstore_parity_sample_size(),
             ehdb_crossstore_parity_settle_secs: default_ehdb_crossstore_parity_settle_secs(),
             ehdb_crossstore_parity_lookback_secs: default_ehdb_crossstore_parity_lookback_secs(),
+            ehdb_crossstore_parity_lag_tolerance_secs: 0,
         }
     }
 }
@@ -1172,6 +1196,29 @@ mod tests {
         // default so the gated build is behavior-neutral; only the explicit
         // operational flip (NOETL_RESULT_STORE_DUAL_WRITE=false) retires it.
         assert!(AppConfig::default().result_store_dual_write);
+    }
+
+    /// The parity lag tolerance is off by default, and its env name is the one
+    /// the wiki and the ops alert both quote.
+    ///
+    /// Asserted through `envy` rather than by reading the struct field, because
+    /// the failure mode is a **name** mismatch: a field renamed without the
+    /// deployment spec following it leaves prod setting a variable nothing
+    /// reads, which is the one inert flag of 77 that noetl/ai-meta#266 found.
+    #[test]
+    fn parity_lag_tolerance_defaults_to_zero_and_reads_its_documented_name() {
+        assert_eq!(
+            AppConfig::default().ehdb_crossstore_parity_lag_tolerance_secs,
+            0,
+            "default must be 0 — no tolerance is the pre-noetl/ai-meta#155 comparator exactly"
+        );
+        // `envy` derives the variable name from the field name; this pins the
+        // derivation so a rename cannot silently orphan the deployed value.
+        let name = format!(
+            "NOETL_{}",
+            stringify!(ehdb_crossstore_parity_lag_tolerance_secs).to_uppercase()
+        );
+        assert_eq!(name, "NOETL_EHDB_CROSSSTORE_PARITY_LAG_TOLERANCE_SECS");
     }
 
     #[test]

--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -99,7 +99,7 @@
 //!
 //! Default-off behind `NOETL_EHDB_EVENTLOG_MIRROR_SOURCE=server`.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::json;
 use tracing::warn;
@@ -208,12 +208,32 @@ fn relay_client() -> &'static reqwest::Client {
     C.get_or_init(reqwest::Client::new)
 }
 
+/// One relay-ready mirror request: the records for one execution, in order.
+///
+/// Carries the relay base URL rather than re-reading it at delivery time so a
+/// batch enqueued under one configuration cannot be delivered under another —
+/// and carries `enqueued_at` because the lag it reports is the whole point of
+/// the async path being auditable.
+#[derive(Debug, Clone)]
+pub struct MirrorBatch {
+    pub base: String,
+    pub execution_id: i64,
+    pub records: Vec<String>,
+    pub enqueued_at: Instant,
+}
+
 /// Mirror a batch of authoritative rows into the event-log tier.
 ///
 /// Called from the `emit_events` chokepoint with the rows that are about to
 /// become authoritative — after terminal dedup and after chain stamping, so the
 /// mirrored set is exactly the set that lands in `noetl.event` and no row is
 /// mirrored that gets suppressed.
+///
+/// With `NOETL_EHDB_EVENTLOG_MIRROR_ASYNC` off this delivers inline, exactly as
+/// it always has. With it on the batch is handed to
+/// [`super::ehdb_eventlog_mirror_queue`] and this returns in microseconds; the
+/// delivery, its metrics and its failure posture are unchanged, they just happen
+/// on the drain task.
 ///
 /// Never returns an error. See the module note on failure posture.
 pub async fn mirror_rows(state: &AppState, rows: &[EventRow]) {
@@ -244,15 +264,34 @@ pub async fn mirror_rows(state: &AppState, rows: &[EventRow]) {
     // One request per batch, records in the order the chokepoint wrote them.
     // N concurrent single-record requests would not preserve that order, and
     // order is one of the properties the comparator checks.
-    let execution_id = rows[0].execution_id;
-    let records: Vec<String> = rows
-        .iter()
-        .map(|r| mirror_payload(r).to_string())
-        .collect();
-    let count = records.len();
+    let batch = MirrorBatch {
+        base,
+        execution_id: rows[0].execution_id,
+        records: rows.iter().map(|r| mirror_payload(r).to_string()).collect(),
+        enqueued_at: Instant::now(),
+    };
 
-    let url = format!("{}/ehdb/tiers/eventlog", base.trim_end_matches('/'));
-    let body = json!({ "execution_id": execution_id.to_string(), "records": records });
+    if super::ehdb_eventlog_mirror_queue::enabled() {
+        super::ehdb_eventlog_mirror_queue::submit(batch).await;
+    } else {
+        deliver(&batch).await;
+    }
+}
+
+/// POST one batch to the tier relay and meter the result.
+///
+/// The delivery half of [`mirror_rows`], split out so the queue's drain task
+/// runs **the same code** the inline path runs. Two deliverers would be two
+/// failure postures, two metric spellings, and one of them would drift.
+pub(crate) async fn deliver(batch: &MirrorBatch) {
+    let execution_id = batch.execution_id;
+    let count = batch.records.len();
+    if count == 0 {
+        return;
+    }
+
+    let url = format!("{}/ehdb/tiers/eventlog", batch.base.trim_end_matches('/'));
+    let body = json!({ "execution_id": execution_id.to_string(), "records": batch.records });
 
     let resp = relay_client()
         .post(&url)
@@ -411,6 +450,20 @@ mod tests {
     ///
     /// The #263 fix adds mirror call sites; it must not have moved or removed the
     /// one that covers everything else.
+    ///
+    /// # This guard was broken, and nothing said so
+    ///
+    /// It matched the literal `if should_publish(state, rows[0].catalog_id)`.
+    /// noetl/ai-meta#155's phase-attribution change (server#352) hoisted that
+    /// call into `let __should_publish = should_publish(…).await;` so it could be
+    /// timed — a correct edit that left the guard unable to find its landmark.
+    /// The guard has been `panic!`-ing ever since, and **no `cargo test` runs in
+    /// CI on any Rust repo** ([ai-meta#232](https://github.com/noetl/ai-meta/issues/232)),
+    /// so a red guard and a green one are the same observable.
+    ///
+    /// Rewritten to anchor on `should_publish(` — the call, which cannot be
+    /// hoisted away without ceasing to exist — rather than on one spelling of
+    /// the statement around it.
     #[test]
     fn the_chokepoint_mirrors_before_it_forks() {
         let ew = include_str!("event_write.rs");
@@ -418,12 +471,67 @@ mod tests {
             .find("ehdb_eventlog_mirror::mirror_rows")
             .expect("event_write::emit_events must still mirror");
         let fork_at = ew
-            .find("if should_publish(state, rows[0].catalog_id)")
+            .find("should_publish(state, rows[0].catalog_id)")
             .expect("the publish/insert fork must still be here");
         assert!(
             mirror_at < fork_at,
             "the mirror must sit BEFORE the publish/insert fork so one call site \
              covers both branches"
+        );
+    }
+
+    /// The async path and the inline path must deliver through the SAME code.
+    ///
+    /// `deliver` carries the whole failure posture — the 501/405 discrimination,
+    /// the four outcome labels, the timeout. A drain task with its own copy would
+    /// be a second posture that drifts, and the drift would only ever be visible
+    /// on the async configuration, i.e. the one with less operational history.
+    #[test]
+    fn there_is_exactly_one_deliverer() {
+        let me = include_str!("ehdb_eventlog_mirror.rs");
+        let queue = include_str!("ehdb_eventlog_mirror_queue.rs");
+        assert_eq!(
+            me.matches("relay_client()\n        .post(").count(),
+            1,
+            "the relay POST must exist once, in `deliver`"
+        );
+        assert!(
+            !queue.contains(".post("),
+            "the queue module must not POST — it calls `deliver`, or the two paths \
+             will report differently for the same failure"
+        );
+        assert!(
+            queue.contains("ehdb_eventlog_mirror::deliver"),
+            "the drain task must call the shared deliverer"
+        );
+    }
+
+    /// Enqueueing must not be able to become a drop.
+    ///
+    /// Counted rather than named: the hazard is a *new* early return added later
+    /// that skips both the queue and the inline path, and a test that lists the
+    /// returns it already knows about cannot catch that. Every early exit from
+    /// `mirror_rows` that is not a delivery has to be one of the two accounted
+    /// ones — "nothing to mirror" and "not the mirror source" — or this fails.
+    #[test]
+    fn mirror_rows_has_no_unaccounted_early_return() {
+        let me = include_str!("ehdb_eventlog_mirror.rs");
+        let body_start = me
+            .find("pub async fn mirror_rows")
+            .expect("mirror_rows must exist");
+        let body_end = me[body_start..]
+            .find("pub(crate) async fn deliver")
+            .expect("deliver must follow mirror_rows")
+            + body_start;
+        let body = &me[body_start..body_end];
+        // `return;` in the guard clause, in the unconfigured branch. Two.
+        assert_eq!(
+            body.matches("return;").count(),
+            2,
+            "mirror_rows grew an early return. Every path out of it either delivers \
+             the events or is one of the two accounted no-ops (empty batch / not the \
+             mirror source); a third would silently drop authoritative events on a \
+             `primary`-serving tier (noetl/ai-meta#155)."
         );
     }
 }

--- a/src/handlers/ehdb_eventlog_mirror_queue.rs
+++ b/src/handlers/ehdb_eventlog_mirror_queue.rs
@@ -1,0 +1,485 @@
+//! Take the event-log mirror off the event-write hot path — a bounded queue
+//! with backpressure, never a drop.
+//!
+//! **[noetl/ai-meta#155](https://github.com/noetl/ai-meta/issues/155) Option 3.**
+//!
+//! # What this is worth
+//!
+//! [`super::ehdb_eventlog_mirror::mirror_rows`] is called inline from the
+//! `emit_events` chokepoint, so every authoritative event pays a relay round
+//! trip plus a tier append before the event write returns. Measured on a real
+//! Muno planner turn on prod: **110 ms per call, 76 calls, 8.4 s of the turn**
+//! — after the runtime cache (ehdb#316) had already cut it from 85.6 s.
+//!
+//! None of that work is on the critical path of anything. The mirror is an
+//! auxiliary verification copy; the authoritative write has already committed
+//! by the time it runs. Moving it behind a queue removes the whole 8.4 s from
+//! the turn and costs an enqueue.
+//!
+//! # Why "never drop" is not a preference
+//!
+//! The event-log tier serves `primary`. A dropped mirror record is not a lost
+//! metric, it is an event the tier will never hold — and the comparator will
+//! correctly call that a `missing_event` divergence forever after. So the
+//! backpressure policy is a ladder, and every rung keeps the event:
+//!
+//! 1. **`try_send`** — room on the queue, done in microseconds.
+//! 2. **`send().await` with a timeout** — the queue is full, so the emit path
+//!    *waits* for room. This is real backpressure: the producer slows to the
+//!    drain rate, nothing is lost, and order is preserved exactly.
+//! 3. **inline delivery** — the queue stayed full past the timeout. The batch
+//!    is mirrored synchronously, i.e. the pre-Option-3 behaviour.
+//!
+//! Rung 3 is the one to be uncomfortable about, and it is metered as its own
+//! outcome because of it: a batch delivered inline while earlier batches for
+//! the *same execution* are still queued lands out of order, and the comparator
+//! reports an `order` divergence. That is a spurious demote — but it is only
+//! reachable when the tier has been unable to accept a batch for the whole
+//! enqueue timeout, which is a state in which the tier is genuinely degraded
+//! and the demote is the right answer for a different reason. It is never a
+//! lost event, and the alert fires on it.
+//!
+//! There is no rung 4. Dropping is not on the ladder.
+//!
+//! # Ordering
+//!
+//! One drain task, FIFO queue, batches delivered sequentially. Per execution
+//! the order the tier receives is exactly the order `emit_events` produced —
+//! which is a stronger guarantee than the inline path gives today, where two
+//! concurrent `emit_events` calls race their two POSTs against each other.
+//!
+//! Across server replicas nothing changes: each replica has its own queue, and
+//! two replicas emitting for one execution were already ordered only by their
+//! POST timing. The drain is immediate — it never waits to accumulate — so the
+//! delay this adds is bounded by one in-flight delivery (~110 ms measured, less
+//! with the batch substrate), against a p50 inter-event gap of 225 ms on a real
+//! prod turn.
+//!
+//! # Where the batch substrate finally pays off
+//!
+//! ehdb#317 + worker#281 landed a batch-capable tier append (one open, N
+//! writes, one fsync) that was measured to be **inert** under the synchronous
+//! mirror: prod events arrive 225 ms apart, so `emit_events` hands the mirror
+//! one record per call and `append_batch` saw zero multi-record calls. The
+//! queue is what creates them — batches accumulate while a delivery is in
+//! flight, and the drain coalesces every batch for one execution into a single
+//! request.
+//!
+//! # Flag
+//!
+//! `NOETL_EHDB_EVENTLOG_MIRROR_ASYNC`, default **off**. Off, `mirror_rows`
+//! takes the same inline path it takes today and this module's only effect is
+//! four gauges reading 0.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use super::ehdb_eventlog_mirror::MirrorBatch;
+
+/// Arm the async queue. Default off.
+pub const ASYNC_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_ASYNC";
+
+/// Queue depth in **batches**. Default 512.
+///
+/// A batch is one `emit_events` call, so 512 is ~40 Muno turns of headroom at
+/// 13 events a turn. Sized to absorb a burst, not to hide a stall: past this
+/// the producer is meant to feel it (rung 2), because a queue deep enough never
+/// to push back is a queue whose lag can exceed the comparator's tolerance
+/// window without anything noticing.
+pub const CAPACITY_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_QUEUE_CAPACITY";
+const DEFAULT_CAPACITY: usize = 512;
+
+/// How long the emit path waits for room before falling back to inline
+/// delivery. Default 5000 ms — the same bound the inline relay already has, so
+/// the worst case a caller can see is unchanged from today.
+pub const ENQUEUE_TIMEOUT_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_ENQUEUE_TIMEOUT_MS";
+const DEFAULT_ENQUEUE_TIMEOUT_MS: u64 = 5_000;
+
+/// Most batches one drain pass takes off the queue before delivering. Default
+/// 64. Bounds how much one execution's coalesced request can grow, so a deep
+/// queue cannot build a request larger than the tier's page cap.
+pub const DRAIN_MAX_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_DRAIN_MAX_BATCHES";
+const DEFAULT_DRAIN_MAX: usize = 64;
+
+/// How long the shutdown flush waits for the queue to empty. Default 10 s, to
+/// match the graceful-shutdown budget in `main`.
+pub const FLUSH_TIMEOUT_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_FLUSH_TIMEOUT_MS";
+const DEFAULT_FLUSH_TIMEOUT_MS: u64 = 10_000;
+
+fn env_bool(name: &str) -> bool {
+    matches!(
+        std::env::var(name)
+            .ok()
+            .map(|s| s.trim().to_ascii_lowercase())
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(default)
+}
+
+fn env_millis(name: &str, default_ms: u64) -> Duration {
+    Duration::from_millis(
+        std::env::var(name)
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(default_ms),
+    )
+}
+
+/// Authoritative events enqueued and not yet durable.
+///
+/// Kept as an atomic beside the gauge rather than read off the gauge, because
+/// the shutdown flush needs to *wait* on it and a Prometheus gauge is a
+/// publication surface, not a synchronisation primitive.
+static PENDING_EVENTS: AtomicI64 = AtomicI64::new(0);
+
+static QUEUE: OnceLock<Option<mpsc::Sender<MirrorBatch>>> = OnceLock::new();
+
+/// Is the async queue armed in this process?
+pub fn enabled() -> bool {
+    queue().is_some()
+}
+
+fn queue() -> Option<&'static mpsc::Sender<MirrorBatch>> {
+    QUEUE.get().and_then(|q| q.as_ref())
+}
+
+/// Arm the queue and start the drain task. Idempotent; call once at startup.
+///
+/// Deliberately started from `main` rather than lazily on first mirror: a lazy
+/// start would make "armed" depend on traffic, and the gauge that says whether
+/// this process is async would read 0 on an idle server that is in fact
+/// configured for it.
+pub fn init() {
+    let armed = env_bool(ASYNC_ENV);
+    crate::metrics::ehdb_eventlog_mirror_async_enabled().set(i64::from(armed));
+    if !armed {
+        let _ = QUEUE.set(None);
+        return;
+    }
+
+    let capacity = env_usize(CAPACITY_ENV, DEFAULT_CAPACITY);
+    let drain_max = env_usize(DRAIN_MAX_ENV, DEFAULT_DRAIN_MAX);
+    let (tx, rx) = mpsc::channel::<MirrorBatch>(capacity);
+    if QUEUE.set(Some(tx)).is_err() {
+        // Already initialised. Do not start a second drain task — two drains
+        // on one queue would deliver batches concurrently and lose the ordering
+        // this module exists to guarantee.
+        return;
+    }
+    info!(
+        target: "noetl_server::ehdb_eventlog_mirror",
+        capacity,
+        drain_max,
+        enqueue_timeout_ms = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS).as_millis() as u64,
+        "async event-log mirror queue ARMED — the mirror is off the event-write path"
+    );
+    tokio::spawn(drain_loop(rx, drain_max));
+}
+
+/// Hand a batch to the queue, or deliver it inline if the queue cannot take it.
+///
+/// Returns after the batch is *accepted*, not after it is durable — that is the
+/// whole point. The exception is the inline rungs, which return after delivery.
+pub async fn submit(batch: MirrorBatch) {
+    let Some(tx) = queue() else {
+        // No queue in this process. Should be unreachable — `mirror_rows` checks
+        // `enabled()` first — but a stale flag read or a re-entrant call must
+        // still deliver the events rather than discard them.
+        let n = batch.records.len();
+        crate::metrics::record_ehdb_eventlog_mirror_queue("queue_closed_inline", n);
+        super::ehdb_eventlog_mirror::deliver(&batch).await;
+        return;
+    };
+
+    let n = batch.records.len();
+    let batch = match tx.try_send(batch) {
+        Ok(()) => {
+            accepted(n);
+            publish_depth(tx);
+            crate::metrics::record_ehdb_eventlog_mirror_queue("enqueued", n);
+            return;
+        }
+        Err(mpsc::error::TrySendError::Closed(b)) => {
+            crate::metrics::record_ehdb_eventlog_mirror_queue("queue_closed_inline", n);
+            warn!(
+                target: "noetl_server::ehdb_eventlog_mirror",
+                execution_id = b.execution_id, events = n,
+                "async mirror queue is closed — the drain task is gone; mirroring inline"
+            );
+            super::ehdb_eventlog_mirror::deliver(&b).await;
+            return;
+        }
+        Err(mpsc::error::TrySendError::Full(b)) => b,
+    };
+
+    // Rung 2 — backpressure. Wait for room. Nothing is lost and order holds.
+    //
+    // `reserve()`, not `send(batch)`. `send` takes the value **into the
+    // future**, so when the timeout cancels that future the batch goes with it
+    // and the events are silently gone — a drop, on the one path whose entire
+    // purpose is not to have one. `reserve` only waits for capacity; the batch
+    // stays in this frame, so the timeout arm still owns it and can deliver it.
+    //
+    // This is not a hypothetical. The first version of this function used
+    // `send`, and `tests/mirror_queue.rs` phase 3 found it immediately: 32 of
+    // 60 records reached the relay. Nothing else in the change would have —
+    // every counter still read correctly, because the events were counted at
+    // the moment they were lost.
+    let timeout = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS);
+    match tokio::time::timeout(timeout, tx.reserve()).await {
+        Ok(Ok(permit)) => {
+            permit.send(batch);
+            accepted(n);
+            publish_depth(tx);
+            crate::metrics::record_ehdb_eventlog_mirror_queue("enqueued_after_wait", n);
+        }
+        Ok(Err(_closed)) => {
+            crate::metrics::record_ehdb_eventlog_mirror_queue("queue_closed_inline", n);
+            super::ehdb_eventlog_mirror::deliver(&batch).await;
+        }
+        Err(_elapsed) => {
+            // Rung 3 — the queue stayed full for the whole timeout. Deliver it
+            // here, on the emit path, exactly as the pre-#155 mirror did.
+            crate::metrics::record_ehdb_eventlog_mirror_queue("queue_full_inline", n);
+            warn!(
+                target: "noetl_server::ehdb_eventlog_mirror",
+                execution_id = batch.execution_id, events = n,
+                timeout_ms = timeout.as_millis() as u64,
+                pending = PENDING_EVENTS.load(Ordering::Relaxed),
+                "async mirror queue stayed full past the enqueue timeout — mirroring inline. \
+                 This batch may land out of order relative to batches still queued for the \
+                 same execution (noetl/ai-meta#155)."
+            );
+            super::ehdb_eventlog_mirror::deliver(&batch).await;
+        }
+    }
+}
+
+/// Publish the queue's occupancy from the producer side.
+///
+/// The drain task also publishes it, but only when it wakes — so on a queue
+/// that is filling faster than it drains, the drain-side write is always the
+/// stale one. The number an operator reads during a backlog has to come from
+/// the side that is causing the backlog.
+fn publish_depth(tx: &mpsc::Sender<MirrorBatch>) {
+    let depth = tx.max_capacity().saturating_sub(tx.capacity());
+    crate::metrics::ehdb_eventlog_mirror_queue_depth().set(depth as i64);
+}
+
+fn accepted(events: usize) {
+    let now = PENDING_EVENTS.fetch_add(events as i64, Ordering::Relaxed) + events as i64;
+    crate::metrics::ehdb_eventlog_mirror_pending_events().set(now);
+}
+
+fn settled(events: usize) {
+    let now = PENDING_EVENTS.fetch_sub(events as i64, Ordering::Relaxed) - events as i64;
+    crate::metrics::ehdb_eventlog_mirror_pending_events().set(now);
+}
+
+/// The single drain task.
+///
+/// Drains immediately — `recv().await` returns on the first batch and the
+/// `try_recv` sweep only takes what is *already* there. There is no accumulation
+/// window on purpose: a window was measured against real prod inter-arrival
+/// times (p50 225 ms) and would have added delay to every event while batching
+/// essentially nothing. The batching that does happen here is free — it is
+/// whatever piled up while the previous delivery was in flight.
+async fn drain_loop(mut rx: mpsc::Receiver<MirrorBatch>, drain_max: usize) {
+    loop {
+        let Some(first) = rx.recv().await else {
+            info!(
+                target: "noetl_server::ehdb_eventlog_mirror",
+                "async mirror queue closed; drain task exiting"
+            );
+            return;
+        };
+        let mut pass: Vec<MirrorBatch> = vec![first];
+        while pass.len() < drain_max {
+            match rx.try_recv() {
+                Ok(b) => pass.push(b),
+                Err(_) => break,
+            }
+        }
+        crate::metrics::ehdb_eventlog_mirror_queue_depth().set(rx.len() as i64);
+        deliver_pass(pass).await;
+    }
+}
+
+/// Deliver one drain pass: coalesce per execution, POST sequentially.
+///
+/// Coalescing is per execution and **order-preserving within it**: batches for
+/// one execution are concatenated in the order they were enqueued, and the
+/// merged request goes out where the first of them sat. Different executions
+/// are independent, so their relative order is not a property anything checks.
+async fn deliver_pass(pass: Vec<MirrorBatch>) {
+    // Preserve first-seen execution order; merge records in enqueue order.
+    let mut order: Vec<i64> = Vec::new();
+    let mut merged: std::collections::HashMap<i64, MirrorBatch> = std::collections::HashMap::new();
+    for b in pass {
+        match merged.get_mut(&b.execution_id) {
+            Some(existing) => {
+                existing.records.extend(b.records);
+                // Keep the OLDEST enqueue time: the lag this batch reports must
+                // be the lag of its slowest record, not of its newest. Taking
+                // the newest would make a backed-up queue publish a healthy
+                // histogram — the exact silence this metric exists to break.
+                if b.enqueued_at < existing.enqueued_at {
+                    existing.enqueued_at = b.enqueued_at;
+                }
+            }
+            None => {
+                order.push(b.execution_id);
+                merged.insert(b.execution_id, b);
+            }
+        }
+    }
+
+    for execution_id in order {
+        let Some(batch) = merged.remove(&execution_id) else {
+            continue;
+        };
+        let n = batch.records.len();
+        let waited = batch.enqueued_at.elapsed();
+        super::ehdb_eventlog_mirror::deliver(&batch).await;
+        // Observed once per event, so the histogram's count is an event count
+        // and lines up with the mirror counter it is read beside.
+        let secs = waited.as_secs_f64();
+        for _ in 0..n {
+            crate::metrics::observe_ehdb_eventlog_mirror_lag(secs);
+        }
+        crate::metrics::record_ehdb_eventlog_mirror_queue("drained", n);
+        settled(n);
+    }
+}
+
+/// Wait for the queue to empty, up to a bounded deadline. Called on shutdown.
+///
+/// Without this, SIGTERM on a server with a non-empty queue silently loses
+/// those events — permanently, because nothing retries a mirror. They would
+/// surface later as a `missing_event` divergence on a `primary` tier with no
+/// trace of the cause. Whatever is still pending when the deadline passes is
+/// counted as `shutdown_abandoned` so the cause is at least attributable.
+pub async fn flush_on_shutdown() {
+    if !enabled() {
+        return;
+    }
+    let deadline = env_millis(FLUSH_TIMEOUT_ENV, DEFAULT_FLUSH_TIMEOUT_MS);
+    let started = Instant::now();
+    let at_entry = PENDING_EVENTS.load(Ordering::Relaxed);
+    if at_entry <= 0 {
+        return;
+    }
+    info!(
+        target: "noetl_server::ehdb_eventlog_mirror",
+        pending = at_entry, deadline_ms = deadline.as_millis() as u64,
+        "flushing the async event-log mirror queue before shutdown"
+    );
+    while started.elapsed() < deadline {
+        if PENDING_EVENTS.load(Ordering::Relaxed) <= 0 {
+            info!(
+                target: "noetl_server::ehdb_eventlog_mirror",
+                flushed = at_entry, took_ms = started.elapsed().as_millis() as u64,
+                "async event-log mirror queue flushed"
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let abandoned = PENDING_EVENTS.load(Ordering::Relaxed).max(0);
+    if abandoned > 0 {
+        crate::metrics::record_ehdb_eventlog_mirror_queue("shutdown_abandoned", abandoned as usize);
+        warn!(
+            target: "noetl_server::ehdb_eventlog_mirror",
+            abandoned,
+            "shutdown flush deadline passed with events still queued for the event-log tier — \
+             they will read as a missing_event divergence (noetl/ai-meta#155)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ladder has no drop rung, asserted on the label set rather than on
+    /// prose. Every outcome here either enqueues the events or delivers them.
+    #[test]
+    fn no_queue_outcome_discards_events() {
+        // `shutdown_abandoned` is the one outcome where events do not reach the
+        // tier, and it is not a *policy* — it is the process being killed. It is
+        // listed here so adding a genuine drop policy has to edit this test.
+        let terminal_without_delivery = ["shutdown_abandoned"];
+        for outcome in crate::metrics::EHDB_EVENTLOG_MIRROR_QUEUE_OUTCOMES {
+            let delivers = matches!(
+                outcome,
+                "enqueued"
+                    | "enqueued_after_wait"
+                    | "queue_full_inline"
+                    | "queue_closed_inline"
+                    | "drained"
+            );
+            assert!(
+                delivers || terminal_without_delivery.contains(&outcome),
+                "queue outcome {outcome:?} neither delivers nor is an accounted shutdown loss — \
+                 if a drop policy was added, noetl/ai-meta#155 says it may not be"
+            );
+        }
+    }
+
+    /// Merging must concatenate in enqueue order and keep the OLDEST timestamp.
+    ///
+    /// Both halves have teeth: reordering here is invisible to every other test
+    /// (the comparator would catch it in kind, days later), and taking the
+    /// newest timestamp would make a backed-up queue publish a healthy lag
+    /// histogram.
+    #[test]
+    fn coalescing_preserves_order_and_reports_the_oldest_lag() {
+        let t0 = Instant::now() - Duration::from_secs(9);
+        let t1 = Instant::now() - Duration::from_secs(1);
+        let mut a = MirrorBatch {
+            base: "http://x".into(),
+            execution_id: 7,
+            records: vec!["r1".into(), "r2".into()],
+            enqueued_at: t1,
+        };
+        let b = MirrorBatch {
+            base: "http://x".into(),
+            execution_id: 7,
+            records: vec!["r3".into()],
+            enqueued_at: t0,
+        };
+        // The same merge the drain pass performs.
+        a.records.extend(b.records.clone());
+        if b.enqueued_at < a.enqueued_at {
+            a.enqueued_at = b.enqueued_at;
+        }
+        assert_eq!(a.records, vec!["r1", "r2", "r3"]);
+        assert!(
+            a.enqueued_at.elapsed() >= Duration::from_secs(8),
+            "merged batch must report the oldest record's wait, not the newest"
+        );
+    }
+
+    #[test]
+    fn capacity_and_timeout_fall_back_to_defaults_on_junk() {
+        // A typo in a tuning knob must not produce a zero-capacity queue (every
+        // send would block) or a zero timeout (every batch would take rung 3).
+        assert_eq!(env_usize("NOETL_TEST_ABSENT_CAPACITY_155", 512), 512);
+        assert_eq!(
+            env_millis("NOETL_TEST_ABSENT_TIMEOUT_155", 5_000),
+            Duration::from_millis(5_000)
+        );
+    }
+}

--- a/src/handlers/ehdb_parity.rs
+++ b/src/handlers/ehdb_parity.rs
@@ -261,7 +261,9 @@ pub struct Divergence {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CrossStoreReport {
     pub execution_id: String,
-    /// Every authoritative event for this execution.
+    /// Authoritative events for this execution that the verdict is **about** —
+    /// i.e. every one of them, minus any held back by the lag tolerance window
+    /// (`pending_authoritative`). The two sum to the execution's total.
     pub authoritative_count: usize,
     /// The subset the tier is expected to hold — see
     /// [`AuthoritativeEvent::mirror_expected`]. This is the number the tier's
@@ -279,6 +281,20 @@ pub struct CrossStoreReport {
     /// the log (noetl/ai-meta#257 §3.4).
     pub unmirrored_by_design: usize,
     pub ehdb_count: usize,
+    /// Mirror-expected authoritative events held back by the lag tolerance
+    /// window — too recent to be comparable, because an async mirror may still
+    /// have them queued (noetl/ai-meta#155).
+    ///
+    /// Reported rather than silently subtracted. A tolerance that quietly grew
+    /// to cover a whole execution would report `match` on a comparison that did
+    /// not happen, and this is the number that makes that visible: if it is
+    /// consistently the whole log, the window is too wide or the mirror is too
+    /// slow, and both are things to act on.
+    pub pending_authoritative: usize,
+    /// Tier records excluded alongside them — events the mirror got to before
+    /// the window expired. Excluded from **both** sides, so a fast mirror is
+    /// not scored as holding extra records.
+    pub pending_tier: usize,
     /// Tier records that parsed and carried an `event_id`.
     pub identified: usize,
     /// Shared `event_id`s whose identifying fields agreed.
@@ -347,7 +363,69 @@ pub fn compare_cross_store(
     authoritative: &[AuthoritativeEvent],
     mirrored: &[MirroredRecord],
 ) -> CrossStoreReport {
+    compare_cross_store_with_horizon(execution_id, authoritative, mirrored, None)
+}
+
+/// [`compare_cross_store`], with a bounded **lag tolerance**.
+///
+/// # Why this exists (noetl/ai-meta#155)
+///
+/// The mirror used to be synchronous: an event was in the tier before
+/// `emit_events` returned, so comparing an execution the instant it was written
+/// was sound. Taking the mirror off the hot path breaks that. Any execution
+/// sampled while its newest events are still on the mirror queue has a tier copy
+/// that is legitimately a few records behind, and this comparator — which is
+/// what demotes a `primary`-serving tier — would call that `missing_event` and
+/// demote a healthy tier.
+///
+/// That is [#263](https://github.com/noetl/ai-meta/issues/263) inverted: #263
+/// was a tier reporting completeness it did not have; this would be a tier
+/// reporting divergence it does not have. Both end with an operator unable to
+/// trust the signal.
+///
+/// # What the tolerance does, and what it deliberately does not do
+///
+/// `horizon` is the largest authoritative `event_id` old enough to be
+/// comparable. Everything after it is **excluded from both sides** — the
+/// authoritative events are not counted missing, and any tier records the
+/// mirror already delivered for them are not counted extra.
+///
+/// Everything at or below the horizon is compared exactly as before. A
+/// genuinely lost event does not become invisible; it becomes invisible **for
+/// the length of the window** and then reports as `missing_event` forever, which
+/// is the same verdict at a bounded delay. The window is therefore a *latency*
+/// concession, never a *coverage* one, and the two controls
+/// `lag_within_window` / `lag_beyond_window` assert both halves of that on every
+/// tick.
+///
+/// The cut is a **prefix**, taken at the first event newer than the horizon
+/// rather than by filtering every event against it. `event_id` is a snowflake so
+/// the two orders agree, but a prefix cut cannot be wrong in the dangerous
+/// direction if they ever disagree: it can only exclude *more* than intended,
+/// never leave a still-queued event inside the compared set.
+///
+/// `None` restores the pre-#155 behaviour exactly, and is what the default
+/// configuration (`..._LAG_TOLERANCE_SECS=0`) produces.
+pub fn compare_cross_store_with_horizon(
+    execution_id: i64,
+    authoritative: &[AuthoritativeEvent],
+    mirrored: &[MirroredRecord],
+    horizon: Option<i64>,
+) -> CrossStoreReport {
     let mut divergences: Vec<Divergence> = Vec::new();
+
+    // Prefix cut. `cut` is the count of comparable authoritative events.
+    let cut = match horizon {
+        None => authoritative.len(),
+        Some(h) => authoritative
+            .iter()
+            .position(|e| e.event_id > h)
+            .unwrap_or(authoritative.len()),
+    };
+    let (comparable, held_back) = authoritative.split_at(cut);
+    let held_back_ids: BTreeSet<i64> = held_back.iter().map(|e| e.event_id).collect();
+    let pending_authoritative = held_back.iter().filter(|e| e.mirror_expected).count();
+    let authoritative = comparable;
 
     // --- parse the tier side -------------------------------------------------
     let mut parsed: Vec<MirroredEvent> = Vec::with_capacity(mirrored.len());
@@ -382,6 +460,17 @@ pub fn compare_cross_store(
         }
     }
 
+    // Drop tier records for events still inside the tolerance window. Doing it
+    // here, before every check, is what keeps the exclusion symmetric: the
+    // count, membership, ordering and payload checks all then run over one
+    // consistent pair of sets rather than each needing its own filter.
+    let pending_tier = parsed
+        .iter()
+        .filter(|m| held_back_ids.contains(&m.event_id))
+        .count();
+    parsed.retain(|m| !held_back_ids.contains(&m.event_id));
+    let ehdb_comparable = mirrored.len() - pending_tier;
+
     // The two authoritative views. `expected` scopes the count / missing checks
     // to events the tier should hold; `auth_by_id` covers the whole log so a
     // tier record matching a server-authored event is recognised rather than
@@ -393,14 +482,16 @@ pub fn compare_cross_store(
     let mirrored_ids: BTreeSet<i64> = parsed.iter().map(|m| m.event_id).collect();
 
     // --- presence ------------------------------------------------------------
-    if !expected.is_empty() && mirrored.is_empty() {
+    if !expected.is_empty() && ehdb_comparable == 0 {
         divergences.push(Divergence {
             kind: DivergenceKind::MissingExecution,
             detail: format!(
-                "authoritative log holds {} mirror-expected events for execution {execution_id} \
-                 (of {} total); the tier holds none",
+                "authoritative log holds {} mirror-expected comparable events for execution \
+                 {execution_id} (of {} comparable, {} held back by the lag tolerance); the tier \
+                 holds none",
                 expected.len(),
-                authoritative.len()
+                authoritative.len(),
+                pending_authoritative
             ),
         });
     }
@@ -409,13 +500,13 @@ pub fn compare_cross_store(
     // Suppressed when the tier is wholly absent: the missing_execution verdict
     // above already says it, and two lines for one fact makes the divergence
     // rate read double.
-    if expected.len() != mirrored.len() && !(mirrored.is_empty() && !expected.is_empty()) {
+    if expected.len() != ehdb_comparable && !(ehdb_comparable == 0 && !expected.is_empty()) {
         divergences.push(Divergence {
             kind: DivergenceKind::Count,
             detail: format!(
-                "authoritative(mirror-expected)={} ehdb={} (authoritative total {})",
+                "authoritative(mirror-expected)={} ehdb={} (authoritative comparable {})",
                 expected.len(),
-                mirrored.len(),
+                ehdb_comparable,
                 authoritative.len()
             ),
         });
@@ -549,7 +640,9 @@ pub fn compare_cross_store(
         authoritative_count: authoritative.len(),
         authoritative_expected: expected.len(),
         unmirrored_by_design: authoritative.len() - expected.len(),
-        ehdb_count: mirrored.len(),
+        ehdb_count: ehdb_comparable,
+        pending_authoritative,
+        pending_tier,
         identified: parsed.len(),
         matched,
         holds: divergences.is_empty(),
@@ -620,7 +713,7 @@ pub struct ControlResult {
 }
 
 /// Every control label value, for pinning.
-pub const CONTROL_NAMES: [&str; 8] = [
+pub const CONTROL_NAMES: [&str; 10] = [
     "identical",
     "missing_execution",
     "count",
@@ -629,6 +722,11 @@ pub const CONTROL_NAMES: [&str; 8] = [
     "order",
     "payload",
     "unidentified",
+    // The lag-tolerance pair (noetl/ai-meta#155). Two controls, not one,
+    // because the property being asserted is a *discrimination* and a single
+    // control can only ever prove half of it.
+    "lag_within_window",
+    "lag_beyond_window",
 ];
 
 fn auth_event(event_id: i64, event_type: &str, step: &str, status: &str) -> AuthoritativeEvent {
@@ -774,6 +872,64 @@ pub fn run_controls() -> Vec<ControlResult> {
         });
     }
 
+    // ---- the lag-tolerance pair (noetl/ai-meta#155) -----------------------
+    //
+    // ONE fixture — three authoritative events, the newest absent from the tier
+    // — driven through the comparator TWICE with only the horizon changed.
+    //
+    // That is the whole point. A tolerance window is dangerous in exactly one
+    // way: it can be a comparator that has been taught to ignore everything, and
+    // such a comparator passes a "clean parity under tolerance" test perfectly.
+    // The only check with teeth is that the *same missing event* is forgiven
+    // inside the window and reported outside it, so both controls run on
+    // identical inputs and their verdicts must differ.
+    {
+        let (auth, mut mirrored) = control_fixtures();
+        mirrored.pop(); // 9_003 is "still on the mirror queue"
+
+        // Inside the window: the horizon stops before 9_003, so its absence is
+        // in-flight, not divergence.
+        let inside = compare_cross_store_with_horizon(1, &auth, &mirrored, Some(9_002));
+        let ok_inside = inside.holds && inside.pending_authoritative == 1;
+        out.push(ControlResult {
+            control: "lag_within_window".to_string(),
+            expected: ok_inside,
+            detail: if ok_inside {
+                format!(
+                    "1 in-flight event held back, {} compared clean",
+                    inside.matched
+                )
+            } else {
+                format!(
+                    "in-flight event was NOT tolerated — kinds {:?}, holds={}, pending={}",
+                    inside.kinds(),
+                    inside.holds,
+                    inside.pending_authoritative
+                )
+            },
+        });
+
+        // Outside it: the same absent event, now old enough. Must still demote.
+        let outside = compare_cross_store_with_horizon(1, &auth, &mirrored, Some(9_003));
+        let ok_outside = outside
+            .kinds()
+            .contains(DivergenceKind::MissingEvent.as_str());
+        out.push(ControlResult {
+            control: "lag_beyond_window".to_string(),
+            expected: ok_outside,
+            detail: if ok_outside {
+                format!("still detected past the window; kinds {:?}", outside.kinds())
+            } else {
+                format!(
+                    "TOLERANCE SWALLOWED A REAL DIVERGENCE — kinds {:?}, holds={}, pending={}",
+                    outside.kinds(),
+                    outside.holds,
+                    outside.pending_authoritative
+                )
+            },
+        });
+    }
+
     out
 }
 
@@ -821,6 +977,15 @@ pub enum ParityOutcome {
     /// Either side hit [`MAX_COMPARE_EVENTS`]; a truncated comparison is not a
     /// comparison.
     SkippedTooLarge,
+    /// Every authoritative event for this execution is inside the mirror lag
+    /// tolerance window, so there was nothing old enough to compare
+    /// (noetl/ai-meta#155).
+    ///
+    /// Its own outcome, not `match`, for the reason the module header gives:
+    /// every way of *not knowing* is reported as itself. Scoring an untaken
+    /// comparison as agreement is precisely how a tolerance window turns into a
+    /// comparator that has been taught to ignore everything.
+    PendingMirror,
     /// The authoritative read failed.
     Error,
 }
@@ -835,13 +1000,14 @@ impl ParityOutcome {
             Self::EhdbUnavailable => "ehdb_unavailable",
             Self::EhdbDisabled => "ehdb_disabled",
             Self::SkippedTooLarge => "skipped_too_large",
+            Self::PendingMirror => "pending_mirror",
             Self::Error => "error",
         }
     }
 }
 
 /// Every [`ParityOutcome`] label value, for pinning.
-pub const PARITY_OUTCOMES: [ParityOutcome; 8] = [
+pub const PARITY_OUTCOMES: [ParityOutcome; 9] = [
     ParityOutcome::Match,
     ParityOutcome::Divergent,
     ParityOutcome::AuthoritativeEmpty,
@@ -849,6 +1015,7 @@ pub const PARITY_OUTCOMES: [ParityOutcome; 8] = [
     ParityOutcome::EhdbUnavailable,
     ParityOutcome::EhdbDisabled,
     ParityOutcome::SkippedTooLarge,
+    ParityOutcome::PendingMirror,
     ParityOutcome::Error,
 ];
 
@@ -1176,12 +1343,30 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
         };
     }
 
-    let report = compare_cross_store(execution_id, &authoritative, &mirrored);
-    let outcome = if report.holds {
-        ParityOutcome::Match
-    } else {
-        ParityOutcome::Divergent
+    // The lag tolerance. Default 0 ⇒ `None` ⇒ byte-identical behaviour to
+    // before noetl/ai-meta#155. A failure to compute it is NOT silently treated
+    // as "no tolerance": that would restore the false-demote hazard on exactly
+    // the configuration that asked for tolerance, so it is reported as `error`.
+    let tolerance = state.config.ehdb_crossstore_parity_lag_tolerance_secs;
+    let horizon = match mirror_lag_horizon(state, execution_id, tolerance).await {
+        Ok(h) => h,
+        Err(e) => {
+            crate::metrics::record_ehdb_crossstore_parity(TIER, ParityOutcome::Error.as_str());
+            return ComparisonResult {
+                outcome: ParityOutcome::Error,
+                report: None,
+                detail: Some(format!("mirror lag horizon read failed: {e}")),
+                tier_query_source,
+            };
+        }
     };
+
+    let report =
+        compare_cross_store_with_horizon(execution_id, &authoritative, &mirrored, horizon);
+    let outcome = outcome_for(&report);
+    if report.pending_authoritative > 0 {
+        crate::metrics::add_ehdb_crossstore_pending(TIER, report.pending_authoritative as u64);
+    }
     crate::metrics::record_ehdb_crossstore_parity(TIER, outcome.as_str());
     crate::metrics::add_ehdb_crossstore_events_compared(TIER, report.matched as u64);
     for kind in report.kinds() {
@@ -1203,6 +1388,61 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
         report: Some(report),
         detail: None,
         tier_query_source,
+    }
+}
+
+/// The largest authoritative `event_id` for this execution that is old enough
+/// to be compared, given a lag tolerance in seconds.
+///
+/// Computed as **`MIN(event_id) - 1` over the events newer than the cutoff**,
+/// not `MAX(event_id)` over the older ones. The two differ exactly when
+/// `event_id` order and `created_at` order disagree, and only the first is safe:
+/// it excludes every event at or after the first recent one, so a still-queued
+/// event can never end up inside the compared set. `MAX` over the old side
+/// would leave it there and report it missing — the false demote this whole
+/// mechanism exists to prevent.
+///
+/// `Ok(None)` means nothing is newer than the cutoff, so the whole execution is
+/// comparable.
+async fn mirror_lag_horizon(
+    state: &AppState,
+    execution_id: i64,
+    tolerance_secs: u64,
+) -> Result<Option<i64>, sqlx::Error> {
+    if tolerance_secs == 0 {
+        return Ok(None);
+    }
+    let row: (Option<i64>,) = sqlx::query_as(
+        r#"
+        SELECT MIN(event_id)
+        FROM noetl.event
+        WHERE execution_id = $1
+          AND created_at > NOW() - INTERVAL '1 second' * $2
+        "#,
+    )
+    .bind(execution_id)
+    .bind(tolerance_secs as i64)
+    .fetch_one(state.pools.pool_for(execution_id))
+    .await?;
+    // `- 1` because the horizon is inclusive: the newest COMPARABLE id.
+    Ok(row.0.map(|min_recent| min_recent - 1))
+}
+
+/// Score a report.
+///
+/// Split out from [`compare_execution`] so the one rule that a lag-tolerance
+/// window could silently break — **an untaken comparison is not agreement** —
+/// is assertable without a database. With the window wide enough, `holds` is
+/// trivially true on an empty comparable set, and scoring that `match` would
+/// publish a healthy parity rate for a comparator that compared nothing.
+fn outcome_for(report: &CrossStoreReport) -> ParityOutcome {
+    if report.authoritative_count == 0 && report.pending_authoritative > 0 {
+        return ParityOutcome::PendingMirror;
+    }
+    if report.holds {
+        ParityOutcome::Match
+    } else {
+        ParityOutcome::Divergent
     }
 }
 
@@ -1435,6 +1675,110 @@ mod tests {
         for r in run_controls() {
             assert!(r.expected, "control {} failed: {}", r.control, r.detail);
         }
+    }
+
+
+    // =======================================================================
+    // Lag tolerance (noetl/ai-meta#155)
+    // =======================================================================
+
+    /// `None` must be byte-identical to the pre-#155 comparator.
+    ///
+    /// The default configuration produces `None`, so this is the assertion that
+    /// the whole feature is genuinely inert until switched on — the property
+    /// every "default off" claim in this repo has at some point turned out not
+    /// to have.
+    #[test]
+    fn no_horizon_is_exactly_the_old_comparator() {
+        let (auth, mut mirrored) = control_fixtures();
+        mirrored.remove(1);
+        let old = compare_cross_store(1, &auth, &mirrored);
+        let new = compare_cross_store_with_horizon(1, &auth, &mirrored, None);
+        assert_eq!(old, new);
+        assert_eq!(new.pending_authoritative, 0);
+        assert_eq!(new.pending_tier, 0);
+        assert!(new.kinds().contains("missing_event"));
+    }
+
+    /// The window forgives an in-flight event and nothing else.
+    ///
+    /// The sharp case: TWO events are absent from the tier — one old, one still
+    /// queued. A window that merely suppressed `missing_event` would pass a
+    /// single-absence test and fail this one. The old id must still be named.
+    #[test]
+    fn the_window_forgives_only_what_is_inside_it() {
+        let auth = vec![
+            auth_event(9_001, "playbook.started", "start", "STARTED"),
+            auth_event(9_002, "step.enter", "fetch", "RUNNING"),
+            auth_event(9_003, "step.exit", "fetch", "COMPLETED"),
+            auth_event(9_004, "playbook.completed", "end", "COMPLETED"),
+        ];
+        // The tier is missing 9_002 (a real loss) and 9_004 (still queued).
+        let mirrored = vec![mirrored_of(1, &auth[0]), mirrored_of(2, &auth[2])];
+
+        let r = compare_cross_store_with_horizon(1, &auth, &mirrored, Some(9_003));
+        assert!(!r.holds, "a real loss inside the compared prefix must diverge");
+        let missing = r
+            .divergences
+            .iter()
+            .find(|d| d.kind == DivergenceKind::MissingEvent)
+            .expect("the old absent event must still be reported");
+        assert!(
+            missing.detail.contains("9002"),
+            "the pre-window loss must be named: {}",
+            missing.detail
+        );
+        assert!(
+            !missing.detail.contains("9004"),
+            "the in-flight event must not be named as missing: {}",
+            missing.detail
+        );
+        assert_eq!(r.pending_authoritative, 1);
+    }
+
+    /// The exclusion is symmetric.
+    ///
+    /// If the mirror is FAST — the record for an in-flight event is already in
+    /// the tier — that record must not be scored as an `extra_event` or as a
+    /// `count` mismatch. Excluding only the authoritative side would make the
+    /// window punish the mirror for being quick, which is a divergence alarm
+    /// that fires more often the healthier the system is.
+    #[test]
+    fn a_tier_record_inside_the_window_is_not_an_extra() {
+        let (auth, mirrored) = control_fixtures(); // tier holds all three
+        let r = compare_cross_store_with_horizon(1, &auth, &mirrored, Some(9_002));
+        assert!(r.holds, "{:?}", r.divergences);
+        assert_eq!(r.pending_authoritative, 1);
+        assert_eq!(r.pending_tier, 1, "the already-mirrored record must be excluded too");
+        assert_eq!(r.authoritative_count, 2);
+        assert_eq!(r.ehdb_count, 2);
+    }
+
+    /// An execution wholly inside the window yields no verdict — and that is
+    /// NOT `match`.
+    #[test]
+    fn nothing_comparable_is_pending_not_agreement() {
+        let (auth, mirrored) = control_fixtures();
+        // Horizon below every id: the entire execution is in flight.
+        let r = compare_cross_store_with_horizon(1, &auth, &mirrored, Some(9_000));
+        assert!(r.holds, "an empty comparison has no divergences by definition");
+        assert_eq!(r.authoritative_count, 0);
+        assert_eq!(r.pending_authoritative, 3);
+        assert_eq!(
+            outcome_for(&r).as_str(),
+            "pending_mirror",
+            "an untaken comparison scored as `match` would publish a healthy parity rate for a \
+             comparator that compared nothing"
+        );
+    }
+
+    /// A tier that is wholly empty still reports `missing_execution` when the
+    /// window does not cover the whole execution.
+    #[test]
+    fn the_window_does_not_hide_a_wholly_absent_tier() {
+        let (auth, _) = control_fixtures();
+        let r = compare_cross_store_with_horizon(1, &auth, &[], Some(9_002));
+        assert!(r.kinds().contains("missing_execution"), "{:?}", r.divergences);
     }
 
     #[test]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod dashboard;
 pub mod database;
 pub mod ehdb;
 pub mod ehdb_eventlog_mirror;
+pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;
 pub mod event_write;
 pub mod events;

--- a/src/main.rs
+++ b/src/main.rs
@@ -788,6 +788,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_ehdb_crossstore_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_series();
+    noetl_server::metrics::init_ehdb_eventlog_mirror_queue_series();
     noetl_server::metrics::init_result_tier_gc_series();
     noetl_server::metrics::init_credential_seal_series();
     noetl_server::metrics::init_system_plugin_seed_series();
@@ -892,6 +893,10 @@ async fn main() -> anyhow::Result<()> {
     // EHDB cross-store parity sampler (noetl/ai-meta#258).  Default-off; the
     // task returns immediately unless NOETL_EHDB_CROSSSTORE_PARITY_ENABLED is
     // set AND the interval is non-zero.
+    // Arm the async mirror queue before the listener binds, so the gauge that
+    // says whether this process is async is true from the first scrape rather
+    // than from the first mirrored event.
+    handlers::ehdb_eventlog_mirror_queue::init();
     handlers::ehdb_parity::spawn_crossstore_parity_sampler(state.clone());
 
     // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when
@@ -1080,6 +1085,12 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
         }
     }
+
+    // The mirror queue holds authoritative events that are not yet in the tier.
+    // Dropping them on SIGTERM would produce a permanent `missing_event`
+    // divergence on a `primary`-serving tier with nothing pointing at the cause
+    // (noetl/ai-meta#155). Bounded, and a no-op when the queue is disabled.
+    noetl_server::handlers::ehdb_eventlog_mirror_queue::flush_on_shutdown().await;
 
     tracing::info!("Server shutdown complete");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -897,6 +897,11 @@ async fn main() -> anyhow::Result<()> {
     // says whether this process is async is true from the first scrape rather
     // than from the first mirrored event.
     handlers::ehdb_eventlog_mirror_queue::init();
+    // Publish the comparator's window so the ops alert reads the configured
+    // value instead of a copy of it (noetl/ai-meta#155).
+    noetl_server::metrics::set_ehdb_crossstore_parity_lag_tolerance(
+        state.config.ehdb_crossstore_parity_lag_tolerance_secs,
+    );
     handlers::ehdb_parity::spawn_crossstore_parity_sampler(state.clone());
 
     // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3353,6 +3353,39 @@ pub fn ehdb_crossstore_pending_total() -> &'static IntCounterVec {
     })
 }
 
+/// Gauge: the comparator's configured lag tolerance window, in seconds.
+///
+/// **Published so the alert does not have to hardcode it.** The rule that
+/// matters — "is the mirror's real lag inside the window the comparator was
+/// told to allow" — compares two numbers, and one of them lives in a
+/// deployment env var. A threshold copied into a PromQL expression is a
+/// representation of that env var (`agents/rules/representation-drift.md`),
+/// true only until someone tunes one side; publishing it makes the comparison
+/// read the value itself.
+///
+/// 0 means no tolerance, which is also the signal that the async mirror is not
+/// meant to be on — the alert uses that to stay silent rather than to divide by
+/// an implicit assumption.
+pub fn ehdb_crossstore_parity_lag_tolerance_seconds() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_crossstore_parity_lag_tolerance_seconds",
+            "The cross-store parity comparator's configured lag tolerance window in seconds; 0 \
+             means no tolerance (noetl/ai-meta#155).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+pub fn set_ehdb_crossstore_parity_lag_tolerance(seconds: u64) {
+    ehdb_crossstore_parity_lag_tolerance_seconds().set(seconds as i64);
+}
+
 pub fn add_ehdb_crossstore_pending(tier: &str, n: u64) {
     ehdb_crossstore_pending_total()
         .with_label_values(&[tier])
@@ -3376,6 +3409,7 @@ pub fn init_ehdb_crossstore_series() {
     ehdb_crossstore_pending_total()
         .with_label_values(&[TIER])
         .inc_by(0);
+    ehdb_crossstore_parity_lag_tolerance_seconds().set(0);
     ehdb_crossstore_events_compared_total()
         .with_label_values(&[TIER])
         .inc_by(0);
@@ -4425,6 +4459,7 @@ mod tests {
             // "this binary predates the window".
             "noetl_ehdb_crossstore_parity_total{outcome=\"pending_mirror\",tier=\"eventlog\"} 0",
             "noetl_ehdb_crossstore_pending_total{tier=\"eventlog\"} 0",
+            "noetl_ehdb_crossstore_parity_lag_tolerance_seconds 0",
             "noetl_ehdb_crossstore_control_total{control=\"lag_within_window\",result=\"expected\"} 0",
             "noetl_ehdb_crossstore_control_total{control=\"lag_beyond_window\",result=\"unexpected\"} 0",
         ] {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3142,6 +3142,223 @@ pub fn init_ehdb_eventlog_mirror_series() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Async mirror queue (noetl/ai-meta#155 Option 3).
+// ---------------------------------------------------------------------------
+
+/// Counter: what happened to a batch when it was handed to the mirror queue.
+///
+/// Deliberately a **second** family rather than more labels on
+/// [`ehdb_eventlog_mirror_total`]. That one answers "did the tier receive
+/// everything the log received", counted in events at delivery time; an
+/// `enqueued` label on it would be counted twice for every event — once on
+/// enqueue and once on delivery — and quietly destroy the only number that
+/// answers the coverage question.
+///
+/// This family answers a different question: is the queue absorbing the load,
+/// or is it pushing back? Counted in **events** for the same reason.
+pub fn ehdb_eventlog_mirror_queue_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_eventlog_mirror_queue_total",
+                "Authoritative events by how the async event-log mirror queue handled them \
+                 (noetl/ai-meta#155).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Every queue outcome. Closed set, pinned at 0.
+///
+/// * `enqueued` — accepted onto the queue immediately.
+/// * `enqueued_after_wait` — the queue was full and the emit path **waited**
+///   for room. This is backpressure working: no event was dropped and order is
+///   preserved. Its rate is the signal that the drain is falling behind.
+/// * `queue_full_inline` — the queue stayed full past the enqueue timeout, so
+///   the batch was mirrored inline on the emit path instead. Still no drop, but
+///   this is the one path that can deliver out of order relative to batches
+///   still queued for the same execution, so it is its own label and it is what
+///   the alert fires on.
+/// * `queue_closed_inline` — no drain task (queue disabled mid-flight, or the
+///   drainer is gone). Mirrored inline; the pre-Option-3 behaviour.
+/// * `drained` — delivered by the drain task. The terminal success label.
+/// * `shutdown_abandoned` — still queued when the process finished its
+///   shutdown flush. These events never reached the tier and WILL show up as a
+///   `missing_event` divergence; the label exists so the cause is attributable
+///   rather than a mystery an hour later.
+pub const EHDB_EVENTLOG_MIRROR_QUEUE_OUTCOMES: [&str; 6] = [
+    "enqueued",
+    "enqueued_after_wait",
+    "queue_full_inline",
+    "queue_closed_inline",
+    "drained",
+    "shutdown_abandoned",
+];
+
+pub fn record_ehdb_eventlog_mirror_queue(outcome: &str, events: usize) {
+    ehdb_eventlog_mirror_queue_total()
+        .with_label_values(&[outcome])
+        .inc_by(events as u64);
+}
+
+/// Histogram: seconds from enqueue to durable in the tier.
+///
+/// **This is the metric the comparator's lag tolerance is checked against.**
+/// The tolerance window (`NOETL_EHDB_CROSSSTORE_PARITY_LAG_TOLERANCE_SECS`)
+/// tells the comparator to ignore events younger than N seconds; that is a
+/// promise about how long the mirror can take, and without this histogram it
+/// would be an assumption. An operator compares this histogram's tail against
+/// the configured window, and the alert does it automatically.
+///
+/// Buckets run to 60s on purpose: the interesting readings are the slow ones,
+/// and a histogram that tops out below the tolerance window cannot show a
+/// breach of it.
+pub fn ehdb_eventlog_mirror_lag_seconds() -> &'static Histogram {
+    static M: OnceLock<Histogram> = OnceLock::new();
+    M.get_or_init(|| {
+        let hist = Histogram::with_opts(
+            HistogramOpts::new(
+                "noetl_ehdb_eventlog_mirror_lag_seconds",
+                "Seconds from an authoritative event being enqueued for the async event-log \
+                 mirror to it being durable in the tier (noetl/ai-meta#155).",
+            )
+            .buckets(vec![
+                0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+            ]),
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(hist.clone()))
+            .expect("histogram registration must succeed");
+        hist
+    })
+}
+
+pub fn observe_ehdb_eventlog_mirror_lag(seconds: f64) {
+    ehdb_eventlog_mirror_lag_seconds().observe(seconds);
+}
+
+/// Gauge: authoritative events enqueued for the mirror and not yet durable.
+///
+/// The coverage number. `mirror_lag_seconds` only records events that *made
+/// it*, so a queue that has stopped draining entirely publishes no lag
+/// observations at all — its histogram goes quiet, which reads exactly like an
+/// idle healthy system. This gauge is what distinguishes the two, and it is why
+/// the alert watches both.
+pub fn ehdb_eventlog_mirror_pending_events() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_eventlog_mirror_pending_events",
+            "Authoritative events enqueued for the async event-log mirror and not yet durable \
+             in the tier (noetl/ai-meta#155).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Gauge: batches sitting on the mirror queue.
+pub fn ehdb_eventlog_mirror_queue_depth() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_eventlog_mirror_queue_depth",
+            "Batches currently on the async event-log mirror queue (noetl/ai-meta#155).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Gauge: 1 when the async mirror queue is armed in this process, 0 otherwise.
+///
+/// Without it, "the flag is off" and "the flag is on but the drain task never
+/// started" produce the same scrape: an idle queue with zero depth. That is the
+/// inert-and-silent shape this codebase has shipped three times already
+/// (noetl/ai-meta#242, #266), so the arming is published rather than inferred.
+pub fn ehdb_eventlog_mirror_async_enabled() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_eventlog_mirror_async_enabled",
+            "1 when the async event-log mirror queue is armed in this process, 0 when the \
+             mirror is inline (noetl/ai-meta#155).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Pin the async-mirror label set and gauges at 0.
+///
+/// Unconditional, and not inside the flag check: a pin behind the flag would be
+/// absent on exactly the configuration whose `queue_full_inline` count someone
+/// would be reading during an incident.
+pub fn init_ehdb_eventlog_mirror_queue_series() {
+    for outcome in EHDB_EVENTLOG_MIRROR_QUEUE_OUTCOMES {
+        ehdb_eventlog_mirror_queue_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+    ehdb_eventlog_mirror_pending_events().set(0);
+    ehdb_eventlog_mirror_queue_depth().set(0);
+    ehdb_eventlog_mirror_async_enabled().set(0);
+    // An unlabelled Histogram is still a family with one child, so it is not
+    // pruned — but observing nothing leaves every bucket at 0, which is what we
+    // want it to read as.
+    let _ = ehdb_eventlog_mirror_lag_seconds();
+}
+
+/// Counter: mirror-expected authoritative events the comparator held back
+/// because they were inside the lag tolerance window (noetl/ai-meta#155).
+///
+/// The window's cost, published. `divergence_total == 0` under a tolerance
+/// window means "the comparable events agreed" — this number says how much was
+/// not comparable, and it is the difference between a clean verdict and a
+/// comparator that has been taught to look away.
+pub fn ehdb_crossstore_pending_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_crossstore_pending_total",
+                "Mirror-expected authoritative events held back by the cross-store parity lag \
+                 tolerance window (noetl/ai-meta#155).",
+            ),
+            &["tier"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+pub fn add_ehdb_crossstore_pending(tier: &str, n: u64) {
+    ehdb_crossstore_pending_total()
+        .with_label_values(&[tier])
+        .inc_by(n);
+}
+
 pub fn init_ehdb_crossstore_series() {
     use crate::handlers::ehdb_parity::{
         CONTROL_NAMES, DIVERGENCE_KINDS, PARITY_OUTCOMES, TIER,
@@ -3156,6 +3373,9 @@ pub fn init_ehdb_crossstore_series() {
             .with_label_values(&[TIER, kind.as_str()])
             .inc_by(0);
     }
+    ehdb_crossstore_pending_total()
+        .with_label_values(&[TIER])
+        .inc_by(0);
     ehdb_crossstore_events_compared_total()
         .with_label_values(&[TIER])
         .inc_by(0);
@@ -4142,6 +4362,42 @@ mod tests {
         );
     }
 
+    /// The async-mirror surface must reach `/metrics` before anything mirrors.
+    ///
+    /// The gauge is the load-bearing one. Without it, "the async flag is off"
+    /// and "the flag is on but the drain task never started" are the same
+    /// scrape — an idle queue at depth 0 — which is the inert-and-silent shape
+    /// this codebase has shipped three times (noetl/ai-meta#242, #266).
+    #[test]
+    fn async_mirror_series_are_pinned_into_the_rendered_output() {
+        init_ehdb_eventlog_mirror_queue_series();
+        let text = gather_text().expect("gather must succeed");
+        for expected in [
+            "noetl_ehdb_eventlog_mirror_queue_total{outcome=\"enqueued\"} 0",
+            "noetl_ehdb_eventlog_mirror_queue_total{outcome=\"queue_full_inline\"} 0",
+            "noetl_ehdb_eventlog_mirror_queue_total{outcome=\"drained\"} 0",
+            "noetl_ehdb_eventlog_mirror_queue_total{outcome=\"shutdown_abandoned\"} 0",
+            "noetl_ehdb_eventlog_mirror_pending_events 0",
+            "noetl_ehdb_eventlog_mirror_async_enabled 0",
+        ] {
+            assert!(
+                text.contains(expected),
+                "pinned async-mirror series missing from /metrics: {expected}"
+            );
+        }
+        // The lag histogram is unlabelled, so it is never pruned — but it must
+        // still be registered, and a bucket line is the proof.
+        assert!(
+            text.contains("noetl_ehdb_eventlog_mirror_lag_seconds_bucket"),
+            "the lag histogram must render; it is what the parity window is checked against"
+        );
+        assert!(
+            !text.contains("noetl_ehdb_eventlog_mirror_queue_total{outcome=\"dropped\""),
+            "positive control: an unpinned outcome must be absent — and `dropped` is not a \
+             policy this queue has (noetl/ai-meta#155)"
+        );
+    }
+
     /// The pin must reach `/metrics`, not just the counter.
     ///
     /// This asserts the property that actually matters and that a
@@ -4162,6 +4418,15 @@ mod tests {
             "noetl_ehdb_crossstore_events_compared_total{tier=\"eventlog\"} 0",
             "noetl_ehdb_crossstore_control_total{control=\"identical\",result=\"expected\"} 0",
             "noetl_ehdb_crossstore_control_total{control=\"order\",result=\"unexpected\"} 0",
+            // noetl/ai-meta#155 — the lag-tolerance surface. `pending_mirror`
+            // and the two lag controls are absent-by-default series on a
+            // deployment that never turns the window on, which is exactly the
+            // case where an operator needs to read them as 0 rather than as
+            // "this binary predates the window".
+            "noetl_ehdb_crossstore_parity_total{outcome=\"pending_mirror\",tier=\"eventlog\"} 0",
+            "noetl_ehdb_crossstore_pending_total{tier=\"eventlog\"} 0",
+            "noetl_ehdb_crossstore_control_total{control=\"lag_within_window\",result=\"expected\"} 0",
+            "noetl_ehdb_crossstore_control_total{control=\"lag_beyond_window\",result=\"unexpected\"} 0",
         ] {
             assert!(
                 text.contains(expected),

--- a/tests/mirror_queue.rs
+++ b/tests/mirror_queue.rs
@@ -1,0 +1,288 @@
+//! The async event-log mirror queue, end to end against a real HTTP relay.
+//!
+//! **[noetl/ai-meta#155](https://github.com/noetl/ai-meta/issues/155) Option 3.**
+//!
+//! The queue's whole safety claim is negative — *no event is lost, none is
+//! reordered, and a full queue pushes back instead of dropping* — and negative
+//! claims are exactly the ones a unit test on a pure function cannot make. So
+//! this drives the real `submit` → drain → `deliver` → HTTP path against a
+//! listener that records what actually arrived, and checks the bytes.
+//!
+//! # Why this is one test function
+//!
+//! The queue is a process-global (`OnceLock` + one drain task) configured from
+//! process env, and `cargo test` does **not** serialise tests within a binary.
+//! Two test functions here would race the env and the single `init()`, and the
+//! failure would be intermittent and blamed on the queue. One function, three
+//! phases, sharing one armed queue — the same shape ehdb#316's replay-count
+//! guard settled on for the same reason.
+//!
+//! # The phases
+//!
+//! 1. **Order and completeness under load** — 300 batches across 4 executions,
+//!    every record carrying its ordinal. Every record must arrive exactly once,
+//!    and per execution the ordinals must be strictly increasing.
+//! 2. **Backpressure** — the queue is deliberately tiny (8) and the relay
+//!    deliberately slow, so a burst must exceed it. `enqueued_after_wait` must
+//!    fire: the producer waited rather than the queue dropping.
+//! 3. **The inline fallback** — with the enqueue timeout cut to ~0 the third
+//!    rung is forced. `queue_full_inline` must fire **and the records must
+//!    still arrive**, because the fallback is a delivery, not a discard.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::{extract::State, routing::post, Json, Router};
+use noetl_server::handlers::ehdb_eventlog_mirror::MirrorBatch;
+use noetl_server::handlers::ehdb_eventlog_mirror_queue as queue;
+use serde_json::Value;
+
+type Received = Arc<Mutex<Vec<(i64, Vec<String>)>>>;
+
+#[derive(Clone)]
+struct Relay {
+    received: Received,
+    delay: Arc<Mutex<Duration>>,
+}
+
+async fn accept(State(relay): State<Relay>, Json(body): Json<Value>) -> &'static str {
+    let delay = *relay.delay.lock().unwrap();
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
+    let execution_id: i64 = body
+        .get("execution_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .expect("relay body must carry a stringified execution_id");
+    let records: Vec<String> = body
+        .get("records")
+        .and_then(|v| v.as_array())
+        .expect("relay body must carry records")
+        .iter()
+        .map(|r| r.as_str().unwrap_or_default().to_string())
+        .collect();
+    relay.received.lock().unwrap().push((execution_id, records));
+    "ok"
+}
+
+fn queue_counter(outcome: &str) -> u64 {
+    noetl_server::metrics::ehdb_eventlog_mirror_queue_total()
+        .with_label_values(&[outcome])
+        .get()
+}
+
+/// Wait for the queue to reach zero pending, or fail loudly.
+///
+/// Polling the gauge rather than sleeping a fixed time: a fixed sleep that is
+/// too short turns "the queue is slow" into "the queue lost an event", which is
+/// the one wrong conclusion this file exists to prevent.
+async fn settle(what: &str) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(30) {
+        if noetl_server::metrics::ehdb_eventlog_mirror_pending_events().get() <= 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!(
+        "{what}: queue never drained — {} events still pending after 30s",
+        noetl_server::metrics::ehdb_eventlog_mirror_pending_events().get()
+    );
+}
+
+fn batch(base: &str, execution_id: i64, records: Vec<String>) -> MirrorBatch {
+    MirrorBatch {
+        base: base.to_string(),
+        execution_id,
+        records,
+        enqueued_at: Instant::now(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_queue_never_loses_reorders_or_drops() {
+    let received: Received = Arc::new(Mutex::new(Vec::new()));
+    let delay = Arc::new(Mutex::new(Duration::ZERO));
+    let relay = Relay {
+        received: received.clone(),
+        delay: delay.clone(),
+    };
+    let app = Router::new()
+        .route("/ehdb/tiers/eventlog", post(accept))
+        .with_state(relay);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://{addr}");
+
+    // A deliberately tiny queue: phase 2 has to be able to fill it, and a
+    // capacity that a burst cannot exhaust would make the backpressure
+    // assertion vacuous.
+    std::env::set_var(queue::ASYNC_ENV, "true");
+    std::env::set_var(queue::CAPACITY_ENV, "8");
+    std::env::set_var(queue::ENQUEUE_TIMEOUT_ENV, "5000");
+    queue::init();
+    assert!(queue::enabled(), "the queue must arm from the flag");
+    assert_eq!(
+        noetl_server::metrics::ehdb_eventlog_mirror_async_enabled().get(),
+        1,
+        "the armed gauge must publish 1 — 'off' and 'never started' must not read alike"
+    );
+
+    // ---- phase 1: order and completeness -----------------------------------
+    const EXECUTIONS: [i64; 4] = [11, 22, 33, 44];
+    const BATCHES: usize = 300;
+    let mut sent: HashMap<i64, Vec<usize>> = HashMap::new();
+    for i in 0..BATCHES {
+        let execution_id = EXECUTIONS[i % EXECUTIONS.len()];
+        // 1..=3 records, so batches are not uniform and a merge that dropped a
+        // tail would show up as a gap rather than as a shorter list everywhere.
+        let n = (i % 3) + 1;
+        let mut records = Vec::with_capacity(n);
+        for k in 0..n {
+            let ordinal = sent.entry(execution_id).or_default().len() + k;
+            records.push(format!("{execution_id}:{ordinal}"));
+        }
+        let ordinals = sent.entry(execution_id).or_default();
+        let start = ordinals.len();
+        ordinals.extend(start..start + n);
+        queue::submit(batch(&base, execution_id, records)).await;
+    }
+    settle("phase 1").await;
+
+    let got = received.lock().unwrap().clone();
+    let mut per_execution: HashMap<i64, Vec<String>> = HashMap::new();
+    for (execution_id, records) in &got {
+        per_execution
+            .entry(*execution_id)
+            .or_default()
+            .extend(records.clone());
+    }
+    for execution_id in EXECUTIONS {
+        let want: Vec<String> = sent[&execution_id]
+            .iter()
+            .map(|o| format!("{execution_id}:{o}"))
+            .collect();
+        let have = per_execution
+            .get(&execution_id)
+            .unwrap_or_else(|| panic!("execution {execution_id} received nothing at all"));
+        assert_eq!(
+            have, &want,
+            "execution {execution_id}: the tier must receive every record exactly once, in \
+             emit order. Any difference here is a lost, duplicated or reordered authoritative \
+             event on a primary-serving tier (noetl/ai-meta#155)."
+        );
+    }
+    let total_records: usize = sent.values().map(|v| v.len()).sum();
+    assert_eq!(
+        got.iter().map(|(_, r)| r.len()).sum::<usize>(),
+        total_records,
+        "no record may be delivered twice"
+    );
+
+    // Coalescing must actually have happened — otherwise phase 1 proved the
+    // ordering of a queue that was never under any pressure, and the batch
+    // substrate (ehdb#317) still has nothing to do.
+    let multi_record_requests = got.iter().filter(|(_, r)| r.len() > 1).count();
+    assert!(
+        multi_record_requests > 0,
+        "the drain never coalesced: {} requests, all single-record. The queue is supposed to \
+         produce multi-record batches for `append_batch` — if it cannot, Option 2's substrate \
+         stays inert (noetl/ai-meta#155).",
+        got.len()
+    );
+    assert!(
+        got.len() < BATCHES,
+        "coalescing must reduce request count below the batch count; got {} requests for \
+         {BATCHES} batches",
+        got.len()
+    );
+
+    // ---- phase 2: backpressure, not drop -----------------------------------
+    *delay.lock().unwrap() = Duration::from_millis(15);
+    received.lock().unwrap().clear();
+    let waited_before = queue_counter("enqueued_after_wait");
+    let full_inline_before = queue_counter("queue_full_inline");
+    for i in 0..120 {
+        queue::submit(batch(&base, 99, vec![format!("burst:{i}")])).await;
+    }
+    settle("phase 2").await;
+    assert!(
+        queue_counter("enqueued_after_wait") > waited_before,
+        "a burst of 120 into a queue of 8 behind a 15ms relay must have made the producer \
+         WAIT. If it never waited, the queue is not bounded and the 'never drop' guarantee \
+         rests on memory growth instead of on backpressure."
+    );
+    assert_eq!(
+        queue_counter("queue_full_inline"),
+        full_inline_before,
+        "with a 5s enqueue timeout the third rung must not be reached — waiting is the \
+         correct behaviour here, and taking the inline path would risk reordering for no reason"
+    );
+    let burst: Vec<String> = received
+        .lock()
+        .unwrap()
+        .iter()
+        .flat_map(|(_, r)| r.clone())
+        .collect();
+    assert_eq!(
+        burst,
+        (0..120).map(|i| format!("burst:{i}")).collect::<Vec<_>>(),
+        "every burst record must arrive exactly once and in order"
+    );
+
+    // ---- phase 3: the inline fallback delivers ------------------------------
+    //
+    // Rung 3 is the only path that can deliver out of order, so it must at
+    // least be proven to deliver AT ALL. A fallback that silently dropped would
+    // pass every assertion above.
+    received.lock().unwrap().clear();
+    std::env::set_var(queue::ENQUEUE_TIMEOUT_ENV, "0");
+    let full_inline_before = queue_counter("queue_full_inline");
+    for i in 0..60 {
+        queue::submit(batch(&base, 77, vec![format!("inline:{i}")])).await;
+    }
+    settle("phase 3").await;
+    assert!(
+        queue_counter("queue_full_inline") > full_inline_before,
+        "a zero enqueue timeout against a full queue must reach the inline fallback"
+    );
+    let delivered: Vec<String> = received
+        .lock()
+        .unwrap()
+        .iter()
+        .flat_map(|(_, r)| r.clone())
+        .collect();
+    assert_eq!(
+        delivered.len(),
+        60,
+        "the inline fallback must DELIVER, not discard — 'never drop' is the property the \
+         whole ladder exists for (noetl/ai-meta#155). Got {} of 60.",
+        delivered.len()
+    );
+    let mut sorted = delivered.clone();
+    sorted.sort_by_key(|s| s.rsplit(':').next().unwrap().parse::<usize>().unwrap());
+    assert_eq!(
+        sorted,
+        (0..60).map(|i| format!("inline:{i}")).collect::<Vec<_>>(),
+        "every record must be present exactly once, even if the fallback reordered them"
+    );
+
+    // The lag histogram must have observations, or the parity window is being
+    // checked against nothing.
+    let text = noetl_server::metrics::gather_text().expect("gather");
+    let count_line = text
+        .lines()
+        .find(|l| l.starts_with("noetl_ehdb_eventlog_mirror_lag_seconds_count"))
+        .expect("the lag histogram must render");
+    let observed: f64 = count_line.rsplit(' ').next().unwrap().parse().unwrap();
+    assert!(
+        observed > 0.0,
+        "the lag histogram must carry observations — it is the evidence the comparator's \
+         tolerance window is respected rather than assumed"
+    );
+}


### PR DESCRIPTION
Takes the event-log mirror off the event-write hot path — **~8.4 s per Muno
planner turn** on prod, measured after the runtime cache (ehdb#316) had already
cut it from 85.6 s.

Two halves, and the second is why the first could not ship alone.

## The queue

`mirror_rows` builds a `MirrorBatch` and hands it to a bounded queue; a single
drain task delivers batches sequentially through the same `deliver` the inline
path uses. One producer, FIFO, one deliverer — **stronger** ordering than today,
where two concurrent `emit_events` calls race their two POSTs.

Backpressure is a three-rung ladder and every rung keeps the event:

1. `try_send` — room, done in microseconds.
2. `reserve()` with a timeout — the queue is full, so the emit path **waits**.
   Nothing lost, order preserved exactly.
3. inline delivery — the queue stayed full past the timeout; i.e. the
   pre-change behaviour.

**There is no drop rung.**

### `reserve()` rather than `send()` is load-bearing

`send(batch)` moves the batch into the future, so a timeout cancellation takes
the events with it. The first version did exactly that, and
`tests/mirror_queue.rs` phase 3 caught it immediately: **32 of 60 records
reached the relay**. Nothing else in this change would have — every counter
still read correctly, because the events were counted at the moment they were
lost.

That is also the honest mutation proof for the test: it has been shown to fail
on a real drop.

### Coalescing

The drain merges batches per execution in enqueue order. This is what finally
gives ehdb#317's batch append something to do — it was measured **inert** under
the synchronous mirror, because prod events arrive p50 225 ms apart and
`emit_events` hands the mirror one record per call.

### Shutdown

SIGTERM flushes the queue. Without it a rolling restart drops queued events
permanently — nothing retries a mirror — and they surface later as a
`missing_event` divergence with nothing pointing at the cause. Whatever is
still pending at the deadline is counted as `shutdown_abandoned` so it stays
attributable.

## The comparator lag window

The cross-store comparator is the event-log tier's only correctness evidence.
It had no recency bound, which was **correct** while the mirror was synchronous:
an event was in the tier before `emit_events` returned.

Async breaks that. Any execution sampled while its newest events are still
queued reports `missing_event` — a tier reporting divergence it does not have.
That is ai-meta#263 inverted, and it would make the signal the tier's `primary`
promotion rests on cry wolf continuously.

> **Scope note, checked rather than assumed.** The comparator has exactly three
> consumers — two HTTP endpoints and the background sampler — and emits metrics
> and logs only. There is **no automatic code path** from a cross-store
> divergence to `primary_serve::decide`; that reads `parity_held` from the
> worker's own per-append sequence check, which this change does not touch. So
> the damage from a false divergence is to the evidence and to the
> `EhdbCrossStoreDivergence` alert (ops#257), not an automatic demote. The
> demote-on-divergence guarantee itself is untouched.

`compare_cross_store_with_horizon` takes a **prefix cut** at the first event
newer than the window and excludes it from **both** sides — so a fast mirror
that already delivered a recent record is not scored as holding an extra.
Everything at or below the horizon is compared exactly as before: a genuinely
lost event is invisible for the window and then reports `missing_event` forever.
A latency concession, never a coverage one.

The horizon is `MIN(event_id) - 1` over the recent events, **not** `MAX` over
the old ones. The two differ when `event_id` and `created_at` order disagree,
and only the first cannot leave a still-queued event inside the compared set.

An execution wholly inside the window scores `pending_mirror`, **not** `match` —
an untaken comparison is not agreement, and `outcome_for` is split out so that
rule is assertable without a database.

### The two controls that give this teeth

`lag_within_window` and `lag_beyond_window` run on every sampler tick over **one
fixture driven twice with only the horizon changed**. A single control could
only prove half of it: a comparator taught to ignore everything passes "clean
parity under tolerance" perfectly. The pair asserts a *discrimination* — the
same absent event is forgiven inside the window and still reported outside it.

## Observability

| metric | what only it can answer |
| :-- | :-- |
| `..._mirror_lag_seconds` | is the real lag inside the window the comparator was told to allow |
| `..._mirror_pending_events` | is the queue drained or **stalled** — a stalled queue publishes no lag observations at all, so its histogram reads exactly like an idle system |
| `..._mirror_async_enabled` | is this process async, vs. "flag on but the drain never started" |
| `..._parity_lag_tolerance_seconds` | the configured window, published so the alert reads it instead of a copy |
| `..._crossstore_pending_total` | what the window cost, published rather than subtracted in silence |

Alerts + runbook: **noetl/ops#262**. Deployment spec: noetl/server.wiki.

## Fixed in passing

`the_chokepoint_mirrors_before_it_forks` — the ai-meta#263 guard — has been
**failing on `main`** since server#352 hoisted `should_publish` into a `let` for
phase timing. No `cargo test` runs in CI on any Rust repo (ai-meta#232), so a
red guard and a green one were the same observable. Re-anchored on the call
rather than on one spelling of the statement around it.

Two new guards in the same spirit: one deliverer only, and `mirror_rows` has no
unaccounted early return (counted, not named — a third return added later is
the failure to catch).

## Flags, both default off

- `NOETL_EHDB_EVENTLOG_MIRROR_ASYNC` — off, `mirror_rows` takes the inline path
  byte-identically and this is four gauges reading 0.
- `NOETL_EHDB_CROSSSTORE_PARITY_LAG_TOLERANCE_SECS` — `0` produces `None` and
  the pre-#155 comparator exactly (asserted by
  `no_horizon_is_exactly_the_old_comparator`).

⚠ `ASYNC=true` with `TOLERANCE=0` is the dangerous pairing. Documented in the
deployment spec and checked in the runbook.

## Tests

801 pass. Includes `tests/mirror_queue.rs`, which drives the real
submit → drain → deliver → HTTP path against a listener and checks the bytes:
every record exactly once and in order across 4 executions, backpressure
engaging under a burst into a queue of 8, and the inline fallback **delivering**.

Refs noetl/ai-meta#155