### PR TITLE
ci: actually run the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+# noetl/ai-meta#232 — actually run the tests.
+#
+# Before this workflow, NO GitHub Actions workflow in this repo (or in
+# noetl/worker, noetl/tools, noetl/cli) ran `cargo test`.  `release.yml` builds
+# and publishes; `semantic-release.yml` versions and tags.  Neither runs a test.
+#
+# That is worse than having no tests, because the repo has ~860 of them and they
+# read as a safety net.  Several are deliberate guards whose entire value is
+# failing when someone changes the thing they guard — for example
+# `tests/auth_gate_wiring.rs::every_privileged_router_is_gated_in_main`, which
+# fails if a privileged router is merged without its auth layer (noetl/ai-meta#303).
+# A guard that no runner executes cannot fail, and a guard that cannot fail is
+# indistinguishable from one that was never written.
+#
+# Deliberately NOT here:
+#   * `cargo fmt --check` — these crates are formatted with rustfmt 1.9.0 and a
+#     different version reformats large parts of the tree; a CI fmt gate would
+#     fail on unrelated files.
+#   * `-D warnings` on clippy — `main` currently carries 5 pre-existing warnings.
+#     Clippy runs and is visible, but does not gate, so this workflow does not
+#     start life red for reasons nobody in this PR caused.
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      # --all-targets, not the default. `cargo build`/`cargo test` alone skip
+      # integration tests and `cfg(test)`-only code, so a binary can be broken
+      # while the lib compiles clean — that has happened in this repo before.
+      - name: build (all targets)
+        run: cargo build --all-targets --locked
+
+      - name: test
+        run: cargo test --all-targets --locked
+
+      - name: clippy (visible, non-gating)
+        run: cargo clippy --all-targets --locked || true


### PR DESCRIPTION
noetl/ai-meta#232. **No workflow in this repo ran `cargo test`.** `release.yml`
builds and publishes; `semantic-release.yml` versions and tags. Neither executes a
test. Same in `noetl/worker`, `noetl/tools`, `noetl/cli`.

That's worse than having no tests, because the repo has ~860 of them and they read
as a safety net. Several are deliberate **guards** whose entire value is failing
when someone changes the thing they guard — e.g.
`tests/auth_gate_wiring.rs::every_privileged_router_is_gated_in_main`, which fails
if a privileged router is merged without its auth layer (noetl/ai-meta#303), and
which was mutation-tested to prove it *can* fail.

**A guard no runner executes cannot fail, and a guard that cannot fail is
indistinguishable from one that was never written.** Today's session added thirteen
such tests to a repo where none of them would ever have run.

## Choices

- **`--all-targets`**, not the default. Plain `cargo build`/`cargo test` skip
  integration tests and `cfg(test)`-only code, so a binary can be broken while the
  lib compiles clean — that has happened here (a `crate::` path in `main.rs` that
  `cargo build --lib` accepted and the binary did not).
- **No `cargo fmt --check`** — these crates are formatted with rustfmt 1.9.0; a
  different version reformats large parts of the tree and the gate would fail on
  unrelated files.
- **No `-D warnings`** — `main` carries 5 pre-existing clippy warnings. Clippy runs
  and stays visible but does not gate, so this workflow doesn't start life red for
  reasons nobody in a given PR caused.

## Verified

Run locally exactly as CI will: **890 tests across all targets, 0 failures.**

`ci:` prefix, so semantic-release produces no version — this changes no binary.

Refs noetl/ai-meta#232