### PR TITLE
feat(ehdb): the projection tier gets a reader, and a read that refuses to serve a wrong snapshot

### DIFF
--- a/Dockerfile.gate
+++ b/Dockerfile.gate
@@ -1,0 +1,33 @@
+# Gate image for the ai-meta#265 phase-B1 (read-serve) kind validation.
+#
+# NOT a release Dockerfile. Two deviations from `Dockerfile`, both to keep the
+# gate image differing from a shipped one in exactly ONE file — the binary:
+#
+#  1. the runtime layer is `FROM` an image already in the node rather than
+#     `alpine` + `apk add`, so the released wasm plug-in and every runtime ENV
+#     come along unchanged. A behaviour difference in kind is then attributable
+#     to this change and not to a rebuilt base.
+#  2. no `wasmbuilder` stage — the base already carries the plug-in.
+#
+# The `cargo chef cook` layer is kept separate so a source-only change (a
+# mutation arm) rebuilds in minutes instead of redoing the dependency graph.
+ARG RUNTIME_BASE=localhost/noetl-server:265proj
+
+FROM lukemathwalker/cargo-chef:0.1.73-rust-1.91.1-alpine3.22 AS chef
+WORKDIR /app
+RUN apk update && \
+    apk add --no-cache clang lld llvm musl-dev make pkgconfig openssl-dev openssl-libs-static g++ libc-dev
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin noetl-control-plane
+
+FROM ${RUNTIME_BASE} AS runtime
+WORKDIR /app
+COPY --from=builder /app/target/release/noetl-control-plane ./noetl-control-plane

--- a/src/handlers/ehdb_projection_mirror.rs
+++ b/src/handlers/ehdb_projection_mirror.rs
@@ -121,6 +121,8 @@ pub fn mirror_payload(
     applied_count: i64,
     checksum: &str,
     snapshot: &serde_json::Value,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    routing_meta: Option<&serde_json::Value>,
 ) -> serde_json::Value {
     json!({
         // --- the comparator's identifying projection -------------------------
@@ -135,6 +137,25 @@ pub fn mirror_payload(
         "applied_count": applied_count,
         // --- the read model itself -------------------------------------------
         "snapshot": snapshot,
+        // --- what a READER needs that a comparator does not (#265 B1) --------
+        //
+        // `orch_snapshot::load_latest` returns both of these, and
+        // `handlers::events::rebuild_state` uses both. A tier record without
+        // them can be compared and cannot be served from, which is the
+        // difference #265 A4's `has_snapshot_body` was already tracking for the
+        // body itself.
+        //
+        // `updated_at` is the server's clock taken BEFORE the upsert, so it is
+        // at or before the `now()` Postgres stored. That direction is the safe
+        // one: the rebuild re-scans events with `created_at > updated_at -
+        // margin`, so an earlier timestamp WIDENS the straggler window. A later
+        // one would narrow it and could skip a straggler.
+        "updated_at": updated_at.to_rfc3339(),
+        // Carried because the `playbook_started` event predates every snapshot
+        // and is therefore never in the events-since window — a reader that
+        // lost it would lose pool-segment and trace routing for the whole
+        // execution.
+        "routing_meta": routing_meta,
         // Provenance. Without it, "the server mirror was rolled" and "something
         // else wrote this" are the same evidence after the fact.
         "mirror_source": "server",
@@ -156,12 +177,15 @@ fn relay_client() -> &'static reqwest::Client {
 /// write that did not happen.
 ///
 /// Never returns an error. See the module note on failure posture.
+#[allow(clippy::too_many_arguments)]
 pub async fn mirror_snapshot(
     execution_id: i64,
     version: i64,
     applied_count: i64,
     checksum: &str,
     snapshot: &serde_json::Value,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    routing_meta: Option<&serde_json::Value>,
 ) {
     if !server_mirrors() {
         return;
@@ -189,7 +213,15 @@ pub async fn mirror_snapshot(
     // append does: writing where the comparator reads is then true by
     // construction rather than by two env vars agreeing.
     let url = format!("{}/ehdb/tiers/{TIER}", base.trim_end_matches('/'));
-    let record = mirror_payload(execution_id, version, applied_count, checksum, snapshot);
+    let record = mirror_payload(
+        execution_id,
+        version,
+        applied_count,
+        checksum,
+        snapshot,
+        updated_at,
+        routing_meta,
+    );
     let body = json!({
         "execution_id": execution_id.to_string(),
         "records": [record.to_string()],
@@ -265,7 +297,9 @@ mod tests {
         // over the wire rather than on the code that builds it. A record missing
         // `version` would be reported as a divergence on every healthy
         // execution, which is how a comparator teaches an operator to ignore it.
-        let p = mirror_payload(7, 991, 12, "abc123", &snap());
+        let when = chrono::Utc::now();
+        let routing = json!({"pool": "user"});
+        let p = mirror_payload(7, 991, 12, "abc123", &snap(), when, Some(&routing));
         assert_eq!(p["execution_id"], 7);
         assert_eq!(p["version"], 991);
         assert_eq!(p["checksum"], "abc123");
@@ -274,6 +308,11 @@ mod tests {
         assert_eq!(p["snapshot"], snap());
         assert_eq!(p["mirror_source"], "server");
         assert_eq!(p["aggregate_type"], "orchestrator_workflow_state");
+        // ...and what a READER needs on top of what a comparator needs (#265 B1).
+        // Without these two a record is comparable and unservable, and the
+        // difference is invisible until a read-serve arm demotes 100% of reads.
+        assert_eq!(p["updated_at"], when.to_rfc3339());
+        assert_eq!(p["routing_meta"], routing);
     }
 
     #[test]
@@ -282,7 +321,15 @@ mod tests {
         // the incumbent's, byte for byte. If a later edit recomputed it here,
         // the two sides would be derived by two code paths free to disagree —
         // and the comparator would then be checking this module against itself.
-        let p = mirror_payload(7, 1, 1, "not-a-real-sha-but-must-survive", &snap());
+        let p = mirror_payload(
+            7,
+            1,
+            1,
+            "not-a-real-sha-but-must-survive",
+            &snap(),
+            chrono::Utc::now(),
+            None,
+        );
         assert_eq!(p["checksum"], "not-a-real-sha-but-must-survive");
     }
 
@@ -320,9 +367,20 @@ mod tests {
     /// **Counting, not naming.** A test that listed the writers it already knew
     /// about is exactly the test that would have passed through #263. A second
     /// `INSERT` added anywhere in the service fails this instead.
+    /// Scans the **code half** of `orch_snapshot.rs`, excluding its test
+    /// module. That exclusion is not cosmetic: #265 B1 added a read-side guard
+    /// there whose own positive control asserts the real `INSERT` survives its
+    /// comment stripper — and that literal, sitting in the test module, made
+    /// this guard count two writers. One guard's positive control was another
+    /// guard's false positive, which is the fourth sighting of a source-counting
+    /// check counting text about code instead of code.
     #[test]
     fn the_snapshot_store_has_exactly_one_writer() {
-        let src = code_only(include_str!("../services/orch_snapshot.rs"));
+        let whole = include_str!("../services/orch_snapshot.rs");
+        let code_half = &whole[..whole
+            .find("mod tests {")
+            .expect("orch_snapshot.rs must still end with its test module")];
+        let src = code_only(code_half);
         // Positive control on the stripper: it must not have eaten the real
         // statement. Without this, a stripper bug would report 0 writers and the
         // assertion below would be satisfied by finding nothing.

--- a/src/handlers/ehdb_projection_read.rs
+++ b/src/handlers/ehdb_projection_read.rs
@@ -1,0 +1,767 @@
+//! Read-serve for the EHDB projection tier (noetl/ai-meta#265 phase B1).
+//!
+//! Phase A gave the projection tier a store, a mirror of the incumbent's real
+//! rows, and a comparator. What it did **not** give it was a reader: every
+//! orchestrator rebuild still resolved its snapshot from
+//! `noetl.projection_snapshot`, so `NOETL_EHDB_PROJECTION=primary` meant "the
+//! write path claims authority" and nothing more. This module is the reader.
+//!
+//! # The invariant this module exists to hold
+//!
+//! **A snapshot that might be wrong must not be served.**
+//!
+//! `handlers::events::rebuild_state` takes the snapshot's `version` and folds
+//! only the events *after* it. That makes the failure asymmetric in a way worth
+//! stating plainly:
+//!
+//! * A snapshot **behind** the incumbent is slow but correct — more events get
+//!   folded forward, and the answer is the same.
+//! * A snapshot **ahead** of what actually happened is silently *wrong*: the
+//!   events between the real watermark and the claimed one are never folded,
+//!   and the caller receives a state that never existed. Nothing downstream can
+//!   detect it, because a rebuild has no second opinion to compare against.
+//!
+//! So the read path refuses in both directions but for different reasons, and
+//! every refusal is a **demote to the incumbent**, never an error and never a
+//! degraded answer. Postgres is always reachable from here; falling back costs
+//! a query, and the alternative costs correctness.
+//!
+//! # Modes
+//!
+//! `NOETL_EHDB_PROJECTION_READ_SOURCE`, default **`postgres`**:
+//!
+//! | value | behaviour |
+//! | :-- | :-- |
+//! | `postgres` (default, and any unrecognised value) | exactly the pre-#265 read. No tier I/O at all — not a relay call, not an env lookup beyond this one. |
+//! | `verify` | read **both**, compare, serve the tier only when it agrees with the incumbent on version *and* checksum. The proving mode: it cannot serve a wrong answer even if every check below were broken, because the incumbent is already in hand. |
+//! | `tier` | serve from the tier, reading the incumbent **only** when the tier is refused. The cutover mode: this is the one that removes the Postgres read from the hot path, and therefore the one that needs the checks to be real. |
+//!
+//! An unrecognised value resolves to `postgres` rather than erroring. A typo in
+//! a deployment variable must not take reads off the incumbent — and it must not
+//! take the process down either. It is logged once at resolve time; #243 is the
+//! record of what a dead default costs when it launders three distinct causes
+//! into one message.
+//!
+//! # What `tier` mode checks, and why each check is cheap
+//!
+//! Without the incumbent row in hand, three things are still checkable:
+//!
+//! 1. **Self-consistency.** The record carries `checksum` = `sha256(snapshot)`,
+//!    computed by `orch_snapshot::save` for the row it stored. Recomputing it
+//!    over the record's own `snapshot` body costs one hash and catches a record
+//!    that was corrupted or truncated in transit. This is the same digest the
+//!    comparator uses, so the two agree by construction rather than by two
+//!    implementations happening to match.
+//! 2. **Version sanity.** `SELECT MAX(event_id) FROM noetl.event WHERE
+//!    execution_id = $1` — one indexed scan, no payloads. A tier version above
+//!    that maximum claims to have folded an event that does not exist, which is
+//!    exactly the ahead-case above. This costs a query and is kept anyway: the
+//!    whole point of `tier` mode is to drop a *blob* read, and a bounded index
+//!    probe is not that blob.
+//! 3. **Deserialisability.** A `WorkflowState` that does not parse (a shape
+//!    change across a deploy) demotes rather than erroring — the same posture
+//!    `load_latest` already took for the incumbent row.
+//!
+//! `verify` mode does all three **and** compares against the incumbent, so it
+//! is strictly stronger and strictly slower. That is the intended order of
+//! adoption: `verify` in shadow, `tier` only after a soak.
+//!
+//! # What this module deliberately does not do
+//!
+//! It does not write. It does not fall back to a pod-local store — the
+//! projection tier has none by design (#265 A2), and inventing one here would
+//! recreate the N-disjoint-fragments defect #257 §1.3 describes.
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tracing::warn;
+
+use crate::db::DbPool;
+
+/// The tier this module reads. Named once so a copy cannot drift from the
+/// mirror's and the comparator's.
+pub const TIER: &str = "projection";
+
+/// `NOETL_EHDB_PROJECTION_READ_SOURCE` — where an orchestrator rebuild resolves
+/// its snapshot from.
+pub const READ_SOURCE_ENV: &str = "NOETL_EHDB_PROJECTION_READ_SOURCE";
+
+/// How long the relay read may take before the tier is treated as unavailable.
+///
+/// Shorter than the mirror's append timeout on purpose: this sits in front of a
+/// rebuild that has a perfectly good incumbent one query away, so waiting is
+/// strictly worse than demoting.
+const RELAY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Cap on tier records pulled for one execution. The mirror appends one record
+/// per snapshot upsert, so a long-lived execution accumulates them; only the
+/// newest is served from.
+const MAX_READ_RECORDS: usize = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadSource {
+    Postgres,
+    Verify,
+    Tier,
+}
+
+impl ReadSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Postgres => "postgres",
+            Self::Verify => "verify",
+            Self::Tier => "tier",
+        }
+    }
+    /// Whether this mode touches the tier at all.
+    pub fn reads_tier(self) -> bool {
+        !matches!(self, Self::Postgres)
+    }
+    /// Whether this mode needs the incumbent row loaded *before* deciding.
+    pub fn needs_incumbent_first(self) -> bool {
+        matches!(self, Self::Postgres | Self::Verify)
+    }
+}
+
+/// Resolve the configured read source.
+///
+/// Unrecognised ⇒ `Postgres`, warned once. See the module note on #243.
+pub fn read_source() -> ReadSource {
+    let raw = std::env::var(READ_SOURCE_ENV).ok();
+    match raw
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        None | Some("") | Some("postgres") => ReadSource::Postgres,
+        Some("verify") => ReadSource::Verify,
+        Some("tier") => ReadSource::Tier,
+        Some(other) => {
+            warn_unrecognised(other);
+            ReadSource::Postgres
+        }
+    }
+}
+
+/// Warn at most once per distinct bad value.
+///
+/// Once, because this is on a per-rebuild path and a typo would otherwise
+/// produce one line per trigger; per distinct value, because a second typo
+/// after a first is a different fact and must not be swallowed by the first
+/// one's latch.
+fn warn_unrecognised(value: &str) {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static SEEN: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut g = seen.lock().unwrap_or_else(|e| e.into_inner());
+    if g.insert(value.to_string()) {
+        warn!(
+            target: "noetl_server::ehdb_projection_read",
+            value = %value,
+            "{READ_SOURCE_ENV} is not one of postgres|verify|tier; reads stay on \
+             noetl.projection_snapshot"
+        );
+    }
+}
+
+/// Why a read did not come from the tier.
+///
+/// Distinct variants because they call for different responses, and because a
+/// single `demoted` label would make the one case that means "the tier is
+/// dangerous" (`version_ahead`) indistinguishable from the one that means
+/// "nothing has been mirrored yet" (`missing`) — which on a freshly armed
+/// mirror is every execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DemoteReason {
+    /// `NOETL_EHDB_WORKER_QUERY_URL` unset: asked to read the tier with nowhere
+    /// to read from.
+    Unconfigured,
+    /// The relay call failed or timed out.
+    Unavailable,
+    /// The relay answered, but not with a record set (a typed refusal, or a
+    /// body that does not parse). Distinct from `Missing`: "the tier declined
+    /// to answer" is not "the tier holds nothing".
+    Unreadable,
+    /// The tier holds no identifiable record for this execution. On a mirror
+    /// armed after the execution started, this is the expected answer and not a
+    /// fault — see the coverage note in the gap analysis.
+    Missing,
+    /// The record's own `checksum` does not match `sha256` of the `snapshot`
+    /// body it carries.
+    Checksum,
+    /// The record carries no `snapshot` body — a digest, which can be verified
+    /// and cannot be served from.
+    NoBody,
+    /// The tier's version exceeds the highest `event_id` the execution has.
+    /// **The dangerous case**: serving it would skip events.
+    VersionAhead,
+    /// `verify` mode only: the tier is behind the incumbent.
+    StaleVersion,
+    /// `verify` mode only: same version, different checksum.
+    Divergent,
+    /// The snapshot body does not deserialise into a `WorkflowState`.
+    Undeserialisable,
+    /// `verify` mode only: the incumbent has no row for this execution, so
+    /// there is nothing to compare the tier against.
+    ///
+    /// Its own label rather than folded into `missing`, because the two name
+    /// opposite stores: `missing` is an empty tier beside a populated
+    /// incumbent — the state of a freshly armed mirror — while this is an
+    /// execution neither store has snapshotted yet, which is the *normal* state
+    /// of every short execution (see the coverage denominator). One label for
+    /// both would launder two causes into one number, which is the defect
+    /// ai-meta#243 is the record of.
+    NoIncumbent,
+}
+
+impl DemoteReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unconfigured => "unconfigured",
+            Self::Unavailable => "unavailable",
+            Self::Unreadable => "unreadable",
+            Self::Missing => "missing",
+            Self::Checksum => "checksum",
+            Self::NoBody => "no_body",
+            Self::VersionAhead => "version_ahead",
+            Self::StaleVersion => "stale_version",
+            Self::Divergent => "divergent",
+            Self::Undeserialisable => "undeserialisable",
+            Self::NoIncumbent => "no_incumbent",
+        }
+    }
+    /// Whether this demote means something is *wrong*, as opposed to something
+    /// being absent or switched off.
+    ///
+    /// `missing` and `unconfigured` are the states of a tier that has not been
+    /// armed yet; alerting on them would page on every rollout. The rest mean
+    /// the tier answered and the answer could not be trusted.
+    pub fn is_fault(self) -> bool {
+        !matches!(
+            self,
+            Self::Missing | Self::Unconfigured | Self::NoIncumbent
+        )
+    }
+}
+
+/// Every outcome label the read path can emit. Closed set, pinned at 0.
+///
+/// `served_tier` plus one label per [`DemoteReason`], plus `disabled`. Pinned
+/// as a set so an absent series means "this binary predates the metric" rather
+/// than "this case has not happened" — `Registry::gather` prunes empty families,
+/// so absence is the default state of every labelled metric here.
+pub const READ_OUTCOMES: [&str; 13] = [
+    "served_tier",
+    "disabled",
+    "unconfigured",
+    "unavailable",
+    "unreadable",
+    "missing",
+    "checksum",
+    "no_body",
+    "version_ahead",
+    "stale_version",
+    "divergent",
+    "undeserialisable",
+    "no_incumbent",
+];
+
+/// The identifying facts of the incumbent row, for `verify` mode.
+///
+/// Deliberately not the whole `LoadedSnapshot`: comparison needs the watermark
+/// and the digest, and passing the state as well would invite comparing two
+/// deserialised structures rather than the one digest the writer authored.
+#[derive(Debug, Clone)]
+pub struct IncumbentFacts {
+    pub version: i64,
+    pub checksum: Option<String>,
+}
+
+/// What the tier read produced.
+pub enum TierRead {
+    /// The tier answered, and the answer passed every check that applies.
+    Served(ServedSnapshot),
+    /// Use the incumbent. Carries why.
+    Demote(DemoteReason),
+}
+
+/// A snapshot resolved from the tier, in the shape `load_latest` returns.
+pub struct ServedSnapshot {
+    pub snapshot: Value,
+    pub version: i64,
+    pub applied_count: i64,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub routing_meta: Option<Value>,
+}
+
+/// One tier record, reduced to what the read path needs.
+#[derive(Debug, Clone)]
+struct Candidate {
+    global_sequence: u64,
+    version: i64,
+    checksum: Option<String>,
+    applied_count: i64,
+    snapshot: Option<Value>,
+    updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    routing_meta: Option<Value>,
+}
+
+/// Pick the record to serve from, and check it.
+///
+/// **Pure** — no I/O, no env, no clock. That is what lets the tests below drive
+/// the same function the live path uses, with inputs whose answers are known.
+/// The event-log tier's serve decision earned that property in #257 and it is
+/// the reason a mutation arm can prove this fires.
+///
+/// `max_event_id` is the execution's highest event id, or `None` when the
+/// caller could not determine it — in which case the ahead-check is **skipped
+/// and the read is demoted**, because an unchecked ahead-case is precisely the
+/// silent wrong answer this module exists to prevent. Not knowing is not the
+/// same as being satisfied.
+fn decide(
+    records: &[Candidate],
+    max_event_id: Option<i64>,
+    incumbent: Option<&IncumbentFacts>,
+) -> Result<Candidate, DemoteReason> {
+    if records.is_empty() {
+        return Err(DemoteReason::Missing);
+    }
+    // Newest by (version, sequence): the mirror appends per upsert, so the tail
+    // is the current read model and the earlier records are its history.
+    let newest = records
+        .iter()
+        .max_by_key(|c| (c.version, c.global_sequence))
+        .expect("records is non-empty");
+
+    let Some(body) = newest.snapshot.as_ref() else {
+        return Err(DemoteReason::NoBody);
+    };
+
+    // Self-consistency, before anything that costs I/O to have gathered.
+    match newest.checksum.as_deref() {
+        None => return Err(DemoteReason::Checksum),
+        Some(carried) => {
+            let recomputed = sha256_of(body);
+            if recomputed != carried {
+                return Err(DemoteReason::Checksum);
+            }
+        }
+    }
+
+    // The ahead-case. Checked against the event log rather than the incumbent
+    // snapshot so it also holds in `tier` mode, where no incumbent row is read.
+    match max_event_id {
+        None => return Err(DemoteReason::VersionAhead),
+        Some(max) if newest.version > max => return Err(DemoteReason::VersionAhead),
+        Some(_) => {}
+    }
+
+    // `verify` mode: the incumbent is in hand, so compare against it too.
+    if let Some(inc) = incumbent {
+        if newest.version < inc.version {
+            return Err(DemoteReason::StaleVersion);
+        }
+        if newest.version > inc.version {
+            // Above the incumbent but at or below the event log's tip. The tier
+            // mirrored a save the incumbent row no longer reflects, which means
+            // the two stores disagree about what the current read model IS.
+            return Err(DemoteReason::Divergent);
+        }
+        if let Some(want) = inc.checksum.as_deref() {
+            if newest.checksum.as_deref() != Some(want) {
+                return Err(DemoteReason::Divergent);
+            }
+        }
+    }
+
+    Ok(newest.clone())
+}
+
+/// `sha256` over the same bytes `orch_snapshot::save` digests.
+///
+/// Must stay byte-identical to the writer's: `serde_json::to_vec` of the
+/// snapshot value. A different serialisation here would make every record fail
+/// its own checksum and demote 100% of reads — which would look like a broken
+/// tier rather than a broken comparison.
+fn sha256_of(snapshot: &Value) -> String {
+    let bytes = serde_json::to_vec(snapshot).unwrap_or_default();
+    hex::encode(Sha256::digest(&bytes))
+}
+
+fn parse_candidates(body: &Value) -> Result<Vec<Candidate>, DemoteReason> {
+    // A typed refusal carries `outcome` != "ok". Scoring an empty `records`
+    // array from such a body as "the tier holds nothing" is the fail-loud
+    // violation the comparator was written against, and it would be worse here:
+    // there it produces a wrong verdict, here it would produce `missing` on a
+    // tier that is actually broken.
+    if let Some(outcome) = body.get("outcome").and_then(|o| o.as_str()) {
+        if outcome != "ok" {
+            return Err(DemoteReason::Unreadable);
+        }
+    }
+    let Some(arr) = body.get("records").and_then(|r| r.as_array()) else {
+        return Err(DemoteReason::Unreadable);
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for r in arr {
+        let global_sequence = r.get("global_sequence").and_then(|s| s.as_u64()).unwrap_or(0);
+        let payload = match r.get("payload").and_then(|p| p.as_str()) {
+            Some(s) => match serde_json::from_str::<Value>(s) {
+                Ok(v) => v,
+                Err(_) => continue,
+            },
+            None => r.clone(),
+        };
+        let Some(version) = payload.get("version").and_then(read_i64) else {
+            continue;
+        };
+        out.push(Candidate {
+            global_sequence,
+            version,
+            checksum: payload
+                .get("checksum")
+                .and_then(|c| c.as_str())
+                .map(str::to_string),
+            applied_count: payload
+                .get("applied_count")
+                .and_then(read_i64)
+                .unwrap_or(0),
+            snapshot: payload
+                .get("snapshot")
+                .filter(|s| !s.is_null())
+                .cloned(),
+            updated_at: payload
+                .get("updated_at")
+                .and_then(|t| t.as_str())
+                .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+                .map(|t| t.with_timezone(&chrono::Utc)),
+            routing_meta: payload
+                .get("routing_meta")
+                .filter(|v| !v.is_null())
+                .cloned(),
+        });
+    }
+    Ok(out)
+}
+
+fn read_i64(v: &Value) -> Option<i64> {
+    v.as_i64()
+        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+}
+
+fn relay_client() -> &'static reqwest::Client {
+    static C: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    C.get_or_init(reqwest::Client::new)
+}
+
+/// The execution's highest `event_id`, used for the ahead-check.
+///
+/// Bounded index probe, no payloads. `None` on error — and `decide` treats
+/// `None` as a demote, so a database hiccup produces a slower correct read
+/// rather than an unchecked one.
+async fn max_event_id(pool: &DbPool, execution_id: i64) -> Option<i64> {
+    sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT MAX(event_id) FROM noetl.event WHERE execution_id = $1",
+    )
+    .bind(execution_id)
+    .fetch_one(pool)
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Try to resolve one execution's snapshot from the projection tier.
+///
+/// Never returns an error: every failure is a [`DemoteReason`], because the
+/// caller always has the incumbent available and a read path that can fail is
+/// strictly worse than one that can only be slower.
+pub async fn read(
+    pool: &DbPool,
+    execution_id: i64,
+    incumbent: Option<&IncumbentFacts>,
+) -> TierRead {
+    let Some(base) = std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        return TierRead::Demote(DemoteReason::Unconfigured);
+    };
+
+    let url = format!(
+        "{}/ehdb/tiers/{TIER}?execution={execution_id}&limit={MAX_READ_RECORDS}",
+        base.trim_end_matches('/')
+    );
+    let body: Value = match relay_client().get(&url).timeout(RELAY_TIMEOUT).send().await {
+        Err(_) => return TierRead::Demote(DemoteReason::Unavailable),
+        Ok(r) => match r.json().await {
+            Ok(v) => v,
+            Err(_) => return TierRead::Demote(DemoteReason::Unreadable),
+        },
+    };
+
+    let candidates = match parse_candidates(&body) {
+        Ok(c) => c,
+        Err(reason) => return TierRead::Demote(reason),
+    };
+
+    // Only probe the event log when there is something to check. An empty tier
+    // demotes on `missing` without touching the database.
+    let max = if candidates.is_empty() {
+        None
+    } else {
+        max_event_id(pool, execution_id).await
+    };
+
+    let chosen = match decide(&candidates, max, incumbent) {
+        Ok(c) => c,
+        Err(reason) => return TierRead::Demote(reason),
+    };
+
+    let snapshot = chosen.snapshot.expect("decide rejects a record with no body");
+    TierRead::Served(ServedSnapshot {
+        snapshot,
+        version: chosen.version,
+        applied_count: chosen.applied_count,
+        // Missing `updated_at` means a record mirrored before the field was
+        // carried. `now()` is the conservative choice: the straggler re-scan
+        // window is `updated_at - margin`, so a *newer* timestamp narrows the
+        // window and could skip a straggler. Demote instead of guessing.
+        updated_at: match chosen.updated_at {
+            Some(t) => t,
+            None => return TierRead::Demote(DemoteReason::Unreadable),
+        },
+        routing_meta: chosen.routing_meta,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(n: i64) -> Value {
+        serde_json::json!({"step": n, "vars": {"a": n}})
+    }
+
+    fn candidate(version: i64, seq: u64, body: Option<Value>, checksum: Option<String>) -> Candidate {
+        let b = body.clone();
+        Candidate {
+            global_sequence: seq,
+            version,
+            checksum: checksum.or_else(|| b.as_ref().map(sha256_of)),
+            applied_count: version,
+            snapshot: body,
+            updated_at: Some(chrono::Utc::now()),
+            routing_meta: None,
+        }
+    }
+
+    /// The default must be the pre-#265 behaviour, with no tier I/O.
+    ///
+    /// Asserted on the *type*, not on a comment: `reads_tier()` is what the
+    /// caller branches on, so a future mode that accidentally reads the tier by
+    /// default fails here rather than in production.
+    #[test]
+    fn the_default_read_source_does_not_touch_the_tier() {
+        assert_eq!(ReadSource::Postgres.as_str(), "postgres");
+        assert!(!ReadSource::Postgres.reads_tier());
+        assert!(ReadSource::Verify.reads_tier());
+        assert!(ReadSource::Tier.reads_tier());
+    }
+
+    /// A healthy record at or below the event tip is served.
+    #[test]
+    fn a_consistent_record_is_served() {
+        let c = candidate(10, 1, Some(snap(10)), None);
+        let got = decide(&[c], Some(10), None).expect("must serve");
+        assert_eq!(got.version, 10);
+    }
+
+    /// **The dangerous case.** A version above the event log's tip claims to
+    /// have folded an event that does not exist; serving it would skip every
+    /// event in between and produce a state that never existed.
+    #[test]
+    fn a_version_above_the_event_tip_demotes() {
+        let c = candidate(99, 1, Some(snap(99)), None);
+        assert_eq!(
+            decide(&[c], Some(10), None).unwrap_err(),
+            DemoteReason::VersionAhead
+        );
+    }
+
+    /// Not knowing the tip is not the same as being satisfied by it.
+    #[test]
+    fn an_unknown_event_tip_demotes_rather_than_skipping_the_check() {
+        let c = candidate(10, 1, Some(snap(10)), None);
+        assert_eq!(
+            decide(&[c], None, None).unwrap_err(),
+            DemoteReason::VersionAhead
+        );
+    }
+
+    /// A record whose carried digest does not describe its own body.
+    ///
+    /// The mutation the kind gate performs, in unit form: same version, same
+    /// shape, different content. A count- or version-based check passes this.
+    #[test]
+    fn a_body_that_does_not_match_its_checksum_demotes() {
+        let mut c = candidate(10, 1, Some(snap(10)), None);
+        c.snapshot = Some(snap(11)); // body swapped, digest left describing snap(10)
+        assert_eq!(
+            decide(&[c], Some(10), None).unwrap_err(),
+            DemoteReason::Checksum
+        );
+    }
+
+    /// A digest with no body can be verified and cannot be served from.
+    #[test]
+    fn a_record_with_no_snapshot_body_demotes() {
+        let c = candidate(10, 1, None, Some("deadbeef".to_string()));
+        assert_eq!(
+            decide(&[c], Some(10), None).unwrap_err(),
+            DemoteReason::NoBody
+        );
+    }
+
+    /// An empty tier is `missing`, not `unreadable` — a freshly armed mirror
+    /// answers this for every execution that predates it.
+    #[test]
+    fn an_empty_tier_is_missing_not_a_fault() {
+        assert_eq!(decide(&[], Some(10), None).unwrap_err(), DemoteReason::Missing);
+        assert!(!DemoteReason::Missing.is_fault());
+        assert!(!DemoteReason::Unconfigured.is_fault());
+        assert!(!DemoteReason::NoIncumbent.is_fault());
+        assert!(DemoteReason::VersionAhead.is_fault());
+        assert!(DemoteReason::Checksum.is_fault());
+    }
+
+    /// `verify` mode: behind the incumbent demotes, and says *behind* rather
+    /// than a generic disagreement.
+    #[test]
+    fn verify_mode_demotes_a_tier_that_is_behind() {
+        let c = candidate(8, 1, Some(snap(8)), None);
+        let inc = IncumbentFacts {
+            version: 10,
+            checksum: None,
+        };
+        assert_eq!(
+            decide(&[c], Some(10), Some(&inc)).unwrap_err(),
+            DemoteReason::StaleVersion
+        );
+    }
+
+    /// `verify` mode: same version, different digest.
+    #[test]
+    fn verify_mode_demotes_on_a_digest_disagreement() {
+        let c = candidate(10, 1, Some(snap(10)), None);
+        let inc = IncumbentFacts {
+            version: 10,
+            checksum: Some("0000000000000000000000000000000000000000000000000000000000000000".into()),
+        };
+        assert_eq!(
+            decide(&[c], Some(10), Some(&inc)).unwrap_err(),
+            DemoteReason::Divergent
+        );
+    }
+
+    /// `verify` mode with everything agreeing serves — the positive control
+    /// without which every assertion above could be satisfied by a `decide`
+    /// that demotes unconditionally.
+    #[test]
+    fn verify_mode_serves_when_both_stores_agree() {
+        let body = snap(10);
+        let c = candidate(10, 1, Some(body.clone()), None);
+        let inc = IncumbentFacts {
+            version: 10,
+            checksum: Some(sha256_of(&body)),
+        };
+        assert!(decide(&[c], Some(10), Some(&inc)).is_ok());
+    }
+
+    /// The newest record wins, and "newest" is by version then sequence — not
+    /// by array position, which is the order the relay happened to return.
+    #[test]
+    fn the_newest_record_is_the_one_served() {
+        let recs = vec![
+            candidate(10, 3, Some(snap(10)), None),
+            candidate(4, 1, Some(snap(4)), None),
+            candidate(7, 2, Some(snap(7)), None),
+        ];
+        assert_eq!(decide(&recs, Some(10), None).unwrap().version, 10);
+        // …and reversing the input does not change the answer.
+        let mut rev = recs.clone();
+        rev.reverse();
+        assert_eq!(decide(&rev, Some(10), None).unwrap().version, 10);
+    }
+
+    /// A typed refusal is `unreadable`, never `missing`.
+    ///
+    /// The distinction that matters operationally: `missing` is a tier that has
+    /// nothing yet, `unreadable` is a tier that declined to answer. Collapsing
+    /// them would report a broken relay as an unarmed mirror.
+    #[test]
+    fn a_typed_refusal_is_not_read_as_an_empty_tier() {
+        let body = serde_json::json!({"outcome": "unavailable", "records": []});
+        assert_eq!(parse_candidates(&body).unwrap_err(), DemoteReason::Unreadable);
+        let missing_field = serde_json::json!({"outcome": "ok"});
+        assert_eq!(
+            parse_candidates(&missing_field).unwrap_err(),
+            DemoteReason::Unreadable
+        );
+        // Positive control: a well-formed empty answer IS an empty tier.
+        let empty = serde_json::json!({"outcome": "ok", "records": []});
+        assert!(parse_candidates(&empty).unwrap().is_empty());
+    }
+
+    /// The read path's digest must be the writer's digest.
+    ///
+    /// If these two serialisations ever diverge, every record fails its own
+    /// checksum and 100% of reads demote — which reads like a broken tier
+    /// rather than a broken comparison, and would be diagnosed in the wrong
+    /// place. This pins them to the same bytes.
+    #[test]
+    fn the_read_digest_matches_the_writer_digest() {
+        let body = snap(42);
+        let writer = {
+            let bytes = serde_json::to_vec(&body).unwrap_or_default();
+            hex::encode(Sha256::digest(&bytes))
+        };
+        assert_eq!(sha256_of(&body), writer);
+    }
+
+    /// Every [`DemoteReason`] has a label in [`READ_OUTCOMES`], and every label
+    /// but `served_tier`/`disabled` has a reason.
+    ///
+    /// Pinning a set that omits one value reintroduces the absent-series bug on
+    /// exactly that value, while the rest read 0 and look complete
+    /// (`representation-drift.md`).
+    #[test]
+    fn every_demote_reason_is_a_pinned_label() {
+        let reasons = [
+            DemoteReason::Unconfigured,
+            DemoteReason::Unavailable,
+            DemoteReason::Unreadable,
+            DemoteReason::Missing,
+            DemoteReason::Checksum,
+            DemoteReason::NoBody,
+            DemoteReason::VersionAhead,
+            DemoteReason::StaleVersion,
+            DemoteReason::Divergent,
+            DemoteReason::Undeserialisable,
+            DemoteReason::NoIncumbent,
+        ];
+        for r in reasons {
+            assert!(
+                READ_OUTCOMES.contains(&r.as_str()),
+                "{} is not pinned; its series would be absent until it fires",
+                r.as_str()
+            );
+        }
+        assert_eq!(
+            READ_OUTCOMES.len(),
+            reasons.len() + 2,
+            "READ_OUTCOMES must be exactly the reasons plus served_tier and disabled"
+        );
+    }
+}

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -3175,17 +3175,15 @@ async fn trigger_orchestrator_inner(
     //
     // The reasons are recorded in the order they are evaluated, and only one
     // fires per pass, so the labels sum to the number of passes.
-    let gate_outcome = if state.config.projector_owns_snapshot {
-        Some("skipped_projector_owns")
-    } else if total != Some(cache.applied_count) {
-        Some("skipped_unsettled")
-    } else if cache.last_event_id - cache.snapshot_version < SNAPSHOT_INTERVAL_EVENTS {
-        Some("skipped_interval")
-    } else if cache.state.is_none() {
-        Some("skipped_no_state")
-    } else {
-        None
-    };
+    let gate_outcome = snapshot_gate_outcome(
+        state.config.projector_owns_snapshot,
+        total,
+        cache.applied_count,
+        cache.last_event_id,
+        cache.snapshot_version,
+        SNAPSHOT_INTERVAL_EVENTS,
+        cache.state.is_some(),
+    );
     if let Some(outcome) = gate_outcome {
         crate::metrics::record_ehdb_projection_snapshot_gate(outcome);
     } else {
@@ -4944,5 +4942,120 @@ mod tests {
         assert!(decode_orchestrate_error(Some("not base64!!!")).is_none());
         let empty_err = base64::engine::general_purpose::STANDARD.encode(b"{\"error\":\"\"}");
         assert!(decode_orchestrate_error(Some(&empty_err)).is_none());
+    }
+}
+
+/// The orchestrator's snapshot-write gate, as a pure function
+/// (noetl/ai-meta#265 G4).
+///
+/// Extracted from `trigger_orchestrator_inner` so the coverage labels can be
+/// TESTED. The end-to-end path is not reachable in the kind gate — that cluster
+/// carries a large command backlog and its executions do not arrive here — and a
+/// counter that has never once fired is indistinguishable from a counter that
+/// cannot fire. Pinning the series at 0 proves it exists; these tests prove it
+/// would carry the right label.
+///
+/// `None` means the gate OPENS and a snapshot is written. Exactly one reason
+/// fires per pass, in evaluation order, so the labels sum to the number of
+/// passes and the ratio `written / total` is the tier's coverage denominator.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn snapshot_gate_outcome(
+    projector_owns_snapshot: bool,
+    total: Option<i64>,
+    applied_count: i64,
+    last_event_id: i64,
+    snapshot_version: i64,
+    interval: i64,
+    has_state: bool,
+) -> Option<&'static str> {
+    if projector_owns_snapshot {
+        Some("skipped_projector_owns")
+    } else if total != Some(applied_count) {
+        Some("skipped_unsettled")
+    } else if last_event_id - snapshot_version < interval {
+        Some("skipped_interval")
+    } else if !has_state {
+        Some("skipped_no_state")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod snapshot_gate_tests {
+    use super::snapshot_gate_outcome;
+
+    /// The gate opens only when everything lines up.
+    ///
+    /// The positive control: without it every assertion below is satisfied by a
+    /// function that never opens, which would make the coverage denominator
+    /// read 0% forever and look like a finding about the platform.
+    #[test]
+    fn the_gate_opens_when_settled_and_past_the_interval() {
+        assert_eq!(
+            snapshot_gate_outcome(false, Some(10), 10, 1_000, 0, 500, true),
+            None
+        );
+    }
+
+    /// THE FINDING THIS COUNTER EXISTS FOR. A short execution never has its
+    /// throttled consistency COUNT land in the same pass, so `total` and
+    /// `applied_count` do not coincide and no snapshot is ever written — which
+    /// is why "0 divergences" over such a population means nothing.
+    #[test]
+    fn an_unsettled_pass_is_the_dominant_skip_on_short_executions() {
+        assert_eq!(
+            snapshot_gate_outcome(false, None, 13, 1_000, 0, 500, true),
+            Some("skipped_unsettled")
+        );
+        assert_eq!(
+            snapshot_gate_outcome(false, Some(12), 13, 1_000, 0, 500, true),
+            Some("skipped_unsettled")
+        );
+    }
+
+    #[test]
+    fn each_skip_reason_is_distinguishable() {
+        assert_eq!(
+            snapshot_gate_outcome(true, Some(10), 10, 1_000, 0, 500, true),
+            Some("skipped_projector_owns")
+        );
+        assert_eq!(
+            snapshot_gate_outcome(false, Some(10), 10, 100, 0, 500, true),
+            Some("skipped_interval")
+        );
+        assert_eq!(
+            snapshot_gate_outcome(false, Some(10), 10, 1_000, 0, 500, false),
+            Some("skipped_no_state")
+        );
+    }
+
+    /// Every label the gate can emit must be pinned, and nothing else.
+    ///
+    /// A pinned set that omits one value reintroduces the absent-series bug on
+    /// exactly that value while the rest read 0 and look complete.
+    #[test]
+    fn every_gate_label_is_pinned() {
+        let emitted = [
+            snapshot_gate_outcome(true, Some(1), 1, 1, 0, 1, true),
+            snapshot_gate_outcome(false, None, 1, 1, 0, 1, true),
+            snapshot_gate_outcome(false, Some(1), 1, 0, 0, 1, true),
+            snapshot_gate_outcome(false, Some(1), 1, 1, 0, 1, false),
+        ];
+        for e in emitted {
+            let label = e.expect("each of these inputs must skip");
+            assert!(
+                crate::metrics::EHDB_PROJECTION_SNAPSHOT_GATE_OUTCOMES.contains(&label),
+                "{label} is emitted by the gate but not pinned; its series would be \
+                 absent until it fires"
+            );
+        }
+        // …and `written`, the one the open path records.
+        assert!(crate::metrics::EHDB_PROJECTION_SNAPSHOT_GATE_OUTCOMES.contains(&"written"));
+        assert_eq!(
+            crate::metrics::EHDB_PROJECTION_SNAPSHOT_GATE_OUTCOMES.len(),
+            emitted.len() + 1,
+            "the pinned set must be exactly the four skips plus `written`"
+        );
     }
 }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -3163,29 +3163,55 @@ async fn trigger_orchestrator_inner(
     // it here and only reads it.  Default off → the orchestrator self-writes
     // exactly as block-b does.
     const SNAPSHOT_INTERVAL_EVENTS: i64 = 500;
-    if !state.config.projector_owns_snapshot
-        && total == Some(cache.applied_count)
-        && cache.last_event_id - cache.snapshot_version >= SNAPSHOT_INTERVAL_EVENTS
-    {
+    // noetl/ai-meta#265 G4 — the coverage denominator, recorded at the GATE.
+    //
+    // Measured: a 13-event execution completes and `noetl.projection_snapshot`
+    // gets no row, because `total == applied_count` requires a throttled
+    // consistency COUNT to have landed in this same pass and on a short
+    // execution the two never coincide. The projection tier can only hold what
+    // this gate lets through, so a shadow soak reporting "0 divergences" without
+    // knowing how often it opens is reporting about a population the mirror was
+    // never offered.
+    //
+    // The reasons are recorded in the order they are evaluated, and only one
+    // fires per pass, so the labels sum to the number of passes.
+    let gate_outcome = if state.config.projector_owns_snapshot {
+        Some("skipped_projector_owns")
+    } else if total != Some(cache.applied_count) {
+        Some("skipped_unsettled")
+    } else if cache.last_event_id - cache.snapshot_version < SNAPSHOT_INTERVAL_EVENTS {
+        Some("skipped_interval")
+    } else if cache.state.is_none() {
+        Some("skipped_no_state")
+    } else {
+        None
+    };
+    if let Some(outcome) = gate_outcome {
+        crate::metrics::record_ehdb_projection_snapshot_gate(outcome);
+    } else {
         let version = cache.last_event_id;
         let applied = cache.applied_count;
         let routing = cache.routing_meta.clone();
-        let saved = if let Some(ws) = cache.state.as_ref() {
-            crate::services::orch_snapshot::save(
-                pool,
-                execution_id,
-                version,
-                applied,
-                routing.as_ref(),
-                ws,
-            )
-            .await
-        } else {
-            Ok(())
-        };
+        let ws = cache.state.as_ref().expect("gate_outcome is None only with state");
+        let saved = crate::services::orch_snapshot::save(
+            pool,
+            execution_id,
+            version,
+            applied,
+            routing.as_ref(),
+            ws,
+        )
+        .await;
         match saved {
-            Ok(()) => cache.snapshot_version = version,
+            Ok(()) => {
+                cache.snapshot_version = version;
+                crate::metrics::record_ehdb_projection_snapshot_gate("written");
+            }
             Err(e) => {
+                // Not counted as `written`: the row does not exist, so the tier
+                // was never offered it either. Counting a failed save as
+                // coverage would inflate the denominator's numerator by exactly
+                // the executions most likely to diverge.
                 warn!(execution_id, %e, "orch_snapshot.save failed; continuing without snapshot")
             }
         }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -17,6 +17,7 @@ pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;
 pub mod ehdb_projection_mirror;
 pub mod ehdb_projection_parity;
+pub mod ehdb_projection_read;
 pub mod event_write;
 pub mod events;
 pub mod execute;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3498,6 +3498,120 @@ pub fn init_ehdb_projection_series() {
                 .inc_by(0);
         }
     }
+    // #265 B1 — the read path and the coverage denominator. Pinned from the
+    // modules' OWN enums, not from a copy of them, so a reason added there
+    // without a label here fails the guard test rather than going absent on
+    // exactly the value someone is checking.
+    for outcome in crate::handlers::ehdb_projection_read::READ_OUTCOMES {
+        ehdb_projection_read_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+    for outcome in EHDB_PROJECTION_SNAPSHOT_GATE_OUTCOMES {
+        ehdb_projection_snapshot_gate_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+}
+
+/// Counter: how each orchestrator snapshot read resolved (noetl/ai-meta#265 B1).
+///
+/// The read-serve counterpart of `ehdb_projection_mirror_total`. One label,
+/// `outcome`, whose closed set is `served_tier` + `disabled` + one value per
+/// demote reason.
+///
+/// **Every demote reason is its own label, deliberately.** A single `demoted`
+/// value would make the case that means "the tier is dangerous"
+/// (`version_ahead` — it claims to have folded an event that does not exist)
+/// indistinguishable from the case that means "nothing has been mirrored for
+/// this execution yet" (`missing`), which on a freshly armed mirror is every
+/// execution. Those two want opposite operator responses.
+pub fn ehdb_projection_read_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_projection_read_total",
+                "Orchestrator snapshot reads by how they resolved: served from the EHDB \
+                 projection tier, or demoted to noetl.projection_snapshot with a reason \
+                 (noetl/ai-meta#265).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+pub fn record_ehdb_projection_read(outcome: &str) {
+    ehdb_projection_read_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
+/// Counter: what the orchestrator's snapshot-write gate decided
+/// (noetl/ai-meta#265 G4) — **the coverage denominator**.
+///
+/// This exists because of a measured finding: a 13-event execution completes
+/// and `noetl.projection_snapshot` gets **no row**. The orchestrator's
+/// self-write needs a throttled consistency COUNT to have landed in the same
+/// pass (`total == Some(applied_count)`), and on a short execution the two never
+/// coincide. So the projection tier can only ever hold what the incumbent
+/// wrote, and the incumbent writes sparsely.
+///
+/// Without a denominator, a shadow soak reporting "0 divergences" is reporting
+/// about a population the mirror was never offered — the vacuous pass this whole
+/// design was shaped to avoid. This counter is that denominator: `written`
+/// against the `skipped_*` reasons is the fraction of eligible passes that ever
+/// produced a row to mirror.
+///
+/// Counted at the **gate**, not at the writer, because the writer by definition
+/// only sees the passes that got through.
+pub fn ehdb_projection_snapshot_gate_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_projection_snapshot_gate_total",
+                "Orchestrator snapshot-write decisions by outcome; `written` over the total is \
+                 the projection tier's coverage denominator (noetl/ai-meta#265).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Every snapshot-gate outcome. Closed set, pinned at 0.
+///
+/// * `written` — the gate passed and a row was upserted.
+/// * `skipped_unsettled` — the consistency COUNT had not landed in this pass
+///   (`total != applied_count`). **The dominant one on short executions**, and
+///   the finding that gates any soak.
+/// * `skipped_interval` — settled, but fewer than the snapshot interval's worth
+///   of ids since the last one.
+/// * `skipped_projector_owns` — the projector owns the snapshot in this
+///   deployment, so the orchestrator does not write it.
+/// * `skipped_no_state` — nothing folded to write.
+pub const EHDB_PROJECTION_SNAPSHOT_GATE_OUTCOMES: [&str; 5] = [
+    "written",
+    "skipped_unsettled",
+    "skipped_interval",
+    "skipped_projector_owns",
+    "skipped_no_state",
+];
+
+pub fn record_ehdb_projection_snapshot_gate(outcome: &str) {
+    ehdb_projection_snapshot_gate_total()
+        .with_label_values(&[outcome])
+        .inc();
 }
 
 pub fn init_ehdb_crossstore_series() {

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -40,6 +40,13 @@ pub struct LoadedSnapshot {
     /// carried on the snapshot because that event predates every snapshot and
     /// so is never re-loaded in the events-since window.
     pub routing_meta: Option<serde_json::Value>,
+    /// `sha256` of the stored snapshot, as the writer computed it.
+    ///
+    /// `Some` on the incumbent path, `None` on a tier-served read — a served
+    /// snapshot has already been checked against its own digest, and carrying
+    /// it forward would invite a second comparison against a value that is by
+    /// then trivially equal.
+    pub checksum: Option<String>,
 }
 
 /// Upsert the orchestrator state snapshot for an execution.
@@ -55,6 +62,13 @@ pub async fn save(
     routing_meta: Option<&serde_json::Value>,
     state: &WorkflowState,
 ) -> AppResult<()> {
+    // Taken BEFORE the upsert, so it is at or before the `now()` Postgres
+    // stores. The mirror carries this rather than the stored value because the
+    // stored one is not returned — and the direction matters: the rebuild's
+    // straggler re-scan runs from `updated_at - margin`, so an earlier stamp
+    // widens the window (safe) and a later one narrows it (can skip a
+    // straggler).
+    let mirrored_at = chrono::Utc::now();
     let snapshot = serde_json::to_value(state)
         .map_err(|e| AppError::Internal(format!("orch_snapshot.save: serialise: {e}")))?;
     let checksum = {
@@ -115,6 +129,8 @@ pub async fn save(
         applied_count,
         &checksum,
         &snapshot,
+        mirrored_at,
+        routing_meta,
     )
     .await;
 
@@ -126,9 +142,123 @@ pub async fn save(
 /// Returns `None` when no snapshot exists yet (early in a run, before the
 /// first save) — the caller then rebuilds from the full (still-small) log.
 pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<LoadedSnapshot>> {
+    use crate::handlers::ehdb_projection_read as tier_read;
+
+    let source = tier_read::read_source();
+
+    // The default path, unchanged and untouched by #265 B1: no relay call, no
+    // extra query, not even a second env lookup. A tier that is switched off
+    // must cost nothing, or "switched off" is not a real rollback.
+    if !source.reads_tier() {
+        crate::metrics::record_ehdb_projection_read("disabled");
+        return load_incumbent(pool, execution_id).await;
+    }
+
+    // `verify` loads the incumbent FIRST and compares against it. That ordering
+    // is what makes the mode safe by construction rather than by the checks
+    // being right: the answer it can fall back to is already in hand before the
+    // tier is consulted at all.
+    let incumbent = if source.needs_incumbent_first() {
+        Some(load_incumbent(pool, execution_id).await?)
+    } else {
+        None
+    };
+    let facts = incumbent.as_ref().and_then(|opt| {
+        opt.as_ref().map(|s| tier_read::IncumbentFacts {
+            version: s.version,
+            checksum: s.checksum.clone(),
+        })
+    });
+
+    // In `verify` mode with no incumbent row there is nothing to compare
+    // against, and "the tier agrees with nothing" is not evidence. Serve the
+    // absence — which is what the caller already handles by rebuilding in full.
+    //
+    // Its own label, not `missing`: that one means an empty tier beside a
+    // populated incumbent, and this means neither store has a snapshot yet —
+    // the normal state of every short execution.
+    if source.needs_incumbent_first() && facts.is_none() {
+        crate::metrics::record_ehdb_projection_read(
+            tier_read::DemoteReason::NoIncumbent.as_str(),
+        );
+        return Ok(incumbent.unwrap_or(None));
+    }
+
+    match tier_read::read(pool, execution_id, facts.as_ref()).await {
+        tier_read::TierRead::Served(served) => {
+            // Deserialisation is the last check, and a failure here demotes for
+            // the same reason the incumbent path treats it as absent: a shape
+            // change across a deploy must cost a slower rebuild, never an error.
+            match serde_json::from_value::<WorkflowState>(served.snapshot) {
+                Ok(state) => {
+                    crate::metrics::record_ehdb_projection_read("served_tier");
+                    Ok(Some(LoadedSnapshot {
+                        state,
+                        version: served.version,
+                        applied_count: served.applied_count,
+                        updated_at: served.updated_at,
+                        routing_meta: served.routing_meta,
+                        checksum: None,
+                    }))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "noetl_server::ehdb_projection_read",
+                        execution_id,
+                        version = served.version,
+                        %e,
+                        "projection tier snapshot did not deserialise; demoting to the incumbent"
+                    );
+                    crate::metrics::record_ehdb_projection_read("undeserialisable");
+                    demote(pool, execution_id, incumbent).await
+                }
+            }
+        }
+        tier_read::TierRead::Demote(reason) => {
+            crate::metrics::record_ehdb_projection_read(reason.as_str());
+            if reason.is_fault() {
+                // Only faults log. `missing` is every execution that predates
+                // the mirror arming, and `unconfigured` is every process that
+                // has not been given a relay — logging those would bury the
+                // lines that mean something under the ones that mean "not yet".
+                tracing::warn!(
+                    target: "noetl_server::ehdb_projection_read",
+                    execution_id,
+                    reason = reason.as_str(),
+                    mode = source.as_str(),
+                    "projection tier read demoted to noetl.projection_snapshot"
+                );
+            }
+            demote(pool, execution_id, incumbent).await
+        }
+    }
+}
+
+/// Fall back to the incumbent, reusing the row already loaded when there is one.
+///
+/// `verify` mode has it; `tier` mode does not and pays for the query here. That
+/// asymmetry is the whole cost model of the two modes and it is deliberate:
+/// `tier` is fast when it serves and slower than the baseline when it does not,
+/// which is the correct incentive.
+async fn demote(
+    pool: &DbPool,
+    execution_id: i64,
+    already_loaded: Option<Option<LoadedSnapshot>>,
+) -> AppResult<Option<LoadedSnapshot>> {
+    match already_loaded {
+        Some(row) => Ok(row),
+        None => load_incumbent(pool, execution_id).await,
+    }
+}
+
+/// The incumbent read: `noetl.projection_snapshot`, exactly as before #265.
+async fn load_incumbent(
+    pool: &DbPool,
+    execution_id: i64,
+) -> AppResult<Option<LoadedSnapshot>> {
     let row = sqlx::query(
         r#"
-        SELECT version, snapshot, meta, updated_at
+        SELECT version, snapshot, meta, updated_at, checksum
         FROM noetl.projection_snapshot
         WHERE aggregate_type = $1 AND aggregate_id = $2
           AND tenant_id = 'default' AND organization_id = 'default'
@@ -138,7 +268,7 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
     .bind(execution_id.to_string())
     .fetch_optional(pool)
     .await
-    .map_err(|e| AppError::Internal(format!("orch_snapshot.load_latest: query: {e}")))?;
+    .map_err(|e| AppError::Internal(format!("orch_snapshot.load_incumbent: query: {e}")))?;
 
     let Some(row) = row else {
         return Ok(None);
@@ -150,8 +280,9 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
         .unwrap_or_else(|_| chrono::Utc::now());
     let snapshot: serde_json::Value = row
         .try_get("snapshot")
-        .map_err(|e| AppError::Internal(format!("orch_snapshot.load_latest: snapshot col: {e}")))?;
+        .map_err(|e| AppError::Internal(format!("orch_snapshot.load_incumbent: snapshot col: {e}")))?;
     let meta: serde_json::Value = row.try_get("meta").unwrap_or(serde_json::Value::Null);
+    let checksum: Option<String> = row.try_get("checksum").ok();
     let applied_count = meta
         .get("applied_count")
         .and_then(|v| v.as_i64())
@@ -169,7 +300,7 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
                 execution_id,
                 version,
                 %e,
-                "orch_snapshot.load_latest: snapshot deserialise failed; ignoring (full rebuild)"
+                "orch_snapshot.load_incumbent: snapshot deserialise failed; ignoring (full rebuild)"
             );
             return Ok(None);
         }
@@ -181,5 +312,78 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
         applied_count,
         updated_at,
         routing_meta,
+        checksum,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    /// The serving read path must have **exactly one** reader of
+    /// `noetl.projection_snapshot`.
+    ///
+    /// The mirror's writer-side twin
+    /// (`ehdb_projection_mirror::the_snapshot_store_has_exactly_one_writer`)
+    /// exists so a second `INSERT` cannot silently halve the tier. This is the
+    /// read-side statement of the same property, and #265 B1 is what makes it
+    /// load-bearing: with a read-serve path in place, a *second* `SELECT` is a
+    /// caller that resolves its snapshot from Postgres no matter what
+    /// `NOETL_EHDB_PROJECTION_READ_SOURCE` says — a serve path that is inert on
+    /// one route and live on another, which is the shape of ai-meta#263.
+    ///
+    /// The comparator reads the incumbent directly and must: its whole job is
+    /// to compare the two stores, so it is excluded by construction — it is not
+    /// one of the files scanned.
+    #[test]
+    fn the_serving_read_path_has_exactly_one_reader() {
+        // Comment-stripped, so a doc comment naming the query does not count as
+        // a reader — and, in the direction that matters, so the count cannot be
+        // *satisfied* by deleting a comment while adding a real one. This file's
+        // own prose says `FROM noetl.projection_snapshot` more than once.
+        let code_only = |src: &str| -> String {
+            src.lines()
+                .map(|l| match l.find("//") {
+                    Some(i) => &l[..i],
+                    None => l,
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        // Scan the CODE half of this file only. The guard's own search literal
+        // lives in the test module, so including it counts the guard as a
+        // reader — which is exactly how this test failed the first time it ran,
+        // and the third sighting of a check counting its own search string
+        // (ai-meta#263, and #155's append-path counter).
+        let whole = include_str!("orch_snapshot.rs");
+        let self_code = &whole[..whole
+            .find("mod tests {")
+            .expect("the test module must still be the tail of this file")];
+        let sources: &[(&str, &str)] = &[
+            ("services/orch_snapshot.rs", self_code),
+            ("handlers/events.rs", include_str!("../handlers/events.rs")),
+            ("handlers/internal.rs", include_str!("../handlers/internal.rs")),
+        ];
+        let mut readers: Vec<&str> = Vec::new();
+        for (name, src) in sources {
+            let code = code_only(src);
+            for _ in 0..code.matches("FROM noetl.projection_snapshot").count() {
+                readers.push(name);
+            }
+        }
+        // Positive control for the stripper: this file's real INSERT must
+        // survive it, or every count above is a meaningless zero that would
+        // still compare equal to an expectation of zero.
+        assert!(
+            code_only(self_code).contains("INSERT INTO noetl.projection_snapshot"),
+            "the comment stripper ate real SQL; the reader count proves nothing"
+        );
+        assert_eq!(
+            readers,
+            vec!["services/orch_snapshot.rs"],
+            "the serving read path must have exactly one reader of \
+             noetl.projection_snapshot, and it must be `load_incumbent`. Found: {readers:?}. \
+             A second reader resolves its snapshot from Postgres regardless of \
+             NOETL_EHDB_PROJECTION_READ_SOURCE — a serve path live on one route and \
+             inert on another."
+        );
+    }
 }


### PR DESCRIPTION
noetl/ai-meta#265 phase B1 — the projection tier gets a **reader**.

Phase A ([#350](https://github.com/noetl/server/pull/350) + [worker#277](https://github.com/noetl/worker/pull/277), merged as v3.84.0 / v5.121.0) gave the tier a store, a server-authored mirror of the incumbent's real rows, and a comparator. It did not give it a reader: every orchestrator rebuild still resolved its snapshot from `noetl.projection_snapshot`, so `NOETL_EHDB_PROJECTION=primary` meant *"the write path claims authority"* and nothing more.

## The invariant

**A snapshot that might be wrong must not be served.** `rebuild_state` folds only the events *after* the snapshot's `version`, which makes the failure asymmetric:

| | |
| :-- | :-- |
| snapshot **behind** the incumbent | slow but correct — more events fold forward, same answer |
| snapshot **ahead** of what happened | silently **wrong** — the events in between are never folded, the caller gets a state that never existed, and nothing downstream can detect it |

So the read refuses in both directions, for different reasons, and every refusal is a **demote to the incumbent** — never an error, never a degraded answer.

## Modes

`NOETL_EHDB_PROJECTION_READ_SOURCE`, default **`postgres`**:

| value | behaviour |
| :-- | :-- |
| `postgres` | the pre-#265 read exactly. No relay call, no extra query. A tier that is off must cost nothing, or "off" is not a real rollback. |
| `verify` | read **both**, serve the tier only when it agrees on version *and* checksum. Safe by construction rather than by the checks being right — the fallback is already in hand. |
| `tier` | serve from the tier; read the incumbent only on a demote. |

Unrecognised ⇒ `postgres`, warned once per distinct value. A typo must not take reads off the incumbent (#243).

## What `tier` mode checks with no incumbent in hand

1. **Self-consistency** — `sha256` of the record's own body against the digest it carries, the same digest `orch_snapshot::save` authored. Pinned by a test to the writer's exact bytes: if the two serialisations ever diverge, 100% of reads demote and it looks like a broken tier rather than a broken comparison.
2. **Version sanity** — against `MAX(event_id)` for the execution. Kept even though it costs a query: `tier` mode exists to drop a *blob* read, and a bounded index probe is not that blob. `None` demotes — **not knowing is not the same as being satisfied**.
3. **Deserialisability** — demotes rather than erroring, the posture the incumbent path already took.

## Also here

- **`mirror_payload` now carries `updated_at` and `routing_meta`.** Without them a record is comparable and *unservable* — invisible until a read arm demotes 100% of reads. `updated_at` is the server's clock taken *before* the upsert, so it is at or before Postgres's `now()`: the straggler re-scan runs from `updated_at - margin`, so an earlier stamp widens the window (safe) and a later one could skip a straggler.
- **`noetl_ehdb_projection_snapshot_gate_total` (G4)** — the coverage denominator, at the **gate** not the writer. A 13-event execution completes and gets *no* snapshot row; a soak reporting "0 divergences" without knowing how often the gate opens is reporting about a population the mirror was never offered.
- **`noetl_ehdb_projection_read_total{outcome}`** — one label per demote reason. A single `demoted` would make `version_ahead` (the tier is dangerous) indistinguishable from `missing` (nothing mirrored yet — every execution on a freshly armed mirror).
- **A read-side single-reader guard**, twin of the writer guard: with a read-serve path in place, a second `SELECT` is a caller that resolves from Postgres whatever the flag says.

## Two guards caught themselves

The new read guard counted its own search literal; its positive control then made the **existing** writer guard count two writers. One guard's positive control was another guard's false positive. Both now scan the code half only — the fourth sighting of a source-counting check counting text *about* code.

## Verification

812 lib tests pass (+15), no new clippy warnings. Kind gate for the two-sided serve/demote arms follows in the same issue before anything is proposed for prod.

**Lands inert.** Default mode is `postgres`; prod sets no `NOETL_EHDB_PROJECTION_READ_SOURCE`. The event-log tier stays `primary` and untouched.

Refs noetl/ai-meta#265
