### PR TITLE
feat(ehdb): take the projection mirror off the write path, and pair it with the window that makes it safe

### DIFF
--- a/src/handlers/ehdb_projection_mirror.rs
+++ b/src/handlers/ehdb_projection_mirror.rs
@@ -169,12 +169,31 @@ fn relay_client() -> &'static reqwest::Client {
     C.get_or_init(reqwest::Client::new)
 }
 
+/// One snapshot on its way to the tier.
+///
+/// Carries the already-rendered record rather than its seven inputs, so the
+/// queue holds a value that cannot be re-derived differently later. `enqueued_at`
+/// is what the lag histogram measures against — the delay this module can be
+/// blamed for starts when the snapshot is accepted, not when it is built.
+#[derive(Debug, Clone)]
+pub struct SnapshotMirror {
+    pub execution_id: i64,
+    pub version: i64,
+    pub record: String,
+    pub enqueued_at: std::time::Instant,
+}
+
 /// Mirror one authoritative snapshot into the projection tier.
 ///
 /// Called from inside [`crate::services::orch_snapshot::save`], **after** its
 /// upsert has succeeded — so a snapshot that failed to become authoritative is
 /// never mirrored, and the tier can never be ahead of the incumbent by way of a
 /// write that did not happen.
+///
+/// With `NOETL_EHDB_PROJECTION_MIRROR_ASYNC` off this delivers inline, exactly
+/// as it did before ai-meta#265 G3. On, it hands the snapshot to the queue and
+/// returns — which is the whole point, since `save` is called from the
+/// orchestrator's own trigger path.
 ///
 /// Never returns an error. See the module note on failure posture.
 #[allow(clippy::too_many_arguments)]
@@ -190,6 +209,39 @@ pub async fn mirror_snapshot(
     if !server_mirrors() {
         return;
     }
+    let record = mirror_payload(
+        execution_id,
+        version,
+        applied_count,
+        checksum,
+        snapshot,
+        updated_at,
+        routing_meta,
+    )
+    .to_string();
+    let m = SnapshotMirror {
+        execution_id,
+        version,
+        record,
+        enqueued_at: std::time::Instant::now(),
+    };
+    if super::ehdb_projection_mirror_queue::enabled() {
+        super::ehdb_projection_mirror_queue::submit(m).await;
+    } else {
+        deliver(&m).await;
+    }
+}
+
+/// The relay POST itself.
+///
+/// Split out from [`mirror_snapshot`] so the queue's drain task delivers
+/// through the **same** code the inline path uses. Two delivery
+/// implementations — one inline, one drained — is how a queue quietly acquires
+/// a different failure taxonomy from the path it replaced, and then an operator
+/// reads the wrong runbook.
+pub(crate) async fn deliver(m: &SnapshotMirror) {
+    let execution_id = m.execution_id;
+    let version = m.version;
     let Some(base) = std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
         .ok()
         .map(|s| s.trim().to_string())
@@ -213,18 +265,9 @@ pub async fn mirror_snapshot(
     // append does: writing where the comparator reads is then true by
     // construction rather than by two env vars agreeing.
     let url = format!("{}/ehdb/tiers/{TIER}", base.trim_end_matches('/'));
-    let record = mirror_payload(
-        execution_id,
-        version,
-        applied_count,
-        checksum,
-        snapshot,
-        updated_at,
-        routing_meta,
-    );
     let body = json!({
         "execution_id": execution_id.to_string(),
-        "records": [record.to_string()],
+        "records": [m.record],
     });
 
     let resp = relay_client()
@@ -269,6 +312,13 @@ pub async fn mirror_snapshot(
                 );
             } else if status.is_success() {
                 crate::metrics::record_ehdb_projection_mirror("mirrored");
+                // Seconds from acceptance to durable in the tier. THE number the
+                // comparator's lag tolerance is checked against: the window is a
+                // promise about how long this can take, and without the
+                // histogram it would be an assumption.
+                crate::metrics::observe_ehdb_projection_mirror_lag(
+                    m.enqueued_at.elapsed().as_secs_f64(),
+                );
             } else {
                 let detail = r.text().await.unwrap_or_default();
                 crate::metrics::record_ehdb_projection_mirror("degraded");

--- a/src/handlers/ehdb_projection_mirror_queue.rs
+++ b/src/handlers/ehdb_projection_mirror_queue.rs
@@ -1,0 +1,473 @@
+//! Take the projection mirror off the orchestrator's write path — a bounded
+//! queue with backpressure, never a drop.
+//!
+//! **[noetl/ai-meta#265](https://github.com/noetl/ai-meta/issues/265) G3.**
+//! The projection-tier twin of `ehdb_eventlog_mirror_queue` (#155 Option 3),
+//! deliberately built to the same shape so one runbook covers both.
+//!
+//! # What this is worth
+//!
+//! [`super::ehdb_projection_mirror::mirror_snapshot`] is called from inside
+//! `orch_snapshot::save`, and one of `save`'s two callers is the **inline
+//! orchestrator self-write** in `trigger_orchestrator_inner`. So every snapshot
+//! upsert on that path pays a relay round trip plus a tier append before the
+//! trigger returns. That is the same shape #155 removed from the event log,
+//! where it measured **78.6 ms → 0.1 ms per call** and moved a median warm
+//! planner turn from 16.9 s to 13.0 s.
+//!
+//! None of that work is on the critical path of anything: the mirror is an
+//! auxiliary verification copy, and the authoritative row has already committed
+//! by the time it runs.
+//!
+//! # The pairing rule, enforced here rather than documented
+//!
+//! **An async mirror without a comparator lag-tolerance window is worse than no
+//! async mirror.** With the window at 0, a snapshot still in flight makes the
+//! tier legitimately behind the incumbent, and the comparator scores that as a
+//! divergence — so arming the queue would manufacture the exact alert the tier
+//! exists to make trustworthy. #155 states this as "set both or neither"; here
+//! it is a startup check.
+//!
+//! [`init`] **refuses to arm** when `NOETL_EHDB_PROJECTION_MIRROR_ASYNC` is on
+//! and `NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS` is 0. Refusing leaves
+//! the process on the inline path, which is correct and merely slower; erroring
+//! out would turn a tuning mistake into an outage, and arming anyway would turn
+//! it into a false page. The refusal is loud: an `error!` line, and
+//! `..._async_enabled` stays **0** so the running state is readable rather than
+//! inferred from the variable someone set.
+//!
+//! # Why "never drop" is not a preference
+//!
+//! A dropped snapshot is not a lost metric. It is a revision the tier will never
+//! hold, and — once B1's read path is serving — a revision the tier is *behind*
+//! by, forever. The ladder is the same as the event log's and every rung keeps
+//! the snapshot:
+//!
+//! 1. **`try_send`** — room on the queue, microseconds.
+//! 2. **`reserve().await` with a timeout** — the queue is full, so the writer
+//!    *waits*. Real backpressure: the producer slows to the drain rate, nothing
+//!    is lost, order is preserved.
+//! 3. **inline delivery** — the queue stayed full past the timeout. Delivered
+//!    synchronously, i.e. the pre-G3 behaviour.
+//!
+//! There is no rung 4.
+//!
+//! ⚠ `reserve()`, **not** `send(value)`. `send` moves the value into the future,
+//! so a timeout cancelling that future takes the snapshot with it — a silent
+//! drop on the one path whose entire purpose is not to have one. #155's first
+//! version used `send` and lost 28 of 60 records, with every counter still
+//! reading correctly because the records were counted at the moment they were
+//! lost.
+//!
+//! # Ordering, and what it is worth here
+//!
+//! One drain task, FIFO, delivered sequentially — so per execution the tier
+//! receives snapshots in the order `save` produced them. That matters less than
+//! it does for the event log (a snapshot is a full read model, not an
+//! increment, and the reader takes the newest by version) but it is not free
+//! either: the read path's monotonicity expectation and the comparator's
+//! `order` divergence kind both read the store's sequence.
+//!
+//! **This module deliberately does not coalesce per execution.** It could —
+//! only the newest version is ever read — but dropping intermediate revisions
+//! is a behaviour change to what the tier *contains*, and it would have to be
+//! gated and proven separately. The queue's job is to move the work off the hot
+//! path, not to change what the work is.
+//!
+//! # Flag
+//!
+//! `NOETL_EHDB_PROJECTION_MIRROR_ASYNC`, default **off**. Off, `mirror_snapshot`
+//! takes the same inline path it took before and this module's only effect is
+//! three gauges reading 0.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+
+use super::ehdb_projection_mirror::SnapshotMirror;
+
+/// Arm the async queue. Default off.
+pub const ASYNC_ENV: &str = "NOETL_EHDB_PROJECTION_MIRROR_ASYNC";
+
+/// Queue depth in **snapshots**. Default 512.
+///
+/// Sized to absorb a burst, not to hide a stall: past this the producer is meant
+/// to feel it (rung 2), because a queue deep enough never to push back is a
+/// queue whose lag can exceed the comparator's tolerance window with nothing
+/// noticing.
+pub const CAPACITY_ENV: &str = "NOETL_EHDB_PROJECTION_MIRROR_QUEUE_CAPACITY";
+const DEFAULT_CAPACITY: usize = 512;
+
+/// How long the writer waits for room before falling back to inline delivery.
+/// Default 5000 ms — the same bound the inline relay already has, so the worst
+/// case a caller can see is unchanged.
+pub const ENQUEUE_TIMEOUT_ENV: &str = "NOETL_EHDB_PROJECTION_MIRROR_ENQUEUE_TIMEOUT_MS";
+const DEFAULT_ENQUEUE_TIMEOUT_MS: u64 = 5_000;
+
+/// Most snapshots one drain pass takes off the queue before delivering.
+pub const DRAIN_MAX_ENV: &str = "NOETL_EHDB_PROJECTION_MIRROR_DRAIN_MAX";
+const DEFAULT_DRAIN_MAX: usize = 64;
+
+/// How long the shutdown flush waits for the queue to empty.
+pub const FLUSH_TIMEOUT_ENV: &str = "NOETL_EHDB_PROJECTION_MIRROR_FLUSH_TIMEOUT_MS";
+const DEFAULT_FLUSH_TIMEOUT_MS: u64 = 10_000;
+
+fn env_bool(name: &str) -> bool {
+    matches!(
+        std::env::var(name)
+            .ok()
+            .map(|s| s.trim().to_ascii_lowercase())
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(default)
+}
+
+fn env_millis(name: &str, default_ms: u64) -> Duration {
+    Duration::from_millis(
+        std::env::var(name)
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(default_ms),
+    )
+}
+
+/// Snapshots accepted onto the queue and not yet durable.
+///
+/// An atomic beside the gauge rather than read off it: the shutdown flush needs
+/// to *wait* on this, and a Prometheus gauge is a publication surface, not a
+/// synchronisation primitive.
+static PENDING: AtomicI64 = AtomicI64::new(0);
+
+static QUEUE: OnceLock<Option<mpsc::Sender<SnapshotMirror>>> = OnceLock::new();
+
+/// Is the queue armed in this process?
+pub fn enabled() -> bool {
+    queue().is_some()
+}
+
+fn queue() -> Option<&'static mpsc::Sender<SnapshotMirror>> {
+    QUEUE.get().and_then(|q| q.as_ref())
+}
+
+/// The pairing check, as a pure function so it is testable without a process.
+///
+/// Returns the reason to refuse, or `None` to arm. See the module note: this is
+/// #155's "set both or neither" turned from prose into a startup condition.
+pub fn refusal_reason(async_requested: bool, lag_tolerance_secs: u64) -> Option<&'static str> {
+    if !async_requested {
+        return None;
+    }
+    if lag_tolerance_secs == 0 {
+        return Some(
+            "NOETL_EHDB_PROJECTION_MIRROR_ASYNC is on but \
+             NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS is 0",
+        );
+    }
+    None
+}
+
+/// Arm the queue and start the drain task. Idempotent; call once at startup.
+///
+/// Started from `main` rather than lazily on first mirror: a lazy start would
+/// make "armed" depend on traffic, so the gauge saying whether this process is
+/// async would read 0 on an idle server that is in fact configured for it.
+pub fn init(lag_tolerance_secs: u64) {
+    let requested = env_bool(ASYNC_ENV);
+
+    if let Some(reason) = refusal_reason(requested, lag_tolerance_secs) {
+        // Loud, and NOT fatal. The process is correct on the inline path, just
+        // slower; killing it would turn a tuning mistake into an outage, and
+        // arming anyway would make the comparator judge a healthy tier on its
+        // own liveness and page for it.
+        error!(
+            target: "noetl_server::ehdb_projection_mirror",
+            reason,
+            "REFUSING to arm the async projection mirror — an async mirror with a zero \
+             tolerance window makes the comparator score in-flight snapshots as divergence. \
+             Staying on the inline path. Set both or neither (noetl/ai-meta#265 G3, #155)."
+        );
+        crate::metrics::ehdb_projection_mirror_async_enabled().set(0);
+        let _ = QUEUE.set(None);
+        return;
+    }
+
+    crate::metrics::ehdb_projection_mirror_async_enabled().set(i64::from(requested));
+    if !requested {
+        let _ = QUEUE.set(None);
+        return;
+    }
+
+    let capacity = env_usize(CAPACITY_ENV, DEFAULT_CAPACITY);
+    let drain_max = env_usize(DRAIN_MAX_ENV, DEFAULT_DRAIN_MAX);
+    let (tx, rx) = mpsc::channel::<SnapshotMirror>(capacity);
+    if QUEUE.set(Some(tx)).is_err() {
+        // Already initialised. Do NOT start a second drain task — two drains on
+        // one queue deliver concurrently and lose the ordering this module is
+        // supposed to guarantee.
+        return;
+    }
+    info!(
+        target: "noetl_server::ehdb_projection_mirror",
+        capacity, drain_max, lag_tolerance_secs,
+        enqueue_timeout_ms = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS).as_millis() as u64,
+        "async projection mirror queue ARMED — the mirror is off the orchestrator write path"
+    );
+    tokio::spawn(drain_loop(rx, drain_max));
+}
+
+/// Hand a snapshot to the queue, or deliver it inline if the queue cannot take
+/// it. Returns after the snapshot is *accepted*, not after it is durable.
+pub async fn submit(m: SnapshotMirror) {
+    let Some(tx) = queue() else {
+        // Unreachable via `mirror_snapshot`, which checks `enabled()` first —
+        // but a stale read must still deliver the snapshot rather than discard it.
+        crate::metrics::record_ehdb_projection_mirror_queue("queue_closed_inline");
+        super::ehdb_projection_mirror::deliver(&m).await;
+        return;
+    };
+
+    let m = match tx.try_send(m) {
+        Ok(()) => {
+            accepted();
+            publish_depth(tx);
+            crate::metrics::record_ehdb_projection_mirror_queue("enqueued");
+            return;
+        }
+        Err(mpsc::error::TrySendError::Closed(m)) => {
+            crate::metrics::record_ehdb_projection_mirror_queue("queue_closed_inline");
+            warn!(
+                target: "noetl_server::ehdb_projection_mirror",
+                execution_id = m.execution_id,
+                "async projection mirror queue is closed — the drain task is gone; \
+                 mirroring inline"
+            );
+            super::ehdb_projection_mirror::deliver(&m).await;
+            return;
+        }
+        Err(mpsc::error::TrySendError::Full(m)) => m,
+    };
+
+    // Rung 2 — backpressure. `reserve()`, never `send(m)`: see the module note.
+    let timeout = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS);
+    match tokio::time::timeout(timeout, tx.reserve()).await {
+        Ok(Ok(permit)) => {
+            permit.send(m);
+            accepted();
+            publish_depth(tx);
+            crate::metrics::record_ehdb_projection_mirror_queue("enqueued_after_wait");
+        }
+        Ok(Err(_closed)) => {
+            crate::metrics::record_ehdb_projection_mirror_queue("queue_closed_inline");
+            super::ehdb_projection_mirror::deliver(&m).await;
+        }
+        Err(_elapsed) => {
+            // Rung 3 — full for the whole timeout. Deliver here, as the pre-G3
+            // mirror did.
+            crate::metrics::record_ehdb_projection_mirror_queue("queue_full_inline");
+            warn!(
+                target: "noetl_server::ehdb_projection_mirror",
+                execution_id = m.execution_id,
+                timeout_ms = timeout.as_millis() as u64,
+                pending = PENDING.load(Ordering::Relaxed),
+                "async projection mirror queue stayed full past the enqueue timeout — \
+                 mirroring inline. This snapshot may land out of order relative to \
+                 snapshots still queued for the same execution (noetl/ai-meta#265 G3)."
+            );
+            super::ehdb_projection_mirror::deliver(&m).await;
+        }
+    }
+}
+
+/// Publish occupancy from the PRODUCER side.
+///
+/// The drain also publishes it, but only when it wakes — so on a queue filling
+/// faster than it drains, the drain-side write is always the stale one. The
+/// number an operator reads during a backlog has to come from the side causing
+/// the backlog.
+fn publish_depth(tx: &mpsc::Sender<SnapshotMirror>) {
+    let depth = tx.max_capacity().saturating_sub(tx.capacity());
+    crate::metrics::ehdb_projection_mirror_queue_depth().set(depth as i64);
+}
+
+fn accepted() {
+    let now = PENDING.fetch_add(1, Ordering::Relaxed) + 1;
+    crate::metrics::ehdb_projection_mirror_pending().set(now);
+}
+
+fn settled() {
+    let now = PENDING.fetch_sub(1, Ordering::Relaxed) - 1;
+    crate::metrics::ehdb_projection_mirror_pending().set(now);
+}
+
+/// The single drain task. Drains immediately; the `try_recv` sweep only takes
+/// what is already there, so nothing waits to accumulate.
+async fn drain_loop(mut rx: mpsc::Receiver<SnapshotMirror>, drain_max: usize) {
+    loop {
+        let Some(first) = rx.recv().await else {
+            info!(
+                target: "noetl_server::ehdb_projection_mirror",
+                "async projection mirror queue closed; drain task exiting"
+            );
+            return;
+        };
+        let mut pass: Vec<SnapshotMirror> = vec![first];
+        while pass.len() < drain_max {
+            match rx.try_recv() {
+                Ok(m) => pass.push(m),
+                Err(_) => break,
+            }
+        }
+        crate::metrics::ehdb_projection_mirror_queue_depth().set(rx.len() as i64);
+        for m in &pass {
+            super::ehdb_projection_mirror::deliver(m).await;
+            crate::metrics::record_ehdb_projection_mirror_queue("drained");
+            settled();
+        }
+    }
+}
+
+/// Wait for the queue to empty at shutdown.
+///
+/// A snapshot still queued when the process exits never reaches the tier, and
+/// the comparator will report it as a divergence for as long as the row lives.
+/// Bounded, and what is left is counted as `shutdown_abandoned` so the cause is
+/// attributable rather than a mystery an hour later.
+pub async fn flush() {
+    if !enabled() {
+        return;
+    }
+    let deadline = env_millis(FLUSH_TIMEOUT_ENV, DEFAULT_FLUSH_TIMEOUT_MS);
+    let started = std::time::Instant::now();
+    while PENDING.load(Ordering::Relaxed) > 0 && started.elapsed() < deadline {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let left = PENDING.load(Ordering::Relaxed);
+    if left > 0 {
+        crate::metrics::ehdb_projection_mirror_queue_total()
+            .with_label_values(&["shutdown_abandoned"])
+            .inc_by(left as u64);
+        warn!(
+            target: "noetl_server::ehdb_projection_mirror",
+            abandoned = left,
+            flush_ms = deadline.as_millis() as u64,
+            "shutdown flush timed out with snapshots still queued — these will show as \
+             projection-tier divergences"
+        );
+    } else {
+        info!(
+            target: "noetl_server::ehdb_projection_mirror",
+            flush_ms = started.elapsed().as_millis() as u64,
+            "async projection mirror queue flushed at shutdown"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pairing rule. This is the whole of G3's safety argument, so it is
+    /// asserted rather than left to the module note.
+    #[test]
+    fn async_without_a_tolerance_window_is_refused() {
+        assert!(
+            refusal_reason(true, 0).is_some(),
+            "async armed with a 0 window must be refused — it makes the comparator \
+             score every in-flight snapshot as divergence"
+        );
+    }
+
+    /// Both halves of the pair, and the two ways of having neither.
+    ///
+    /// The positive control matters as much as the refusal: without it, a
+    /// `refusal_reason` that refused unconditionally would satisfy the test
+    /// above and silently make the async path unreachable — inert, and
+    /// indistinguishable from a flag nobody set.
+    #[test]
+    fn the_pair_arms_and_the_absence_of_it_is_not_a_refusal() {
+        assert!(
+            refusal_reason(true, 30).is_none(),
+            "async + a real window must ARM; refusing here makes G3 permanently inert"
+        );
+        assert!(
+            refusal_reason(false, 0).is_none(),
+            "async off is the default and is not a misconfiguration"
+        );
+        assert!(
+            refusal_reason(false, 30).is_none(),
+            "a window with no async mirror is harmless — it only widens what the \
+             comparator forgives"
+        );
+    }
+
+    /// Every queue outcome the code can emit must be in the pinned set.
+    ///
+    /// A pinned set that omits one value reintroduces the absent-series bug on
+    /// exactly that value, while the rest read 0 and look complete.
+    #[test]
+    fn every_queue_outcome_is_pinned() {
+        for label in [
+            "enqueued",
+            "enqueued_after_wait",
+            "queue_full_inline",
+            "queue_closed_inline",
+            "drained",
+            "shutdown_abandoned",
+        ] {
+            assert!(
+                crate::metrics::EHDB_PROJECTION_MIRROR_QUEUE_OUTCOMES.contains(&label),
+                "{label} is emitted but not pinned; its series would be absent until it fires"
+            );
+        }
+        assert_eq!(
+            crate::metrics::EHDB_PROJECTION_MIRROR_QUEUE_OUTCOMES.len(),
+            6,
+            "the pinned set must be exactly the six the ladder can produce"
+        );
+    }
+
+    /// The source must not contain a bare `tx.send(` on the enqueue path.
+    ///
+    /// Counting CODE, not naming a function: #155 lost 28 of 60 records to
+    /// exactly this, and every counter still read correctly because the records
+    /// were counted at the moment they were lost. A comment explaining the
+    /// hazard must not satisfy the check, and the check must not be satisfied by
+    /// deleting that comment either — so `//` is stripped first, with a positive
+    /// control that the stripper left the real `reserve()` behind.
+    #[test]
+    fn the_enqueue_path_uses_reserve_not_send() {
+        let whole = include_str!("ehdb_projection_mirror_queue.rs");
+        let code_half = &whole[..whole
+            .find("mod tests {")
+            .expect("the test module must still be the tail of this file")];
+        let code: String = code_half
+            .lines()
+            .map(|l| match l.find("//") {
+                Some(i) => &l[..i],
+                None => l,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            code.contains("tx.reserve()"),
+            "the comment stripper ate the real enqueue; this guard proves nothing"
+        );
+        assert!(
+            !code.contains("tx.send("),
+            "the enqueue path must use `reserve()`. `send(value)` moves the snapshot into \
+             the future, so a cancelled timeout takes it with it — a silent drop on the \
+             one path whose purpose is not to have one."
+        );
+    }
+}

--- a/src/handlers/ehdb_projection_parity.rs
+++ b/src/handlers/ehdb_projection_parity.rs
@@ -653,11 +653,22 @@ pub enum ParityOutcome {
     Truncated,
     /// The comparator is switched off.
     Disabled,
+    /// The tier is behind or absent, AND the incumbent row is younger than the
+    /// configured lag-tolerance window — so the async mirror has not had its
+    /// promised time yet and the comparison was **not taken**
+    /// (noetl/ai-meta#265 G3).
+    ///
+    /// A distinct outcome and not a `match`, because an untaken comparison is
+    /// not agreement: scoring it `match` would publish a healthy parity rate
+    /// for a comparator that compared nothing. And not a `divergent`, because
+    /// it names a state the async mirror is *supposed* to pass through.
+    PendingMirror,
 }
 
 impl ParityOutcome {
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::PendingMirror => "pending_mirror",
             Self::Match => "match",
             Self::Divergent => "divergent",
             Self::NoAuthoritative => "no_authoritative",
@@ -671,7 +682,8 @@ impl ParityOutcome {
     }
 }
 
-pub const PARITY_OUTCOMES: [ParityOutcome; 9] = [
+pub const PARITY_OUTCOMES: [ParityOutcome; 10] = [
+    ParityOutcome::PendingMirror,
     ParityOutcome::Match,
     ParityOutcome::Divergent,
     ParityOutcome::NoAuthoritative,
@@ -700,6 +712,51 @@ pub struct ComparisonResult {
     pub snapshot_age_seconds: Option<i64>,
     /// Which store answered the tier read, as the worker reported it.
     pub tier_source: Option<String>,
+}
+
+/// `NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS` — how long the comparator
+/// forgives a tier that is merely BEHIND (noetl/ai-meta#265 G3).
+///
+/// **Default 0**, i.e. no tolerance, which is correct for a synchronous mirror:
+/// with the mirror inline the tier is durable before `save` returns, so a tier
+/// that is behind is genuinely behind. The window exists for the async mirror,
+/// and the two are a pair — `ehdb_projection_mirror_queue::refusal_reason`
+/// refuses to arm the queue while this is 0, because an async mirror judged
+/// with no tolerance manufactures the exact alert the tier exists to make
+/// trustworthy.
+///
+/// The window forgives **only lateness**. A tier ahead of the event log, or one
+/// whose content disagrees at the same version, is divergent at any age — see
+/// [`tolerable`].
+pub const PARITY_LAG_TOLERANCE_ENV: &str = "NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS";
+
+pub fn parity_lag_tolerance_secs() -> u64 {
+    std::env::var(PARITY_LAG_TOLERANCE_ENV)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+/// Whether a report describes lateness ONLY, and is therefore forgivable inside
+/// the window.
+///
+/// **Pure, and the whole safety argument of the tolerance window.** A window
+/// that forgave any divergence would be a comparator taught to look away; this
+/// one forgives exactly the two shapes an in-flight snapshot produces — the tier
+/// has nothing for the execution yet, or it holds an older revision.
+///
+/// Every other kind stays divergent at any age. `ahead_version` in particular:
+/// a tier ahead of the incumbent cannot be explained by a mirror that has not
+/// caught up, so forgiving it inside the window would hide the one divergence
+/// class that means "serving this would be wrong".
+pub fn tolerable(report: &CrossStoreReport) -> bool {
+    !report.divergences.is_empty()
+        && report.divergences.iter().all(|d| {
+            matches!(
+                d.kind,
+                DivergenceKind::MissingExecution | DivergenceKind::StaleVersion
+            )
+        })
 }
 
 /// `NOETL_EHDB_PROJECTION_PARITY_ENABLED` — the comparator's own switch.
@@ -912,19 +969,46 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
     }
 
     let report = compare_cross_store(&auth, &records);
+    // The lag window (#265 G3). Applied to the SCORE, never to the comparison:
+    // the report is computed identically either way, so what the window changes
+    // is whether the verdict is taken, not what it would have said.
+    let tolerance = parity_lag_tolerance_secs();
+    let within_window = tolerance > 0
+        && auth.age_seconds >= 0
+        && (auth.age_seconds as u64) < tolerance;
     let outcome = if report.holds {
         ParityOutcome::Match
+    } else if within_window && tolerable(&report) {
+        ParityOutcome::PendingMirror
     } else {
         ParityOutcome::Divergent
     };
     crate::metrics::record_ehdb_crossstore_parity(TIER, outcome.as_str());
-    for kind in report.kinds() {
-        crate::metrics::record_ehdb_crossstore_divergence(TIER, kind);
+    // AN UNTAKEN COMPARISON PUBLISHES NO DIVERGENCE EVIDENCE.
+    //
+    // `pending_mirror` means the report describes a comparison that was not
+    // taken, so recording its kinds would move `crossstore_divergence_total` —
+    // the counter the paging rule reads — for a verdict that is explicitly not a
+    // divergence. server#354 is the record of this exact mistake on tier 1:
+    // probing an in-flight execution through the on-demand endpoint left
+    // `{kind="count"} 1` behind, which is ai-meta#264 — investigating with the
+    // endpoint inflates the counter its own alert reads, invisibly.
+    if outcome == ParityOutcome::Divergent {
+        for kind in report.kinds() {
+            crate::metrics::record_ehdb_crossstore_divergence(TIER, kind);
+        }
+    }
+    if outcome == ParityOutcome::PendingMirror {
+        // The window's COST, published. `divergence_total == 0` under a
+        // tolerance window means "the comparable executions agreed"; this says
+        // how much was not comparable, and it is the difference between a clean
+        // verdict and a comparator that has been taught to look away.
+        crate::metrics::add_ehdb_crossstore_pending(TIER, 1);
     }
     if report.holds {
         crate::metrics::add_ehdb_crossstore_events_compared(TIER, 1);
     }
-    if !report.holds {
+    if !report.holds && outcome == ParityOutcome::Divergent {
         warn!(
             target: "noetl_server::ehdb_projection_parity",
             execution_id,
@@ -997,6 +1081,94 @@ mod tests {
         assert_eq!(r.tier_records, 3);
     }
 
+
+    /// The lag window forgives LATENESS ONLY.
+    ///
+    /// This is the whole safety argument of #265 G3, so it is driven through
+    /// the same `compare_cross_store` the live path uses, on the same fixtures
+    /// the controls use — not against a hand-built report that could be shaped
+    /// to agree.
+    ///
+    /// Two-sided by construction: `tolerable` must be TRUE for the two shapes
+    /// an in-flight snapshot produces and FALSE for every other kind. A
+    /// `tolerable` that returned true unconditionally would be a comparator
+    /// taught to look away, and it would pass a one-sided test.
+    #[test]
+    fn the_lag_window_forgives_only_lateness() {
+        let (auth, base) = control_fixtures();
+
+        // Forgivable: the tier holds nothing for this execution yet.
+        let empty = compare_cross_store(&auth, &[]);
+        assert!(!empty.holds);
+        assert!(
+            tolerable(&empty),
+            "an empty tier is what an un-drained queue looks like: {:?}",
+            empty.kinds()
+        );
+
+        // Forgivable: the tier holds an older revision — the queue has the
+        // newest one and has not delivered it yet.
+        let mut behind = base.clone();
+        behind.pop();
+        let r = compare_cross_store(&auth, &behind);
+        assert!(!r.holds);
+        assert!(
+            tolerable(&r),
+            "a tier one revision behind is what an in-flight snapshot looks like: {:?}",
+            r.kinds()
+        );
+
+        // NOT forgivable at any age: a tier AHEAD of the incumbent. A mirror
+        // that has not caught up cannot produce this, and it is the one class
+        // that means serving would be wrong. Built with the SAME closure the
+        // control suite uses, so this cannot drift from what the comparator
+        // proves it can detect.
+        let mut ahead = base.clone();
+        ahead.push(control_record(4, 9_900, "dddd", 99));
+        let r = compare_cross_store(&auth, &ahead);
+        assert!(!r.holds);
+        assert!(
+            !tolerable(&r),
+            "an AHEAD tier must never be forgiven by a lag window: {:?}",
+            r.kinds()
+        );
+
+        // NOT forgivable: same version, different content.
+        let mut corrupt = base.clone();
+        let last = corrupt.len() - 1;
+        corrupt[last] = control_record(3, 9_003, "deadbeefdeadbeef", 12);
+        let r = compare_cross_store(&auth, &corrupt);
+        assert!(!r.holds);
+        assert!(
+            !tolerable(&r),
+            "a content disagreement is not lateness: {:?}",
+            r.kinds()
+        );
+
+        // And the degenerate case: a report with NO divergences is not
+        // "tolerable", it is a match. Without this, `tolerable` returning true
+        // on a clean report would turn every healthy comparison into
+        // `pending_mirror` and publish a parity rate of zero.
+        let clean = compare_cross_store(&auth, &base);
+        assert!(clean.holds);
+        assert!(!tolerable(&clean), "a clean report is a match, not a pending one");
+    }
+
+    /// The window is off by default, and reads the variable it documents.
+    #[test]
+    fn the_lag_tolerance_defaults_to_zero() {
+        // Zero is the correct default for a SYNCHRONOUS mirror: the tier is
+        // durable before `save` returns, so a tier that is behind is genuinely
+        // behind and nothing should be forgiven.
+        assert_eq!(PARITY_LAG_TOLERANCE_ENV, "NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS");
+        assert!(PARITY_OUTCOMES.iter().any(|o| o.as_str() == "pending_mirror"));
+        assert_eq!(
+            PARITY_OUTCOMES.len(),
+            10,
+            "pending_mirror must be pinned, or its series is absent until the first \
+             held-back verdict and absence reads as 'this build has no window'"
+        );
+    }
     #[test]
     fn every_control_discriminates() {
         // The anti-vacuity check, run as a test as well as in the binary: if a

--- a/src/handlers/ehdb_projection_read.rs
+++ b/src/handlers/ehdb_projection_read.rs
@@ -196,8 +196,22 @@ pub enum DemoteReason {
     /// The tier's version exceeds the highest `event_id` the execution has.
     /// **The dangerous case**: serving it would skip events.
     VersionAhead,
-    /// `verify` mode only: the tier is behind the incumbent.
+    /// `verify` mode only: the tier is behind the incumbent, and the incumbent
+    /// row is OLDER than the comparator's lag-tolerance window — so the async
+    /// mirror has had its promised time and has not caught up.
     StaleVersion,
+    /// `verify` mode only: the tier is behind, but the incumbent row is younger
+    /// than the lag-tolerance window (noetl/ai-meta#265 G3).
+    ///
+    /// **Not a fault**, and that distinction is what keeps "abort if any
+    /// fault-class counter moves" a usable cutover rule once the async mirror
+    /// is armed. With an async mirror a transiently-behind tier is the system
+    /// working, and folding it into `stale_version` would make the rule fire on
+    /// every rollout — which is how an abort condition gets ignored.
+    ///
+    /// The read still demotes. Serving is not the question; whether anyone
+    /// should be paged is.
+    StaleWithinWindow,
     /// `verify` mode only: same version, different checksum.
     Divergent,
     /// The snapshot body does not deserialise into a `WorkflowState`.
@@ -226,6 +240,7 @@ impl DemoteReason {
             Self::NoBody => "no_body",
             Self::VersionAhead => "version_ahead",
             Self::StaleVersion => "stale_version",
+            Self::StaleWithinWindow => "stale_within_window",
             Self::Divergent => "divergent",
             Self::Undeserialisable => "undeserialisable",
             Self::NoIncumbent => "no_incumbent",
@@ -240,7 +255,7 @@ impl DemoteReason {
     pub fn is_fault(self) -> bool {
         !matches!(
             self,
-            Self::Missing | Self::Unconfigured | Self::NoIncumbent
+            Self::Missing | Self::Unconfigured | Self::NoIncumbent | Self::StaleWithinWindow
         )
     }
 }
@@ -251,7 +266,7 @@ impl DemoteReason {
 /// as a set so an absent series means "this binary predates the metric" rather
 /// than "this case has not happened" — `Registry::gather` prunes empty families,
 /// so absence is the default state of every labelled metric here.
-pub const READ_OUTCOMES: [&str; 13] = [
+pub const READ_OUTCOMES: [&str; 14] = [
     "served_tier",
     "disabled",
     "unconfigured",
@@ -265,6 +280,7 @@ pub const READ_OUTCOMES: [&str; 13] = [
     "divergent",
     "undeserialisable",
     "no_incumbent",
+    "stale_within_window",
 ];
 
 /// The identifying facts of the incumbent row, for `verify` mode.
@@ -276,6 +292,10 @@ pub const READ_OUTCOMES: [&str; 13] = [
 pub struct IncumbentFacts {
     pub version: i64,
     pub checksum: Option<String>,
+    /// When the incumbent row was written. Used ONLY to decide whether a
+    /// behind-tier is inside the lag-tolerance window; never to decide whether
+    /// to serve.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// What the tier read produced.
@@ -323,6 +343,8 @@ fn decide(
     records: &[Candidate],
     max_event_id: Option<i64>,
     incumbent: Option<&IncumbentFacts>,
+    lag_tolerance_secs: u64,
+    now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Candidate, DemoteReason> {
     if records.is_empty() {
         return Err(DemoteReason::Missing);
@@ -360,7 +382,16 @@ fn decide(
     // `verify` mode: the incumbent is in hand, so compare against it too.
     if let Some(inc) = incumbent {
         if newest.version < inc.version {
-            return Err(DemoteReason::StaleVersion);
+            // Inside the window this is the async mirror doing its job, not a
+            // fault — see `StaleWithinWindow`. Outside it, the mirror has had
+            // its promised time. Same demote either way; different alerting.
+            let age = (now - inc.updated_at).num_seconds();
+            let inside = lag_tolerance_secs > 0 && age >= 0 && (age as u64) < lag_tolerance_secs;
+            return Err(if inside {
+                DemoteReason::StaleWithinWindow
+            } else {
+                DemoteReason::StaleVersion
+            });
         }
         if newest.version > inc.version {
             // Above the incumbent but at or below the event log's tip. The tier
@@ -514,7 +545,13 @@ pub async fn read(
         max_event_id(pool, execution_id).await
     };
 
-    let chosen = match decide(&candidates, max, incumbent) {
+    let chosen = match decide(
+        &candidates,
+        max,
+        incumbent,
+        crate::handlers::ehdb_projection_parity::parity_lag_tolerance_secs(),
+        chrono::Utc::now(),
+    ) {
         Ok(c) => c,
         Err(reason) => return TierRead::Demote(reason),
     };
@@ -574,7 +611,7 @@ mod tests {
     #[test]
     fn a_consistent_record_is_served() {
         let c = candidate(10, 1, Some(snap(10)), None);
-        let got = decide(&[c], Some(10), None).expect("must serve");
+        let got = decide(&[c], Some(10), None, 0, chrono::Utc::now()).expect("must serve");
         assert_eq!(got.version, 10);
     }
 
@@ -585,7 +622,7 @@ mod tests {
     fn a_version_above_the_event_tip_demotes() {
         let c = candidate(99, 1, Some(snap(99)), None);
         assert_eq!(
-            decide(&[c], Some(10), None).unwrap_err(),
+            decide(&[c], Some(10), None, 0, chrono::Utc::now()).unwrap_err(),
             DemoteReason::VersionAhead
         );
     }
@@ -595,7 +632,7 @@ mod tests {
     fn an_unknown_event_tip_demotes_rather_than_skipping_the_check() {
         let c = candidate(10, 1, Some(snap(10)), None);
         assert_eq!(
-            decide(&[c], None, None).unwrap_err(),
+            decide(&[c], None, None, 0, chrono::Utc::now()).unwrap_err(),
             DemoteReason::VersionAhead
         );
     }
@@ -609,7 +646,7 @@ mod tests {
         let mut c = candidate(10, 1, Some(snap(10)), None);
         c.snapshot = Some(snap(11)); // body swapped, digest left describing snap(10)
         assert_eq!(
-            decide(&[c], Some(10), None).unwrap_err(),
+            decide(&[c], Some(10), None, 0, chrono::Utc::now()).unwrap_err(),
             DemoteReason::Checksum
         );
     }
@@ -619,7 +656,7 @@ mod tests {
     fn a_record_with_no_snapshot_body_demotes() {
         let c = candidate(10, 1, None, Some("deadbeef".to_string()));
         assert_eq!(
-            decide(&[c], Some(10), None).unwrap_err(),
+            decide(&[c], Some(10), None, 0, chrono::Utc::now()).unwrap_err(),
             DemoteReason::NoBody
         );
     }
@@ -628,10 +665,11 @@ mod tests {
     /// answers this for every execution that predates it.
     #[test]
     fn an_empty_tier_is_missing_not_a_fault() {
-        assert_eq!(decide(&[], Some(10), None).unwrap_err(), DemoteReason::Missing);
+        assert_eq!(decide(&[], Some(10), None, 0, chrono::Utc::now()).unwrap_err(), DemoteReason::Missing);
         assert!(!DemoteReason::Missing.is_fault());
         assert!(!DemoteReason::Unconfigured.is_fault());
         assert!(!DemoteReason::NoIncumbent.is_fault());
+        assert!(!DemoteReason::StaleWithinWindow.is_fault());
         assert!(DemoteReason::VersionAhead.is_fault());
         assert!(DemoteReason::Checksum.is_fault());
     }
@@ -644,9 +682,10 @@ mod tests {
         let inc = IncumbentFacts {
             version: 10,
             checksum: None,
+            updated_at: chrono::Utc::now() - chrono::Duration::seconds(3600),
         };
         assert_eq!(
-            decide(&[c], Some(10), Some(&inc)).unwrap_err(),
+            decide(&[c], Some(10), Some(&inc), 0, chrono::Utc::now()).unwrap_err(),
             DemoteReason::StaleVersion
         );
     }
@@ -658,9 +697,10 @@ mod tests {
         let inc = IncumbentFacts {
             version: 10,
             checksum: Some("0000000000000000000000000000000000000000000000000000000000000000".into()),
+            updated_at: chrono::Utc::now() - chrono::Duration::seconds(3600),
         };
         assert_eq!(
-            decide(&[c], Some(10), Some(&inc)).unwrap_err(),
+            decide(&[c], Some(10), Some(&inc), 0, chrono::Utc::now()).unwrap_err(),
             DemoteReason::Divergent
         );
     }
@@ -675,8 +715,9 @@ mod tests {
         let inc = IncumbentFacts {
             version: 10,
             checksum: Some(sha256_of(&body)),
+            updated_at: chrono::Utc::now() - chrono::Duration::seconds(3600),
         };
-        assert!(decide(&[c], Some(10), Some(&inc)).is_ok());
+        assert!(decide(&[c], Some(10), Some(&inc), 0, chrono::Utc::now()).is_ok());
     }
 
     /// The newest record wins, and "newest" is by version then sequence — not
@@ -688,11 +729,11 @@ mod tests {
             candidate(4, 1, Some(snap(4)), None),
             candidate(7, 2, Some(snap(7)), None),
         ];
-        assert_eq!(decide(&recs, Some(10), None).unwrap().version, 10);
+        assert_eq!(decide(&recs, Some(10), None, 0, chrono::Utc::now()).unwrap().version, 10);
         // …and reversing the input does not change the answer.
         let mut rev = recs.clone();
         rev.reverse();
-        assert_eq!(decide(&rev, Some(10), None).unwrap().version, 10);
+        assert_eq!(decide(&rev, Some(10), None, 0, chrono::Utc::now()).unwrap().version, 10);
     }
 
     /// A typed refusal is `unreadable`, never `missing`.
@@ -730,6 +771,55 @@ mod tests {
         assert_eq!(sha256_of(&body), writer);
     }
 
+    /// Inside the lag window a behind-tier is NOT a fault — and outside it, it is.
+    ///
+    /// Two-sided on purpose: the only thing that differs between these two
+    /// assertions is the incumbent row's age, so a `decide` that ignored the
+    /// window (or one that forgave everything) fails one of them.
+    #[test]
+    fn a_behind_tier_is_a_fault_only_outside_the_window() {
+        let now = chrono::Utc::now();
+        let mk = |age_secs: i64| IncumbentFacts {
+            version: 10,
+            checksum: None,
+            updated_at: now - chrono::Duration::seconds(age_secs),
+        };
+        let c = || candidate(8, 1, Some(snap(8)), None);
+
+        let fresh = decide(&[c()], Some(10), Some(&mk(5)), 30, now).unwrap_err();
+        assert_eq!(fresh, DemoteReason::StaleWithinWindow);
+        assert!(!fresh.is_fault(), "an in-flight mirror must not read as a fault");
+
+        let old = decide(&[c()], Some(10), Some(&mk(120)), 30, now).unwrap_err();
+        assert_eq!(old, DemoteReason::StaleVersion);
+        assert!(old.is_fault(), "a mirror past its promised window IS a fault");
+
+        // …and with no window configured, age is irrelevant.
+        assert_eq!(
+            decide(&[c()], Some(10), Some(&mk(1)), 0, now).unwrap_err(),
+            DemoteReason::StaleVersion
+        );
+    }
+
+    /// The window forgives LATENESS ONLY. A tier ahead of the event log is
+    /// refused at any age, because "the mirror has not caught up" cannot explain
+    /// a record claiming an event that does not exist.
+    #[test]
+    fn the_window_never_forgives_the_dangerous_case() {
+        let now = chrono::Utc::now();
+        let inc = IncumbentFacts {
+            version: 10,
+            checksum: None,
+            updated_at: now,
+        };
+        let c = candidate(99, 1, Some(snap(99)), None);
+        assert_eq!(
+            decide(&[c], Some(10), Some(&inc), 3600, now).unwrap_err(),
+            DemoteReason::VersionAhead,
+            "an enormous window must not turn version_ahead into a tolerated state"
+        );
+    }
+
     /// Every [`DemoteReason`] has a label in [`READ_OUTCOMES`], and every label
     /// but `served_tier`/`disabled` has a reason.
     ///
@@ -750,6 +840,7 @@ mod tests {
             DemoteReason::Divergent,
             DemoteReason::Undeserialisable,
             DemoteReason::NoIncumbent,
+            DemoteReason::StaleWithinWindow,
         ];
         for r in reasons {
             assert!(

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -17,6 +17,7 @@ pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;
 pub mod ehdb_projection_mirror;
 pub mod ehdb_projection_parity;
+pub mod ehdb_projection_mirror_queue;
 pub mod ehdb_projection_read;
 pub mod event_write;
 pub mod events;

--- a/src/main.rs
+++ b/src/main.rs
@@ -911,6 +911,16 @@ async fn main() -> anyhow::Result<()> {
     // says whether this process is async is true from the first scrape rather
     // than from the first mirrored event.
     handlers::ehdb_eventlog_mirror_queue::init();
+    // #265 G3 — the projection tier's own queue, with its own window. Passed
+    // the tolerance rather than reading it inside, so the pairing check is a
+    // pure function the tests can drive without a process. Publishing the
+    // window here too means the running value is readable off /metrics instead
+    // of off the Deployment spec, which is a different representation and can
+    // disagree with what the process actually parsed.
+    let projection_lag_tolerance =
+        handlers::ehdb_projection_parity::parity_lag_tolerance_secs();
+    noetl_server::metrics::set_ehdb_projection_parity_lag_tolerance(projection_lag_tolerance);
+    handlers::ehdb_projection_mirror_queue::init(projection_lag_tolerance);
     // Publish the comparator's window so the ops alert reads the configured
     // value instead of a copy of it (noetl/ai-meta#155).
     noetl_server::metrics::set_ehdb_crossstore_parity_lag_tolerance(
@@ -1110,6 +1120,9 @@ async fn main() -> anyhow::Result<()> {
     // divergence on a `primary`-serving tier with nothing pointing at the cause
     // (noetl/ai-meta#155). Bounded, and a no-op when the queue is disabled.
     noetl_server::handlers::ehdb_eventlog_mirror_queue::flush_on_shutdown().await;
+    // A snapshot still queued at exit never reaches the tier, and the
+    // comparator reports it as a divergence for as long as the row lives.
+    noetl_server::handlers::ehdb_projection_mirror_queue::flush().await;
 
     tracing::info!("Server shutdown complete");
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3512,6 +3512,30 @@ pub fn init_ehdb_projection_series() {
             .with_label_values(&[outcome])
             .inc_by(0);
     }
+    // #265 G3 — the async mirror queue. Pinned UNCONDITIONALLY, outside any
+    // config branch: server#315 pinned the event log's publish-skip reasons
+    // inside `if event_bus_mode.publishes_ehdb()` and left them absent on
+    // exactly the configuration whose reason someone would be reading. The
+    // configuration an operator checks before turning this on is the one with
+    // it off.
+    for outcome in EHDB_PROJECTION_MIRROR_QUEUE_OUTCOMES {
+        ehdb_projection_mirror_queue_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+    ehdb_projection_mirror_pending().set(0);
+    ehdb_projection_mirror_queue_depth().set(0);
+    ehdb_projection_mirror_async_enabled().set(0);
+    // An unlabelled Histogram is a family with one child, so it is not pruned;
+    // observing nothing leaves every bucket at 0, which is what it should read.
+    let _ = ehdb_projection_mirror_lag_seconds();
+    // The pending counter is the shared cross-store family, so the projection
+    // tier's series must be seeded too — otherwise `{tier="projection"}` is
+    // absent until the first held-back verdict, and absent reads as "this build
+    // has no tolerance window".
+    ehdb_crossstore_pending_total()
+        .with_label_values(&[TIER])
+        .inc_by(0);
 }
 
 /// Counter: how each orchestrator snapshot read resolved (noetl/ai-meta#265 B1).
@@ -3612,6 +3636,184 @@ pub fn record_ehdb_projection_snapshot_gate(outcome: &str) {
     ehdb_projection_snapshot_gate_total()
         .with_label_values(&[outcome])
         .inc();
+}
+
+/// Counter: what happened to a snapshot when it was handed to the projection
+/// mirror queue (noetl/ai-meta#265 G3).
+///
+/// A **second** family rather than more labels on `ehdb_projection_mirror_total`.
+/// That one answers "did the tier receive what the incumbent stored", counted at
+/// delivery; an `enqueued` label on it would be counted twice for every snapshot
+/// — once on enqueue, once on delivery — and destroy the only number that
+/// answers the coverage question. This family answers a different one: is the
+/// queue absorbing the load, or pushing back?
+pub fn ehdb_projection_mirror_queue_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_projection_mirror_queue_total",
+                "Authoritative snapshots by how the async projection mirror queue handled \
+                 them (noetl/ai-meta#265 G3).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Every queue outcome. Closed set, pinned at 0.
+///
+/// * `enqueued` — accepted immediately.
+/// * `enqueued_after_wait` — the queue was full and the writer **waited** for
+///   room. Backpressure working: nothing lost, order preserved. Its rate is the
+///   signal that the drain is falling behind.
+/// * `queue_full_inline` — full past the enqueue timeout, so the snapshot was
+///   mirrored inline. Still no drop, but this is the one path that can deliver
+///   out of order relative to snapshots still queued for the same execution, so
+///   it is its own label and it is what an alert fires on.
+/// * `queue_closed_inline` — no drain task. Mirrored inline; the pre-G3 path.
+/// * `drained` — delivered by the drain task. The terminal success label.
+/// * `shutdown_abandoned` — still queued when the process finished its flush.
+///   These never reached the tier and WILL show as a projection divergence; the
+///   label exists so the cause is attributable rather than a mystery an hour later.
+pub const EHDB_PROJECTION_MIRROR_QUEUE_OUTCOMES: [&str; 6] = [
+    "enqueued",
+    "enqueued_after_wait",
+    "queue_full_inline",
+    "queue_closed_inline",
+    "drained",
+    "shutdown_abandoned",
+];
+
+pub fn record_ehdb_projection_mirror_queue(outcome: &str) {
+    ehdb_projection_mirror_queue_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
+/// Histogram: seconds from acceptance to durable in the projection tier.
+///
+/// **The metric the comparator's lag tolerance is checked against.** The window
+/// tells the comparator to forgive a tier that is behind by less than N seconds;
+/// that is a promise about how long this can take, and without the histogram it
+/// would be an assumption. Buckets run to 60 s so a breach of a large window is
+/// still visible — a histogram topping out below the tolerance cannot show one.
+pub fn ehdb_projection_mirror_lag_seconds() -> &'static Histogram {
+    static M: OnceLock<Histogram> = OnceLock::new();
+    M.get_or_init(|| {
+        let hist = Histogram::with_opts(
+            HistogramOpts::new(
+                "noetl_ehdb_projection_mirror_lag_seconds",
+                "Seconds from a snapshot being accepted for the projection mirror to it \
+                 being durable in the tier (noetl/ai-meta#265 G3).",
+            )
+            .buckets(vec![
+                0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+            ]),
+        )
+        .expect("static histogram spec must be valid");
+        registry()
+            .register(Box::new(hist.clone()))
+            .expect("histogram registration must succeed");
+        hist
+    })
+}
+
+pub fn observe_ehdb_projection_mirror_lag(seconds: f64) {
+    ehdb_projection_mirror_lag_seconds().observe(seconds);
+}
+
+/// Gauge: snapshots accepted for the mirror and not yet durable.
+///
+/// The coverage number for the queue. `mirror_lag_seconds` only records
+/// snapshots that MADE it, so a queue that has stopped draining publishes no
+/// observations at all — its histogram goes quiet, which reads exactly like an
+/// idle healthy system. This gauge is what distinguishes the two.
+pub fn ehdb_projection_mirror_pending() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_projection_mirror_pending_snapshots",
+            "Snapshots accepted for the async projection mirror and not yet durable in the \
+             tier (noetl/ai-meta#265 G3).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Gauge: snapshots sitting on the queue.
+pub fn ehdb_projection_mirror_queue_depth() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_projection_mirror_queue_depth",
+            "Snapshots currently on the async projection mirror queue (noetl/ai-meta#265 G3).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Gauge: 1 when the async projection mirror is ARMED in this process, 0 otherwise.
+///
+/// Reads 0 in three distinguishable-by-log situations: the flag is off, the flag
+/// is on but the drain never started, and the flag is on but the pairing check
+/// REFUSED it (async with a zero tolerance window). Without this gauge all three
+/// look like an idle queue, and the third — the one that means someone set half
+/// a pair — is the one worth finding.
+pub fn ehdb_projection_mirror_async_enabled() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_projection_mirror_async_enabled",
+            "1 when the async projection mirror queue is armed in this process, 0 when the \
+             mirror is inline or the pairing check refused to arm it (noetl/ai-meta#265 G3).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+/// Gauge: the PROJECTION comparator's configured lag tolerance, in seconds.
+///
+/// Its own gauge rather than a reading of the event log's: the two windows are
+/// separate variables that cut over independently, and one gauge would make an
+/// alert for tier 1 silently start reading tier 2's tuning. Published so a rule
+/// does not have to hardcode the threshold — a number copied into PromQL is a
+/// representation of an env var, true until someone tunes one side.
+pub fn ehdb_projection_parity_lag_tolerance_seconds() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_projection_parity_lag_tolerance_seconds",
+            "The projection cross-store comparator's configured lag tolerance in seconds; 0 \
+             means no tolerance (noetl/ai-meta#265 G3).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+pub fn set_ehdb_projection_parity_lag_tolerance(seconds: u64) {
+    ehdb_projection_parity_lag_tolerance_seconds().set(seconds as i64);
 }
 
 pub fn init_ehdb_crossstore_series() {

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -167,6 +167,7 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
         opt.as_ref().map(|s| tier_read::IncumbentFacts {
             version: s.version,
             checksum: s.checksum.clone(),
+            updated_at: s.updated_at,
         })
     });
 


### PR DESCRIPTION
noetl/ai-meta#265 **G3** — the projection mirror comes off the orchestrator's write path, and the window that makes that safe ships with it.

## Two halves, deliberately in one PR

`mirror_snapshot` is called from inside `orch_snapshot::save`, and one of `save`'s two callers is the **inline orchestrator self-write** in `trigger_orchestrator_inner`. Every snapshot upsert on that path paid a relay round trip plus a tier append before the trigger returned — the shape #155 removed from the event log (78.6 ms → 0.1 ms per call, a median warm planner turn 16.9 s → 13.0 s).

An async mirror **without** a comparator tolerance window is worse than no async mirror: a snapshot in flight makes the tier legitimately behind, and a zero-window comparator scores that as divergence — manufacturing the exact alert the tier exists to make trustworthy. #155 states this as *set both or neither*. Here it is a **startup condition**: `refusal_reason` is a pure function and `init` **refuses to arm** when async is on with a 0 window. Refusing leaves the process inline (correct, merely slower); erroring would make a tuning mistake an outage, arming anyway would make it a false page. `..._async_enabled` stays 0 so the running state is readable rather than inferred from the variable someone set.

## Kind gate — 6 arms, 75 assertions, **0 failures**

Full write-up: `ai-meta:playbooks/265-projection-tier/RESULTS-G3.md`. Reproduce with `./run-async-gate.sh <settled_execution_id>`.

| arm | proves | result |
| :-- | :-- | --: |
| `refusal` | async ON + window **0** ⇒ refuses to arm, stays inline, logged | **13/13** |
| `armed` | async ON + real window ⇒ arms. Only the window moved | **13/13** |
| `delivery` | 32 concurrent submits: `enqueued == drained`, pending → 0, tier gains exactly 32 | **13/13** |
| `window-in` | behind tier, age **32 s** vs window **3600 s** ⇒ `pending_mirror`, **no divergence evidence** | **13/13** |
| `window-out` | the **same** tier, age **86432 s** vs window **30 s** ⇒ `divergent`, evidence published | **12/12** |
| `ahead-in-window` | tier **ahead** of the event tip, window 3600 s, fresh incumbent ⇒ still `divergent` | **11/11** |

The assertion with teeth is that an untaken comparison publishes **no** divergence evidence — server#354 is the record of that exact mistake on tier 1 (ai-meta#264: investigating with the endpoint inflates the counter its own alert reads).

## Notable in the implementation

- ⚠ **`reserve()`, never `send(value)`** on the enqueue path. `send` moves the value into the future, so a cancelled timeout takes the snapshot with it — a silent drop on the one path whose purpose is not to have one. #155's first version lost 28 of 60 records that way with every counter still reading correctly. A source guard counts code (`//` stripped, positive control that the stripper left the real call).
- **No per-execution coalescing**, though it would be safe to read — dropping intermediate revisions changes what the tier *contains*, and that needs its own flag and gate.
- The read path gains **`stale_within_window`**, non-fault. With an async mirror a transiently-behind tier is the system working; folding it into `stale_version` would make "abort if any fault-class counter moves" fire on every rollout. The read still demotes — serving is not the question, paging is.

## Stated as NOT established

- **Nothing about two servers racing.** kind runs one server replica, so the queue, its ordering guarantee and the 32-way concurrency are all in-process. Across replicas each has its own queue; unchanged by G3 and unmeasured.
- **No latency claim for the projection mirror.** The 78.6 → 0.1 ms figure is the event log's, on prod. The kind cluster carries a ~672k-command backlog and is the wrong place to measure this.
- **Rung 3 never fired** — `queue_full_inline` stayed 0, so the out-of-order path the alert targets is untested here; unit tests cover the ladder.

824 lib tests (+8), no new clippy warnings. **Lands inert:** async off, window 0. Prod re-verified read-only on exit — all five projection variables 0 occurrences, `NOETL_EHDB_EVENTLOG=primary` unchanged, prod's own event-log async mirror untouched.

Refs noetl/ai-meta#265
