### PR TITLE
fix(executions): make the page cap visible, and stop a negative limit 500ing

### DIFF
--- a/src/handlers/executions.rs
+++ b/src/handlers/executions.rs
@@ -4,6 +4,7 @@
 
 use axum::{
     extract::{Path, Query, State},
+    response::IntoResponse,
     Json,
 };
 use serde::{Deserialize, Serialize};
@@ -50,7 +51,7 @@ pub struct FinalizeResponse {
 pub async fn list(
     State(service): State<ExecutionService>,
     Query(query): Query<ListExecutionsQuery>,
-) -> Result<Json<Vec<crate::services::execution::ExecutionSummary>>, AppError> {
+) -> Result<axum::response::Response, AppError> {
     let filter = ExecutionFilter {
         catalog_id: query.catalog_id,
         path: query.path,
@@ -59,8 +60,50 @@ pub async fn list(
         offset: query.offset,
     };
 
+    // noetl/ai-meta#255 — the cap has to be VISIBLE.  `?limit=300` used to return
+    // exactly 100 rows with no error, no warning and no marker: a response
+    // indistinguishable from "there are only 100".  Anyone paginating by "ask for
+    // more than I expect and see whether I got fewer" got a wrong answer.
+    let paging = crate::services::execution::resolve_paging(query.limit, query.offset)
+        .map_err(AppError::BadRequest)?;
     let executions = service.list(&filter).await?;
-    Ok(Json(executions))
+
+    // Headers rather than an envelope: the body stays a bare JSON array, so every
+    // existing caller — the SPA, the gateway, scripts — keeps working.  Changing
+    // the shape to signal truncation would break them all to fix a reporting gap.
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "x-noetl-limit-applied",
+        paging.limit.to_string().parse().expect("ascii digits"),
+    );
+    if paging.capped {
+        headers.insert(
+            "x-noetl-limit-capped",
+            "true".parse().expect("ascii literal"),
+        );
+        crate::metrics::record_executions_limit(true);
+        tracing::info!(
+            requested = paging.requested_limit,
+            applied = paging.limit,
+            "GET /api/executions limit capped (noetl/ai-meta#255)"
+        );
+    } else {
+        crate::metrics::record_executions_limit(false);
+    }
+    // `has_more` is deliberately "the page came back full", not a COUNT(*): the
+    // count would cost a second aggregate over the same window, and a full page is
+    // exactly the condition under which a caller must ask again.  It can be a
+    // false positive on an exact multiple, which is the safe direction — it says
+    // "check again", never "you have everything" when you do not.
+    let full_page = executions.len() as i32 >= paging.limit && paging.limit > 0;
+    headers.insert(
+        "x-noetl-has-more",
+        if full_page { "true" } else { "false" }
+            .parse()
+            .expect("ascii literal"),
+    );
+
+    Ok((headers, Json(executions)).into_response())
 }
 
 /// Get execution details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -883,6 +883,8 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
+    noetl_server::metrics::init_executions_limit_series();
+
     // Publish the version and pin the known label sets, unconditionally and
     // before any configuration branch can skip them.  `Registry::gather` prunes
     // empty metric families, so a labelled metric is ABSENT from /metrics until

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4094,6 +4094,43 @@ pub fn record_ehdb_projection_refold_refusal(reason: &str) {
         .inc();
 }
 
+/// Whether `GET /api/executions` served a capped page (noetl/ai-meta#255).
+///
+/// Both label values are pinned at 0 at startup: the interesting question is
+/// "is anything hitting the cap?", and an absent `capped="true"` series would be
+/// indistinguishable from a binary that predates the metric.
+pub fn executions_limit_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_executions_limit_total",
+                "GET /api/executions requests by whether the page size was capped at MAX_LIMIT (noetl/ai-meta#255).",
+            ),
+            &["capped"],
+        )
+        .expect("executions_limit_total metric");
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register executions_limit_total");
+        m
+    })
+}
+
+/// Record one list request.
+pub fn record_executions_limit(capped: bool) {
+    executions_limit_total()
+        .with_label_values(&[if capped { "true" } else { "false" }])
+        .inc();
+}
+
+/// Pin both outcomes, unconditionally.
+pub fn init_executions_limit_series() {
+    for v in ["true", "false"] {
+        executions_limit_total().with_label_values(&[v]).inc_by(0);
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/services/execution.rs
+++ b/src/services/execution.rs
@@ -78,6 +78,70 @@ pub struct ExecutionFilter {
     pub offset: Option<i32>,
 }
 
+/// Default page size when the caller does not ask (noetl/ai-meta#255).
+pub const DEFAULT_LIMIT: i32 = 50;
+/// Largest page this endpoint will serve. A request above it is CAPPED, and the
+/// capping is reported rather than hidden.
+pub const MAX_LIMIT: i32 = 100;
+
+/// A resolved page window, plus whether the cap changed what the caller asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Paging {
+    /// What the query will actually use.
+    pub limit: i32,
+    pub offset: i32,
+    /// What the caller asked for, when they asked. `None` means "unspecified".
+    pub requested_limit: Option<i32>,
+    /// True when `requested_limit` exceeded [`MAX_LIMIT`] and was reduced.
+    pub capped: bool,
+}
+
+/// Resolve `?limit=` / `?offset=` into a window, or reject the request.
+///
+/// Pure, so the whole truth table is testable without a database.
+///
+/// # Why this exists
+///
+/// The previous expression was `filter.limit.unwrap_or(50).min(100)`. Two
+/// defects lived in it:
+///
+/// 1. **Silent truncation.** `?limit=300` returned exactly 100 rows with no
+///    error, no warning and no marker — a response *indistinguishable from
+///    "there are only 100"*. Anyone paginating by "ask for more than I expect
+///    and see if I get fewer" gets a wrong answer, and any script treating the
+///    result as exhaustive is silently sampling. That is the
+///    `representation-drift` shape: a complete-looking answer that is not.
+/// 2. **`?limit=-1` returned HTTP 500.** `(-1).min(100)` is `-1`, which reached
+///    Postgres as `LIMIT -1` and errored. A client mistake surfaced as a server
+///    fault.
+///
+/// Negative values are rejected rather than clamped: clamping a negative to 0 or
+/// to the default would be another silent reinterpretation of what was asked,
+/// which is the very thing this function exists to stop. `limit=0` is honoured —
+/// asking for nothing is a legitimate, unambiguous request.
+pub fn resolve_paging(limit: Option<i32>, offset: Option<i32>) -> Result<Paging, String> {
+    if let Some(l) = limit {
+        if l < 0 {
+            return Err(format!(
+                "limit must be >= 0 (got {l}); the maximum served is {MAX_LIMIT}"
+            ));
+        }
+    }
+    if let Some(o) = offset {
+        if o < 0 {
+            return Err(format!("offset must be >= 0 (got {o})"));
+        }
+    }
+    let requested_limit = limit;
+    let effective = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
+    Ok(Paging {
+        limit: effective,
+        offset: offset.unwrap_or(0),
+        requested_limit,
+        capped: matches!(requested_limit, Some(l) if l > MAX_LIMIT),
+    })
+}
+
 /// Execution management service.
 ///
 /// Phase F R4-4b moved this from a single `DbPool` to a
@@ -336,8 +400,19 @@ impl ExecutionService {
     /// path filter into the cluster lookup as a pre-filter.
     #[allow(clippy::type_complexity)]
     pub async fn list(&self, filter: &ExecutionFilter) -> AppResult<Vec<ExecutionSummary>> {
-        let limit = filter.limit.unwrap_or(50).min(100);
-        let offset = filter.offset.unwrap_or(0);
+        // noetl/ai-meta#255 — resolved by `resolve_paging`, which reports whether
+        // the cap was applied instead of silently clamping.
+        // 400, not 422, to match `?limit=abc` — axum already rejects an
+        // unparseable limit with 400, and two shapes of the same mistake
+        // answering with two different codes is its own small confusion.
+        // Rejected here, not unwrapped: a negative limit used to reach Postgres as
+        // `LIMIT -1` and surface as HTTP 500 — a client mistake reported as a
+        // server fault. Returning the validation error keeps that a 400 even if a
+        // future caller reaches the service without going through the handler.
+        let paging = resolve_paging(filter.limit, filter.offset)
+            .map_err(crate::error::AppError::BadRequest)?;
+        let limit = paging.limit;
+        let offset = paging.offset;
         let fetch_cap: i64 = (limit as i64) + (offset as i64);
         // Candidate window for stage 1 (noetl/ai-meta#62).  Without a status
         // filter the N most-recent *executions* are exactly the answer, so the
@@ -1121,6 +1196,93 @@ impl ExecutionService {
             }
         }
         "RUNNING".to_string()
+    }
+}
+
+#[cfg(test)]
+mod paging_tests {
+    use super::*;
+
+    /// The default, unchanged: no `?limit=` means [`DEFAULT_LIMIT`].
+    #[test]
+    fn unspecified_uses_the_default_and_is_not_capped() {
+        let p = resolve_paging(None, None).unwrap();
+        assert_eq!(p.limit, DEFAULT_LIMIT);
+        assert_eq!(p.offset, 0);
+        assert_eq!(p.requested_limit, None);
+        assert!(!p.capped, "an unspecified limit was not capped, it was defaulted");
+    }
+
+    /// noetl/ai-meta#255 defect 1: the cap applied silently.
+    /// It still applies — but it now SAYS SO.
+    #[test]
+    fn over_the_cap_is_capped_and_reports_it() {
+        let p = resolve_paging(Some(300), None).unwrap();
+        assert_eq!(p.limit, MAX_LIMIT, "the cap still bounds the query");
+        assert_eq!(p.requested_limit, Some(300), "what was asked is preserved");
+        assert!(p.capped, "the whole point: truncation must be visible");
+    }
+
+    /// The boundary, both sides. `MAX_LIMIT` exactly is NOT capped — an
+    /// off-by-one here would report truncation on a complete page, which is the
+    /// mirror of the original bug and just as misleading.
+    #[test]
+    fn the_cap_boundary_is_exact() {
+        let at = resolve_paging(Some(MAX_LIMIT), None).unwrap();
+        assert_eq!(at.limit, MAX_LIMIT);
+        assert!(!at.capped, "exactly MAX_LIMIT is served whole, not capped");
+
+        let over = resolve_paging(Some(MAX_LIMIT + 1), None).unwrap();
+        assert!(over.capped);
+        assert_eq!(over.limit, MAX_LIMIT);
+
+        let under = resolve_paging(Some(MAX_LIMIT - 1), None).unwrap();
+        assert!(!under.capped);
+        assert_eq!(under.limit, MAX_LIMIT - 1);
+    }
+
+    /// noetl/ai-meta#255 defect 2, previously unreported: `?limit=-1` reached
+    /// Postgres as `LIMIT -1` and returned **HTTP 500** — a client mistake
+    /// surfacing as a server fault.
+    #[test]
+    fn a_negative_limit_is_rejected_not_turned_into_a_server_error() {
+        let e = resolve_paging(Some(-1), None).unwrap_err();
+        assert!(e.contains("limit must be >= 0"), "{e}");
+        assert!(e.contains("-1"), "the offending value must be quoted back: {e}");
+        assert!(resolve_paging(None, Some(-1)).is_err(), "offset too");
+    }
+
+    /// Rejected rather than clamped, deliberately: clamping a negative to 0 or to
+    /// the default would be another silent reinterpretation of the request, which
+    /// is exactly the class of behaviour this change removes.
+    #[test]
+    fn a_negative_is_not_silently_reinterpreted() {
+        assert!(resolve_paging(Some(-5), None).is_err());
+        // Positive control: 0 IS honoured, so the rule above is about negatives
+        // and not a blanket refusal of small values.
+        let zero = resolve_paging(Some(0), None).unwrap();
+        assert_eq!(zero.limit, 0);
+        assert!(!zero.capped);
+    }
+
+    /// `capped` must track the REQUEST, not the effective value. Asserted as a
+    /// sweep so a future refactor that sets `capped` from `limit == MAX_LIMIT`
+    /// fails here — that version would mark an honest `?limit=100` as truncated.
+    #[test]
+    fn capped_reflects_the_request_not_the_effective_limit() {
+        for (req, want_capped) in [
+            (None, false),
+            (Some(0), false),
+            (Some(1), false),
+            (Some(MAX_LIMIT - 1), false),
+            (Some(MAX_LIMIT), false),
+            (Some(MAX_LIMIT + 1), true),
+            (Some(i32::MAX), true),
+        ] {
+            let p = resolve_paging(req, None).unwrap();
+            assert_eq!(p.capped, want_capped, "requested {req:?}");
+            assert!(p.limit <= MAX_LIMIT, "the cap always bounds the query");
+        }
     }
 }
 


### PR DESCRIPTION
noetl/ai-meta#255. `GET /api/executions?limit=300` returned exactly 100 rows with
no error, no warning and no marker — **a response indistinguishable from "there are
only 100"**. Anyone paginating by *"ask for more than I expect and see whether I got
fewer"* got a wrong answer. It has misled a reader before, and it misled me again
this session while sampling executions.

## A second defect, not in the issue

Found while probing the boundary in kind:

| request | before |
|:--|:--|
| `?limit=3` | 200 |
| `?limit=300` | 200, **silently capped** |
| **`?limit=-1`** | **500** ← `(-1).min(100)` is `-1`, so Postgres got `LIMIT -1` |
| `?limit=0` | 200 |
| `?limit=abc` | 400 |

A client mistake surfacing as a server fault — one character away from the same
expression as the first bug.

## What changed

`filter.limit.unwrap_or(50).min(100)` becomes `resolve_paging`: a pure function,
magic numbers named (`DEFAULT_LIMIT`, `MAX_LIMIT`), truth table testable without a
database. The cap still bounds the query — it now **reports itself**:

```
x-noetl-limit-applied: <n>
x-noetl-limit-capped:  true      (only when the request exceeded the cap)
x-noetl-has-more:      true|false
```

**Headers rather than an envelope, deliberately.** The body stays a bare JSON array,
so every existing caller — SPA, gateway, scripts — keeps working. Changing the shape
to signal truncation would break them all to fix a reporting gap.

`has_more` is *"the page came back full"*, not a `COUNT(*)`: the count costs a second
aggregate over the same window, and a full page is exactly when a caller must ask
again. It can false-positive on an exact multiple — the safe direction: it says
"check again", never "you have everything" when you don't.

A negative limit is **rejected (400**, matching `?limit=abc`) rather than clamped —
clamping to 0 or to the default would be another silent reinterpretation, the very
class of behaviour being removed. `limit=0` is honoured. The rejection lives in the
**service**, not just the handler, so a caller reaching `list` directly still gets a
400 rather than a panic.

## Tests

Six, including the cap boundary **on both sides** — `MAX_LIMIT` itself must *not*
report capped, since marking a complete page as truncated is the mirror of the
original bug — and a sweep asserting `capped` tracks the **request**, not the
effective value, so a refactor computing it as `limit == MAX_LIMIT` fails here.

**Mutation-tested:** restoring the silent clamp fails 5 of the 6.

869 lib tests green; clippy 5 = 5. Lands inert — prod stays v3.90.0.

Refs noetl/ai-meta#255