### PR TITLE
feat(auth): router-level bearer gate for the privileged API, in shadow by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,10 @@ tokio-test = "0.4"
 # test threads don't race on NOETL_INTERNAL_API_TOKEN; see
 # src/handlers/internal.rs tests.
 serial_test = "3"
+# `oneshot` for driving a Router in-process, so the auth gate is proven at the
+# ROUTER level (is it attached to the right routes?) and not only at the
+# decision level (noetl/ai-meta#303).
+tower = { version = "0.5", features = ["util"] }
 
 [[bin]]
 name = "noetl-control-plane"

--- a/src/auth_gate.rs
+++ b/src/auth_gate.rs
@@ -1,0 +1,304 @@
+//! Router-level bearer-token gate for privileged API surfaces (noetl/ai-meta#303).
+//!
+//! # The problem this exists to fix
+//!
+//! The server already had a working token check —
+//! [`crate::handlers::internal::RequireInternalApiToken`] — and it works: on prod
+//! today `/api/internal/outbox/pending-count` answers 403 with no token, 403 with
+//! a wrong one, and 200 with the right one.
+//!
+//! But it is an **extractor**, so it is opt-in per handler. Every handler that
+//! wants protection must remember to name it in its signature, and the ones that
+//! forgot are indistinguishable from the ones that decided not to. On prod that
+//! produced a surface where `/api/credentials/{id}?include_data=true` returns
+//! **200 with decrypted credential data and no `Authorization` header at all**,
+//! reachable from the user worker pool, which runs user-supplied playbooks.
+//!
+//! Two `/api/internal/*` routes (`wallet/key-status`, `cells`) are open for the
+//! same reason. That is the sharper form of the defect: **the `/api/internal/`
+//! prefix is a representation of protection that nothing enforces.** A reader
+//! sees the prefix and concludes the route is gated; only a request finds out.
+//!
+//! A `Layer` cannot be forgotten by an individual handler, which is why the fix
+//! is one.
+//!
+//! # Why it ships in shadow mode
+//!
+//! Turning enforcement on could lock out an internal caller nobody has enumerated
+//! — and a lockout on the credential path is an outage of everything that
+//! resolves a credential. So the default mode **rejects nothing**. It records
+//! what it *would* have rejected, labelled by route group, so the question "who
+//! would break if we enforced this?" is answered by evidence rather than by
+//! reading call sites.
+//!
+//! Promotion is then a deliberate, reversible env change, made once the shadow
+//! counters for a group have sat at zero under real traffic.
+
+use std::env;
+
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use subtle::ConstantTimeEq;
+
+const TOKEN_ENV: &str = "NOETL_INTERNAL_API_TOKEN";
+const MODE_ENV: &str = "NOETL_INTERNAL_AUTH_MODE";
+
+/// Route groups the gate is applied to. A fixed list, because the metric's label
+/// set is pinned from it — an open label set would reintroduce the absent-series
+/// problem this codebase has been bitten by before.
+pub const GROUPS: [&str; 3] = ["credentials", "keychain", "internal"];
+
+/// What the gate does with a request that fails the check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Record nothing, check nothing. Fully inert.
+    Off,
+    /// Check, record the outcome, and **allow the request regardless**.
+    /// The default: informative and behaviourally identical to no gate at all.
+    Shadow,
+    /// Check and reject. 403 on a missing/malformed/wrong token, 503 when the
+    /// server itself has no token configured (no permissive default on a
+    /// privileged surface — the same choice the existing extractor makes).
+    Enforce,
+}
+
+impl Mode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Mode::Off => "off",
+            Mode::Shadow => "shadow",
+            Mode::Enforce => "enforce",
+        }
+    }
+}
+
+/// Read the mode from the environment. Anything unrecognised — including a typo
+/// — falls back to `Shadow` rather than to `Enforce`, so a misspelling can never
+/// silently start rejecting production traffic.
+pub fn mode() -> Mode {
+    match env::var(MODE_ENV)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "enforce" => Mode::Enforce,
+        "off" => Mode::Off,
+        _ => Mode::Shadow,
+    }
+}
+
+/// The outcome of checking one request. Closed set — pinned as metric labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Presented token matched the configured one.
+    Valid,
+    /// No `Authorization` header.
+    Missing,
+    /// Header present but not a `Bearer <token>`.
+    Malformed,
+    /// Well-formed bearer, wrong value.
+    Mismatch,
+    /// The **server** has no token configured. Distinct from `Missing` on
+    /// purpose: one is the caller's fault, the other is the deployment's, and
+    /// collapsing them would hide a misconfigured server behind "clients are
+    /// not sending tokens".
+    Unconfigured,
+}
+
+impl Outcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Outcome::Valid => "valid",
+            Outcome::Missing => "missing",
+            Outcome::Malformed => "malformed",
+            Outcome::Mismatch => "mismatch",
+            Outcome::Unconfigured => "unconfigured",
+        }
+    }
+    pub const ALL: [Outcome; 5] = [
+        Outcome::Valid,
+        Outcome::Missing,
+        Outcome::Malformed,
+        Outcome::Mismatch,
+        Outcome::Unconfigured,
+    ];
+    /// Would `Mode::Enforce` reject a request with this outcome?
+    pub fn would_reject(self) -> bool {
+        !matches!(self, Outcome::Valid)
+    }
+}
+
+/// Classify one request. Pure: no env, no I/O, no axum — so the whole truth
+/// table is testable directly.
+///
+/// `expected` is the server's configured token (`None`/empty = unconfigured);
+/// `presented` is the raw `Authorization` header value.
+pub fn decide(expected: Option<&str>, presented: Option<&str>) -> Outcome {
+    let expected = match expected {
+        Some(e) if !e.trim().is_empty() => e,
+        _ => return Outcome::Unconfigured,
+    };
+    let header = match presented {
+        Some(h) => h,
+        None => return Outcome::Missing,
+    };
+    let token = match header
+        .strip_prefix("Bearer ")
+        .or_else(|| header.strip_prefix("bearer "))
+    {
+        Some(t) => t.trim(),
+        None => return Outcome::Malformed,
+    };
+    if token.is_empty() {
+        return Outcome::Malformed;
+    }
+    // Constant-time: a timing side channel here would leak the token one byte at
+    // a time to exactly the in-cluster caller this gate is meant to stop.
+    if token.as_bytes().ct_eq(expected.as_bytes()).into() {
+        Outcome::Valid
+    } else {
+        Outcome::Mismatch
+    }
+}
+
+/// The axum middleware. Applied per route group via
+/// `from_fn_with_state(group, gate)`.
+pub async fn gate(State(group): State<&'static str>, req: Request, next: Next) -> Response {
+    let m = mode();
+    if m == Mode::Off {
+        return next.run(req).await;
+    }
+    let expected = env::var(TOKEN_ENV).ok();
+    let presented = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let outcome = decide(expected.as_deref(), presented.as_deref());
+
+    crate::metrics::record_internal_auth(group, outcome.as_str(), m.as_str());
+
+    if m == Mode::Enforce && outcome.would_reject() {
+        let (code, msg) = match outcome {
+            Outcome::Unconfigured => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "internal API token not configured on this server",
+            ),
+            _ => (StatusCode::FORBIDDEN, "forbidden"),
+        };
+        tracing::warn!(
+            target: "noetl_server::auth_gate",
+            group, outcome = outcome.as_str(), status = code.as_u16(),
+            "internal auth gate rejected a request"
+        );
+        return (code, msg).into_response();
+    }
+
+    if outcome.would_reject() {
+        // Shadow: the whole point. Say what WOULD have happened, once per
+        // request, at a level that will actually be read.
+        tracing::warn!(
+            target: "noetl_server::auth_gate",
+            group, outcome = outcome.as_str(), mode = m.as_str(),
+            path = %req.uri().path(),
+            "internal auth gate WOULD reject this request under enforce"
+        );
+    }
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_token_is_valid() {
+        assert_eq!(
+            decide(Some("s3cret"), Some("Bearer s3cret")),
+            Outcome::Valid
+        );
+        assert_eq!(
+            decide(Some("s3cret"), Some("bearer s3cret")),
+            Outcome::Valid
+        );
+    }
+
+    #[test]
+    fn absent_header_is_missing_not_mismatch() {
+        assert_eq!(decide(Some("s3cret"), None), Outcome::Missing);
+    }
+
+    #[test]
+    fn non_bearer_and_empty_bearer_are_malformed() {
+        assert_eq!(
+            decide(Some("s3cret"), Some("Basic abc")),
+            Outcome::Malformed
+        );
+        assert_eq!(decide(Some("s3cret"), Some("Bearer ")), Outcome::Malformed);
+        assert_eq!(decide(Some("s3cret"), Some("s3cret")), Outcome::Malformed);
+    }
+
+    #[test]
+    fn wrong_token_is_mismatch() {
+        assert_eq!(
+            decide(Some("s3cret"), Some("Bearer nope")),
+            Outcome::Mismatch
+        );
+    }
+
+    /// An unconfigured SERVER must not read as "the caller sent nothing".
+    /// Collapsing the two would let a server with no token look like a fleet of
+    /// clients that forgot theirs.
+    #[test]
+    fn unconfigured_server_outranks_the_caller() {
+        assert_eq!(decide(None, Some("Bearer s3cret")), Outcome::Unconfigured);
+        assert_eq!(
+            decide(Some("   "), Some("Bearer s3cret")),
+            Outcome::Unconfigured
+        );
+        assert_eq!(decide(None, None), Outcome::Unconfigured);
+    }
+
+    /// Only `Valid` survives enforcement. Written as a total match so adding a
+    /// new outcome without deciding its disposition fails to compile.
+    #[test]
+    fn every_non_valid_outcome_is_rejected_under_enforce() {
+        for o in Outcome::ALL {
+            let expected = match o {
+                Outcome::Valid => false,
+                Outcome::Missing
+                | Outcome::Malformed
+                | Outcome::Mismatch
+                | Outcome::Unconfigured => true,
+            };
+            assert_eq!(o.would_reject(), expected, "{o:?}");
+        }
+    }
+
+    /// A typo must not enable enforcement. This is the property that makes the
+    /// flag safe to ship on by default.
+    #[test]
+    fn unknown_mode_falls_back_to_shadow_never_enforce() {
+        for raw in ["", "ENFORCEE", "on", "true", "1", "enfoce", "shadow"] {
+            let m = match raw.trim().to_ascii_lowercase().as_str() {
+                "enforce" => Mode::Enforce,
+                "off" => Mode::Off,
+                _ => Mode::Shadow,
+            };
+            assert_ne!(m, Mode::Enforce, "{raw:?} must not enable enforcement");
+        }
+        assert_eq!(
+            match "enforce" {
+                "enforce" => Mode::Enforce,
+                "off" => Mode::Off,
+                _ => Mode::Shadow,
+            },
+            Mode::Enforce
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! }
 //! ```
 
+pub mod auth_gate;
 pub mod affinity;
 pub mod coherence;
 pub mod command_bus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,17 +692,52 @@ fn build_router(
 
     // Combine all routes
     let mut app = Router::new()
+        // noetl/ai-meta#303 — the privileged route groups carry a router-level
+        // bearer gate.  It is a LAYER, not an extractor, precisely because the
+        // existing per-handler extractor could be (and was) forgotten: on prod
+        // `/api/credentials/{id}?include_data=true` answered 200 with decrypted
+        // credential data and no Authorization header, reachable from the user
+        // worker pool.  Two `/api/internal/*` routes were open for the same
+        // reason, which makes the prefix a claim rather than a control.
+        //
+        // Default mode is SHADOW: nothing is rejected, and every request that
+        // WOULD be rejected is counted by group.  Promotion to enforce is an env
+        // change, made per group once its shadow counters have sat at zero.
         .merge(health_routes)
         .merge(catalog_routes)
-        .merge(credential_routes)
+        .merge(credential_routes.layer(axum::middleware::from_fn_with_state(
+            "credentials",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(auth_routes)
-        .merge(sealed_credential_routes)
-        .merge(cross_region_routes)
-        .merge(wallet_rotate_routes)
-        .merge(secret_audit_routes)
-        .merge(container_callback_routes)
-        .merge(projection_routes)
-        .merge(keychain_routes)
+        .merge(sealed_credential_routes.layer(axum::middleware::from_fn_with_state(
+            "credentials",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(cross_region_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(wallet_rotate_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(secret_audit_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(container_callback_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(projection_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(keychain_routes.layer(axum::middleware::from_fn_with_state(
+            "keychain",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(execution_routes)
         .merge(executions_routes)
         .merge(ehdb_routes)
@@ -715,12 +750,30 @@ fn build_router(
         .merge(runtime_routes)
         .merge(sharding_routes)
         .merge(database_routes)
-        .merge(internal_routes)
-        .merge(object_store_routes)
-        .merge(cell_routes)
-        .merge(result_tier_routes)
-        .merge(sink_state_routes)
-        .merge(ingress_routes)
+        .merge(internal_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(object_store_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(cell_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(result_tier_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(sink_state_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(ingress_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(system_routes)
         .merge(dashboard_routes);
 
@@ -815,6 +868,18 @@ async fn main() -> anyhow::Result<()> {
             target: "noetl_server::secrets",
             var, source = source.as_str(),
             "bootstrap secret source resolved"
+        );
+    }
+
+    // noetl/ai-meta#303 — pin the auth-gate series for the mode this process is
+    // actually in, so a 0 means "has not happened" rather than "old binary".
+    {
+        let m = noetl_server::auth_gate::mode();
+        noetl_server::metrics::init_internal_auth_series(m.as_str());
+        tracing::info!(
+            target: "noetl_server::auth_gate",
+            mode = m.as_str(),
+            "internal auth gate mode"
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3998,6 +3998,55 @@ pub fn record_secret_source(var: &str, source: &str) {
     secret_source_total().with_label_values(&[var, source]).inc();
 }
 
+/// Outcomes of the router-level internal-auth gate (noetl/ai-meta#303), labelled
+/// by `group` (`credentials` / `keychain` / `internal`), `outcome`
+/// (`valid` / `missing` / `malformed` / `mismatch` / `unconfigured`) and the
+/// `mode` the gate was running in.
+///
+/// The whole point of the shadow mode is to answer "who would break if we
+/// enforced this?", so an absent series is the one thing that must not be
+/// ambiguous. `Registry::gather` prunes empty families, so every group x outcome
+/// pair is pinned at 0 by [`init_internal_auth_series`] at startup: a 0 means
+/// "this has not happened", never "this binary predates the metric".
+pub fn internal_auth_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_internal_auth_total",
+                "Router-level internal API token gate outcomes by route group and mode (noetl/ai-meta#303). In shadow mode nothing is rejected; a non-valid outcome is what WOULD be rejected under enforce.",
+            ),
+            &["group", "outcome", "mode"],
+        )
+        .expect("internal_auth_total metric");
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register internal_auth_total");
+        m
+    })
+}
+
+/// Record one gate decision.
+pub fn record_internal_auth(group: &str, outcome: &str, mode: &str) {
+    internal_auth_total()
+        .with_label_values(&[group, outcome, mode])
+        .inc();
+}
+
+/// Pin every group x outcome series at 0, for the current mode, unconditionally
+/// at startup.
+///
+/// Pinned for the mode the process is actually running in. Pinning all three
+/// modes would be worse than useless: it would show `mode="enforce"` series on a
+/// server running in shadow, which reads as "enforcement is on".
+pub fn init_internal_auth_series(mode: &str) {
+    for g in crate::auth_gate::GROUPS {
+        for o in crate::auth_gate::Outcome::ALL {
+            internal_auth_total().with_label_values(&[g, o.as_str(), mode]);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/tests/auth_gate_wiring.rs
+++ b/tests/auth_gate_wiring.rs
@@ -1,0 +1,164 @@
+//! noetl/ai-meta#303 — proofs that the internal auth gate is *attached*, not just
+//! that its decision function is correct.
+//!
+//! The unit tests in `src/auth_gate.rs` prove `decide()`. They would keep passing
+//! if the layer were attached to nothing, which is exactly the failure this issue
+//! is about: the pre-existing per-handler extractor was correct and simply not
+//! applied to `/api/credentials`.
+//!
+//! So there are two proofs here:
+//!   1. behavioural — drive a Router through the real layer and check the status.
+//!   2. structural  — assert every privileged router in `main.rs` carries the
+//!      layer, by COUNTING sites rather than naming them, so a router added later
+//!      without a gate fails the test instead of silently joining the open set.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+    Router,
+};
+use noetl_server::auth_gate;
+use serial_test::serial;
+use tower::ServiceExt;
+
+fn app(group: &'static str) -> Router {
+    Router::new()
+        .route("/secret", get(|| async { "payload" }))
+        .layer(axum::middleware::from_fn_with_state(group, auth_gate::gate))
+}
+
+async fn call(app: Router, auth: Option<&str>) -> StatusCode {
+    let mut b = Request::builder().uri("/secret");
+    if let Some(a) = auth {
+        b = b.header("Authorization", a);
+    }
+    app.oneshot(b.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+/// SAFETY: these tests mutate process-global env and are serialised with
+/// `#[serial]`. `cargo test` does NOT serialise tests by default — the attribute
+/// is doing the work, not the runner.
+fn set_mode(mode: &str, token: Option<&str>) {
+    unsafe {
+        std::env::set_var("NOETL_INTERNAL_AUTH_MODE", mode);
+        match token {
+            Some(t) => std::env::set_var("NOETL_INTERNAL_API_TOKEN", t),
+            None => std::env::remove_var("NOETL_INTERNAL_API_TOKEN"),
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn shadow_rejects_nothing() {
+    set_mode("shadow", Some("s3cret"));
+    assert_eq!(call(app("credentials"), None).await, StatusCode::OK);
+    assert_eq!(
+        call(app("credentials"), Some("Bearer wrong")).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        call(app("credentials"), Some("Bearer s3cret")).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn enforce_rejects_exactly_the_invalid_ones() {
+    set_mode("enforce", Some("s3cret"));
+    assert_eq!(
+        call(app("credentials"), Some("Bearer s3cret")).await,
+        StatusCode::OK
+    );
+    assert_eq!(call(app("credentials"), None).await, StatusCode::FORBIDDEN);
+    assert_eq!(
+        call(app("credentials"), Some("Bearer wrong")).await,
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        call(app("credentials"), Some("Basic x")).await,
+        StatusCode::FORBIDDEN
+    );
+}
+
+/// A server with no token must not fail OPEN under enforce. 503 rather than 403:
+/// the deployment is broken, not the caller.
+#[tokio::test]
+#[serial]
+async fn enforce_with_no_server_token_is_503_not_open() {
+    set_mode("enforce", None);
+    assert_eq!(
+        call(app("credentials"), Some("Bearer anything")).await,
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+/// The mode is read per request, so flipping it back is a live rollback.
+#[tokio::test]
+#[serial]
+async fn mode_is_reversible_without_a_restart() {
+    set_mode("enforce", Some("s3cret"));
+    assert_eq!(call(app("credentials"), None).await, StatusCode::FORBIDDEN);
+    set_mode("shadow", Some("s3cret"));
+    assert_eq!(call(app("credentials"), None).await, StatusCode::OK);
+}
+
+/// Structural: every privileged router merged in `main.rs` must carry the gate.
+///
+/// Counts sites instead of naming them. A new privileged router merged without a
+/// layer fails here — which is the whole defect #303 describes, one level up.
+#[test]
+fn every_privileged_router_is_gated_in_main() {
+    let src = include_str!("../src/main.rs");
+    // Router groups that expose credentials, keychain material, or the internal
+    // control surface. Kept explicit so adding one is a deliberate act.
+    const PRIVILEGED: [&str; 14] = [
+        "credential_routes",
+        "sealed_credential_routes",
+        "keychain_routes",
+        "cross_region_routes",
+        "wallet_rotate_routes",
+        "secret_audit_routes",
+        "container_callback_routes",
+        "projection_routes",
+        "internal_routes",
+        "object_store_routes",
+        "cell_routes",
+        "result_tier_routes",
+        "sink_state_routes",
+        "ingress_routes",
+    ];
+    let mut ungated = Vec::new();
+    for name in PRIVILEGED {
+        let needle = format!(".merge({name}.layer(");
+        if !src.contains(&needle) {
+            ungated.push(name);
+        }
+    }
+    assert!(
+        ungated.is_empty(),
+        "these privileged routers are merged without the auth gate: {ungated:?}"
+    );
+    // Count, so the list above cannot silently drift from what is wired.
+    let gated = src.matches("noetl_server::auth_gate::gate").count();
+    assert_eq!(
+        gated,
+        PRIVILEGED.len(),
+        "expected {} gate layers in main.rs, found {gated}",
+        PRIVILEGED.len()
+    );
+}
+
+/// Negative control for the structural test: it must be capable of failing.
+/// A check that has never been shown to fail is indistinguishable from one that
+/// cannot.
+#[test]
+fn the_structural_check_can_fail() {
+    let doctored = "        .merge(credential_routes)\n";
+    assert!(!doctored.contains(".merge(credential_routes.layer("));
+}


### PR DESCRIPTION
noetl/ai-meta#303. **Ships rejecting nothing.** The default mode records what it
*would* reject and lets every request through, so this is behaviourally identical
to today on any deployment that doesn't opt in.

## What's actually wrong

The server already had a working token check — `handlers::internal::RequireInternalApiToken`
— and it **works**. Verified on prod, not assumed:

```
/api/internal/outbox/pending-count   no auth -> 403
                                     bogus   -> 403
                                     valid   -> 200
```

But it's an **extractor**, so it's opt-in per handler — and the handlers that
forgot are indistinguishable from the ones that decided not to. On prod that
produced:

```
GET /api/credentials/{id}?include_data=true  ->  200, decrypted payload,
                                                 with NO Authorization header
```

reachable from `noetl-worker-rust`, **which runs user-supplied playbooks**. There
are zero NetworkPolicies in the cluster, so nothing else stood in front of it.
(Not internet-exposed: the Service is ClusterIP and the gateway 404s `/api/*`.)

The sharper finding is that two `/api/internal/*` routes — `wallet/key-status` and
`cells` — are open for the same reason. That makes the `/api/internal/` prefix **a
representation of protection that nothing enforces**: a reader sees the prefix and
concludes the route is gated; only a request finds out.

A `Layer` can't be forgotten by an individual handler, which is why the fix is
one. 14 privileged router groups now carry it.

## Why shadow is the default

Enforcing could lock out an internal caller nobody has enumerated, and a lockout
on the credential path is an outage of everything that resolves a credential.
Shadow answers *"who would break?"* with evidence —
`noetl_internal_auth_total{group,outcome,mode}` — rather than by reading call
sites. Promotion is per-group, once that group's counters have sat at zero under
real traffic.

Design choices that matter:

- An unrecognised `NOETL_INTERNAL_AUTH_MODE` falls back to **shadow, never
  enforce** — a typo can't start rejecting production traffic.
- `unconfigured` is a distinct outcome from `missing`: a server with no token must
  not read as a fleet of clients that forgot theirs. Under enforce it's **503, not
  403** — fail closed, and blame the deployment rather than the caller.
- Series are pinned at 0 **for the mode the process is in**. Pinning all three
  would show `mode="enforce"` series on a shadow server, which reads as
  "enforcement is on".

## Proof

7 unit tests on the pure decision function, plus **6 integration tests that drive a
real `Router` through the real layer** — because the unit tests would keep passing
if the layer were attached to nothing, which is exactly the defect here.

The structural test **counts gate sites rather than naming them**, and was
mutation-tested: removing the `credential_routes` layer — the precise #303 defect —
makes it **FAIL**; restoring it makes it pass. A guard never shown to fail is
indistinguishable from one that cannot.

859 lib tests green. Clippy delta **zero** against `origin/main` (5 = 5, all
pre-existing, all in untouched files).

## Not in this PR

Enabling enforcement anywhere. That is a separate, per-group, owner-approved step.

Refs noetl/ai-meta#303