### PR TITLE
fix(catalog): reject unknown tool kinds at registration, not at execute

### DIFF
--- a/orchestrate-core/src/playbook.rs
+++ b/orchestrate-core/src/playbook.rs
@@ -82,6 +82,56 @@ pub enum ToolKind {
     Wasm,
 }
 
+impl ToolKind {
+    /// Every variant, for validating a submitted kind and for naming the valid
+    /// set in the rejection (noetl/ai-meta#256).
+    ///
+    /// Kept honest by `every_variant_is_in_all`, which round-trips each entry
+    /// through serde and asserts the count — a variant added without extending
+    /// this array fails that test rather than silently becoming a kind the
+    /// registration validator rejects.
+    pub const ALL: [ToolKind; 25] = [
+        ToolKind::Http,
+        ToolKind::Postgres,
+        ToolKind::Duckdb,
+        ToolKind::Ducklake,
+        ToolKind::Python,
+        ToolKind::Workbook,
+        ToolKind::Playbook,
+        ToolKind::Playbooks,
+        ToolKind::Secrets,
+        ToolKind::Iterator,
+        ToolKind::Container,
+        ToolKind::Script,
+        ToolKind::Snowflake,
+        ToolKind::Transfer,
+        ToolKind::SnowflakeTransfer,
+        ToolKind::Gcs,
+        ToolKind::Gateway,
+        ToolKind::Nats,
+        ToolKind::Shell,
+        ToolKind::Artifact,
+        ToolKind::Noop,
+        ToolKind::TaskSequence,
+        ToolKind::Rhai,
+        ToolKind::Subscription,
+        ToolKind::Wasm,
+    ];
+
+    /// Parse a wire value, using serde as the oracle rather than a second copy
+    /// of the name list — two lists are two chances to disagree.
+    pub fn parse(value: &str) -> Option<Self> {
+        serde_json::from_value::<ToolKind>(serde_json::Value::String(value.to_string())).ok()
+    }
+
+    /// The valid set, sorted, for an error message.
+    pub fn valid_set() -> String {
+        let mut v: Vec<String> = Self::ALL.iter().map(|k| k.to_string()).collect();
+        v.sort();
+        v.join(", ")
+    }
+}
+
 impl std::fmt::Display for ToolKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
@@ -1690,5 +1740,63 @@ workflow:
             Some(&serde_json::json!(200)),
             "literal value must be preserved"
         );
+    }
+}
+
+#[cfg(test)]
+mod tool_kind_tests {
+    use super::*;
+
+    /// `ALL` must actually contain every variant. There is no reflection, so the
+    /// guard is: each entry round-trips through serde, the count matches, and the
+    /// names are distinct. A new variant that is not added here makes the count
+    /// assertion fail.
+    #[test]
+    fn every_variant_is_in_all() {
+        assert_eq!(ToolKind::ALL.len(), 25);
+        let mut names: Vec<String> = ToolKind::ALL.iter().map(|k| k.to_string()).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), 25, "ALL contains a duplicate");
+        for k in ToolKind::ALL {
+            let name = k.to_string();
+            assert_eq!(
+                ToolKind::parse(&name),
+                Some(k),
+                "{name} does not round-trip through serde"
+            );
+        }
+    }
+
+    /// The kinds noetl/ai-meta#256 found in the live catalog must be rejected.
+    /// These are not hypothetical: all four were registered and are permanently
+    /// unexecutable.
+    #[test]
+    fn the_kinds_found_in_the_live_catalog_are_rejected() {
+        for bad in ["agent", "mcp", "provider", "result_fetch"] {
+            assert!(ToolKind::parse(bad).is_none(), "{bad} must not parse");
+        }
+        // Negative control from the issue's own probe table.
+        assert!(ToolKind::parse("totally_bogus_kind").is_none());
+        // Positive control: the check is capable of accepting something.
+        assert_eq!(ToolKind::parse("noop"), Some(ToolKind::Noop));
+        assert_eq!(ToolKind::parse("task_sequence"), Some(ToolKind::TaskSequence));
+    }
+
+    /// Case and whitespace are NOT silently accepted — `Agent` is as invalid as
+    /// `agent`, and normalising here would be a second interpretation of the
+    /// author's input rather than a validation of it.
+    #[test]
+    fn parsing_is_exact_not_forgiving() {
+        assert!(ToolKind::parse("HTTP").is_none());
+        assert!(ToolKind::parse(" http").is_none());
+        assert_eq!(ToolKind::parse("http"), Some(ToolKind::Http));
+    }
+
+    #[test]
+    fn the_valid_set_names_real_kinds() {
+        let s = ToolKind::valid_set();
+        assert!(s.contains("noop") && s.contains("task_sequence") && s.contains("wasm"));
+        assert!(!s.contains("agent"), "the invalid kinds must not be advertised");
     }
 }

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -64,6 +64,19 @@ impl CatalogService {
             validate_subscription_spec(&yaml)?;
         }
 
+        // noetl/ai-meta#256 — reject an unknown tool kind HERE, not at execute.
+        //
+        // Registration used to accept literal nonsense: a probe registering
+        // `totally_bogus_kind` was ACCEPTED and then failed at invocation with
+        // "data did not match any variant of untagged enum ToolDefinition". So
+        // registration success carried no information about whether a playbook
+        // could ever run, and six live paths had been unexecutable since the day
+        // they were written, with nothing saying so until somebody invoked them.
+        //
+        // The failure now lands on the author at registration instead of on a
+        // user at invocation.
+        validate_tool_kinds(&yaml)?;
+
         // Get next version
         let version = queries::get_next_version(&self.pool, &path).await?;
 
@@ -394,6 +407,69 @@ const SUBSCRIPTION_ACTIVATIONS: &[&str] = &["continuous", "scheduled"];
 /// shape and explicitly does **not** require a `workflow:` step DAG (a
 /// subscription is activated on a runtime, never dispatched as a one-shot
 /// DAG).
+/// Collect every `tool.kind` in a playbook's workflow, with the step it sits on.
+///
+/// Walks the whole `workflow:` tree rather than only its top level, because
+/// nested constructs (`iterator`, `task_sequence`) carry steps of their own and a
+/// top-level-only scan would report a clean playbook with a broken inner step.
+fn collect_tool_kinds(node: &serde_yaml::Value, step: Option<String>, out: &mut Vec<(String, String)>) {
+    match node {
+        serde_yaml::Value::Mapping(map) => {
+            let here = map
+                .get(serde_yaml::Value::from("step"))
+                .or_else(|| map.get(serde_yaml::Value::from("name")))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .or(step);
+            if let Some(tool) = map.get(serde_yaml::Value::from("tool")) {
+                if let Some(k) = tool.get(serde_yaml::Value::from("kind")).and_then(|v| v.as_str()) {
+                    out.push((here.clone().unwrap_or_else(|| "<unnamed>".into()), k.to_string()));
+                }
+            }
+            for (_k, v) in map {
+                collect_tool_kinds(v, here.clone(), out);
+            }
+        }
+        serde_yaml::Value::Sequence(seq) => {
+            for v in seq {
+                collect_tool_kinds(v, step.clone(), out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Reject a playbook whose workflow names a tool kind that does not exist
+/// (noetl/ai-meta#256).
+///
+/// Fail-closed: an unknown kind is a 4xx naming the offending step, the kind, and
+/// the valid set. `ToolKind::parse` uses serde as the oracle, so this cannot drift
+/// from the enum the executor actually deserialises against — a second hand-written
+/// list would be a second chance to disagree.
+fn validate_tool_kinds(yaml: &serde_yaml::Value) -> AppResult<()> {
+    let Some(workflow) = yaml.get("workflow") else {
+        return Ok(());
+    };
+    let mut found = Vec::new();
+    collect_tool_kinds(workflow, None, &mut found);
+    let mut bad: Vec<String> = found
+        .iter()
+        .filter(|(_, k)| noetl_orchestrate_core::playbook::ToolKind::parse(k).is_none())
+        .map(|(step, k)| format!("step '{step}' has kind '{k}'"))
+        .collect();
+    if bad.is_empty() {
+        return Ok(());
+    }
+    bad.dedup();
+    Err(AppError::Validation(format!(
+        "unknown tool kind(s): {}. Valid kinds: {}. \
+         (noetl/ai-meta#256 — registering an unknown kind used to succeed and fail \
+         only at execute, leaving the playbook permanently unexecutable.)",
+        bad.join("; "),
+        noetl_orchestrate_core::playbook::ToolKind::valid_set()
+    )))
+}
+
 fn validate_subscription_spec(yaml: &serde_yaml::Value) -> AppResult<()> {
     let spec = yaml
         .get("spec")
@@ -773,6 +849,87 @@ fn validate_push_ingress(spec: &serde_yaml::Value) -> AppResult<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tool_kind_validation_tests {
+    use super::*;
+
+    fn yaml(src: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(src).expect("test yaml parses")
+    }
+
+    /// A valid playbook registers. Positive control first: without it, a
+    /// validator that rejected everything would pass every negative test below.
+    #[test]
+    fn a_valid_kind_is_accepted() {
+        let y = yaml(
+            "workflow:\n  - step: a\n    tool:\n      kind: noop\n",
+        );
+        assert!(validate_tool_kinds(&y).is_ok());
+    }
+
+    /// The four kinds noetl/ai-meta#256 found live, plus the issue's own negative
+    /// control. Each was ACCEPTED by registration before this change.
+    #[test]
+    fn the_kinds_found_in_the_live_catalog_are_rejected_with_the_step_named() {
+        for bad in ["agent", "mcp", "provider", "result_fetch", "totally_bogus_kind"] {
+            let y = yaml(&format!(
+                "workflow:\n  - step: call_thing\n    tool:\n      kind: {bad}\n"
+            ));
+            let e = validate_tool_kinds(&y).unwrap_err().to_string();
+            assert!(e.contains(bad), "the offending kind must be quoted back: {e}");
+            assert!(
+                e.contains("call_thing"),
+                "the offending STEP must be named, or the author has to hunt: {e}"
+            );
+            assert!(e.contains("noop"), "the valid set must be offered: {e}");
+        }
+    }
+
+    /// A nested step must not hide behind a clean top level. The consolidated
+    /// planner in the live catalog carries NINE bad steps, several inside nested
+    /// constructs — a top-level-only scan would have called it clean.
+    #[test]
+    fn a_nested_bad_kind_is_found() {
+        let y = yaml(
+            "workflow:\n\
+             \x20 - step: outer\n\
+             \x20   tool:\n\
+             \x20     kind: iterator\n\
+             \x20   steps:\n\
+             \x20     - step: inner\n\
+             \x20       tool:\n\
+             \x20         kind: agent\n",
+        );
+        let e = validate_tool_kinds(&y).unwrap_err().to_string();
+        assert!(e.contains("inner"), "the nested step must be named: {e}");
+        assert!(e.contains("agent"));
+    }
+
+    /// A playbook with no workflow (a Subscription, a resource) is not a step DAG
+    /// and must not be rejected for having no tool kinds.
+    #[test]
+    fn no_workflow_is_not_an_error() {
+        assert!(validate_tool_kinds(&yaml("kind: Subscription\nspec: {}\n")).is_ok());
+    }
+
+    /// Every step is reported, not just the first — an author fixing one at a
+    /// time across nine steps is nine round trips.
+    #[test]
+    fn all_offending_steps_are_reported_not_only_the_first() {
+        let y = yaml(
+            "workflow:\n\
+             \x20 - step: one\n\
+             \x20   tool:\n\
+             \x20     kind: agent\n\
+             \x20 - step: two\n\
+             \x20   tool:\n\
+             \x20     kind: mcp\n",
+        );
+        let e = validate_tool_kinds(&y).unwrap_err().to_string();
+        assert!(e.contains("one") && e.contains("two"), "{e}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
noetl/ai-meta#256. `POST /api/catalog/register` did not validate tool kinds **at
all**. A probe registering the literal string `totally_bogus_kind` was **accepted**,
then failed at invocation with `data did not match any variant of untagged enum
ToolDefinition`.

So **registration success carried no information** about whether a playbook could
ever run — and six live paths had been unexecutable since the day they were
written, with nothing saying so until somebody invoked them.

## Re-verified against the live catalog first

Issues have been stale repeatedly this session, so I re-scanned prod before writing
anything: **1,364 rows → 225 distinct paths** at latest version. The same six paths
still carry an invalid kind — and the scan found **more** than the issue recorded:

| version | path | invalid kind | bad steps |
|:--|:--|:--|:--|
| v3 | `automation/agents/troubleshoot/diagnose_execution` | `mcp` | 1 |
| v2 | `muno/playbooks/itinerary-planner-consolidated` | `agent` | **9** |
| v1 | `tests/inline_cancel_smoke_parent` | `agent` | 1 |
| v1 | `tests/inline_runner_phase_d_smoke` | `agent` | 1 |
| v3 | `tests/spike/spike_e2e_test` | `agent` | 1 |
| v1 | `travel/playbooks/catalog/calendar/list` | `agent` | 1 |

The production planner `muno/playbooks/itinerary-planner` is **clean**, exactly as
the issue warned — only the `-consolidated` path is affected.

## What changes

`validate_tool_kinds` runs at registration, beside the existing
`validate_subscription_spec`, rejecting with a 4xx that names **the offending step**,
the kind, and the valid set — so the failure lands on the author at registration
rather than on a user at invocation.

It walks the **whole** `workflow:` tree, not just the top level: nested constructs
carry steps of their own, and a top-level-only scan would call the consolidated
planner clean since several of its nine bad steps are nested.

`ToolKind::parse` uses **serde as the oracle** rather than a second hand-written
name list — two lists are two chances to disagree, and the entire failure mode here
is a registration path whose idea of validity differed from the executor's.
`ToolKind::ALL` exists only to *name* the valid set in the error, kept honest by a
test that round-trips every entry and asserts the count.

Parsing is exact, not forgiving: `HTTP` and ` http` are rejected. Normalising would
be a second interpretation of the author's input rather than a validation of it.

## Proof

**Mutation-tested:** disabling the validator fails 3 of the 5 registration tests,
while the positive control and the no-workflow case correctly keep passing.

874 lib tests green; clippy 5 = 5.

## Not in this PR

Nothing is deleted and no registered playbook is touched. The six paths are reported
on the issue for an archive-or-fix decision — that's the owner's.

Refs noetl/ai-meta#256