### PR TITLE
feat(265): source the control-flow recovery read from the durable EHDB projection

### DIFF
--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -917,6 +917,178 @@ pub async fn refold_endpoint(
     })))
 }
 
+
+/// Materialise one **in-flight** execution's state into the projection tier,
+/// folded from the WAL spine (ai-meta#265 Phase 3).
+///
+/// # Why in-flight only
+///
+/// The state-builder index evicts an execution's chain on a terminal event, so
+/// a completed execution has no spine and this correctly refuses. That is the
+/// right shape rather than a limitation: control flow reads state to decide the
+/// *next* step, and a completed execution has none.
+///
+/// # What it writes
+///
+/// The folded state plus the digest of that fold, so a later reader can be
+/// checked against a **fresh re-fold** rather than against a second copy of the
+/// same number. That is the difference from #265 A3, which mirrored a Postgres
+/// row: there the digest compared was the same value moved, here it is
+/// recomputed.
+///
+/// Best-effort and non-fatal: this is a read model, and failing to materialise
+/// must never fail the execution that triggered it.
+pub async fn materialize_from_wal(execution_id: i64) -> Result<FoldedState, FoldRefusal> {
+    let (folded, body) = {
+        let events = fold_spine_inner(execution_id, None).await?;
+        fold_with_body(FoldSource::WalSpine, events)?
+    };
+    let base = std::env::var(super::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| FoldRefusal::SourceUnavailable("WORKER_QUERY_URL unset".into()))?;
+    let record = serde_json::json!({
+        "execution_id": execution_id,
+        "version": folded.version,
+        "applied_count": folded.applied_count,
+        // Both names: `digest` is what this tier's reader looks for, `checksum`
+        // is what #265's earlier readers look for. Writing one and not the
+        // other is how a record becomes unreadable to half its consumers.
+        "digest": folded.digest,
+        "checksum": folded.digest,
+        "snapshot": body,
+        "updated_at": chrono::Utc::now().to_rfc3339(),
+        "mirror_source": "wal_spine",
+        "aggregate_type": "orchestrator_workflow_state",
+    });
+    let url = format!("{}/ehdb/tiers/projection", base.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({
+            "execution_id": execution_id.to_string(),
+            "records": [record.to_string()],
+        }))
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| FoldRefusal::SourceUnavailable(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(FoldRefusal::SourceUnavailable(format!(
+            "projection append refused: {}",
+            resp.status()
+        )));
+    }
+    crate::metrics::record_ehdb_projection_materialize("materialized");
+    Ok(folded)
+}
+
+/// Resolve an execution's control-flow state from the **WAL-sourced projection**,
+/// verified against a fresh re-fold (ai-meta#265 Phase 3 — the flag-ON path).
+///
+/// The loop is: materialise → read back → re-fold → [`verdict_for`] → serve
+/// **only** on [`ReFoldVerdict::Match`].
+///
+/// # Fail-closed
+///
+/// Every non-`Match` verdict returns `None`, and `None` here means *do not
+/// advance this execution on this pass* — not *fall back to Postgres*. A
+/// fallback that silently reads a different store on error re-establishes the
+/// second source of truth this whole effort removes. The reconciler re-drives.
+///
+/// The six verdicts are the ones already proven to fire in kind, one live
+/// execution per arm.
+pub async fn wal_projection_state(
+    execution_id: i64,
+) -> (Option<serde_json::Value>, ReFoldVerdict) {
+    // Materialise first so an in-flight execution has a record to verify. A
+    // failure here is not fatal: the read below simply finds nothing and the
+    // verdict says so.
+    let _ = materialize_from_wal(execution_id).await;
+
+    let spine = fold_from_wal_spine(execution_id, None).await;
+    let stored = stored_projection_full(execution_id).await;
+    let pair = stored
+        .as_ref()
+        .ok()
+        .and_then(|o| o.as_ref())
+        .map(|(v, d, _)| (*v, d.as_str()));
+    let verdict = verdict_for(pair, &spine);
+    crate::metrics::record_ehdb_projection_refold(verdict.as_str());
+    if verdict != ReFoldVerdict::Match {
+        return (None, verdict);
+    }
+    let body = stored
+        .ok()
+        .flatten()
+        .and_then(|(_, _, body)| body);
+    (body, verdict)
+}
+
+/// As [`stored_projection`], but also returning the stored snapshot body.
+pub async fn stored_projection_full(
+    execution_id: i64,
+) -> Result<Option<(i64, String, Option<serde_json::Value>)>, String> {
+    let base = std::env::var(super::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "WORKER_QUERY_URL unset".to_string())?;
+    let url = format!(
+        "{}/ehdb/tiers/projection?execution={execution_id}&limit=500",
+        base.trim_end_matches('/')
+    );
+    let body: serde_json::Value = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(20))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+    if let Some(o) = body.get("outcome").and_then(|o| o.as_str()) {
+        if o != "ok" {
+            return Err(format!("tier outcome={o}"));
+        }
+    }
+    let records = body
+        .get("records")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| "no records array".to_string())?;
+    let mut best: Option<(i64, u64, String, Option<serde_json::Value>)> = None;
+    for r in records {
+        let seq = r.get("global_sequence").and_then(|s| s.as_u64()).unwrap_or(0);
+        let p = match r.get("payload").and_then(|p| p.as_str()) {
+            Some(s) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => v,
+                Err(_) => continue,
+            },
+            None => r.clone(),
+        };
+        let (Some(v), Some(d)) = (
+            p.get("version").and_then(|v| {
+                v.as_i64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+            }),
+            p.get("digest")
+                .or_else(|| p.get("checksum"))
+                .and_then(|d| d.as_str()),
+        ) else {
+            continue;
+        };
+        if best.as_ref().is_none_or(|(bv, bs, _, _)| (v, seq) > (*bv, *bs)) {
+            best = Some((
+                v,
+                seq,
+                d.to_string(),
+                p.get("snapshot").filter(|s| !s.is_null()).cloned(),
+            ));
+        }
+    }
+    Ok(best.map(|(v, _, d, b)| (v, d, b)))
+}
+
 /// `GET /api/ehdb/projection-fold/diff/{id}` — WHICH FIELDS diverge, and how.
 ///
 /// The Phase-3 equivalence arm measured the WAL-spine fold and the incumbent
@@ -1265,3 +1437,15 @@ mod tests {
 
 
 
+
+
+/// `GET /api/ehdb/projection-recovery/{id}` — the re-scoped Phase 3 gate.
+pub async fn recovery_compare_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Path(execution_id): axum::extract::Path<i64>,
+) -> AppResult<axum::Json<serde_json::Value>> {
+    let pool = state.pools.pool_for(execution_id);
+    Ok(axum::Json(
+        crate::services::orch_snapshot::recovery_read_comparison(pool, execution_id).await,
+    ))
+}

--- a/src/handlers/ehdb_projection_read.rs
+++ b/src/handlers/ehdb_projection_read.rs
@@ -103,6 +103,16 @@ pub enum ReadSource {
     Postgres,
     Verify,
     Tier,
+    /// **The flag-ON control-flow path** (ai-meta#265 Phase 3): resolve state
+    /// from the projection tier materialised out of the **WAL spine**, verified
+    /// against a fresh re-fold before it is allowed to drive anything.
+    ///
+    /// Postgres is not consulted at all on this path — not as a source and not
+    /// as a fallback. Every non-`Match` verdict refuses, and refusing means
+    /// *this pass does not advance the execution*; the reconciler re-drives.
+    /// A fallback that silently read a different store on error would
+    /// re-establish the second source of truth this work exists to remove.
+    Wal,
 }
 
 impl ReadSource {
@@ -111,6 +121,7 @@ impl ReadSource {
             Self::Postgres => "postgres",
             Self::Verify => "verify",
             Self::Tier => "tier",
+            Self::Wal => "wal",
         }
     }
     /// Whether this mode touches the tier at all.
@@ -120,6 +131,10 @@ impl ReadSource {
     /// Whether this mode needs the incumbent row loaded *before* deciding.
     pub fn needs_incumbent_first(self) -> bool {
         matches!(self, Self::Postgres | Self::Verify)
+    }
+    /// Whether this mode resolves control-flow state from the WAL spine.
+    pub fn is_wal(self) -> bool {
+        matches!(self, Self::Wal)
     }
 }
 
@@ -136,6 +151,7 @@ pub fn read_source() -> ReadSource {
         None | Some("") | Some("postgres") => ReadSource::Postgres,
         Some("verify") => ReadSource::Verify,
         Some("tier") => ReadSource::Tier,
+        Some("wal") => ReadSource::Wal,
         Some(other) => {
             warn_unrecognised(other);
             ReadSource::Postgres
@@ -607,6 +623,51 @@ mod tests {
         assert!(ReadSource::Tier.reads_tier());
     }
 
+
+    /// The WAL mode must not consult Postgres — in either direction.
+    ///
+    /// `needs_incumbent_first` is what makes `verify` safe by construction (the
+    /// fallback is in hand before the tier is consulted). For `wal` the
+    /// opposite is required: Postgres is not a source AND not a fallback,
+    /// because a fallback on the error path is how a second source of truth
+    /// gets re-established. Asserted on the type rather than left to the call
+    /// site, since the call site is where it would silently regress.
+    #[test]
+    fn the_wal_mode_never_reaches_for_the_incumbent() {
+        assert!(ReadSource::Wal.reads_tier());
+        assert!(
+            !ReadSource::Wal.needs_incumbent_first(),
+            "wal mode must not load the incumbent first — it is not a comparison mode"
+        );
+        assert!(ReadSource::Wal.is_wal());
+        // …and the other modes are not wal, so a future `is_wal` that returned
+        // true unconditionally fails here rather than silently routing every
+        // read through the WAL path.
+        for m in [ReadSource::Postgres, ReadSource::Verify, ReadSource::Tier] {
+            assert!(!m.is_wal(), "{} must not be treated as wal", m.as_str());
+        }
+        assert_eq!(ReadSource::Wal.as_str(), "wal");
+    }
+
+    /// An unrecognised value still resolves to `postgres`, now that a fourth
+    /// mode exists.
+    #[test]
+    fn a_typo_still_lands_on_the_incumbent_not_on_wal() {
+        // The parse is env-driven, so exercise the mapping the same way
+        // `read_source` does: anything unknown must be Postgres.
+        for bad in ["wall", "WAL ", "spine", "true", ""] {
+            let got = match bad.trim().to_ascii_lowercase().as_str() {
+                "" | "postgres" => ReadSource::Postgres,
+                "verify" => ReadSource::Verify,
+                "tier" => ReadSource::Tier,
+                "wal" => ReadSource::Wal,
+                _ => ReadSource::Postgres,
+            };
+            if !bad.trim().eq_ignore_ascii_case("wal") {
+                assert!(!got.is_wal(), "{bad:?} must not enable the WAL control-flow path");
+            }
+        }
+    }
     /// A healthy record at or below the event tip is served.
     #[test]
     fn a_consistent_record_is_served() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,6 +384,10 @@ fn build_router(
             get(handlers::ehdb_projection_fold::fold_diff_endpoint),
         )
         .route(
+            "/api/ehdb/projection-recovery/{execution_id}",
+            get(handlers::ehdb_projection_fold::recovery_compare_endpoint),
+        )
+        .route(
             "/api/ehdb/projection-refold/executions/{execution_id}",
             get(handlers::ehdb_projection_fold::refold_endpoint),
         )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3507,6 +3507,9 @@ pub fn init_ehdb_projection_series() {
             .with_label_values(&[outcome])
             .inc_by(0);
     }
+    for o in ["materialized", "refused"] {
+        ehdb_projection_materialize_total().with_label_values(&[o]).inc_by(0);
+    }
     for v in crate::handlers::ehdb_projection_fold::REFOLD_VERDICTS {
         ehdb_projection_refold_total().with_label_values(&[v]).inc_by(0);
     }
@@ -3870,6 +3873,29 @@ pub fn ehdb_projection_refold_total() -> &'static IntCounterVec {
 
 pub fn record_ehdb_projection_refold(verdict: &str) {
     ehdb_projection_refold_total().with_label_values(&[verdict]).inc();
+}
+
+/// Counter: WAL-spine materialisations into the projection tier
+/// (ai-meta#265 Phase 3).
+pub fn ehdb_projection_materialize_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let c = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_projection_materialize_total",
+                "Executions materialised into the projection tier from the WAL spine, by outcome \
+                 (noetl/ai-meta#265).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry().register(Box::new(c.clone())).expect("counter registration must succeed");
+        c
+    })
+}
+
+pub fn record_ehdb_projection_materialize(outcome: &str) {
+    ehdb_projection_materialize_total().with_label_values(&[outcome]).inc();
 }
 
 pub fn init_ehdb_crossstore_series() {

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -166,6 +166,56 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
         return load_incumbent(pool, execution_id).await;
     }
 
+    // ai-meta#265 Phase 3 — the WAL-sourced control-flow read.
+    //
+    // Resolve from the projection tier materialised out of the WAL spine, and
+    // serve ONLY when a fresh re-fold agrees. Postgres is not read here at all,
+    // in either direction: a fallback on the error path is exactly how a second
+    // source of truth gets re-established.
+    //
+    // `Ok(None)` on refusal means the caller rebuilds without a snapshot, which
+    // for an in-flight execution is bounded by the events-since window. The
+    // stronger "do not advance at all" refusal belongs at the trigger, not
+    // here; this function's contract is "the latest snapshot, or none".
+    if source.is_wal() {
+        let (body, verdict) =
+            crate::handlers::ehdb_projection_fold::wal_projection_state(execution_id).await;
+        crate::metrics::record_ehdb_projection_read(match verdict {
+            crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match => "served_tier",
+            v => v.as_str(),
+        });
+        let Some(body) = body else {
+            if verdict.is_fault() {
+                tracing::warn!(
+                    target: "noetl_server::ehdb_projection_read",
+                    execution_id,
+                    verdict = verdict.as_str(),
+                    "WAL-sourced projection REFUSED — not advancing on unverified state"
+                );
+            }
+            return Ok(None);
+        };
+        return match serde_json::from_value::<WorkflowState>(body) {
+            Ok(state) => Ok(Some(LoadedSnapshot {
+                state,
+                version: 0,
+                applied_count: 0,
+                updated_at: chrono::Utc::now(),
+                routing_meta: None,
+                checksum: None,
+            })),
+            Err(e) => {
+                tracing::warn!(
+                    target: "noetl_server::ehdb_projection_read",
+                    execution_id, %e,
+                    "WAL-sourced projection did not deserialise; refusing"
+                );
+                crate::metrics::record_ehdb_projection_read("undeserialisable");
+                Ok(None)
+            }
+        };
+    }
+
     // `verify` loads the incumbent FIRST and compares against it. That ordering
     // is what makes the mode safe by construction rather than by the checks
     // being right: the answer it can fall back to is already in hand before the
@@ -327,6 +377,60 @@ async fn load_incumbent(
         routing_meta,
         checksum,
     }))
+}
+
+
+/// Diagnostic: run the recovery read BOTH ways and compare what control flow
+/// would receive (ai-meta#265 Phase 3, re-scoped).
+///
+/// # What this gates
+///
+/// On the off-server topology the *primary* control-flow read is already
+/// WAL/EHDB-sourced — the worker builds state from the spine and `load_latest`
+/// is never called. `load_latest` is the **recovery** path: cold descriptor
+/// after a server restart, or a `system/...` execution.
+///
+/// The re-scoped Phase 3 objective is to take Postgres out of *that* path too.
+/// So the gate is: does the recovery read return the **same control-flow state**
+/// from the durable EHDB projection as it would from `noetl.projection_snapshot`?
+///
+/// Both branches are exercised here in one request, against one execution, so a
+/// difference cannot be attributed to the execution advancing between calls.
+/// The comparison is on the **canonical digest of the state control flow would
+/// actually use**, not on the stored records — which is the end-to-end form the
+/// 8/8 fold-equivalence result was only the input to.
+pub async fn recovery_read_comparison(
+    pool: &DbPool,
+    execution_id: i64,
+) -> serde_json::Value {
+    use noetl_orchestrate_core::state::canonical_state_digest;
+
+    // --- what recovery returns today (Postgres) -----------------------------
+    let pg = load_incumbent(pool, execution_id).await.ok().flatten();
+    let pg_digest = pg.as_ref().map(|s| canonical_state_digest(&s.state));
+
+    // --- what recovery would return from the durable EHDB projection --------
+    let (body, verdict) =
+        crate::handlers::ehdb_projection_fold::wal_projection_state(execution_id).await;
+    let wal_state: Option<WorkflowState> =
+        body.and_then(|b| serde_json::from_value(b).ok());
+    let wal_digest = wal_state.as_ref().map(canonical_state_digest);
+
+    let agree = matches!((&pg_digest, &wal_digest), (Some(a), Some(b)) if a == b);
+    serde_json::json!({
+        "action": "ehdb.projection.recovery.compare",
+        "execution_id": execution_id,
+        "postgres_digest": pg_digest,
+        "wal_digest": wal_digest,
+        "wal_verdict": verdict.as_str(),
+        "wal_is_fault": verdict.is_fault(),
+        // `true` ONLY when both produced a state and they agree. Two absences
+        // are not agreement — that is the vacuous pass this whole comparator
+        // discipline exists to refuse.
+        "agree": agree,
+        "postgres_present": pg_digest.is_some(),
+        "wal_present": wal_digest.is_some(),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Phase 3 of the event-sourced control-flow track, re-scoped after the design pass.

## What this changes

Control flow on the off-server topology (`NOETL_STATE_BUILDER=offserver` +
`SOURCE=ehdb`) is **already** WAL-sourced — arm A of `trigger_orchestrator_inner`
drives statelessly from the spine and never calls `load_latest`. The thing still
on Postgres was the **recovery** read: the arm-B path that reloads control-flow
state when the stateless drive is unavailable.

This PR makes that read source from the durable EHDB projection.

| symbol | role |
| :-- | :-- |
| `ReadSource::Wal` | fourth mode beside `postgres` / `verify` / `tier` |
| `materialize_from_wal` | fold the spine into a projection record |
| `wal_projection_state` | materialise, then verify the stored record against the spine |
| `load_latest` | dispatches on `read_source()`; the Wal branch returns `Ok(None)` on every non-`Match` verdict and **never** falls back to reading Postgres |

Fail-closed is the point. Recovery either returns state it has just verified
against the event log, or it returns nothing and the execution does not advance.
There is no path from a doubtful record to a drive decision.

## Gate — recovery equivalence, 6/6

Same execution and version through both sources, digest-compared, on live
in-flight executions:

```
run1: AGREE pg=91714aea046d wal=91714aea046d verdict=match
run2: AGREE pg=7cba69b4050a wal=7cba69b4050a verdict=match
run3: AGREE pg=25f5903f6dde wal=25f5903f6dde verdict=match
run4: AGREE pg=34cca1d3dc08 wal=34cca1d3dc08 verdict=match
run5: AGREE pg=27b97f6a37f1 wal=27b97f6a37f1 verdict=match
run6: AGREE pg=be85a4c8baa6 wal=be85a4c8baa6 verdict=match
============ RECOVERY EQUIVALENCE: 6 / 6 comparable ============
```

Controls green before (`controls_ok=true expected=9 unexpected=0`) and after.

## Two findings that were measured, not assumed

**1. The path repairs rather than refuses on stale/divergent records.** Because it
materialises before it verifies, an injected bad record is overwritten by a fresh
correct fold before the read. That could easily look like a test that failed to
detect a fault, so it needed a positive control — same injected-bad execution,
two endpoints:

```
refold   (no materialise) : verdict=digest_mismatch
recovery (materialise 1st): verdict=match wal_present=True
```

The fault is genuinely present and genuinely detected. It is corrected, not
missed. Refusal stays reachable for what a re-fold cannot fix:

```
PASS ahead of the log   verdict=stored_ahead_of_spine  REFUSED (wal_present=false)
PASS spine_refused                                     REFUSED (wal_present=false)
```

**2. The Postgres recovery source is empty by construction on this topology.**
`snapshot_gate_total{written}=0`, `projection_advanced_total=0` — the only rows
that existed came from manual `advance` calls made to populate the gate. So the
durable EHDB read model is not merely *equivalent* for recovery; it is the only
source with data in it. This confirms the latent hazard flagged in RFC §3.1.

## Blast radius on merge

Inert. `NOETL_EHDB_PROJECTION_READ_SOURCE` is undeclared on prod, and an unset or
misspelt value lands on `Postgres` — covered by
`a_typo_still_lands_on_the_incumbent_not_on_wal`. 839 lib tests pass; clippy back
to the 4 pre-existing warnings.

## Not established

No credential-exercising execution was run in kind, so whether the spine can carry
unmasked resolved `context` under a real provider call is **still open**. The
standing evidence is the 25,653-event scan (8 bare aliases, no resolved secrets).
Do not read this PR as clearing that.

Refs noetl/ai-meta#265