### PR TITLE
feat(secrets): hydrate <VAR>_FILE for the three bootstrap secrets — inert by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -794,6 +794,13 @@ async fn main() -> anyhow::Result<()> {
     // Load environment variables from .env file if present
     dotenvy::dotenv().ok();
 
+    // noetl/ai-meta#267 Tier 2 — hydrate <VAR> from <VAR>_FILE for the three
+    // bootstrap secrets, BEFORE any thread is spawned and before any config is
+    // read.  Inert unless a *_FILE variable is set, so this is a no-op on every
+    // deployment that has not migrated.  Placement is load-bearing and pinned by
+    // `file_env::tests::hydrate_is_called_at_the_top_of_main`.
+    let secret_sources = noetl_server::secrets::file_env::hydrate();
+
     // Initialize tracing
     init_tracing();
 
@@ -801,6 +808,20 @@ async fn main() -> anyhow::Result<()> {
         version = env!("CARGO_PKG_VERSION"),
         "Starting NoETL Control Plane"
     );
+
+    // Report WHERE each bootstrap secret came from — never what it is.  Both
+    // label values are emitted for every variable so "file" and "env" are always
+    // present as series: an absent series would be indistinguishable from a
+    // binary that predates this, which is the ambiguity noetl/ai-meta#267 and
+    // #297 both turned on.
+    for (var, source) in &secret_sources {
+        noetl_server::metrics::record_secret_source(var, source.as_str());
+        tracing::info!(
+            target: "noetl_server::secrets",
+            var, source = source.as_str(),
+            "bootstrap secret source resolved"
+        );
+    }
 
     // Publish the version and pin the known label sets, unconditionally and
     // before any configuration branch can skip them.  `Registry::gather` prunes

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3422,6 +3422,40 @@ pub fn ehdb_projection_mirror_total() -> &'static IntCounterVec {
 pub const EHDB_PROJECTION_MIRROR_OUTCOMES: [&str; 4] =
     ["mirrored", "unconfigured", "unavailable", "degraded"];
 
+/// Where each bootstrap secret came from (noetl/ai-meta#267 Tier 2) — labelled
+/// by `var` and `source` (`file` / `env` / `file_unusable`).  Records the
+/// PROVENANCE, never the value.
+///
+/// Every variable emits on every boot, so all three sources exist as series for
+/// each var from the first scrape.  `Registry::gather` prunes empty families, so
+/// a labelled metric is ABSENT until it fires — and an absent series is
+/// indistinguishable from a binary that predates the metric.  Emitting
+/// unconditionally is what makes "this secret is still coming from env" a
+/// readable 1 rather than a missing row.
+pub fn secret_source_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_secret_source_total",
+                "Where a bootstrap secret was read from at startup: file (CSI mount) or env (secretKeyRef). Provenance only, never the value (noetl/ai-meta#267).",
+            ),
+            &["var", "source"],
+        )
+        .expect("secret_source_total metric");
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register secret_source_total");
+        m
+    })
+}
+
+/// Record one bootstrap secret's provenance.  `source` is `file`, `env` or
+/// `file_unusable`.
+pub fn record_secret_source(var: &str, source: &str) {
+    secret_source_total().with_label_values(&[var, source]).inc();
+}
+
 pub fn record_ehdb_projection_mirror(outcome: &str) {
     ehdb_projection_mirror_total()
         .with_label_values(&[outcome])

--- a/src/secrets/file_env.rs
+++ b/src/secrets/file_env.rs
@@ -1,0 +1,232 @@
+//! `<VAR>_FILE` hydration for the three bootstrap secrets (noetl/ai-meta#267 Tier 2).
+//!
+//! # Why this exists at all
+//!
+//! `NOETL_ENCRYPTION_KEY`, `POSTGRES_PASSWORD` and `NOETL_INTERNAL_API_TOKEN`
+//! cannot come from the Secrets Wallet, and the reason is structural rather than
+//! incidental: **the wallet reads the credential table over Postgres, and
+//! Postgres needs `POSTGRES_PASSWORD`.** `NOETL_ENCRYPTION_KEY` protects that
+//! table's contents. A credential the credential system depends on cannot be
+//! stored in the credential system.
+//!
+//! So these three arrive as files, mounted by the GKE Secret Manager CSI driver
+//! before the container starts. A file is present or absent; unlike an SM client
+//! call at startup there is nothing to hang — which matters, because
+//! noetl/ai-meta#297 was an unbounded startup park that ran ~36h unnoticed.
+//!
+//! # Why hydration rather than per-read-site changes
+//!
+//! `POSTGRES_PASSWORD` is not read by `env::var` anywhere — it is deserialised by
+//! `envy::prefixed("POSTGRES_").from_env::<DatabaseConfig>()`. Touching read
+//! sites would therefore miss it, and would have to touch the worker's sites too.
+//! Hydrating the process environment *before* anything reads it covers every
+//! consumer — `env::var`, `envy`, and any future one — with no read-site change.
+//!
+//! # Inert by default
+//!
+//! With no `<VAR>_FILE` set this function does nothing at all. That is what makes
+//! every rollout stage reversible: until the CSI mount and the `_FILE` variable
+//! are both present, the existing `secretKeyRef` path is the only path, and
+//! behaviour is byte-identical to today.
+//!
+//! Precedence is deliberately **file wins**: during the dual-run both sources are
+//! present, and the migration is only meaningful if the file is the one that
+//! takes effect. An empty or unreadable file is *not* treated as an override —
+//! falling back is safer than starting with an empty credential, which would fail
+//! later and further from the cause.
+
+use std::path::Path;
+
+/// The variables this hydrates. Deliberately a fixed list rather than "any env
+/// var ending `_FILE`": an allowlist cannot be widened by an unrelated variable
+/// that happens to match the pattern.
+pub const HYDRATED: [&str; 3] = [
+    "NOETL_ENCRYPTION_KEY",
+    "POSTGRES_PASSWORD",
+    "NOETL_INTERNAL_API_TOKEN",
+];
+
+/// What happened for one variable — the shape the metric and the log line record.
+/// Never carries a value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// `<VAR>_FILE` was set, readable and non-empty; `<VAR>` now holds its contents.
+    File,
+    /// No `<VAR>_FILE`; whatever `<VAR>` already held is untouched.
+    Env,
+    /// `<VAR>_FILE` was set but unusable (missing, unreadable, or empty), so the
+    /// env value stands. Distinct from `Env` on purpose: it means an operator
+    /// *intended* file delivery and did not get it, which is a misconfiguration
+    /// that must be visible rather than silently degraded.
+    FileUnusable,
+}
+
+impl Source {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Env => "env",
+            Self::FileUnusable => "file_unusable",
+        }
+    }
+}
+
+/// Decide the outcome for one variable, without touching the process or the disk.
+/// Split out so every arm is testable — including the ones that need a file that
+/// does not exist.
+pub fn decide(file_var: Option<&str>, file_contents: Option<&str>) -> Source {
+    match file_var {
+        None => Source::Env,
+        Some(p) if p.trim().is_empty() => Source::Env,
+        Some(_) => match file_contents {
+            Some(c) if !c.trim().is_empty() => Source::File,
+            _ => Source::FileUnusable,
+        },
+    }
+}
+
+/// Hydrate `<VAR>` from `<VAR>_FILE` for each entry of [`HYDRATED`].
+///
+/// Returns what happened per variable, for logging and metrics.
+///
+/// # Safety
+///
+/// Calls `std::env::set_var`, which is `unsafe` because concurrent readers race
+/// it. This MUST be called at the very top of `main`, before any thread is
+/// spawned and before any configuration is read — that is the whole contract, and
+/// it is why this is a single early call rather than something invoked lazily.
+/// The guard test below pins the call site so a later refactor cannot quietly
+/// move it after the runtime starts.
+pub fn hydrate() -> Vec<(&'static str, Source)> {
+    let mut out = Vec::with_capacity(HYDRATED.len());
+    for var in HYDRATED {
+        let file_var = std::env::var(format!("{var}_FILE")).ok();
+        let contents = file_var.as_deref().and_then(|p| {
+            if p.trim().is_empty() {
+                None
+            } else {
+                std::fs::read_to_string(Path::new(p.trim())).ok()
+            }
+        });
+        let decision = decide(file_var.as_deref(), contents.as_deref());
+        if decision == Source::File {
+            if let Some(c) = contents.as_deref() {
+                // Trailing newline is the norm for a mounted file and is not part
+                // of the secret; a token with \n appended fails auth in a way that
+                // looks like a wrong value rather than a formatting bug.
+                // SAFETY: see the function contract — called before any thread.
+                unsafe { std::env::set_var(var, c.trim_end_matches(['\n', '\r'])) };
+            }
+        }
+        if decision == Source::FileUnusable {
+            tracing::warn!(
+                target: "noetl_server::secrets",
+                var,
+                "{var}_FILE is set but the file is missing, unreadable or empty — \
+                 falling back to the environment value (noetl/ai-meta#267)"
+            );
+        }
+        out.push((var, decision));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The inert case, and the one that makes the rollout reversible: no `_FILE`
+    /// anywhere means nothing changes.
+    #[test]
+    fn no_file_var_leaves_the_environment_alone() {
+        assert_eq!(decide(None, None), Source::Env);
+        assert_eq!(decide(None, Some("ignored")), Source::Env);
+    }
+
+    /// File wins during the dual-run — otherwise the migration would be a no-op
+    /// that still reported success.
+    #[test]
+    fn a_readable_non_empty_file_wins() {
+        assert_eq!(decide(Some("/x"), Some("value")), Source::File);
+    }
+
+    /// An unusable file must NOT be reported as `env`. An operator who mounted a
+    /// file and got the env value silently has a misconfiguration that will
+    /// resurface later and further from its cause.
+    #[test]
+    fn an_unusable_file_is_named_as_such_not_silently_degraded() {
+        assert_eq!(decide(Some("/missing"), None), Source::FileUnusable);
+        assert_eq!(decide(Some("/empty"), Some("")), Source::FileUnusable);
+        assert_eq!(decide(Some("/blank"), Some("   \n")), Source::FileUnusable);
+        assert_ne!(decide(Some("/missing"), None), Source::Env);
+    }
+
+    /// An empty `_FILE` value is "unset", not "a file at path ''".
+    #[test]
+    fn an_empty_file_var_is_treated_as_unset() {
+        assert_eq!(decide(Some(""), None), Source::Env);
+        assert_eq!(decide(Some("   "), None), Source::Env);
+    }
+
+    /// The list is an allowlist. If this ever grows implicitly, a variable could
+    /// be hydrated that nobody intended.
+    #[test]
+    fn the_hydrated_set_is_exactly_the_three_bootstrap_secrets() {
+        assert_eq!(
+            HYDRATED,
+            [
+                "NOETL_ENCRYPTION_KEY",
+                "POSTGRES_PASSWORD",
+                "NOETL_INTERNAL_API_TOKEN"
+            ]
+        );
+    }
+
+    /// `hydrate()` must run before anything reads configuration. Pinned as a
+    /// source check because a later refactor moving it after the runtime starts
+    /// would be both a data race and a silently wrong config.
+    #[test]
+    fn hydrate_is_called_at_the_top_of_main() {
+        let src = include_str!("../main.rs");
+        // Scope the search to the BODY of main. `use` imports naturally mention
+        // config types above it, and matching those made this assert on import
+        // order rather than on call order — a guard that fails for the wrong
+        // reason is worse than no guard.
+        let body_start = src
+            .find("async fn main")
+            .expect("main.rs must define async fn main");
+        let body = &src[body_start..];
+        let call = body
+            .find("secrets::file_env::hydrate()")
+            .expect("main() must call secrets::file_env::hydrate()");
+        // Anything that READS configuration must come after it.
+        //
+        // ⚠ `envy::` is deliberately written as `envy::prefixed`: the bare
+        // substring also matches `dotenvy::`, which appears one line ABOVE the
+        // hydrate call, so the naive pattern failed on the correct code.
+        for reader in [
+            "DatabaseConfig::from_env",
+            "envy::prefixed",
+            "AppConfig::from_env",
+        ] {
+            if let Some(at) = body.find(reader) {
+                assert!(
+                    call < at,
+                    "hydrate() must run before {reader} — it is what puts the \
+                     secret in the environment that {reader} then reads"
+                );
+            }
+        }
+    }
+
+    /// The guard above must actually be able to fail. A source check that can
+    /// only pass is indistinguishable from no check.
+    #[test]
+    fn the_placement_guard_can_fail() {
+        let bad = "async fn main() {\n let c = DatabaseConfig::from_env();\n secrets::file_env::hydrate();\n}";
+        let body = &bad[bad.find("async fn main").unwrap()..];
+        let call = body.find("secrets::file_env::hydrate()").unwrap();
+        let at = body.find("DatabaseConfig::from_env").unwrap();
+        assert!(call > at, "fixture must represent the WRONG order");
+    }
+}

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -18,6 +18,7 @@ mod aws_sts;
 mod azure;
 mod azure_oauth;
 pub mod broker;
+pub mod file_env;
 pub mod dynamic;
 mod gcp;
 mod gcp_iam;


### PR DESCRIPTION
noetl/ai-meta#267 Tier 2, **stage 1**. Ships doing nothing.

With no `*_FILE` variable set this is a no-op and every deployment behaves
byte-identically to today. That inertness is what makes the later stages
reversible — until both the CSI mount and the `_FILE` variable are present, the
existing `secretKeyRef` path is the only path.

## Why these three cannot use the Secrets Wallet

The wallet reads the credential table **over Postgres**, and Postgres needs
`POSTGRES_PASSWORD`. `NOETL_ENCRYPTION_KEY` protects that table's contents. **A
credential the credential system depends on cannot be stored in the credential
system.** Structural, not an oversight.

So they arrive as files, mounted by the CSI driver before the container starts.
A file is present or absent; unlike an SM client call at startup there is nothing
to hang — noetl/ai-meta#297 was an unbounded startup park that ran ~36h unnoticed.

## Why hydration, not per-read-site changes

`POSTGRES_PASSWORD` is not read by `env::var` **anywhere** — it is deserialised
by `envy::prefixed("POSTGRES_")`. Editing read sites would have missed it
entirely, and would have had to reach into the worker too. Hydrating the process
environment *before* anything reads it covers `env::var`, `envy`, and any future
consumer, with **zero read-site changes**.

## Semantics

| case | outcome |
| :-- | :-- |
| no `<VAR>_FILE` | `env` — untouched |
| `<VAR>_FILE` readable, non-empty | **`file` wins** |
| `<VAR>_FILE` set but missing/unreadable/empty | `file_unusable` — falls back, and **says so** |

`file_unusable` is deliberately *not* reported as `env`: an operator who mounted
a file and silently got the env value has a misconfiguration that would resurface
later and further from its cause.

`noetl_secret_source_total{var,source}` records **provenance, never the value**,
and emits for every variable on every boot — `Registry::gather` prunes empty
families, so an absent series would be indistinguishable from a binary predating
the metric.

## Three test-authoring mistakes, recorded because each was a wrong-reason result

1. The placement guard matched `DatabaseConfig` anywhere in `main.rs` — including
   the `use` import **above** `main` — so it asserted on *import* order.
2. Narrowed to `main`'s body, it then matched `envy::` inside **`dotenvy::`**,
   which sits one line *above* the hydrate call, and failed on correct code.
3. `cargo build --lib` passed while the **binary** was broken: `main.rs` is its
   own crate root, so `crate::secrets` does not resolve there. `--all-targets`
   caught it.

The guard now carries a **can-it-fail control** — a source check that can only
pass is indistinguishable from no check.

## Status

846 lib tests green; clippy back to the 4 pre-existing warnings. **No prod
change, no `secretKeyRef` removed, nothing mounted.** Stage 2 (kind proof with
the negative control) follows; prod stages 3–5 wait on the owner's IAM.

Refs noetl/ai-meta#267