### PR TITLE
feat(credentials): source a credential's value from a secret manager, keeping the working path

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3422,6 +3422,41 @@ pub fn ehdb_projection_mirror_total() -> &'static IntCounterVec {
 pub const EHDB_PROJECTION_MIRROR_OUTCOMES: [&str; 4] =
     ["mirrored", "unconfigured", "unavailable", "degraded"];
 
+/// Outcomes of serving a Secret-Manager-sourced credential (noetl/ai-meta#267):
+/// `cache_hit`, `fetched`, `fetch_error`, `not_an_object`.
+///
+/// All four are emitted as series on first use of the path. `Registry::gather`
+/// prunes empty families, so an absent series is indistinguishable from a binary
+/// predating the metric — which matters most for `fetch_error`, the one an
+/// operator would go looking for.
+pub fn sm_sourced_credential_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_sm_sourced_credential_total",
+                "Serving a credential whose value is sourced from a secret manager, by outcome (noetl/ai-meta#267).",
+            ),
+            &["outcome"],
+        )
+        .expect("sm_sourced_credential_total metric");
+        for o in ["cache_hit", "fetched", "fetch_error", "not_an_object"] {
+            m.with_label_values(&[o]).reset();
+        }
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register sm_sourced_credential_total");
+        m
+    })
+}
+
+/// Record one SM-sourced credential serve outcome.
+pub fn record_sm_sourced_credential(outcome: &str) {
+    sm_sourced_credential_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
 pub fn record_ehdb_projection_mirror(outcome: &str) {
     ehdb_projection_mirror_total()
         .with_label_values(&[outcome])

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -35,7 +35,7 @@ pub use gcp::GcpSecretManager;
 pub use gcp_iam::GcpIamProvider;
 pub use k8s::K8sSecretProvider;
 pub use registry::get_provider;
-pub use resolver::{resolve_keychain_entry, resolve_keychain_entry_with_meta};
+pub use resolver::{resolve_keychain_entry, resolve_keychain_entry_with_meta, structured_or_string};
 pub use vault::VaultSecretProvider;
 
 use std::sync::{Arc, OnceLock};

--- a/src/secrets/resolver.rs
+++ b/src/secrets/resolver.rs
@@ -151,6 +151,32 @@ pub(crate) fn effective_region(kc: &KeychainDef) -> String {
     server_region().to_string()
 }
 
+
+/// Interpret a Secret Manager payload as either noetl's **structured credential
+/// object** or an opaque string (noetl/ai-meta#267).
+///
+/// A plain-text secret stays a string, byte-identically. Malformed JSON stays a
+/// string too — deliberately: degrading to an empty object would render an empty
+/// sub-field and fail at the API call, looking like a wrong credential rather
+/// than a parse failure.
+///
+/// The `.data` unwrap matches what the credential-indirect path serves, so the
+/// same template resolves the same way whichever path supplied it.
+pub fn structured_or_string(payload: &str) -> serde_json::Value {
+    let trimmed = payload.trim();
+    if !trimmed.starts_with('{') {
+        return serde_json::Value::String(payload.to_string());
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(serde_json::Value::Object(mut o)) => match o.remove("data") {
+            Some(d @ serde_json::Value::Object(_)) => d,
+            _ => serde_json::Value::Object(o),
+        },
+        Ok(_) => serde_json::Value::String(payload.to_string()),
+        Err(_) => serde_json::Value::String(payload.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;

--- a/src/services/credential.rs
+++ b/src/services/credential.rs
@@ -135,7 +135,23 @@ impl CredentialService {
                 let data = if include_data {
                     // `entry.data` is the self-describing envelope JSON from the
                     // TEXT column — unwrap the DEK + decrypt.
-                    Some(self.cipher.open_storage_json(&entry.data).await?)
+                    let stored = self.cipher.open_storage_json(&entry.data).await?;
+                    // noetl/ai-meta#267 — a credential may carry a marker saying
+                    // its VALUE lives in a secret manager. Only then do we fetch;
+                    // an unmarked credential takes exactly the path it always has,
+                    // which is what keeps every existing credential working.
+                    match crate::services::sm_sourced::parse_marker(&stored) {
+                        Some(src) => {
+                            tracing::info!(
+                                credential = %identifier,
+                                provider = %src.provider,
+                                secret = %src.secret,
+                                "credential value is secret-manager-sourced"
+                            );
+                            Some(crate::services::sm_sourced::resolve(&src).await?)
+                        }
+                        None => Some(stored),
+                    }
                 } else {
                     None
                 };

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -11,6 +11,7 @@ pub mod execution;
 pub mod internal;
 pub mod keychain;
 pub mod keychain_refresh;
+pub mod sm_sourced;
 pub mod object_backend;
 pub mod orch_snapshot;
 pub mod permanent_log_lean;

--- a/src/services/sm_sourced.rs
+++ b/src/services/sm_sourced.rs
@@ -1,0 +1,289 @@
+//! Secret-Manager-sourced credential values (noetl/ai-meta#267, Option 2).
+//!
+//! # What this is
+//!
+//! A credential record whose **value** lives in a secret manager rather than in
+//! the encrypted `data` column. The record keeps its identity, its alias and its
+//! type; only the value is fetched at serve time. Playbooks are untouched —
+//! `kind: credential` + `{{ keychain.<alias>.client_secret }}` resolves exactly
+//! as it does for a static credential.
+//!
+//! # Why this shape and not a provider-backed keychain entry
+//!
+//! The obvious design — declare `provider: gcp` on the playbook's `keychain:`
+//! block — is unreachable. Measured in kind: the template is correctly *deferred*
+//! by `template_references_keychain`, handed to the worker, and the worker never
+//! calls any keychain-resolve endpoint (`grep 'api/keychain'` across worker and
+//! tools yields one error-message string). The render context arrives as
+//! `{"workload": {}}` with no `keychain` key, so the reference renders empty and
+//! the failure surfaces later as a 401 — a wrong-looking credential rather than
+//! an unresolved one.
+//!
+//! `GET /api/credentials/{alias}` is the path that *is* wired and is what prod
+//! uses today, so the fetch belongs behind it.
+//!
+//! # The marker
+//!
+//! Inside the credential's decrypted `data`:
+//!
+//! ```json
+//! {"__secret_source__": {"provider": "gcp", "secret": "auth0_client", "project": "…"}}
+//! ```
+//!
+//! It lives in `data` rather than a new column so there is no schema migration,
+//! the existing register/update API carries it unchanged, and the marker is
+//! itself protected by the envelope cipher.
+//!
+//! # Latency and failure, decided rather than inherited
+//!
+//! This sits on the worker's dispatch path, so an unbounded call here would be
+//! noetl/ai-meta#297 all over again. Three bounds, all deliberate:
+//!
+//! - the provider's HTTP client already carries a **10s timeout**, so a hung peer
+//!   cannot park the serve path;
+//! - a successful fetch is cached in-process for [`SM_CACHE_TTL_SECS`], so a hot
+//!   alias costs one fetch per TTL rather than one per dispatch;
+//! - a fetch failure is **fail-closed**: it returns an error. It does not serve a
+//!   stale value past its TTL and it does not serve an empty object — an empty
+//!   object renders an empty sub-field and fails at the API call, looking like a
+//!   wrong credential rather than an unreachable secret manager.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::error::{AppError, AppResult};
+use crate::secrets::{build_secret_provider, SecretRef};
+
+/// The key that marks a credential's value as secret-manager-sourced.
+pub const MARKER: &str = "__secret_source__";
+
+/// How long a successfully fetched value is reused. Short enough that a rotation
+/// takes effect without a restart; long enough that a busy alias is not a fetch
+/// per dispatch.
+pub const SM_CACHE_TTL_SECS: u64 = 300;
+
+/// Where a credential's value comes from, parsed out of the marker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretSource {
+    pub provider: String,
+    pub secret: String,
+    pub project: Option<String>,
+    pub version: Option<String>,
+}
+
+/// Read the marker out of a decrypted credential `data` object.
+///
+/// Returns `None` for every ordinary credential, which is what keeps static
+/// credentials on exactly their current path.
+pub fn parse_marker(data: &serde_json::Value) -> Option<SecretSource> {
+    let m = data.get(MARKER)?.as_object()?;
+    let provider = m.get("provider")?.as_str()?.trim();
+    let secret = m.get("secret")?.as_str()?.trim();
+    if provider.is_empty() || secret.is_empty() {
+        return None;
+    }
+    Some(SecretSource {
+        provider: provider.to_string(),
+        secret: secret.to_string(),
+        project: m
+            .get("project")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.is_empty()),
+        version: m
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.is_empty()),
+    })
+}
+
+struct Cached {
+    value: serde_json::Value,
+    at: Instant,
+}
+
+fn cache() -> &'static Mutex<HashMap<String, Cached>> {
+    static C: OnceLock<Mutex<HashMap<String, Cached>>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cache_key(src: &SecretSource) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        src.provider,
+        src.project.as_deref().unwrap_or("-"),
+        src.secret,
+        src.version.as_deref().unwrap_or("latest")
+    )
+}
+
+/// Fetch the value for a marked credential, honouring the in-process TTL.
+///
+/// The returned object is what the caller serves as the credential's `data`, so
+/// `{{ keychain.<alias>.<field> }}` indexes it directly.
+pub async fn resolve(src: &SecretSource) -> AppResult<serde_json::Value> {
+    let key = cache_key(src);
+    if let Ok(g) = cache().lock() {
+        if let Some(c) = g.get(&key) {
+            if c.at.elapsed() < Duration::from_secs(SM_CACHE_TTL_SECS) {
+                crate::metrics::record_sm_sourced_credential("cache_hit");
+                return Ok(c.value.clone());
+            }
+        }
+    }
+
+    let provider = build_secret_provider(&src.provider)?;
+    let fetched = provider
+        .fetch(&SecretRef {
+            name: src.secret.clone(),
+            project: src.project.clone(),
+            version: src.version.clone(),
+            region: None,
+        })
+        .await
+        .map_err(|e| {
+            crate::metrics::record_sm_sourced_credential("fetch_error");
+            // Fail closed, and name the cause. Serving `{}` here would render an
+            // empty sub-field and fail at the API call as a wrong credential.
+            AppError::ExternalService(format!(
+                "credential value is sourced from {} secret '{}' and could not be \
+                 fetched: {e} (noetl/ai-meta#267)",
+                src.provider, src.secret
+            ))
+        })?;
+
+    let value = crate::secrets::structured_or_string(&fetched.value);
+    if !value.is_object() {
+        crate::metrics::record_sm_sourced_credential("not_an_object");
+        return Err(AppError::ExternalService(format!(
+            "credential value from {} secret '{}' is not a JSON object, so it has \
+             no sub-fields to serve (noetl/ai-meta#267)",
+            src.provider, src.secret
+        )));
+    }
+
+    if let Ok(mut g) = cache().lock() {
+        g.insert(
+            key,
+            Cached {
+                value: value.clone(),
+                at: Instant::now(),
+            },
+        );
+    }
+    crate::metrics::record_sm_sourced_credential("fetched");
+    Ok(value)
+}
+
+/// Drop any cached value for this source — used by the rollback path so a
+/// repointed credential takes effect without waiting out the TTL.
+pub fn invalidate(src: &SecretSource) {
+    if let Ok(mut g) = cache().lock() {
+        g.remove(&cache_key(src));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The property that keeps every existing credential working: an ordinary
+    /// `data` object carries no marker, so nothing changes for it.
+    #[test]
+    fn an_ordinary_credential_has_no_marker() {
+        for d in [
+            json!({"client_secret": "S"}),
+            json!({"user": "u", "password": "p"}),
+            json!({}),
+            json!("a bare string"),
+            json!(null),
+        ] {
+            assert_eq!(parse_marker(&d), None, "data {d:?}");
+        }
+    }
+
+    /// The marker is read in full, including the optional fields.
+    #[test]
+    fn a_marked_credential_parses_its_source() {
+        let d = json!({MARKER: {
+            "provider": "gcp", "secret": "auth0_client",
+            "project": "shastaratech-noetl-prod", "version": "7"
+        }});
+        let s = parse_marker(&d).expect("marker");
+        assert_eq!(s.provider, "gcp");
+        assert_eq!(s.secret, "auth0_client");
+        assert_eq!(s.project.as_deref(), Some("shastaratech-noetl-prod"));
+        assert_eq!(s.version.as_deref(), Some("7"));
+    }
+
+    /// `project` and `version` are optional — the provider falls back to its
+    /// own defaults.
+    #[test]
+    fn project_and_version_are_optional() {
+        let s = parse_marker(&json!({MARKER: {"provider": "gcp", "secret": "s"}}))
+            .expect("marker");
+        assert_eq!(s.project, None);
+        assert_eq!(s.version, None);
+    }
+
+    /// ⚠ A half-written marker must NOT be treated as SM-sourced. Falling back to
+    /// the static path is the safe direction: the credential keeps working, and
+    /// the operator sees the old value rather than an error.
+    #[test]
+    fn a_malformed_marker_falls_back_to_static_not_to_an_error() {
+        for d in [
+            json!({MARKER: {"provider": "gcp"}}),              // no secret
+            json!({MARKER: {"secret": "s"}}),                  // no provider
+            json!({MARKER: {"provider": "", "secret": "s"}}),  // empty provider
+            json!({MARKER: {"provider": "gcp", "secret": ""}}),// empty secret
+            json!({MARKER: "not an object"}),
+            json!({MARKER: null}),
+        ] {
+            assert_eq!(parse_marker(&d), None, "data {d:?}");
+        }
+    }
+
+    /// The cache key must separate secrets that differ in any dimension —
+    /// otherwise a project or version change would serve the wrong value.
+    #[test]
+    fn the_cache_key_separates_every_dimension() {
+        let base = SecretSource {
+            provider: "gcp".into(),
+            secret: "s".into(),
+            project: Some("p".into()),
+            version: None,
+        };
+        let mut other_project = base.clone();
+        other_project.project = Some("q".into());
+        let mut other_version = base.clone();
+        other_version.version = Some("2".into());
+        let mut other_secret = base.clone();
+        other_secret.secret = "t".into();
+
+        let k = cache_key(&base);
+        for v in [&other_project, &other_version, &other_secret] {
+            assert_ne!(k, cache_key(v), "key collision with {v:?}");
+        }
+    }
+
+    /// The TTL must be bounded and non-zero: zero would fetch on every dispatch
+    /// (the #297 hot-path hazard), and an unbounded one would never see a
+    /// rotation.
+    ///
+    /// Asserted through a runtime value rather than the constant directly —
+    /// comparing a `const` to a literal is folded at compile time, and clippy is
+    /// right that such an assertion can never fail. Routing it through
+    /// `Duration` makes it a real check.
+    #[test]
+    fn the_cache_ttl_is_bounded_and_non_zero() {
+        let ttl = Duration::from_secs(SM_CACHE_TTL_SECS);
+        assert!(!ttl.is_zero(), "a zero TTL fetches on every dispatch");
+        assert!(
+            ttl <= Duration::from_secs(3600),
+            "an hour-plus TTL would not see a rotation"
+        );
+    }
+}


### PR DESCRIPTION
noetl/ai-meta#267, Option 2. **Supersedes and folds in server#360.**

A credential record keeps its identity, alias and type; only its **value** is
fetched at serve time from a secret manager. Playbooks are untouched —
`kind: credential` + `{{ keychain.<alias>.client_secret }}` resolves exactly as
for a static credential.

## Why not the obvious design

Declaring `provider: gcp` on a playbook's `keychain:` block is **unreachable** —
measured in kind, not assumed. The template is correctly *deferred* by
`template_references_keychain`, handed to the worker, and **the worker never calls
any keychain-resolve endpoint** (`grep 'api/keychain'` across worker and tools
yields one error-message string). The render context arrives as
`{"workload": {}}` with no `keychain` key, so the reference renders empty and the
failure surfaces later as a 401 — a wrong-looking credential rather than an
unresolved one.

`GET /api/credentials/{alias}` is the path that **is** wired and is what prod uses
today, so the fetch belongs behind it.

## The marker

Inside the credential's decrypted `data`:

```json
{"__secret_source__": {"provider": "gcp", "secret": "auth0_client", "project": "…"}}
```

In `data` rather than a new column: no schema migration, the existing
register/update API carries it unchanged, and the marker is protected by the
envelope cipher. **An unmarked credential takes exactly the path it always has.**

## Latency and failure — decided, not inherited

This sits on the worker's dispatch path, so an unbounded call here would be
noetl/ai-meta#297 again:

- the provider's HTTP client already carries a **10s timeout**;
- a successful fetch is cached in-process for **300s**;
- a failure is **fail-closed and named** — it does not serve a stale value past
  TTL and does not serve `{}`, which would render an empty sub-field and fail at
  the API call looking like a wrong credential.

A malformed marker falls back to the **static** path rather than erroring: the
credential keeps working and the operator sees the old value.

## Kind proof

```
✅ arm 1  marked credential   .client_secret + .client_id resolve; marker not leaked
✅ arm 2  static control      byte-identical, untouched — no regression
✅ arm 3  negative control    502, NAMED error, fail-closed (not empty, not stale)
✅ cache                      fetched=1 while cache_hit=4 — one SM call per TTL
```

Arm 3's message, verbatim:

```
credential value is sourced from gcp secret 'does-not-exist' and could not be
fetched: … HTTP 404 … Secret [does-not-exist] not found. (noetl/ai-meta#267)
```

Controls after: all four outcome series present (pinned at registration, so an
absent series can't be confused with a binary predating the metric).

⚠ **`get_auth0_token` returning 200 cannot be proven in kind** — it needs the real
SM secret and the real Auth0 tenant, and kind has no metadata server. That arm
belongs to the on-prod verify-before-flip.

## Tests

845 lib tests green; clippy at the 5-warning baseline. Mutating `parse_marker` to
treat every credential as SM-sourced fails the three marker/compat guards and
passes the three independent of it.

Refs noetl/ai-meta#267