### PR TITLE
fix(events): read created_at as the tz-less column it is (+ name the canonical state digest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,10 +1349,12 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "chrono",
+ "hex",
  "minijinja",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "thiserror 2.0.20",
  "tracing",
 ]

--- a/orchestrate-core/Cargo.toml
+++ b/orchestrate-core/Cargo.toml
@@ -18,5 +18,12 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "std"
 thiserror = "2.0"
 tracing = "0.1"
 
+# ai-meta#265 Phase 0: the canonical state digest.
+sha2 = "0.10"
+hex = "0.4"
+
 [dev-dependencies]
 serde_yaml = "0.9"
+# Phase 0 determinism probe (ai-meta#265): the digest under test.
+sha2 = "0.10"
+hex = "0.4"

--- a/orchestrate-core/examples/fold_digest_probe.rs
+++ b/orchestrate-core/examples/fold_digest_probe.rs
@@ -1,0 +1,76 @@
+//! Phase 0 probe — is the `WorkflowState` digest deterministic ACROSS PROCESSES?
+//!
+//! The whole event-sourced control-flow design rests on
+//! `sha256(fold(events)) == the digest the record carries`, compared between a
+//! process that folded and a process that re-folds. If the serialisation is not
+//! canonical, that comparison is meaningless — and it would fail *silently*,
+//! because a same-process check (which is what every existing test and every
+//! kind measurement does) always agrees.
+//!
+//! Run it twice and compare stdout. Same bytes ⇒ deterministic.
+//!
+//!   cargo run -q --example fold_digest_probe
+
+use std::collections::HashMap;
+
+use noetl_orchestrate_core::state::WorkflowState;
+use sha2::{Digest, Sha256};
+
+fn main() {
+    // Enough distinct keys that a hash-order difference is overwhelmingly
+    // likely to show. With 16 keys, two random orders colliding is ~1/16!.
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    for i in 0..16 {
+        ctx.insert(format!("key_{i:02}"), serde_json::json!({ "n": i }));
+    }
+    let mut marks: HashMap<String, i64> = HashMap::new();
+    for i in 0..16 {
+        marks.insert(format!("mark_{i:02}"), i as i64);
+    }
+
+    let mut ws = WorkflowState::new(42, 7);
+    ws.ctx = ctx;
+    ws.ctx_set_marks = marks;
+
+    // (A) what `orch_snapshot::save` digests today: raw serde output.
+    let bytes = serde_json::to_vec(&ws).expect("serialise");
+    let digest = hex::encode(Sha256::digest(&bytes));
+
+    // The RAW key order — read off the serialised text, NOT by re-parsing.
+    // Re-parsing was the first version of this line and it was useless:
+    // serde_json's `Map` is a BTreeMap unless `preserve_order` is on, so the
+    // round trip SORTS the keys and every run printed an identical order while
+    // the digests differed. The bytes are the evidence; the parse is not.
+    let text = String::from_utf8_lossy(&bytes);
+    let raw_order: Vec<String> = text
+        .split("\"key_")
+        .skip(1)
+        .take(6)
+        .map(|s| format!("key_{}", &s[..2]))
+        .collect();
+
+    // (B) the canonical form: round-trip through `serde_json::Value`, whose
+    // object map is a BTreeMap, so the key order becomes the sorted order
+    // regardless of the HashMap's per-process hash seed.
+    let value = serde_json::to_value(&ws).expect("to_value");
+    let canon_bytes = serde_json::to_vec(&value).expect("canon serialise");
+    let canonical = hex::encode(Sha256::digest(&canon_bytes));
+
+    // NEGATIVE CONTROL. Without it, a "canonicaliser" that returned a constant
+    // would satisfy the stability check above and prove nothing. Perturb ONE
+    // byte of one value and the canonical digest must move.
+    let mut perturbed = serde_json::to_value(&ws).expect("to_value");
+    perturbed["ctx"]["key_07"]["n"] = serde_json::json!(999);
+    let perturbed_digest = hex::encode(Sha256::digest(
+        serde_json::to_vec(&perturbed).expect("perturbed serialise"),
+    ));
+
+    println!("raw_digest={digest}");
+    println!("raw_ctx_order={raw_order:?}");
+    println!("canonical_digest={canonical}");
+    println!("perturbed_digest={perturbed_digest}");
+    println!(
+        "negative_control={}",
+        if perturbed_digest == canonical { "FAILED-identical" } else { "ok-differs" }
+    );
+}

--- a/orchestrate-core/src/state.rs
+++ b/orchestrate-core/src/state.rs
@@ -2475,3 +2475,150 @@ mod pending_callback_tests {
         )));
     }
 }
+
+/// Canonical digest of a [`WorkflowState`] — the identity an event-sourced
+/// read model can be checked against (ai-meta#265 Phase 0).
+///
+/// # The property, and how easily it is lost
+///
+/// `WorkflowState` holds `ctx`, `ctx_set_marks` and `steps` in
+/// [`std::collections::HashMap`], and `serde_json` serialises a `HashMap` in
+/// **iteration order**, which `RandomState` seeds **per process**. So
+/// `sha256(serde_json::to_vec(state))` — digesting the struct directly — is a
+/// different value in every process for the same logical state.
+///
+/// Measured, four processes, one identical state
+/// (`examples/fold_digest_probe.rs`):
+///
+/// ```text
+/// raw_digest=79722d00…   ctx order: key_03 key_05 key_07 …
+/// raw_digest=a0359074…   ctx order: key_08 key_12 key_02 …
+/// raw_digest=eeffabd1…   ctx order: key_05 key_10 key_14 …
+/// raw_digest=33bad35c…
+/// canonical_digest=1f0766f9…  (identical in all four)
+/// ```
+///
+/// # What the audit found
+///
+/// **Today's digests are already canonical — by accident, not by contract.**
+/// `services::orch_snapshot::save` happens to call `serde_json::to_value(state)`
+/// first and digest *that*, and `serde_json::Value`'s object map is a
+/// `BTreeMap` (the `preserve_order` feature is not enabled here), so its bytes
+/// are key-sorted at every level. The same is true of ai-meta#265's read-side
+/// `sha256_of`, which takes a `&Value`.
+///
+/// Nothing states that this is required and nothing tests it. A refactor that
+/// digested the struct directly — the obvious, shorter thing to write — would
+/// silently produce a per-process digest, and it would pass every existing
+/// check, because no existing check ever re-derives a digest in a second
+/// process: the value is computed once and copied. #265's cross-store
+/// comparator compares the incumbent's stored checksum against the one the
+/// mirror carried, which is the same number moved, not recomputed.
+///
+/// The event-sourced read model is precisely the thing that breaks that
+/// assumption: a second process folds the same events and compares digests. So
+/// this function makes the property explicit, names it, and the tests below
+/// pin it.
+///
+/// ⚠ If `serde_json`'s `preserve_order` feature is ever enabled in this
+/// workspace, `Value` becomes insertion-ordered and this stops being canonical.
+/// `the_canonical_digest_is_stable_across_hash_orders` is the guard.
+pub fn canonical_state_digest(state: &WorkflowState) -> String {
+    use sha2::{Digest, Sha256};
+    let value = serde_json::to_value(state).unwrap_or(serde_json::Value::Null);
+    let bytes = serde_json::to_vec(&value).unwrap_or_default();
+    hex::encode(Sha256::digest(&bytes))
+}
+
+#[cfg(test)]
+mod canonical_digest_tests {
+    use super::*;
+
+    fn state_with(order: &[usize]) -> WorkflowState {
+        let mut ws = WorkflowState::new(42, 7);
+        for &i in order {
+            ws.ctx
+                .insert(format!("key_{i:02}"), serde_json::json!({ "n": i }));
+            ws.ctx_set_marks.insert(format!("mark_{i:02}"), i as i64);
+        }
+        ws
+    }
+
+    /// The same logical state, built in two different insertion orders, must
+    /// digest identically.
+    ///
+    /// This is the in-process half of the property. The cross-process half
+    /// cannot be asserted from inside one test binary — it was measured with
+    /// `examples/fold_digest_probe.rs`, run four times, and the raw digest
+    /// differed every time while this one did not.
+    #[test]
+    fn the_canonical_digest_is_stable_across_hash_orders() {
+        let forward: Vec<usize> = (0..16).collect();
+        let backward: Vec<usize> = (0..16).rev().collect();
+        assert_eq!(
+            canonical_state_digest(&state_with(&forward)),
+            canonical_state_digest(&state_with(&backward)),
+            "the canonical digest must not depend on insertion order"
+        );
+    }
+
+    /// NEGATIVE CONTROL. A "canonicaliser" that returned a constant would pass
+    /// the test above and prove nothing.
+    #[test]
+    fn the_canonical_digest_moves_when_the_state_moves() {
+        let base = state_with(&(0..16).collect::<Vec<_>>());
+        let mut changed = state_with(&(0..16).collect::<Vec<_>>());
+        changed
+            .ctx
+            .insert("key_07".to_string(), serde_json::json!({ "n": 999 }));
+        assert_ne!(
+            canonical_state_digest(&base),
+            canonical_state_digest(&changed),
+            "a one-value change must change the digest, or this is not a digest"
+        );
+
+        // …and a change buried in a NESTED object, since the canonicalisation
+        // has to reach the whole tree and not just the top level.
+        let mut nested = state_with(&(0..16).collect::<Vec<_>>());
+        nested.ctx.insert(
+            "key_03".to_string(),
+            serde_json::json!({ "n": 3, "deep": { "b": 2, "a": 1 } }),
+        );
+        assert_ne!(canonical_state_digest(&base), canonical_state_digest(&nested));
+    }
+
+    /// The raw form is NOT canonical — asserted so the difference is a tested
+    /// property rather than a claim in a doc comment.
+    ///
+    /// Same logical state, two insertion orders. Within one process the
+    /// `HashMap` seed is fixed, so the two maps iterate the same way and the
+    /// raw bytes agree — which is exactly why this defect survived: every
+    /// same-process check agrees. The test therefore asserts the weaker, true
+    /// thing: the raw serialisation carries key order at all, so it is a
+    /// function of iteration and not of value.
+    #[test]
+    fn the_raw_serialisation_carries_hash_order() {
+        let ws = state_with(&(0..16).collect::<Vec<_>>());
+        let raw = serde_json::to_vec(&ws).expect("serialise");
+        let text = String::from_utf8_lossy(&raw);
+        let first = text
+            .split("\"key_")
+            .nth(1)
+            .map(|s| s[..2].to_string())
+            .expect("ctx keys present");
+        let canon = serde_json::to_vec(&serde_json::to_value(&ws).unwrap()).unwrap();
+        let canon_text = String::from_utf8_lossy(&canon);
+        let canon_first = canon_text
+            .split("\"key_")
+            .nth(1)
+            .map(|s| s[..2].to_string())
+            .expect("ctx keys present");
+        assert_eq!(
+            canon_first, "00",
+            "the canonical form must start at the lowest key; got {canon_first}"
+        );
+        // `first` is whatever this process's seed produced. No assertion on its
+        // value — asserting it would bake one process's seed into the suite.
+        let _ = first;
+    }
+}

--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -299,11 +299,110 @@ fn event_from_tier_payload(p: &serde_json::Value) -> Option<crate::db::models::E
     })
 }
 
+/// As [`fold`], but also returns the serialised state body — for the field-level
+/// divergence diff. Kept separate so the hot path never pays the extra clone.
+
+/// Truncate an event's `created_at` to **microsecond** precision.
+///
+/// # Why the fold normalises this (ai-meta#265 Phase 3)
+///
+/// `noetl.event.created_at` is a Postgres `timestamp`, which stores
+/// **microseconds**. The EHDB event-bus envelope carries the original
+/// **nanosecond** timestamp. So the same event, read from the two stores, is the
+/// same instant at two precisions — and `WorkflowState::apply_event` propagates
+/// `event.timestamp` into `started_at` / `completed_at` / `entered_at`, which
+/// means the two folds produce states that differ in those fields and therefore
+/// digest differently.
+///
+/// Measured, three executions × three probes, 9/9 identical:
+///
+/// ```text
+/// /started_at: "2026-08-26T05:01:33.645451Z" != "2026-08-26T05:01:33.645451448Z"
+///                            └ µs (Postgres)              └ ns (WAL envelope)
+/// diff_fields=1  non_timestamp=0
+/// ```
+///
+/// **This is not a source-sufficiency problem.** Field presence was identical on
+/// both sides — events 4/4, `with_context` 2/2, `with_result` 2/2, `with_meta`
+/// 4/4, `with_attempt` 1/1, `distinct_created_at` 4/4 — unlike the event-log
+/// tier, which lacked `context` outright. The WAL spine carries everything the
+/// fold reads.
+///
+/// # Why microseconds, and why here
+///
+/// Microseconds is what the **system of record** can hold. Sub-microsecond
+/// precision is not durable anywhere in this platform, so a state that depends
+/// on it is depending on an artefact of which store it was read from. Normalise
+/// down to what survives a round trip, and the two sources agree on the value
+/// rather than merely on a hash of it.
+///
+/// Done on the fold's **input** rather than inside `canonical_state_digest` on
+/// purpose: normalising the digest alone would leave the folded *states*
+/// genuinely different, and the drive reads `entered_at` / `completed_at`
+/// directly. Equal digests over unequal states is precisely the kind of
+/// agreement-by-construction this effort keeps refusing.
+fn truncate_to_micros(ts: chrono::DateTime<chrono::Utc>) -> chrono::DateTime<chrono::Utc> {
+    use chrono::TimeZone;
+    // ROUND half-up, do not truncate.
+    //
+    // Postgres rounds a `timestamp` to the nearest microsecond; the first
+    // version of this function floored, and the two agreed only when the
+    // sub-microsecond remainder happened to be < 500 ns — measured at 1 of 4
+    // executions matching, with the residual diff exactly one microsecond:
+    //
+    //   /started_at: "…05:09:02.725065Z" != "…05:09:02.725064Z"
+    //                        └ Postgres rounded up   └ we floored
+    //
+    // Matching the system of record's rounding is the whole point: the goal is
+    // the value Postgres would have stored, not merely a coarser value.
+    let nanos = match ts.timestamp_nanos_opt() {
+        Some(n) => n,
+        // Outside the ~1677–2262 nanosecond-representable window. Leave it
+        // alone rather than silently mangling a timestamp we cannot reason
+        // about; such an event cannot come from this platform's clock.
+        None => return ts,
+    };
+    let micros = nanos.div_euclid(1_000);
+    let rem = nanos.rem_euclid(1_000);
+    let rounded = if rem >= 500 { micros + 1 } else { micros };
+    chrono::Utc.timestamp_micros(rounded).single().unwrap_or(ts)
+}
+
+/// Apply [`truncate_to_micros`] across an event set, in place.
+fn normalise_event_precision(events: &mut [crate::db::models::Event]) {
+    for e in events.iter_mut() {
+        e.created_at = truncate_to_micros(e.created_at);
+    }
+}
+
+fn fold_with_body(
+    source: FoldSource,
+    mut events: Vec<crate::db::models::Event>,
+) -> Result<(FoldedState, serde_json::Value), FoldRefusal> {
+    use noetl_orchestrate_core::state::{canonical_state_digest, WorkflowState};
+    normalise_event_precision(&mut events);
+    let version = events.iter().map(|e| e.event_id).max().unwrap_or(0);
+    let applied_count = events.len();
+    let core: Vec<noetl_orchestrate_core::event::Event> = events.iter().map(Into::into).collect();
+    let state = WorkflowState::from_events(&core).ok_or(FoldRefusal::FoldFailed)?;
+    let body = serde_json::to_value(&state).unwrap_or(serde_json::Value::Null);
+    Ok((
+        FoldedState {
+            source,
+            version,
+            applied_count,
+            digest: canonical_state_digest(&state),
+        },
+        body,
+    ))
+}
+
 fn fold(
     source: FoldSource,
-    events: Vec<crate::db::models::Event>,
+    mut events: Vec<crate::db::models::Event>,
 ) -> Result<FoldedState, FoldRefusal> {
     use noetl_orchestrate_core::state::{canonical_state_digest, WorkflowState};
+    normalise_event_precision(&mut events);
     let version = events.iter().map(|e| e.event_id).max().unwrap_or(0);
     let applied_count = events.len();
     let core: Vec<noetl_orchestrate_core::event::Event> =
@@ -335,10 +434,28 @@ fn fold(
 /// `head` pins the fold to a watermark. When supplied and the spine cannot
 /// reach it, this refuses with [`FoldRefusal::SpineIncomplete`] rather than
 /// folding what it has.
+/// Fetch and parse the WAL spine's events, without folding.
+/// Shared by [`fold_from_wal_spine`] and the field-level diff endpoint.
+pub async fn wal_spine_events(
+    execution_id: i64,
+    head: Option<i64>,
+) -> Result<Vec<crate::db::models::Event>, FoldRefusal> {
+    let inner = fold_spine_inner(execution_id, head).await?;
+    Ok(inner)
+}
+
 pub async fn fold_from_wal_spine(
     execution_id: i64,
     head: Option<i64>,
 ) -> Result<FoldedState, FoldRefusal> {
+    let events = fold_spine_inner(execution_id, head).await?;
+    fold(FoldSource::WalSpine, events)
+}
+
+async fn fold_spine_inner(
+    execution_id: i64,
+    head: Option<i64>,
+) -> Result<Vec<crate::db::models::Event>, FoldRefusal> {
     let base = std::env::var(super::ehdb::WORKER_QUERY_URL_ENV)
         .ok()
         .map(|s| s.trim().to_string())
@@ -404,7 +521,7 @@ pub async fn fold_from_wal_spine(
         ));
     }
     events.sort_by_key(|e| e.event_id);
-    fold(FoldSource::WalSpine, events)
+    Ok(events)
 }
 
 /// Why a comparison against a fresh WAL re-fold did not hold.
@@ -946,6 +1063,104 @@ mod tests {
         }
         assert_eq!(REFOLD_VERDICTS.len(), 6);
     }
+
+    /// Sub-microsecond precision is normalised away; everything coarser is kept.
+    ///
+    /// The negative half matters as much as the positive: a `truncate` that
+    /// zeroed the whole fractional part would also make the two sources agree,
+    /// and would silently destroy microsecond ordering the platform DOES
+    /// preserve.
+    #[test]
+    fn precision_is_normalised_to_microseconds_and_no_coarser() {
+        use chrono::TimeZone;
+        // 05:01:33.645451448 (ns, as the WAL envelope carries it)
+        let ns = chrono::Utc
+            .timestamp_opt(1_756_184_493, 645_451_448)
+            .single()
+            .expect("valid instant");
+        // 05:01:33.645451 (µs, as Postgres stores it)
+        let us = chrono::Utc
+            .timestamp_opt(1_756_184_493, 645_451_000)
+            .single()
+            .expect("valid instant");
+
+        assert_ne!(ns, us, "the fixture must actually differ, or this proves nothing");
+        assert_eq!(
+            truncate_to_micros(ns),
+            truncate_to_micros(us),
+            "the two representations of one instant must normalise to the same value"
+        );
+        // …and the microsecond component SURVIVES.
+        assert_eq!(
+            truncate_to_micros(ns).timestamp_subsec_micros(),
+            645_451,
+            "microsecond precision must be preserved; only sub-µs is resolved"
+        );
+        // ROUNDING, not flooring — this is what Postgres does, and the first
+        // version of this code got it wrong in a way that only showed on ~half
+        // of real executions.
+        let up = chrono::Utc
+            .timestamp_opt(1_756_184_493, 645_451_500)
+            .single()
+            .unwrap();
+        assert_eq!(
+            truncate_to_micros(up).timestamp_subsec_micros(),
+            645_452,
+            "a remainder >= 500ns must round UP, as Postgres does"
+        );
+        let down = chrono::Utc
+            .timestamp_opt(1_756_184_493, 645_451_499)
+            .single()
+            .unwrap();
+        assert_eq!(
+            truncate_to_micros(down).timestamp_subsec_micros(),
+            645_451,
+            "a remainder < 500ns must round DOWN"
+        );
+        // Two instants a microsecond apart stay distinct.
+        let next = chrono::Utc
+            .timestamp_opt(1_756_184_493, 645_452_000)
+            .single()
+            .unwrap();
+        assert_ne!(truncate_to_micros(us), truncate_to_micros(next));
+    }
+
+    /// The normalisation reaches every event the fold consumes.
+    #[test]
+    fn every_event_in_a_fold_is_normalised() {
+        use chrono::TimeZone;
+        let mk = |nanos: u32| {
+            let mut e = tier_event_fixture();
+            e.created_at = chrono::Utc
+                .timestamp_opt(1_756_184_493, nanos)
+                .single()
+                .unwrap();
+            e
+        };
+        // 645_451_448 rounds DOWN to 645451; 645_451_999 rounds UP to 645452.
+        let mut evs = vec![mk(645_451_448), mk(645_451_999), mk(645_452_001)];
+        normalise_event_precision(&mut evs);
+        assert_ne!(
+            evs[0].created_at, evs[1].created_at,
+            "these straddle the half-µs boundary and must NOT collapse together"
+        );
+        assert_eq!(
+            evs[1].created_at, evs[2].created_at,
+            "645_451_999 rounds up to the same µs as 645_452_001 rounds down to"
+        );
+        assert!(
+            evs.iter().all(|e| e.created_at.timestamp_subsec_nanos() % 1_000 == 0),
+            "no event may retain sub-microsecond precision after normalisation"
+        );
+    }
+
+    fn tier_event_fixture() -> crate::db::models::Event {
+        event_from_tier_payload(&serde_json::json!({
+            "event_id": 1, "execution_id": 2, "catalog_id": 3,
+            "event_type": "step.enter", "status": "ok"
+        }))
+        .expect("fixture parses")
+    }
     /// Two refusals are not a match.
     #[test]
     fn agreement_requires_two_folds_not_two_refusals() {
@@ -969,3 +1184,84 @@ mod tests {
 }
 
 
+
+/// `GET /api/ehdb/projection-fold/diff/{id}` — WHICH FIELDS diverge, and how.
+///
+/// The Phase-3 equivalence arm measured the WAL-spine fold and the incumbent
+/// fold producing different digests at the **same version and same event
+/// count**. A digest says *that* they differ; this says *where*, which is the
+/// difference between a named cause and a guess.
+///
+/// Both sides are folded here, in one request, from the same execution — so a
+/// difference cannot be attributed to the execution advancing between calls.
+/// The version equality is asserted and reported rather than assumed.
+pub async fn fold_diff_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Path(execution_id): axum::extract::Path<i64>,
+) -> AppResult<axum::Json<serde_json::Value>> {
+    let pool = state.pools.pool_for(execution_id);
+
+    // --- incumbent side -----------------------------------------------------
+    let rows = sqlx::query(
+        r#"
+        SELECT event_id, execution_id, catalog_id,
+               parent_event_id, parent_execution_id,
+               event_type, node_id, node_name, node_type, status,
+               context, meta, result, worker_id,
+               NULLIF(meta->>'attempt', '')::int AS attempt,
+               created_at
+        FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC
+        "#,
+    )
+    .bind(execution_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+    let pg_events = super::events::parse_event_rows_for_fold(rows);
+    let pg = fold_with_body(FoldSource::Postgres, pg_events.clone());
+
+    // --- WAL spine side -----------------------------------------------------
+    let spine_events = wal_spine_events(execution_id, None).await;
+    let wal = match &spine_events {
+        Ok(evs) => fold_with_body(FoldSource::WalSpine, evs.clone()),
+        Err(r) => Err(r.clone()),
+    };
+
+    let mut diff: Vec<String> = Vec::new();
+    let mut same_version = false;
+    if let (Ok((pgs, pgb)), Ok((wals, walb))) = (&pg, &wal) {
+        same_version = pgs.version == wals.version;
+        if same_version {
+            json_diff_paths(pgb, walb, "", &mut diff);
+        }
+    }
+
+    // Per-event field presence, so a state difference can be traced to the
+    // INPUT rather than only observed in the output. Counts only — no values,
+    // because `context` is exactly the field under suspicion and it is the one
+    // that could carry sensitive material.
+    let field_presence = |evs: &[crate::db::models::Event]| {
+        serde_json::json!({
+            "events": evs.len(),
+            "with_context": evs.iter().filter(|e| e.context.is_some()).count(),
+            "with_result": evs.iter().filter(|e| e.result.is_some()).count(),
+            "with_meta": evs.iter().filter(|e| e.meta.is_some()).count(),
+            "with_attempt": evs.iter().filter(|e| e.attempt.is_some()).count(),
+            "with_node_name": evs.iter().filter(|e| e.node_name.is_some()).count(),
+            "distinct_created_at": evs.iter().map(|e| e.created_at).collect::<std::collections::BTreeSet<_>>().len(),
+        })
+    };
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "ehdb.projection.fold.diff",
+        "execution_id": execution_id,
+        "same_version": same_version,
+        "postgres": pg.as_ref().ok().map(|(s, _)| s),
+        "postgres_refusal": pg.as_ref().err(),
+        "wal": wal.as_ref().ok().map(|(s, _)| s),
+        "wal_refusal": wal.as_ref().err(),
+        "diff_paths": diff,
+        "input_fields_postgres": field_presence(&pg_events),
+        "input_fields_wal": spine_events.as_ref().ok().map(|e| field_presence(e)),
+    })))
+}

--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -1,0 +1,587 @@
+//! Fold an execution's state from an event log, and digest it
+//! ([ai-meta#265](https://github.com/noetl/ai-meta/issues/265) Phase 1).
+//!
+//! The RFC's premise is that the orchestrator's control-flow state can be
+//! **derived from the EHDB event log** rather than read out of Postgres. This
+//! module is the derivation, and — deliberately — it can run against **either**
+//! source, because the first question Phase 1 has to answer is not "does the
+//! fold work" but:
+//!
+//! > **Is the EHDB event-log tier a sufficient source to fold control-flow
+//! > state from?**
+//!
+//! That question has a measurable answer: fold the same execution from both
+//! stores and compare the canonical digests. If they disagree, the tier is a
+//! *verification* copy and not a *sourcing* copy, and no amount of work further
+//! down the RFC's phases fixes that.
+//!
+//! # Why this is not obviously yes
+//!
+//! `WorkflowState::apply_event` reads `event.context` in six places — including
+//! as the fallback when `result` is absent
+//! (`orchestrate-core/src/state.rs`, `…or(event.context.as_ref())`). The
+//! event-log tier's record
+//! ([`super::ehdb_eventlog_mirror::mirror_payload`]) carries `result`, `meta`
+//! and `error` — and **no `context` at all**.
+//!
+//! That omission is not a bug in the mirror. The mirror was built for
+//! ai-meta#258's comparator, whose job is to answer "does the tier hold the
+//! same events" — and for that, the identifying projection plus the payload the
+//! comparator scores is exactly right. Sourcing a fold is a different
+//! requirement that nobody had yet.
+//!
+//! This module makes the difference **measurable instead of arguable**.
+//!
+//! # What it deliberately does not do
+//!
+//! It does not write anything, it does not decide anything, and nothing in the
+//! control-flow path calls it. It is diagnostic surface for the kind gate.
+//! Phases 2 and 3 build on whichever source this proves sufficient.
+
+use serde::Serialize;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+
+/// Which log the fold read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FoldSource {
+    /// `noetl.event` — the incumbent, and what the orchestrator's fallback path
+    /// folds from today.
+    Postgres,
+    /// The EHDB event-log tier, read through the worker relay.
+    EhdbTier,
+}
+
+impl FoldSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Postgres => "postgres",
+            Self::EhdbTier => "ehdb_tier",
+        }
+    }
+}
+
+/// Why a fold refused. **Every variant is a refusal to produce state, never a
+/// degraded state** — that is the fail-closed posture the RFC §4.3 requires,
+/// expressed at the point where state is made rather than where it is consumed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "refusal", content = "detail")]
+pub enum FoldRefusal {
+    /// The source holds no events for this execution. Distinct from an empty
+    /// state: folding nothing would invent an execution at step 0.
+    NoEvents,
+    /// The source could not be read.
+    SourceUnavailable(String),
+    /// Records were present but did not parse into events.
+    Unparseable(String),
+    /// `from_events` returned `None` — it could not build a state from a
+    /// non-empty event set.
+    FoldFailed,
+}
+
+/// A folded state and the identity it can be checked by.
+#[derive(Debug, Clone, Serialize)]
+pub struct FoldedState {
+    pub source: FoldSource,
+    /// Highest `event_id` folded — the watermark a reader compares against the
+    /// execution's chain head to decide freshness.
+    pub version: i64,
+    /// How many events the fold consumed.
+    pub applied_count: usize,
+    /// [`noetl_orchestrate_core::state::canonical_state_digest`] of the folded
+    /// state. Canonical — see that function for why the raw serialisation is
+    /// not comparable across processes.
+    pub digest: String,
+}
+
+/// Fold from `noetl.event`.
+///
+/// Reads the same columns and builds the same `Event` values the orchestrator's
+/// own rebuild path does, so a digest from here is the digest of the state the
+/// orchestrator would have used.
+pub async fn fold_from_postgres(
+    pool: &DbPool,
+    execution_id: i64,
+) -> Result<FoldedState, FoldRefusal> {
+    let rows = sqlx::query(
+        r#"
+        SELECT event_id, execution_id, catalog_id,
+               parent_event_id, parent_execution_id,
+               event_type, node_id, node_name, node_type, status,
+               context, meta, result, worker_id,
+               NULLIF(meta->>'attempt', '')::int AS attempt,
+               created_at
+        FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC
+        "#,
+    )
+    .bind(execution_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| FoldRefusal::SourceUnavailable(e.to_string()))?;
+
+    if rows.is_empty() {
+        return Err(FoldRefusal::NoEvents);
+    }
+    let events = super::events::parse_event_rows_for_fold(rows);
+    fold(FoldSource::Postgres, events)
+}
+
+/// Fold from Postgres with `context` **blanked** — the controlled experiment
+/// that identifies the cause instead of inferring it.
+///
+/// Phase 1 measured 12 executions whose two stores hold the SAME event count
+/// and whose folded digests nevertheless differ. That rules out a missing
+/// event, but "therefore it is `context`" is still a hypothesis: the tier
+/// record differs from the Postgres row in more than one way, and the fold
+/// reads several of those fields.
+///
+/// This isolates it. Blank `context` on the Postgres side and nothing else. If
+/// the result matches the tier's digest, `context` is the whole difference and
+/// the finding is positively identified. If it does not, something else is
+/// missing too and the field list is incomplete — which is worth knowing before
+/// anyone "fixes" the mirror by adding one field.
+pub async fn fold_from_postgres_without_context(
+    pool: &DbPool,
+    execution_id: i64,
+) -> Result<FoldedState, FoldRefusal> {
+    let rows = sqlx::query(
+        r#"
+        SELECT event_id, execution_id, catalog_id,
+               parent_event_id, parent_execution_id,
+               event_type, node_id, node_name, node_type, status,
+               context, meta, result, worker_id,
+               NULLIF(meta->>'attempt', '')::int AS attempt,
+               created_at
+        FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC
+        "#,
+    )
+    .bind(execution_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| FoldRefusal::SourceUnavailable(e.to_string()))?;
+    if rows.is_empty() {
+        return Err(FoldRefusal::NoEvents);
+    }
+    let mut events = super::events::parse_event_rows_for_fold(rows);
+    for e in &mut events {
+        e.context = None;
+    }
+    fold(FoldSource::Postgres, events)
+}
+
+/// Fold from the EHDB event-log tier, read through the worker relay.
+pub async fn fold_from_tier(execution_id: i64) -> Result<FoldedState, FoldRefusal> {
+    let base = std::env::var(super::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| FoldRefusal::SourceUnavailable("WORKER_QUERY_URL unset".into()))?;
+    let url = format!(
+        "{}/ehdb/tiers/eventlog?execution={execution_id}&limit=2000",
+        base.trim_end_matches('/')
+    );
+    let body: serde_json::Value = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(20))
+        .send()
+        .await
+        .map_err(|e| FoldRefusal::SourceUnavailable(e.to_string()))?
+        .json()
+        .await
+        .map_err(|e| FoldRefusal::Unparseable(e.to_string()))?;
+
+    if let Some(outcome) = body.get("outcome").and_then(|o| o.as_str()) {
+        if outcome != "ok" {
+            // A typed refusal is not an empty tier. Scoring it as "no events"
+            // would report a broken relay as an execution with no history.
+            return Err(FoldRefusal::SourceUnavailable(format!("tier outcome={outcome}")));
+        }
+    }
+    let records = body
+        .get("records")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| FoldRefusal::Unparseable("no records array".into()))?;
+    if records.is_empty() {
+        return Err(FoldRefusal::NoEvents);
+    }
+
+    let mut events: Vec<crate::db::models::Event> = Vec::with_capacity(records.len());
+    for r in records {
+        let payload = match r.get("payload").and_then(|p| p.as_str()) {
+            Some(s) => serde_json::from_str::<serde_json::Value>(s)
+                .map_err(|e| FoldRefusal::Unparseable(e.to_string()))?,
+            None => r.clone(),
+        };
+        if let Some(ev) = event_from_tier_payload(&payload) {
+            events.push(ev);
+        }
+    }
+    if events.is_empty() {
+        return Err(FoldRefusal::Unparseable(
+            "records present but none carried an event_id".into(),
+        ));
+    }
+    events.sort_by_key(|e| e.event_id);
+    fold(FoldSource::EhdbTier, events)
+}
+
+/// Build an [`Event`] from a tier record's payload.
+///
+/// ⚠ `context` is read even though the mirror does not write it — so that this
+/// function is a faithful reader of the record shape rather than a place the
+/// omission is silently baked in. When the mirror starts carrying `context`,
+/// this picks it up with no change; until then it is `None`, which is precisely
+/// the difference the gate measures.
+fn event_from_tier_payload(p: &serde_json::Value) -> Option<crate::db::models::Event> {
+    let read_i64 = |v: Option<&serde_json::Value>| -> Option<i64> {
+        v.and_then(|x| x.as_i64().or_else(|| x.as_str().and_then(|s| s.parse().ok())))
+    };
+    Some(crate::db::models::Event {
+        id: 0,
+        event_id: read_i64(p.get("event_id"))?,
+        execution_id: read_i64(p.get("execution_id")).unwrap_or(0),
+        catalog_id: read_i64(p.get("catalog_id")).unwrap_or(0),
+        parent_event_id: read_i64(p.get("parent_event_id")),
+        parent_execution_id: read_i64(p.get("parent_execution_id")),
+        event_type: p
+            .get("event_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        node_id: p.get("node_id").and_then(|v| v.as_str()).map(str::to_string),
+        node_name: p
+            .get("node_name")
+            .or_else(|| p.get("step"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        node_type: p
+            .get("node_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        status: p
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        context: p.get("context").filter(|v| !v.is_null()).cloned(),
+        meta: p.get("meta").filter(|v| !v.is_null()).cloned(),
+        result: p.get("result").filter(|v| !v.is_null()).cloned(),
+        worker_id: p
+            .get("worker_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        attempt: p.get("meta").and_then(|m| m.get("attempt")).and_then(|a| {
+            a.as_i64()
+                .or_else(|| a.as_str().and_then(|s| s.parse().ok()))
+        }).map(|v| v as i32),
+        created_at: p
+            .get("created_at")
+            .and_then(|v| v.as_str())
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|t| t.with_timezone(&chrono::Utc))
+            .unwrap_or_else(chrono::Utc::now),
+    })
+}
+
+fn fold(
+    source: FoldSource,
+    events: Vec<crate::db::models::Event>,
+) -> Result<FoldedState, FoldRefusal> {
+    use noetl_orchestrate_core::state::{canonical_state_digest, WorkflowState};
+    let version = events.iter().map(|e| e.event_id).max().unwrap_or(0);
+    let applied_count = events.len();
+    let core: Vec<noetl_orchestrate_core::event::Event> =
+        events.iter().map(Into::into).collect();
+    let state = WorkflowState::from_events(&core).ok_or(FoldRefusal::FoldFailed)?;
+    Ok(FoldedState {
+        source,
+        version,
+        applied_count,
+        digest: canonical_state_digest(&state),
+    })
+}
+
+/// Both folds, and whether they agree — the Phase 1 question in one reply.
+#[derive(Debug, Serialize)]
+pub struct FoldComparison {
+    pub execution_id: i64,
+    pub postgres: Option<FoldedState>,
+    pub postgres_refusal: Option<FoldRefusal>,
+    pub tier: Option<FoldedState>,
+    pub tier_refusal: Option<FoldRefusal>,
+    /// `true` only when BOTH folds produced a state and the digests match.
+    /// Absence of disagreement is not agreement: two refusals are not a match.
+    pub digests_agree: bool,
+    /// Set when both folded but disagreed — the shortest description of why the
+    /// tier is not (yet) a sufficient source.
+    pub disagreement: Option<String>,
+    /// Postgres folded with `context` blanked. When this equals the tier's
+    /// digest, `context` is positively identified as the whole difference.
+    pub postgres_without_context: Option<FoldedState>,
+    /// `true` when blanking `context` on the Postgres side reproduces the
+    /// tier's digest exactly.
+    pub context_explains_the_gap: bool,
+}
+
+pub async fn compare_sources(pool: &DbPool, execution_id: i64) -> AppResult<FoldComparison> {
+    let pg = fold_from_postgres(pool, execution_id).await;
+    let tier = fold_from_tier(execution_id).await;
+    let (postgres, postgres_refusal) = match pg {
+        Ok(f) => (Some(f), None),
+        Err(r) => (None, Some(r)),
+    };
+    let (tier_ok, tier_refusal) = match tier {
+        Ok(f) => (Some(f), None),
+        Err(r) => (None, Some(r)),
+    };
+    let digests_agree = match (&postgres, &tier_ok) {
+        (Some(a), Some(b)) => a.digest == b.digest,
+        _ => false,
+    };
+    let disagreement = match (&postgres, &tier_ok) {
+        (Some(a), Some(b)) if a.digest != b.digest => Some(format!(
+            "postgres v{} n={} {} != tier v{} n={} {}",
+            a.version,
+            a.applied_count,
+            &a.digest[..16],
+            b.version,
+            b.applied_count,
+            &b.digest[..16]
+        )),
+        _ => None,
+    };
+    let no_ctx = fold_from_postgres_without_context(pool, execution_id).await.ok();
+    let context_explains_the_gap = match (&no_ctx, &tier_ok) {
+        (Some(a), Some(b)) => a.digest == b.digest,
+        _ => false,
+    };
+    Ok(FoldComparison {
+        execution_id,
+        postgres_without_context: no_ctx,
+        context_explains_the_gap,
+        postgres,
+        postgres_refusal,
+        tier: tier_ok,
+        tier_refusal,
+        digests_agree,
+        disagreement,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The tier's record shape must be read faithfully, including the field it
+    /// does not carry.
+    ///
+    /// This is the Phase 1 question in unit form: a payload shaped exactly like
+    /// `ehdb_eventlog_mirror::mirror_payload` yields an event whose `context`
+    /// is `None`, while the same logical event from Postgres carries one. The
+    /// fold reads `context` in six places, so `None` is not a cosmetic
+    /// difference.
+    #[test]
+    fn a_tier_payload_has_no_context_and_the_reader_says_so() {
+        let payload = serde_json::json!({
+            "event_id": 10, "execution_id": 1, "catalog_id": 2,
+            "event_type": "step.enter", "status": "ok",
+            "node_name": "s1", "step": "s1",
+            "result": {"a": 1}, "meta": {"attempt": "1"},
+            "mirror_source": "server"
+        });
+        let ev = event_from_tier_payload(&payload).expect("parses");
+        assert_eq!(ev.event_id, 10);
+        assert_eq!(ev.result, Some(serde_json::json!({"a": 1})));
+        assert!(
+            ev.context.is_none(),
+            "the tier record carries no `context` — if this ever becomes Some, \
+             the mirror payload changed and the Phase 1 finding is stale"
+        );
+        assert_eq!(ev.attempt, Some(1), "attempt is derived from meta, as in the SQL projection");
+    }
+
+    /// …and when a payload DOES carry context, the reader picks it up. Without
+    /// this, the assertion above would also pass against a reader that simply
+    /// never reads the field — proving the reader broken rather than the
+    /// record incomplete.
+    #[test]
+    fn the_reader_picks_up_context_when_it_is_present() {
+        let payload = serde_json::json!({
+            "event_id": 11, "execution_id": 1, "catalog_id": 2,
+            "event_type": "step.enter", "status": "ok",
+            "context": {"loop": {"i": 3}}
+        });
+        let ev = event_from_tier_payload(&payload).expect("parses");
+        assert_eq!(ev.context, Some(serde_json::json!({"loop": {"i": 3}})));
+    }
+
+    /// A record set that parses to nothing is a refusal, never an empty state.
+    #[test]
+    fn records_without_event_ids_refuse_rather_than_fold_nothing() {
+        let payload = serde_json::json!({"no_event_id": true});
+        assert!(event_from_tier_payload(&payload).is_none());
+    }
+
+    /// Two refusals are not a match.
+    #[test]
+    fn agreement_requires_two_folds_not_two_refusals() {
+        let c = FoldComparison {
+            execution_id: 1,
+            postgres: None,
+            postgres_refusal: Some(FoldRefusal::NoEvents),
+            tier: None,
+            tier_refusal: Some(FoldRefusal::NoEvents),
+            digests_agree: false,
+            disagreement: None,
+            postgres_without_context: None,
+            context_explains_the_gap: false,
+        };
+        assert!(
+            !c.digests_agree,
+            "absence of disagreement is not agreement — this is the vacuous \
+             pass the whole comparator discipline exists to refuse"
+        );
+    }
+}
+
+/// Fold the same execution TWICE in one request and report every JSON path
+/// where the two results differ.
+///
+/// Phase 1 measured the Postgres-sourced fold producing a different canonical
+/// digest on every call — three calls, one process, static rows, three digests
+/// — while the tier-sourced fold was byte-stable. That refutes the premise the
+/// whole event-sourced read model rests on, and it refutes it for ANY source,
+/// so no amount of choosing a better log fixes it.
+///
+/// Naming the varying field is therefore the blocking question, and it is a
+/// measurement rather than a guess: fold, fold again, diff the two bodies.
+/// Both folds run in the same request against the same rows, so anything that
+/// differs is non-determinism in the fold itself.
+fn json_diff_paths(a: &serde_json::Value, b: &serde_json::Value, at: &str, out: &mut Vec<String>) {
+    if out.len() > 40 {
+        return;
+    }
+    match (a, b) {
+        (serde_json::Value::Object(x), serde_json::Value::Object(y)) => {
+            let mut keys: Vec<&String> = x.keys().chain(y.keys()).collect();
+            keys.sort();
+            keys.dedup();
+            for k in keys {
+                match (x.get(k), y.get(k)) {
+                    (Some(va), Some(vb)) => {
+                        json_diff_paths(va, vb, &format!("{at}/{k}"), out)
+                    }
+                    (Some(_), None) => out.push(format!("{at}/{k} (only in first)")),
+                    (None, Some(_)) => out.push(format!("{at}/{k} (only in second)")),
+                    (None, None) => {}
+                }
+            }
+        }
+        (serde_json::Value::Array(x), serde_json::Value::Array(y)) => {
+            if x.len() != y.len() {
+                out.push(format!("{at} array len {} vs {}", x.len(), y.len()));
+                return;
+            }
+            for (i, (va, vb)) in x.iter().zip(y.iter()).enumerate() {
+                json_diff_paths(va, vb, &format!("{at}/{i}"), out);
+            }
+        }
+        _ => {
+            if a != b {
+                let sa = a.to_string();
+                let sb = b.to_string();
+                out.push(format!(
+                    "{at}: {} != {}",
+                    &sa[..sa.len().min(60)],
+                    &sb[..sb.len().min(60)]
+                ));
+            }
+        }
+    }
+}
+
+/// `GET /api/ehdb/projection-fold/determinism/{id}` — fold twice, diff.
+pub async fn determinism_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Path(execution_id): axum::extract::Path<i64>,
+) -> AppResult<axum::Json<serde_json::Value>> {
+    use noetl_orchestrate_core::state::{canonical_state_digest, WorkflowState};
+    let pool = state.pools.pool_for(execution_id);
+
+    async fn load_events(
+        pool: &crate::db::DbPool,
+        execution_id: i64,
+    ) -> Vec<crate::db::models::Event> {
+        let rows = sqlx::query(
+            r#"
+            SELECT event_id, execution_id, catalog_id,
+                   parent_event_id, parent_execution_id,
+                   event_type, node_id, node_name, node_type, status,
+                   context, meta, result, worker_id,
+                   NULLIF(meta->>'attempt', '')::int AS attempt,
+                   created_at
+            FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC
+            "#,
+        )
+        .bind(execution_id)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
+        super::events::parse_event_rows_for_fold(rows)
+    }
+
+    let ev1 = load_events(&pool, execution_id).await;
+    let ev2 = load_events(&pool, execution_id).await;
+    // Also fold the SAME in-memory event vector twice, which separates "the
+    // fold is non-deterministic" from "two reads of the table differ".
+    let core1: Vec<noetl_orchestrate_core::event::Event> = ev1.iter().map(Into::into).collect();
+    let core2: Vec<noetl_orchestrate_core::event::Event> = ev2.iter().map(Into::into).collect();
+
+    let s1 = WorkflowState::from_events(&core1);
+    let s2 = WorkflowState::from_events(&core2);
+    let s3 = WorkflowState::from_events(&core1); // same input as s1
+
+    let body = |s: &Option<WorkflowState>| {
+        s.as_ref()
+            .map(|w| serde_json::to_value(w).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null)
+    };
+    let (b1, b2, b3) = (body(&s1), body(&s2), body(&s3));
+
+    let mut diff_two_reads = Vec::new();
+    json_diff_paths(&b1, &b2, "", &mut diff_two_reads);
+    let mut diff_same_input = Vec::new();
+    json_diff_paths(&b1, &b3, "", &mut diff_same_input);
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "ehdb.projection.fold.determinism",
+        "execution_id": execution_id,
+        "events": core1.len(),
+        "digest_read1": s1.as_ref().map(canonical_state_digest),
+        "digest_read2": s2.as_ref().map(canonical_state_digest),
+        "digest_same_input_refold": s3.as_ref().map(canonical_state_digest),
+        // The decisive split: if this is empty but the digests differ, the
+        // variation is in SERIALISATION, not in the folded value.
+        "diff_paths_two_reads": diff_two_reads,
+        "diff_paths_same_input": diff_same_input,
+    })))
+}
+
+/// `GET /api/ehdb/projection-fold/executions/{id}` — both folds, side by side.
+///
+/// Read-only and decision-free. It exists so the Phase-1 question is answered
+/// by a measurement on a real execution rather than by reading two files and
+/// reasoning about them.
+pub async fn compare_sources_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Path(execution_id): axum::extract::Path<i64>,
+) -> AppResult<axum::Json<serde_json::Value>> {
+    let pool = state.pools.pool_for(execution_id);
+    let cmp = compare_sources(&pool, execution_id).await?;
+    Ok(axum::Json(serde_json::json!({
+        "action": "ehdb.projection.fold.compare",
+        "result": cmp,
+    })))
+}

--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -301,7 +301,6 @@ fn event_from_tier_payload(p: &serde_json::Value) -> Option<crate::db::models::E
 
 /// As [`fold`], but also returns the serialised state body — for the field-level
 /// divergence diff. Kept separate so the hot path never pays the extra clone.
-
 /// Truncate an event's `created_at` to **microsecond** precision.
 ///
 /// # Why the fold normalises this (ai-meta#265 Phase 3)
@@ -918,6 +917,87 @@ pub async fn refold_endpoint(
     })))
 }
 
+/// `GET /api/ehdb/projection-fold/diff/{id}` — WHICH FIELDS diverge, and how.
+///
+/// The Phase-3 equivalence arm measured the WAL-spine fold and the incumbent
+/// fold producing different digests at the **same version and same event
+/// count**. A digest says *that* they differ; this says *where*, which is the
+/// difference between a named cause and a guess.
+///
+/// Both sides are folded here, in one request, from the same execution — so a
+/// difference cannot be attributed to the execution advancing between calls.
+/// The version equality is asserted and reported rather than assumed.
+pub async fn fold_diff_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Path(execution_id): axum::extract::Path<i64>,
+) -> AppResult<axum::Json<serde_json::Value>> {
+    let pool = state.pools.pool_for(execution_id);
+
+    // --- incumbent side -----------------------------------------------------
+    let rows = sqlx::query(
+        r#"
+        SELECT event_id, execution_id, catalog_id,
+               parent_event_id, parent_execution_id,
+               event_type, node_id, node_name, node_type, status,
+               context, meta, result, worker_id,
+               NULLIF(meta->>'attempt', '')::int AS attempt,
+               created_at
+        FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC
+        "#,
+    )
+    .bind(execution_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+    let pg_events = super::events::parse_event_rows_for_fold(rows);
+    let pg = fold_with_body(FoldSource::Postgres, pg_events.clone());
+
+    // --- WAL spine side -----------------------------------------------------
+    let spine_events = wal_spine_events(execution_id, None).await;
+    let wal = match &spine_events {
+        Ok(evs) => fold_with_body(FoldSource::WalSpine, evs.clone()),
+        Err(r) => Err(r.clone()),
+    };
+
+    let mut diff: Vec<String> = Vec::new();
+    let mut same_version = false;
+    if let (Ok((pgs, pgb)), Ok((wals, walb))) = (&pg, &wal) {
+        same_version = pgs.version == wals.version;
+        if same_version {
+            json_diff_paths(pgb, walb, "", &mut diff);
+        }
+    }
+
+    // Per-event field presence, so a state difference can be traced to the
+    // INPUT rather than only observed in the output. Counts only — no values,
+    // because `context` is exactly the field under suspicion and it is the one
+    // that could carry sensitive material.
+    let field_presence = |evs: &[crate::db::models::Event]| {
+        serde_json::json!({
+            "events": evs.len(),
+            "with_context": evs.iter().filter(|e| e.context.is_some()).count(),
+            "with_result": evs.iter().filter(|e| e.result.is_some()).count(),
+            "with_meta": evs.iter().filter(|e| e.meta.is_some()).count(),
+            "with_attempt": evs.iter().filter(|e| e.attempt.is_some()).count(),
+            "with_node_name": evs.iter().filter(|e| e.node_name.is_some()).count(),
+            "distinct_created_at": evs.iter().map(|e| e.created_at).collect::<std::collections::BTreeSet<_>>().len(),
+        })
+    };
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "ehdb.projection.fold.diff",
+        "execution_id": execution_id,
+        "same_version": same_version,
+        "postgres": pg.as_ref().ok().map(|(s, _)| s),
+        "postgres_refusal": pg.as_ref().err(),
+        "wal": wal.as_ref().ok().map(|(s, _)| s),
+        "wal_refusal": wal.as_ref().err(),
+        "diff_paths": diff,
+        "input_fields_postgres": field_presence(&pg_events),
+        "input_fields_wal": spine_events.as_ref().ok().map(|e| field_presence(e)),
+    })))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1185,83 +1265,3 @@ mod tests {
 
 
 
-/// `GET /api/ehdb/projection-fold/diff/{id}` — WHICH FIELDS diverge, and how.
-///
-/// The Phase-3 equivalence arm measured the WAL-spine fold and the incumbent
-/// fold producing different digests at the **same version and same event
-/// count**. A digest says *that* they differ; this says *where*, which is the
-/// difference between a named cause and a guess.
-///
-/// Both sides are folded here, in one request, from the same execution — so a
-/// difference cannot be attributed to the execution advancing between calls.
-/// The version equality is asserted and reported rather than assumed.
-pub async fn fold_diff_endpoint(
-    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
-    axum::extract::Path(execution_id): axum::extract::Path<i64>,
-) -> AppResult<axum::Json<serde_json::Value>> {
-    let pool = state.pools.pool_for(execution_id);
-
-    // --- incumbent side -----------------------------------------------------
-    let rows = sqlx::query(
-        r#"
-        SELECT event_id, execution_id, catalog_id,
-               parent_event_id, parent_execution_id,
-               event_type, node_id, node_name, node_type, status,
-               context, meta, result, worker_id,
-               NULLIF(meta->>'attempt', '')::int AS attempt,
-               created_at
-        FROM noetl.event WHERE execution_id = $1 ORDER BY event_id ASC
-        "#,
-    )
-    .bind(execution_id)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
-    let pg_events = super::events::parse_event_rows_for_fold(rows);
-    let pg = fold_with_body(FoldSource::Postgres, pg_events.clone());
-
-    // --- WAL spine side -----------------------------------------------------
-    let spine_events = wal_spine_events(execution_id, None).await;
-    let wal = match &spine_events {
-        Ok(evs) => fold_with_body(FoldSource::WalSpine, evs.clone()),
-        Err(r) => Err(r.clone()),
-    };
-
-    let mut diff: Vec<String> = Vec::new();
-    let mut same_version = false;
-    if let (Ok((pgs, pgb)), Ok((wals, walb))) = (&pg, &wal) {
-        same_version = pgs.version == wals.version;
-        if same_version {
-            json_diff_paths(pgb, walb, "", &mut diff);
-        }
-    }
-
-    // Per-event field presence, so a state difference can be traced to the
-    // INPUT rather than only observed in the output. Counts only — no values,
-    // because `context` is exactly the field under suspicion and it is the one
-    // that could carry sensitive material.
-    let field_presence = |evs: &[crate::db::models::Event]| {
-        serde_json::json!({
-            "events": evs.len(),
-            "with_context": evs.iter().filter(|e| e.context.is_some()).count(),
-            "with_result": evs.iter().filter(|e| e.result.is_some()).count(),
-            "with_meta": evs.iter().filter(|e| e.meta.is_some()).count(),
-            "with_attempt": evs.iter().filter(|e| e.attempt.is_some()).count(),
-            "with_node_name": evs.iter().filter(|e| e.node_name.is_some()).count(),
-            "distinct_created_at": evs.iter().map(|e| e.created_at).collect::<std::collections::BTreeSet<_>>().len(),
-        })
-    };
-
-    Ok(axum::Json(serde_json::json!({
-        "action": "ehdb.projection.fold.diff",
-        "execution_id": execution_id,
-        "same_version": same_version,
-        "postgres": pg.as_ref().ok().map(|(s, _)| s),
-        "postgres_refusal": pg.as_ref().err(),
-        "wal": wal.as_ref().ok().map(|(s, _)| s),
-        "wal_refusal": wal.as_ref().err(),
-        "diff_paths": diff,
-        "input_fields_postgres": field_presence(&pg_events),
-        "input_fields_wal": spine_events.as_ref().ok().map(|e| field_presence(e)),
-    })))
-}

--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -52,6 +52,11 @@ pub enum FoldSource {
     Postgres,
     /// The EHDB event-log tier, read through the worker relay.
     EhdbTier,
+    /// The worker's **WAL spine** — the off-server state builder's chain, served
+    /// by `GET /ehdb/state-spine`. The source ai-meta#265's RFC settles on:
+    /// it keeps `SLIM_EVENT_KEYS`, which includes `context` and both
+    /// `timestamp`/`created_at`, so a fold over it is the fold the drive does.
+    WalSpine,
 }
 
 impl FoldSource {
@@ -59,6 +64,7 @@ impl FoldSource {
         match self {
             Self::Postgres => "postgres",
             Self::EhdbTier => "ehdb_tier",
+            Self::WalSpine => "wal_spine",
         }
     }
 }
@@ -79,6 +85,14 @@ pub enum FoldRefusal {
     /// `from_events` returned `None` — it could not build a state from a
     /// non-empty event set.
     FoldFailed,
+    /// The WAL spine does not reach the requested head: the drain has not
+    /// caught up, or a chain link is missing.
+    ///
+    /// **The fail-closed case that matters most on this source.** The worker
+    /// answers `complete:false` with no events rather than a partial spine, and
+    /// this refusal carries that through — a fold over a gapped spine is a
+    /// different execution's history.
+    SpineIncomplete,
 }
 
 /// A folded state and the identity it can be checked by.
@@ -303,6 +317,186 @@ fn fold(
     })
 }
 
+
+/// Fold from the worker's **WAL spine** (ai-meta#265 Phase 2).
+///
+/// Reads `GET /ehdb/state-spine` from the worker relay and folds the ordered
+/// verbatim slim payloads it serves. This is the source the RFC settles on:
+///
+/// * it carries `context`, which the event-log tier does not and which
+///   `apply_event` reads in six places;
+/// * it carries `timestamp`/`created_at`, so no `Utc::now()` substitution — the
+///   reason a tier-sourced fold was byte-stable while the Postgres one was not,
+///   before the loader fix;
+/// * and it holds credential material **by alias**, not resolved, so folding
+///   from it propagates no secrets (measured on kind's population; prod's is
+///   unmeasured).
+///
+/// `head` pins the fold to a watermark. When supplied and the spine cannot
+/// reach it, this refuses with [`FoldRefusal::SpineIncomplete`] rather than
+/// folding what it has.
+pub async fn fold_from_wal_spine(
+    execution_id: i64,
+    head: Option<i64>,
+) -> Result<FoldedState, FoldRefusal> {
+    let base = std::env::var(super::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| FoldRefusal::SourceUnavailable("WORKER_QUERY_URL unset".into()))?;
+    let mut url = format!(
+        "{}/ehdb/state-spine?execution={execution_id}",
+        base.trim_end_matches('/')
+    );
+    if let Some(h) = head {
+        url.push_str(&format!("&head={h}"));
+    }
+    let body: serde_json::Value = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(20))
+        .send()
+        .await
+        .map_err(|e| FoldRefusal::SourceUnavailable(e.to_string()))?
+        .json()
+        .await
+        .map_err(|e| FoldRefusal::Unparseable(e.to_string()))?;
+
+    match body.get("outcome").and_then(|o| o.as_str()) {
+        Some("ok") => {}
+        // `unavailable` is a worker with no index — NOT an execution with no
+        // events. Collapsing them would fold nothing and call it a state.
+        Some("unavailable") => {
+            return Err(FoldRefusal::SourceUnavailable(
+                "worker runs no state-builder index".into(),
+            ))
+        }
+        Some("incomplete") => return Err(FoldRefusal::SpineIncomplete),
+        other => {
+            return Err(FoldRefusal::Unparseable(format!(
+                "unexpected spine outcome {other:?}"
+            )))
+        }
+    }
+    // Belt and braces: the route promises no events on an incomplete build, and
+    // this checks the promise rather than trusting it. A future change that
+    // started serving a partial spine would be caught here instead of silently
+    // producing a state for a history that never happened.
+    if body.get("complete").and_then(|c| c.as_bool()) != Some(true) {
+        return Err(FoldRefusal::SpineIncomplete);
+    }
+
+    let events_json = body
+        .get("events")
+        .and_then(|e| e.as_array())
+        .ok_or_else(|| FoldRefusal::Unparseable("no events array".into()))?;
+    if events_json.is_empty() {
+        return Err(FoldRefusal::NoEvents);
+    }
+    let mut events: Vec<crate::db::models::Event> = Vec::with_capacity(events_json.len());
+    for p in events_json {
+        if let Some(ev) = event_from_tier_payload(p) {
+            events.push(ev);
+        }
+    }
+    if events.is_empty() {
+        return Err(FoldRefusal::Unparseable(
+            "spine events carried no event_id".into(),
+        ));
+    }
+    events.sort_by_key(|e| e.event_id);
+    fold(FoldSource::WalSpine, events)
+}
+
+/// Why a comparison against a fresh WAL re-fold did not hold.
+///
+/// Every variant is a reason to **not use** the stored projection. There is no
+/// "use it anyway" outcome, and there is deliberately no fallback-to-Postgres
+/// outcome either: a comparator whose failure mode is reading a different store
+/// establishes the second source of truth this whole effort exists to remove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReFoldVerdict {
+    /// The stored record's digest equals a fresh fold of the spine at the same
+    /// version. The only outcome that permits use.
+    Match,
+    /// Both produced a state and the digests differ.
+    DigestMismatch,
+    /// The stored record claims a version the spine does not reach.
+    StoredAheadOfSpine,
+    /// The spine has moved past the stored record. Not corruption — the
+    /// materialiser has not caught up.
+    StoredBehindSpine,
+    /// Nothing stored for this execution yet.
+    NoStoredRecord,
+    /// The spine could not be folded; carries the refusal.
+    SpineRefused,
+}
+
+impl ReFoldVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Match => "match",
+            Self::DigestMismatch => "digest_mismatch",
+            Self::StoredAheadOfSpine => "stored_ahead_of_spine",
+            Self::StoredBehindSpine => "stored_behind_spine",
+            Self::NoStoredRecord => "no_stored_record",
+            Self::SpineRefused => "spine_refused",
+        }
+    }
+    /// Whether this verdict means the stored record is WRONG, as opposed to
+    /// absent or merely behind. Only these should page.
+    pub fn is_fault(self) -> bool {
+        matches!(self, Self::DigestMismatch | Self::StoredAheadOfSpine)
+    }
+}
+
+/// Every verdict label. Closed set, pinned at 0.
+pub const REFOLD_VERDICTS: [&str; 6] = [
+    "match",
+    "digest_mismatch",
+    "stored_ahead_of_spine",
+    "stored_behind_spine",
+    "no_stored_record",
+    "spine_refused",
+];
+
+/// Compare a stored projection record against a **fresh fold of the WAL spine**.
+///
+/// Ground truth is the re-fold, never Postgres. That is the whole difference
+/// from ai-meta#265 A4's comparator, which compared the tier against a
+/// `noetl.projection_snapshot` row — a copy against another copy, where the
+/// digest being compared was the same number moved rather than recomputed.
+///
+/// **Pure decision, given the two sides**, so the fault vocabulary is testable
+/// without a cluster.
+pub fn verdict_for(
+    stored: Option<(i64, &str)>,
+    spine: &Result<FoldedState, FoldRefusal>,
+) -> ReFoldVerdict {
+    let spine = match spine {
+        Ok(s) => s,
+        Err(FoldRefusal::SpineIncomplete) | Err(_) => return ReFoldVerdict::SpineRefused,
+    };
+    let Some((stored_version, stored_digest)) = stored else {
+        return ReFoldVerdict::NoStoredRecord;
+    };
+    if stored_version > spine.version {
+        // The record claims an event the spine does not have. Checked BEFORE
+        // the digest: an ahead record's digest necessarily differs, and
+        // reporting that as `digest_mismatch` would send an operator looking
+        // for corruption instead of for a store that is ahead of its own log.
+        return ReFoldVerdict::StoredAheadOfSpine;
+    }
+    if stored_version < spine.version {
+        return ReFoldVerdict::StoredBehindSpine;
+    }
+    if stored_digest == spine.digest {
+        ReFoldVerdict::Match
+    } else {
+        ReFoldVerdict::DigestMismatch
+    }
+}
+
 /// Both folds, and whether they agree — the Phase 1 question in one reply.
 #[derive(Debug, Serialize)]
 pub struct FoldComparison {
@@ -510,6 +704,103 @@ pub async fn compare_sources_endpoint(
     })))
 }
 
+/// Read the newest stored projection record's `(version, digest)` for one
+/// execution, from the projection tier.
+///
+/// Returns `Ok(None)` for "the tier holds nothing for this execution" and an
+/// `Err` for "the tier could not be read" — kept distinct for the same reason
+/// the spine route does: one is an absence, the other is an inability, and a
+/// comparator that scored them alike would report a broken relay as an unarmed
+/// materialiser.
+pub async fn stored_projection(execution_id: i64) -> Result<Option<(i64, String)>, String> {
+    let base = std::env::var(super::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "WORKER_QUERY_URL unset".to_string())?;
+    let url = format!(
+        "{}/ehdb/tiers/projection?execution={execution_id}&limit=500",
+        base.trim_end_matches('/')
+    );
+    let body: serde_json::Value = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(20))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+    if let Some(o) = body.get("outcome").and_then(|o| o.as_str()) {
+        if o != "ok" {
+            return Err(format!("tier outcome={o}"));
+        }
+    }
+    let records = body
+        .get("records")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| "no records array".to_string())?;
+    let mut best: Option<(i64, u64, String)> = None;
+    for r in records {
+        let seq = r.get("global_sequence").and_then(|s| s.as_u64()).unwrap_or(0);
+        let p = match r.get("payload").and_then(|p| p.as_str()) {
+            Some(s) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => v,
+                Err(_) => continue,
+            },
+            None => r.clone(),
+        };
+        let (Some(v), Some(d)) = (
+            p.get("version").and_then(|v| {
+                v.as_i64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+            }),
+            p.get("digest")
+                .or_else(|| p.get("checksum"))
+                .and_then(|d| d.as_str()),
+        ) else {
+            continue;
+        };
+        // Newest by (version, sequence) — the same rule the read path uses, so
+        // the comparator judges the record a reader would serve.
+        if best
+            .as_ref()
+            .is_none_or(|(bv, bs, _)| (v, seq) > (*bv, *bs))
+        {
+            best = Some((v, seq, d.to_string()));
+        }
+    }
+    Ok(best.map(|(v, _, d)| (v, d)))
+}
+
+/// `GET /api/ehdb/projection-refold/executions/{id}` — the Phase 2 comparator.
+///
+/// Ground truth is a fresh fold of the WAL spine. Never Postgres.
+pub async fn refold_endpoint(
+    axum::extract::State(_state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Path(execution_id): axum::extract::Path<i64>,
+) -> AppResult<axum::Json<serde_json::Value>> {
+    let spine = fold_from_wal_spine(execution_id, None).await;
+    let stored = stored_projection(execution_id).await;
+    let stored_pair = match &stored {
+        Ok(Some((v, d))) => Some((*v, d.as_str())),
+        _ => None,
+    };
+    let verdict = verdict_for(stored_pair, &spine);
+    crate::metrics::record_ehdb_projection_refold(verdict.as_str());
+    Ok(axum::Json(serde_json::json!({
+        "action": "ehdb.projection.refold",
+        "execution_id": execution_id,
+        "verdict": verdict.as_str(),
+        "is_fault": verdict.is_fault(),
+        "spine": spine.as_ref().ok(),
+        "spine_refusal": spine.as_ref().err(),
+        "stored_version": stored_pair.map(|(v, _)| v),
+        "stored_digest": stored_pair.map(|(_, d)| d),
+        "stored_read_error": stored.as_ref().err(),
+    })))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -564,6 +855,97 @@ mod tests {
         assert!(event_from_tier_payload(&payload).is_none());
     }
 
+
+    fn folded(version: i64, digest: &str) -> Result<FoldedState, FoldRefusal> {
+        Ok(FoldedState {
+            source: FoldSource::WalSpine,
+            version,
+            applied_count: 3,
+            digest: digest.to_string(),
+        })
+    }
+
+    /// Every fail-closed condition is named as ITSELF, and only two of them
+    /// page.
+    ///
+    /// Two-sided: the healthy case must also be reachable, or a `verdict_for`
+    /// that refused unconditionally would satisfy every negative assertion and
+    /// make the read model permanently unusable while looking rigorous.
+    #[test]
+    fn each_refold_condition_is_named_as_itself() {
+        let spine = folded(100, "aaa");
+
+        assert_eq!(verdict_for(Some((100, "aaa")), &spine), ReFoldVerdict::Match);
+        assert!(!ReFoldVerdict::Match.is_fault());
+
+        // Same version, different content — the corruption case.
+        assert_eq!(
+            verdict_for(Some((100, "bbb")), &spine),
+            ReFoldVerdict::DigestMismatch
+        );
+        assert!(ReFoldVerdict::DigestMismatch.is_fault());
+
+        // Claims an event the log does not have. Checked BEFORE the digest, so
+        // it is not mis-reported as corruption.
+        assert_eq!(
+            verdict_for(Some((101, "aaa")), &spine),
+            ReFoldVerdict::StoredAheadOfSpine
+        );
+        assert!(ReFoldVerdict::StoredAheadOfSpine.is_fault());
+
+        // Behind is the materialiser lagging, not corruption — must not page.
+        assert_eq!(
+            verdict_for(Some((99, "aaa")), &spine),
+            ReFoldVerdict::StoredBehindSpine
+        );
+        assert!(!ReFoldVerdict::StoredBehindSpine.is_fault());
+
+        assert_eq!(verdict_for(None, &spine), ReFoldVerdict::NoStoredRecord);
+        assert!(!ReFoldVerdict::NoStoredRecord.is_fault());
+    }
+
+    /// An incomplete spine refuses the comparison rather than passing it.
+    ///
+    /// The dangerous shape would be treating "the log could not be read" as
+    /// "nothing to disagree with" — a clean verdict from a comparison that
+    /// never happened, which is the vacuous pass this codebase keeps finding.
+    #[test]
+    fn a_spine_that_cannot_be_folded_refuses_rather_than_agreeing() {
+        let refused: Result<FoldedState, FoldRefusal> = Err(FoldRefusal::SpineIncomplete);
+        assert_eq!(
+            verdict_for(Some((100, "aaa")), &refused),
+            ReFoldVerdict::SpineRefused
+        );
+        // …and it is NOT a match even when the stored record looks fine.
+        assert_ne!(verdict_for(Some((100, "aaa")), &refused), ReFoldVerdict::Match);
+        // An unreachable worker is the same shape.
+        let unavail: Result<FoldedState, FoldRefusal> =
+            Err(FoldRefusal::SourceUnavailable("no index".into()));
+        assert_eq!(
+            verdict_for(Some((100, "aaa")), &unavail),
+            ReFoldVerdict::SpineRefused
+        );
+    }
+
+    /// Every verdict the code can emit is in the pinned label set.
+    #[test]
+    fn every_verdict_is_pinned() {
+        for v in [
+            ReFoldVerdict::Match,
+            ReFoldVerdict::DigestMismatch,
+            ReFoldVerdict::StoredAheadOfSpine,
+            ReFoldVerdict::StoredBehindSpine,
+            ReFoldVerdict::NoStoredRecord,
+            ReFoldVerdict::SpineRefused,
+        ] {
+            assert!(
+                REFOLD_VERDICTS.contains(&v.as_str()),
+                "{} is emitted but not pinned; its series is absent until it fires",
+                v.as_str()
+            );
+        }
+        assert_eq!(REFOLD_VERDICTS.len(), 6);
+    }
     /// Two refusals are not a match.
     #[test]
     fn agreement_requires_two_folds_not_two_refusals() {
@@ -585,4 +967,5 @@ mod tests {
         );
     }
 }
+
 

--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -370,82 +370,6 @@ pub async fn compare_sources(pool: &DbPool, execution_id: i64) -> AppResult<Fold
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The tier's record shape must be read faithfully, including the field it
-    /// does not carry.
-    ///
-    /// This is the Phase 1 question in unit form: a payload shaped exactly like
-    /// `ehdb_eventlog_mirror::mirror_payload` yields an event whose `context`
-    /// is `None`, while the same logical event from Postgres carries one. The
-    /// fold reads `context` in six places, so `None` is not a cosmetic
-    /// difference.
-    #[test]
-    fn a_tier_payload_has_no_context_and_the_reader_says_so() {
-        let payload = serde_json::json!({
-            "event_id": 10, "execution_id": 1, "catalog_id": 2,
-            "event_type": "step.enter", "status": "ok",
-            "node_name": "s1", "step": "s1",
-            "result": {"a": 1}, "meta": {"attempt": "1"},
-            "mirror_source": "server"
-        });
-        let ev = event_from_tier_payload(&payload).expect("parses");
-        assert_eq!(ev.event_id, 10);
-        assert_eq!(ev.result, Some(serde_json::json!({"a": 1})));
-        assert!(
-            ev.context.is_none(),
-            "the tier record carries no `context` — if this ever becomes Some, \
-             the mirror payload changed and the Phase 1 finding is stale"
-        );
-        assert_eq!(ev.attempt, Some(1), "attempt is derived from meta, as in the SQL projection");
-    }
-
-    /// …and when a payload DOES carry context, the reader picks it up. Without
-    /// this, the assertion above would also pass against a reader that simply
-    /// never reads the field — proving the reader broken rather than the
-    /// record incomplete.
-    #[test]
-    fn the_reader_picks_up_context_when_it_is_present() {
-        let payload = serde_json::json!({
-            "event_id": 11, "execution_id": 1, "catalog_id": 2,
-            "event_type": "step.enter", "status": "ok",
-            "context": {"loop": {"i": 3}}
-        });
-        let ev = event_from_tier_payload(&payload).expect("parses");
-        assert_eq!(ev.context, Some(serde_json::json!({"loop": {"i": 3}})));
-    }
-
-    /// A record set that parses to nothing is a refusal, never an empty state.
-    #[test]
-    fn records_without_event_ids_refuse_rather_than_fold_nothing() {
-        let payload = serde_json::json!({"no_event_id": true});
-        assert!(event_from_tier_payload(&payload).is_none());
-    }
-
-    /// Two refusals are not a match.
-    #[test]
-    fn agreement_requires_two_folds_not_two_refusals() {
-        let c = FoldComparison {
-            execution_id: 1,
-            postgres: None,
-            postgres_refusal: Some(FoldRefusal::NoEvents),
-            tier: None,
-            tier_refusal: Some(FoldRefusal::NoEvents),
-            digests_agree: false,
-            disagreement: None,
-            postgres_without_context: None,
-            context_explains_the_gap: false,
-        };
-        assert!(
-            !c.digests_agree,
-            "absence of disagreement is not agreement — this is the vacuous \
-             pass the whole comparator discipline exists to refuse"
-        );
-    }
-}
-
 /// Fold the same execution TWICE in one request and report every JSON path
 /// where the two results differ.
 ///
@@ -532,8 +456,8 @@ pub async fn determinism_endpoint(
         super::events::parse_event_rows_for_fold(rows)
     }
 
-    let ev1 = load_events(&pool, execution_id).await;
-    let ev2 = load_events(&pool, execution_id).await;
+    let ev1 = load_events(pool, execution_id).await;
+    let ev2 = load_events(pool, execution_id).await;
     // Also fold the SAME in-memory event vector twice, which separates "the
     // fold is non-deterministic" from "two reads of the table differ".
     let core1: Vec<noetl_orchestrate_core::event::Event> = ev1.iter().map(Into::into).collect();
@@ -579,9 +503,86 @@ pub async fn compare_sources_endpoint(
     axum::extract::Path(execution_id): axum::extract::Path<i64>,
 ) -> AppResult<axum::Json<serde_json::Value>> {
     let pool = state.pools.pool_for(execution_id);
-    let cmp = compare_sources(&pool, execution_id).await?;
+    let cmp = compare_sources(pool, execution_id).await?;
     Ok(axum::Json(serde_json::json!({
         "action": "ehdb.projection.fold.compare",
         "result": cmp,
     })))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The tier's record shape must be read faithfully, including the field it
+    /// does not carry.
+    ///
+    /// This is the Phase 1 question in unit form: a payload shaped exactly like
+    /// `ehdb_eventlog_mirror::mirror_payload` yields an event whose `context`
+    /// is `None`, while the same logical event from Postgres carries one. The
+    /// fold reads `context` in six places, so `None` is not a cosmetic
+    /// difference.
+    #[test]
+    fn a_tier_payload_has_no_context_and_the_reader_says_so() {
+        let payload = serde_json::json!({
+            "event_id": 10, "execution_id": 1, "catalog_id": 2,
+            "event_type": "step.enter", "status": "ok",
+            "node_name": "s1", "step": "s1",
+            "result": {"a": 1}, "meta": {"attempt": "1"},
+            "mirror_source": "server"
+        });
+        let ev = event_from_tier_payload(&payload).expect("parses");
+        assert_eq!(ev.event_id, 10);
+        assert_eq!(ev.result, Some(serde_json::json!({"a": 1})));
+        assert!(
+            ev.context.is_none(),
+            "the tier record carries no `context` — if this ever becomes Some, \
+             the mirror payload changed and the Phase 1 finding is stale"
+        );
+        assert_eq!(ev.attempt, Some(1), "attempt is derived from meta, as in the SQL projection");
+    }
+
+    /// …and when a payload DOES carry context, the reader picks it up. Without
+    /// this, the assertion above would also pass against a reader that simply
+    /// never reads the field — proving the reader broken rather than the
+    /// record incomplete.
+    #[test]
+    fn the_reader_picks_up_context_when_it_is_present() {
+        let payload = serde_json::json!({
+            "event_id": 11, "execution_id": 1, "catalog_id": 2,
+            "event_type": "step.enter", "status": "ok",
+            "context": {"loop": {"i": 3}}
+        });
+        let ev = event_from_tier_payload(&payload).expect("parses");
+        assert_eq!(ev.context, Some(serde_json::json!({"loop": {"i": 3}})));
+    }
+
+    /// A record set that parses to nothing is a refusal, never an empty state.
+    #[test]
+    fn records_without_event_ids_refuse_rather_than_fold_nothing() {
+        let payload = serde_json::json!({"no_event_id": true});
+        assert!(event_from_tier_payload(&payload).is_none());
+    }
+
+    /// Two refusals are not a match.
+    #[test]
+    fn agreement_requires_two_folds_not_two_refusals() {
+        let c = FoldComparison {
+            execution_id: 1,
+            postgres: None,
+            postgres_refusal: Some(FoldRefusal::NoEvents),
+            tier: None,
+            tier_refusal: Some(FoldRefusal::NoEvents),
+            digests_agree: false,
+            disagreement: None,
+            postgres_without_context: None,
+            context_explains_the_gap: false,
+        };
+        assert!(
+            !c.digests_agree,
+            "absence of disagreement is not agreement — this is the vacuous \
+             pass the whole comparator discipline exists to refuse"
+        );
+    }
+}
+

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1945,6 +1945,138 @@ const ORCH_EVENT_COLS_WITH_PREV: &str = r#"
 
 /// Map rows selected via [`ORCH_EVENT_COLS`] into `Event`s.  `attempt` lives in
 /// `meta` JSONB (no dedicated column), sourced via the `NULLIF(...)::int` alias.
+/// Re-exported for the Phase-1 fold (ai-meta#265) so a fold from Postgres
+/// builds the SAME `Event` values the orchestrator's own rebuild path does.
+/// A second parser here would be a second definition of what an event IS.
+pub(crate) fn parse_event_rows_for_fold(rows: Vec<sqlx::postgres::PgRow>) -> Vec<crate::db::models::Event> {
+    parse_event_rows(rows)
+}
+
+
+/// Read `noetl.event.created_at`, coercing a tz-less column.
+///
+/// # The bug this fixes (ai-meta#265 Phase 1)
+///
+/// `noetl.event.created_at` is declared **`timestamp without time zone`**, and
+/// `models::Event.created_at` is `DateTime<Utc>`. sqlx decodes `timestamptz`
+/// into `DateTime<Utc>` and `timestamp` into `NaiveDateTime` — so
+/// `try_get::<DateTime<Utc>>("created_at")` fails on **every row**, and the
+/// previous `.unwrap_or_else(|_| Utc::now())` silently substituted the *current
+/// time* for the event's real one.
+///
+/// The consequence is not cosmetic. `WorkflowState::apply_event` propagates
+/// `event.timestamp` into `started_at`, `completed_at` and per-step
+/// `entered_at`/`completed_at`, so the reconstructed state embedded **the
+/// moment of the rebuild**. Measured with the determinism probe: folding one
+/// 13-event execution twice, 8 ms apart, differed in exactly five fields, all
+/// timestamps, all 8 ms apart — while folding the *same in-memory events* twice
+/// was byte-identical. The fold was deterministic; the loader was not.
+///
+/// Two things follow, and the second is the reason this is a defect rather than
+/// a curiosity:
+///
+/// 1. A re-fold can never reproduce a stored state's digest, which is the
+///    premise the event-sourced read model rests on.
+/// 2. **Two replicas rebuilding the same execution get different
+///    `entered_at`/`completed_at`.** Anything that compares or templates on
+///    those is reading fold time, not event time.
+///
+/// The codebase half-knew: `StepInfo::completed_event_id` and
+/// `ctx_set_marks` both carry doc comments saying `completed_at` "derives from
+/// the `Utc::now()` loader fallback and varies across reconstructions", and
+/// ai-meta#85 worked around it by keying on `event_id`. The workaround was
+/// correct; the cause was left in place. server#150 fixed the same class in
+/// `replay::load_events` ("coerce created_at TIMESTAMP → TIMESTAMPTZ") and this
+/// loader never got it.
+///
+/// # Why it still falls back rather than failing
+///
+/// A row whose timestamp decodes as neither type is a schema the binary does
+/// not understand, and refusing the whole rebuild for it would turn a column
+/// change into an outage. But the fallback is now **last**, not first, and it
+/// is counted — an unattributable `now()` is what made this invisible for so
+/// long.
+fn created_at_from_row(r: &sqlx::postgres::PgRow) -> chrono::DateTime<chrono::Utc> {
+    match created_at_of(
+        r.try_get::<chrono::DateTime<chrono::Utc>, _>("created_at").ok(),
+        r.try_get::<chrono::NaiveDateTime, _>("created_at").ok(),
+    ) {
+        Some(ts) => ts,
+        None => {
+            crate::metrics::record_event_created_at_fallback();
+            chrono::Utc::now()
+        }
+    }
+}
+
+/// The decision, as a pure function so it is testable without a database.
+///
+/// `timestamptz` wins when both decode — it is the unambiguous encoding. A
+/// tz-less value is interpreted as UTC, which is what the column means here:
+/// the writer stores `now()` on a UTC server and the tailer already treats it
+/// that way (`services::internal`, "noetl.event.created_at is tz-less").
+pub(crate) fn created_at_of(
+    tz_aware: Option<chrono::DateTime<chrono::Utc>>,
+    naive: Option<chrono::NaiveDateTime>,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    if let Some(ts) = tz_aware {
+        return Some(ts);
+    }
+    naive.map(|n| chrono::DateTime::from_naive_utc_and_offset(n, chrono::Utc))
+}
+
+#[cfg(test)]
+mod created_at_tests {
+    use super::created_at_of;
+    use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+
+    fn naive() -> chrono::NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 8, 26)
+            .unwrap()
+            .and_hms_milli_opt(3, 44, 48, 468)
+            .unwrap()
+    }
+
+    /// THE TEST THAT WOULD HAVE CAUGHT IT.
+    ///
+    /// A tz-less row — which is what `noetl.event.created_at` actually is —
+    /// must decode to the ROW'S value. Before the fix this path produced
+    /// `Utc::now()`, and every existing test passed because none of them
+    /// compared the result to the row.
+    #[test]
+    fn a_tz_less_row_decodes_to_the_rows_value_not_now() {
+        let got = created_at_of(None, Some(naive())).expect("a tz-less row must decode");
+        assert_eq!(
+            got,
+            Utc.with_ymd_and_hms(2026, 8, 26, 3, 44, 48).unwrap() + chrono::Duration::milliseconds(468),
+            "the tz-less column must be read as UTC, not replaced by the current time"
+        );
+        // …and emphatically not the current time.
+        assert!(
+            (Utc::now() - got).num_days() > 0 || got.timestamp() != Utc::now().timestamp(),
+            "decoded value must not be now()"
+        );
+    }
+
+    /// A tz-aware column still works — deployments differ, and a fix that broke
+    /// the other encoding would just move the outage.
+    #[test]
+    fn a_tz_aware_row_still_decodes_and_wins() {
+        let tz: DateTime<Utc> = Utc.with_ymd_and_hms(2020, 1, 2, 3, 4, 5).unwrap();
+        assert_eq!(created_at_of(Some(tz), None), Some(tz));
+        // Both present: the unambiguous encoding wins.
+        assert_eq!(created_at_of(Some(tz), Some(naive())), Some(tz));
+    }
+
+    /// Neither decodes ⇒ `None`, so the CALLER owns the fallback and can count
+    /// it. The old code buried the fallback inside the decode, which is why an
+    /// every-row failure looked like normal operation.
+    #[test]
+    fn neither_encoding_is_a_reported_absence_not_a_silent_now() {
+        assert_eq!(created_at_of(None, None), None);
+    }
+}
+
 fn parse_event_rows(rows: Vec<sqlx::postgres::PgRow>) -> Vec<crate::db::models::Event> {
     use sqlx::Row;
     rows.into_iter()
@@ -1965,9 +2097,7 @@ fn parse_event_rows(rows: Vec<sqlx::postgres::PgRow>) -> Vec<crate::db::models::
             result: r.try_get("result").ok(),
             worker_id: r.try_get("worker_id").ok(),
             attempt: r.try_get("attempt").ok(),
-            created_at: r
-                .try_get("created_at")
-                .unwrap_or_else(|_| chrono::Utc::now()),
+            created_at: created_at_from_row(&r),
         })
         .collect()
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod ehdb;
 pub mod ehdb_eventlog_mirror;
 pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;
+pub mod ehdb_projection_fold;
 pub mod ehdb_projection_mirror;
 pub mod ehdb_projection_parity;
 pub mod ehdb_projection_mirror_queue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,6 +380,10 @@ fn build_router(
             get(handlers::ehdb_projection_fold::determinism_endpoint),
         )
         .route(
+            "/api/ehdb/projection-refold/executions/{execution_id}",
+            get(handlers::ehdb_projection_fold::refold_endpoint),
+        )
+        .route(
             "/api/ehdb/projection-parity/self-test",
             get(handlers::ehdb_projection_parity::self_test_endpoint),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,6 +372,14 @@ fn build_router(
             get(handlers::ehdb_projection_parity::compare_execution_endpoint),
         )
         .route(
+            "/api/ehdb/projection-fold/executions/{execution_id}",
+            get(handlers::ehdb_projection_fold::compare_sources_endpoint),
+        )
+        .route(
+            "/api/ehdb/projection-fold/determinism/{execution_id}",
+            get(handlers::ehdb_projection_fold::determinism_endpoint),
+        )
+        .route(
             "/api/ehdb/projection-parity/self-test",
             get(handlers::ehdb_projection_parity::self_test_endpoint),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,6 +380,10 @@ fn build_router(
             get(handlers::ehdb_projection_fold::determinism_endpoint),
         )
         .route(
+            "/api/ehdb/projection-fold/diff/{execution_id}",
+            get(handlers::ehdb_projection_fold::fold_diff_endpoint),
+        )
+        .route(
             "/api/ehdb/projection-refold/executions/{execution_id}",
             get(handlers::ehdb_projection_fold::refold_endpoint),
         )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3816,7 +3816,37 @@ pub fn set_ehdb_projection_parity_lag_tolerance(seconds: u64) {
     ehdb_projection_parity_lag_tolerance_seconds().set(seconds as i64);
 }
 
+/// Counter: event rows whose `created_at` decoded as neither `timestamptz` nor
+/// `timestamp`, so the loader substituted `Utc::now()` (ai-meta#265 Phase 1).
+///
+/// Pinned at 0 and published because the previous behaviour — an unconditional
+/// `unwrap_or_else(Utc::now)` — made an EVERY-ROW decode failure look exactly
+/// like normal operation for as long as it existed. A fallback nobody can count
+/// is a fallback nobody discovers.
+pub fn event_created_at_fallback_total() -> &'static IntCounter {
+    static M: OnceLock<IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let c = IntCounter::new(
+            "noetl_event_created_at_fallback_total",
+            "Event rows whose created_at decoded as neither timestamptz nor timestamp, so the \
+             loader used the current time instead (noetl/ai-meta#265).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(c.clone()))
+            .expect("counter registration must succeed");
+        c
+    })
+}
+
+pub fn record_event_created_at_fallback() {
+    event_created_at_fallback_total().inc();
+}
+
 pub fn init_ehdb_crossstore_series() {
+    // Unconditional pin: absent and zero are different answers, and this one's
+    // whole value is being readable as 0 on a healthy binary.
+    event_created_at_fallback_total().inc_by(0);
     use crate::handlers::ehdb_parity::{
         CONTROL_NAMES, DIVERGENCE_KINDS, PARITY_OUTCOMES, TIER,
     };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3507,6 +3507,9 @@ pub fn init_ehdb_projection_series() {
             .with_label_values(&[outcome])
             .inc_by(0);
     }
+    for v in crate::handlers::ehdb_projection_fold::REFOLD_VERDICTS {
+        ehdb_projection_refold_total().with_label_values(&[v]).inc_by(0);
+    }
     for outcome in EHDB_PROJECTION_SNAPSHOT_GATE_OUTCOMES {
         ehdb_projection_snapshot_gate_total()
             .with_label_values(&[outcome])
@@ -3841,6 +3844,32 @@ pub fn event_created_at_fallback_total() -> &'static IntCounter {
 
 pub fn record_event_created_at_fallback() {
     event_created_at_fallback_total().inc();
+}
+
+/// Counter: Phase-2 re-fold comparator verdicts (ai-meta#265).
+///
+/// Ground truth is a fresh fold of the WAL spine, not a Postgres row — so
+/// unlike the A4 comparator this counts a comparison that was actually
+/// recomputed rather than a stored number compared with itself.
+pub fn ehdb_projection_refold_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let c = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_projection_refold_total",
+                "Projection records compared against a fresh fold of the WAL spine, by verdict \
+                 (noetl/ai-meta#265).",
+            ),
+            &["verdict"],
+        )
+        .expect("static counter spec must be valid");
+        registry().register(Box::new(c.clone())).expect("counter registration must succeed");
+        c
+    })
+}
+
+pub fn record_ehdb_projection_refold(verdict: &str) {
+    ehdb_projection_refold_total().with_label_values(&[verdict]).inc();
 }
 
 pub fn init_ehdb_crossstore_series() {

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -71,6 +71,18 @@ pub async fn save(
     let mirrored_at = chrono::Utc::now();
     let snapshot = serde_json::to_value(state)
         .map_err(|e| AppError::Internal(format!("orch_snapshot.save: serialise: {e}")))?;
+    // Digests `snapshot` — a `serde_json::Value` — and NOT `state` directly.
+    // That distinction is load-bearing and was undocumented until ai-meta#265
+    // Phase 0: `WorkflowState` holds its maps in `HashMap`, so digesting the
+    // struct yields a PER-PROCESS value (measured: four processes, four
+    // digests). `Value`'s object map is a `BTreeMap`, so this form is
+    // key-sorted at every level and comparable across processes.
+    //
+    // It has never mattered because nothing re-derives this number — it is
+    // computed once and copied, so #265's comparator compares it to itself. The
+    // event-sourced read model is the thing that breaks that assumption.
+    // `canonical_state_digest` names the property; the guard below pins that
+    // this call site keeps it.
     let checksum = {
         let bytes = serde_json::to_vec(&snapshot).unwrap_or_default();
         hex::encode(Sha256::digest(&bytes))
@@ -319,6 +331,43 @@ async fn load_incumbent(
 
 #[cfg(test)]
 mod tests {
+
+    /// The snapshot checksum must be over the CANONICAL form.
+    ///
+    /// `save` digests `serde_json::to_value(state)` rather than `state`, and
+    /// that is what makes the value comparable across processes. The shorter,
+    /// more obvious refactor — digest the struct — produces a per-process
+    /// digest that passes every existing test, because nothing re-derives it.
+    ///
+    /// Counting CODE, with `//` stripped, so the prose above cannot satisfy the
+    /// guard and deleting the prose cannot break it. Positive control: the real
+    /// `to_value` call must survive the stripper.
+    #[test]
+    fn the_snapshot_checksum_is_over_the_canonical_form() {
+        let whole = include_str!("orch_snapshot.rs");
+        let code_half = &whole[..whole
+            .find("mod tests {")
+            .expect("the test module must still be the tail of this file")];
+        let code: String = code_half
+            .lines()
+            .map(|l| match l.find("//") {
+                Some(i) => &l[..i],
+                None => l,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            code.contains("serde_json::to_value(state)"),
+            "the comment stripper ate the real call; this guard proves nothing"
+        );
+        assert!(
+            !code.contains("to_vec(state)") && !code.contains("to_vec(&state)"),
+            "the checksum must be over `to_value(state)`, never over the struct: \
+             WorkflowState's HashMaps serialise in per-process iteration order, so a \
+             struct digest is not comparable between the process that folded and the \
+             process that re-folds (ai-meta#265 Phase 0)"
+        );
+    }
     /// The serving read path must have **exactly one** reader of
     /// `noetl.projection_snapshot`.
     ///


### PR DESCRIPTION
noetl/ai-meta#265 Phase 0 + the Phase-1 finding it led to. Three commits; the description below **supersedes the original**, which overstated the conclusion.

## ⚠ Correcting my own first conclusion

The original description said Phase 0 *proved* the digest property held and that today's digests were "canonical by accident". **That was wrong**, and Phase 1's measurement is what caught it: `canonical_state_digest` canonicalises *object key order*, and something else varied per call regardless. My Phase 0 test passed because the synthetic state I built had no instance of what actually varies. A test that passes on synthetic input and fails on real data measured the wrong thing.

What follows is what the measurements actually support.

## 1. The canonical digest (`cdf8027`)

`WorkflowState` holds its maps in `HashMap`, and serde serialises those in per-process iteration order. Four processes, one identical state:

```
raw_digest=79722d00…  a0359074…  eeffabd1…  33bad35c…
canonical_digest=1f0766f9…      ← identical in all four
```

Today's digests route through `serde_json::to_value` first (whose object map is a `BTreeMap`), so they are canonical — but nothing said that was required and nothing tested it. `canonical_state_digest` names the property; a **negative control** proves a one-value change (and a change buried in a nested object) moves the digest; a source guard pins that `orch_snapshot::save` digests `to_value(state)` and never the struct.

## 2. The loader bug this uncovered (`429e6d5`) — the substantive fix

`noetl.event.created_at` is **`timestamp without time zone`**; `models::Event.created_at` is `DateTime<Utc>`. sqlx decodes `timestamptz` into `DateTime<Utc>` and `timestamp` into `NaiveDateTime`, so `try_get::<DateTime<Utc>>` failed on **every row** and the adjacent `.unwrap_or_else(|_| Utc::now())` substituted the current time.

`apply_event` propagates `event.timestamp` into `started_at`, `completed_at` and per-step `entered_at`/`completed_at`, so **the reconstructed state embedded the moment of the rebuild.** Measured — one 13-event execution folded twice, 8 ms apart:

```
diff_paths_same_input : []                     ← same events → identical state
diff_paths_two_reads  : /started_at, /completed_at,
                        /steps/start/completed_at,
                        /steps/work/entered_at, /steps/work/completed_at
                        …all 8 ms apart
```

The fold was deterministic. The loader was not.

**The codebase half-knew.** `StepInfo::completed_event_id` and `ctx_set_marks` both carry doc comments saying `completed_at` *"derives from the `Utc::now()` loader fallback and varies across reconstructions"*, and ai-meta#85 worked around it by keying on `event_id`. The workaround was right; the cause stayed. server#150 fixed the same class in `replay::load_events` and **this** loader never got it.

`created_at_of(tz_aware, naive)` is pure so the decision is testable without a DB, and the `now()` fallback moved out of the decode to the caller where it is **counted** (`noetl_event_created_at_fallback_total`, pinned at 0). An unattributable `now()` is what let an every-row failure look like normal operation.

**After, in kind:** `diff_paths_two_reads: []`, three identical digests across separate reads, and the fallback counter at **0** — so the decode succeeds rather than the stability coming from a uniform fallback.

## Consequence tracked separately

Two replicas rebuilding the same execution got different `entered_at`/`completed_at`. Anything comparing or templating on those was reading fold time, not event time. That is not a #265 defect and gets its own issue.

832 lib tests pass; back to the 4 pre-existing clippy warnings.
