### PR TITLE
fix(event-bus): NOETL_EVENT_BUS is required — stop laundering three causes into one

### DIFF
--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -29,10 +29,20 @@ use std::collections::BTreeMap;
 use crate::command_bus::{parse_writer_addrs, EhdbCommandPublisher};
 
 /// Which transport carries event payloads (env `NOETL_EVENT_BUS`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// There is deliberately **no `Default`**, for the same reason
+/// [`CommandBusMode`](crate::command_bus::CommandBusMode) has none: a default
+/// here would have to name a transport, and the only transport that exists is
+/// EHDB — so defaulting means guessing (noetl/ai-meta#243).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventBusMode {
-    /// Publish to NATS only — today's path (default).
-    #[default]
+    /// Publish to NATS only.
+    ///
+    /// ⚠ NATS was deleted at T5 (noetl/ai-meta#194). The variant survives so a
+    /// stale `NOETL_EVENT_BUS=nats` produces a specific, actionable error rather
+    /// than a generic parse failure — and because `publishes_nats()` still
+    /// distinguishes `Shadow` from `Ehdb` on the write path. It is not
+    /// selectable.
     Nats,
     /// Publish to the per-shard EHDB events writer only — the cutover.
     Ehdb,
@@ -41,16 +51,39 @@ pub enum EventBusMode {
 }
 
 impl EventBusMode {
-    /// Parse the `NOETL_EVENT_BUS` value; anything unrecognised is the safe
-    /// default (`nats`). Matching [`CommandBusMode`](crate::command_bus::CommandBusMode)
-    /// exactly is deliberate: an operator who has flipped the command bus should
-    /// not have to learn a second vocabulary, and a typo must never silently
-    /// stop publishing to NATS.
-    pub fn from_env_value(value: &str) -> Self {
+    /// Parse the `NOETL_EVENT_BUS` value. Required — there is no default.
+    ///
+    /// The comment this replaces said a typo "must never silently stop publishing
+    /// to NATS". That property inverted when T5 deleted NATS: falling back to
+    /// `nats` no longer keeps a working path, it selects a transport that does not
+    /// exist. The old catch-all then laundered three different situations into one
+    /// outcome — **unset**, **a typo**, and **a stale `nats`** all became
+    /// `EventBusMode::Nats`, a value nothing sets on purpose, with no error and a
+    /// server that starts clean while writing the durable event log nowhere.
+    ///
+    /// Each failure mode now names itself, matching
+    /// [`CommandBusMode::from_env_value`](crate::command_bus::CommandBusMode::from_env_value)
+    /// so an operator who has flipped the command bus does not learn a second
+    /// vocabulary (noetl/ai-meta#243).
+    pub fn from_env_value(value: &str) -> Result<Self, String> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "ehdb" => Self::Ehdb,
-            "shadow" => Self::Shadow,
-            _ => Self::Nats,
+            "ehdb" => Ok(Self::Ehdb),
+            "shadow" => Ok(Self::Shadow),
+            "nats" => Err(
+                "NOETL_EVENT_BUS=nats selects a transport that no longer exists — NATS was \
+                 removed at T5 (noetl/ai-meta#212). Set NOETL_EVENT_BUS=ehdb."
+                    .to_string(),
+            ),
+            "" => Err(
+                "NOETL_EVENT_BUS is required and unset. There is no default: the only transport \
+                 is EHDB, and guessing would mean starting a server that writes the durable \
+                 event log nowhere while looking healthy. Set NOETL_EVENT_BUS=ehdb."
+                    .to_string(),
+            ),
+            other => Err(format!(
+                "NOETL_EVENT_BUS={other:?} is not a known transport. Valid values: ehdb, \
+                 shadow. (nats was removed at T5.)"
+            )),
         }
     }
 
@@ -128,17 +161,61 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mode_parses_like_the_command_bus_and_defaults_safe() {
-        assert_eq!(EventBusMode::from_env_value("nats"), EventBusMode::Nats);
-        assert_eq!(EventBusMode::from_env_value("EHDB"), EventBusMode::Ehdb);
+    fn the_two_selectable_modes_parse_case_and_space_insensitively() {
+        assert_eq!(EventBusMode::from_env_value("EHDB"), Ok(EventBusMode::Ehdb));
         assert_eq!(
             EventBusMode::from_env_value(" Shadow "),
-            EventBusMode::Shadow
+            Ok(EventBusMode::Shadow)
         );
-        // The important one: a typo must not silently stop publishing to NATS.
-        assert_eq!(EventBusMode::from_env_value("ehbd"), EventBusMode::Nats);
-        assert_eq!(EventBusMode::from_env_value(""), EventBusMode::Nats);
-        assert_eq!(EventBusMode::default(), EventBusMode::Nats);
+    }
+
+    /// The heart of noetl/ai-meta#243: three different situations used to become
+    /// one value. Each must now name ITSELF, because the whole cost of the old
+    /// behaviour was that the message did not say which of these had happened.
+    #[test]
+    fn unset_typo_and_stale_nats_are_three_distinct_errors() {
+        let unset = EventBusMode::from_env_value("").unwrap_err();
+        let typo = EventBusMode::from_env_value("ehbd").unwrap_err();
+        let stale = EventBusMode::from_env_value("nats").unwrap_err();
+
+        assert!(unset.contains("required and unset"), "{unset}");
+        assert!(typo.contains("ehbd"), "the typo must be quoted back: {typo}");
+        assert!(
+            stale.contains("no longer exists"),
+            "a stale nats must say the transport is gone, not just 'invalid': {stale}"
+        );
+
+        // Distinct, not merely non-empty. Three identical messages would satisfy
+        // a naive "is it an error" test while reproducing the exact defect.
+        assert_ne!(unset, typo);
+        assert_ne!(typo, stale);
+        assert_ne!(unset, stale);
+
+        // Every one of them actionable in the same way.
+        for m in [&unset, &typo, &stale] {
+            assert!(m.contains("NOETL_EVENT_BUS"), "must name the variable: {m}");
+        }
+        for m in [&unset, &stale] {
+            assert!(m.contains("ehdb"), "must name the fix: {m}");
+        }
+    }
+
+    /// A typo must NOT silently select a mode — the property the old catch-all
+    /// broke. Written as a sweep so a future catch-all fails here.
+    #[test]
+    fn no_unrecognised_value_ever_yields_a_mode() {
+        for v in [
+            "", " ", "ehbd", "EHDB ehdb", "natss", "true", "1", "off", "none",
+            "shadow-mode", "ehdb;shadow", "\u{0}",
+        ] {
+            assert!(
+                EventBusMode::from_env_value(v).is_err(),
+                "{v:?} must not resolve to a mode"
+            );
+        }
+        // Positive control: the sweep is capable of passing a value through, so
+        // the assertions above are measuring the parser and not a broken loop.
+        assert!(EventBusMode::from_env_value("ehdb").is_ok());
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -862,11 +862,20 @@ impl AppState {
             None
         };
 
-        // noetl/ai-meta#212 L1 T3 — the events-bus transport. Same shape as the
-        // command bus above: default `nats` builds no EHDB state at all.
-        let event_bus_mode = crate::event_bus::EventBusMode::from_env_value(
+        // noetl/ai-meta#212 L1 T3 — the events-bus transport, REQUIRED since
+        // noetl/ai-meta#243.  Exactly the shape of the command bus above, and for
+        // the same reason: the old default `nats` meant unset, a typo and a stale
+        // `nats` all produced a server that started clean and wrote the durable
+        // event log nowhere.  Failing at startup is the point.
+        let event_bus_mode = match crate::event_bus::EventBusMode::from_env_value(
             &std::env::var("NOETL_EVENT_BUS").unwrap_or_default(),
-        );
+        ) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::error!(error = %e, "event bus misconfigured — refusing to start");
+                panic!("{e}");
+            }
+        };
         let ehdb_event_publisher = if event_bus_mode.publishes_ehdb() {
             let publisher = crate::event_bus::EhdbEventPublisher::from_env();
             crate::metrics::set_ehdb_event_publisher_configured(publisher.is_configured());


### PR DESCRIPTION
noetl/ai-meta#243, the **server half**. The command bus was fixed in worker
v5.118.2; the events bus kept the same defect in the same crate.

`EventBusMode::from_env_value` ended in `_ => Self::Nats`, so **three different
situations produced one value**:

| input | old result |
|:--|:--|
| unset | `Nats` |
| a typo (`ehbd`) | `Nats` |
| a stale `nats` | `Nats` |

`Nats` is a transport **T5 deleted**. So each of those started a server that came
up clean, reported healthy, and wrote the durable event log **nowhere** — with
nothing saying which of the three had happened, or that anything had.

Erasing *which* cause is the expensive part: an operator can't tell a missing
variable from a fat-fingered one from a value that used to be right.

## The fix

Required, with a distinct actionable message per case, matching
`CommandBusMode::from_env_value` exactly so nobody learns a second vocabulary.
`Default` is removed — a default here must name a transport, and the only
transport that exists is EHDB, so defaulting *is* guessing. The `Nats` variant
stays so a stale value gives a specific error, and because `publishes_nats()`
still distinguishes `Shadow` from `Ehdb` on the write path.

Startup fails loudly in `AppState::new`, same shape as the command bus.

## Verified safe *before* writing it

This turns a silent mis-start into a refusal to start, so the precondition
matters: prod sets `NOETL_EVENT_BUS=ehdb`, **and**
`ci/manifests/noetl/server-rust-deployment-prod.yaml:117` declares it — so the
running cluster and a DR re-apply both satisfy the new requirement.

## The old tests asserted the bug

`assert_eq!(from_env_value("ehbd"), Nats)` and `from_env_value("") == Nats`, under
a name that called it *"defaults safe"*. Replaced with:

- three errors asserted **distinct**, not merely non-empty — three identical
  messages would satisfy a naive "is it an error" test while reproducing the exact
  defect;
- a sweep proving no unrecognised value ever yields a mode, **with a positive
  control** so the sweep measures the parser rather than a broken loop.

**Mutation-tested:** restoring the catch-all makes both new tests FAIL; removing it
makes them pass.

863 lib tests green; clippy 5 = 5 against `main`. Inert on prod — this lands on
main and prod stays v3.90.0.

Refs noetl/ai-meta#243