### PR TITLE
feat(catalog): give catalog registration a log

### DIFF
--- a/src/db/models/catalog.rs
+++ b/src/db/models/catalog.rs
@@ -61,6 +61,42 @@ fn default_resource_type() -> String {
     "Playbook".to_string()
 }
 
+/// Bulk registration — N items in one call.
+///
+/// Bulk-loading the catalog was previously a shell loop of single POSTs (see
+/// `repos/ops/automation/development/validate-*.sh`), which is 2,518 round trips
+/// for a full load and has no per-item outcome a caller can act on.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CatalogRegisterBatchRequest {
+    pub items: Vec<CatalogRegisterRequest>,
+}
+
+/// One item's outcome. **Partial failure is first-class**: a single bad YAML
+/// yields an error at its index and the rest still register — the same posture
+/// `execute_batch` takes, and the reason a bulk load does not become
+/// all-or-nothing on one malformed file.
+#[derive(Debug, Clone, Serialize)]
+pub struct CatalogRegisterBatchItem {
+    pub index: usize,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CatalogRegisterBatchResponse {
+    pub count: usize,
+    pub registered: usize,
+    pub failed: usize,
+    pub results: Vec<CatalogRegisterBatchItem>,
+}
+
 /// Response after registering a catalog resource.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogRegisterResponse {

--- a/src/handlers/catalog.rs
+++ b/src/handlers/catalog.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use crate::db::models::{
     CatalogDeleteRequest, CatalogDeleteResponse, CatalogEntries, CatalogEntriesRequest,
     CatalogEntryRequest, CatalogEntryResponse, CatalogRegisterRequest, CatalogRegisterResponse,
+    CatalogRegisterBatchItem, CatalogRegisterBatchRequest, CatalogRegisterBatchResponse,
 };
 use crate::error::{AppError, AppResult};
 use crate::services::ui_schema::{infer_ui_schema, UiSchemaResponse};
@@ -65,6 +66,71 @@ async fn register_inner(
 ) -> AppResult<(StatusCode, Json<CatalogRegisterResponse>)> {
     let response = service.register(request).await?;
     Ok((StatusCode::OK, Json(response)))
+}
+
+/// Register many catalog resources in one call.
+///
+/// `POST /api/catalog/register/batch`
+///
+/// Each item goes through the **same** `CatalogService::register` the single
+/// endpoint uses, so validation, versioning and the step-2 catalog-log emit all
+/// behave identically — a batch is N registrations in one round trip, not a
+/// second registration path that could drift from the first.
+///
+/// ⚠ Each item still takes the next version for its path. This endpoint is for
+/// loading NEW content; it is **not** the backfill. Re-posting the existing
+/// catalog through here would create a second version of every entry. Seeding
+/// the log from rows that already exist is `POST /api/catalog-log/backfill`,
+/// which preserves the existing version.
+pub async fn register_batch(
+    State(service): State<CatalogService>,
+    Json(request): Json<CatalogRegisterBatchRequest>,
+) -> AppResult<(StatusCode, Json<CatalogRegisterBatchResponse>)> {
+    const MAX_ITEMS: usize = 1000;
+    if request.items.len() > MAX_ITEMS {
+        return Err(AppError::Validation(format!(
+            "batch of {} exceeds the {MAX_ITEMS}-item cap; page the load",
+            request.items.len()
+        )));
+    }
+    let count = request.items.len();
+    let mut results = Vec::with_capacity(count);
+    let (mut registered, mut failed) = (0usize, 0usize);
+    for (index, item) in request.items.into_iter().enumerate() {
+        match service.register(item).await {
+            Ok(r) => {
+                registered += 1;
+                results.push(CatalogRegisterBatchItem {
+                    index,
+                    status: "registered".into(),
+                    path: Some(r.path),
+                    version: Some(r.version),
+                    catalog_id: Some(r.catalog_id),
+                    error: None,
+                });
+            }
+            Err(e) => {
+                failed += 1;
+                results.push(CatalogRegisterBatchItem {
+                    index,
+                    status: "error".into(),
+                    path: None,
+                    version: None,
+                    catalog_id: None,
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+    Ok((
+        StatusCode::OK,
+        Json(CatalogRegisterBatchResponse {
+            count,
+            registered,
+            failed,
+            results,
+        }),
+    ))
 }
 
 /// Delete catalog entries.

--- a/src/handlers/catalog_log.rs
+++ b/src/handlers/catalog_log.rs
@@ -199,7 +199,20 @@ pub async fn record_registration(
 
     match resp {
         Ok(r) if r.status().is_success() => {
-            crate::metrics::record_catalog_log(mode.as_str(), "recorded");
+            // ⚠ A 2xx is NOT sufficient. The tier relay answers 200 with an
+            // outcome in the BODY, so a refused append arrives as a successful
+            // HTTP response. Trusting the status alone lost three registrations
+            // in kind while reporting `recorded` for every one of them.
+            let body = r.text().await.unwrap_or_default();
+            let outcome = classify_append_reply(&body);
+            crate::metrics::record_catalog_log(mode.as_str(), outcome);
+            if outcome != "recorded" {
+                tracing::warn!(
+                    target: "noetl_server::catalog_log",
+                    path, version, body = %body.chars().take(200).collect::<String>(),
+                    "catalog log append did not land; the catalog row is committed regardless"
+                );
+            }
         }
         Ok(r) => {
             crate::metrics::record_catalog_log(mode.as_str(), "append_failed");
@@ -218,6 +231,31 @@ pub async fn record_registration(
             );
         }
     }
+}
+
+/// Classify a tier-append reply body.
+///
+/// The relay answers **200 with the outcome in the body**, so the HTTP status
+/// says only that the request was understood. This reads what actually happened.
+/// Split out so the rule is asserted by a test rather than only by a live relay.
+pub fn classify_append_reply(body: &str) -> &'static str {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(body) else {
+        // A non-JSON 200 is not a success we can confirm. Refusing to call it
+        // one is the whole point: an unconfirmable append must not be counted
+        // as a landed record.
+        return "append_failed";
+    };
+    if let Some(o) = v.get("outcome").and_then(|o| o.as_str()) {
+        if o != "ok" {
+            return "append_failed";
+        }
+    }
+    if let Some(n) = v.get("appended").and_then(|n| n.as_i64()) {
+        if n < 1 {
+            return "append_failed";
+        }
+    }
+    "recorded"
 }
 
 /// One folded catalog entry, keyed by `(path, version)`.
@@ -327,6 +365,21 @@ pub async fn verify_endpoint(
         .send()
         .await
     {
+        // ⚠ Status FIRST. A 502 from the relay carries a JSON error body with no
+        // `records` key, so parsing it without checking the status reported
+        // `records_read: 0` — an unreachable tier reading exactly like an empty
+        // one. That is the absent-vs-error conflation, and it hid a real failure
+        // for a full gate round.
+        Ok(r) if !r.status().is_success() => {
+            let st = r.status();
+            let text = r.text().await.unwrap_or_default();
+            return Ok(axum::Json(serde_json::json!({
+                "action": "catalog.log.verify",
+                "outcome": "unavailable",
+                "status": st.as_u16(),
+                "error": text.chars().take(400).collect::<String>(),
+            })));
+        }
         Ok(r) => match r.json().await {
             Ok(v) => v,
             Err(e) => {
@@ -510,6 +563,27 @@ mod tests {
         assert!(!fold_agrees(0, 3));
         assert!(!fold_agrees(9, 1));
         assert!(fold_agrees(9, 0));
+    }
+
+    /// ⚠ A 200 with a failure body must NOT count as a landed record.
+    ///
+    /// This is the regression that lost three registrations in kind: the relay
+    /// answers 200 with the outcome in the body, and trusting the status alone
+    /// reported every one of them as `recorded`.
+    #[test]
+    fn a_two_hundred_with_a_failure_body_is_not_a_landed_record() {
+        assert_eq!(classify_append_reply(r#"{"outcome":"ok","appended":1}"#), "recorded");
+        assert_eq!(
+            classify_append_reply(r#"{"outcome":"unconfigured"}"#),
+            "append_failed",
+            "an unconfigured mirror reported as recorded is a silently lost record"
+        );
+        assert_eq!(classify_append_reply(r#"{"outcome":"ok","appended":0}"#), "append_failed");
+        assert_eq!(
+            classify_append_reply("not json at all"),
+            "append_failed",
+            "an unconfirmable append must not be counted as a landed record"
+        );
     }
 
     #[test]

--- a/src/handlers/catalog_log.rs
+++ b/src/handlers/catalog_log.rs
@@ -233,6 +233,100 @@ pub async fn record_registration(
     }
 }
 
+/// Emit a **backfill** registration for an existing catalog row.
+///
+/// ⚠⚠ This is NOT `register`. It deliberately does **not** touch
+/// `noetl.catalog`: the row already exists, and putting it through the normal
+/// registration path would run `MAX(version)+1` and create a *second* version of
+/// every one of the 2,518 existing entries — doubling the catalog to describe it.
+///
+/// It emits the same `catalog.registered` record the live path emits, carrying
+/// the row's **existing** `catalog_id`, `path`, `kind`, `version` and `content`,
+/// so the relation folds identically whether an entry arrived live or by
+/// backfill. `backfilled: true` rides along so provenance stays honest — the
+/// event says when the log learned about the registration, not when the
+/// registration happened.
+pub async fn record_backfill(
+    catalog_id: i64,
+    path: &str,
+    kind: &str,
+    version: i16,
+    content: &str,
+    archived: bool,
+) -> bool {
+    let mode = mode();
+    if !mode.enabled() {
+        return false;
+    }
+    let Some(base) = relay_base() else {
+        return false;
+    };
+
+    let mut rec = serde_json::to_value(build(
+        catalog_id,
+        path,
+        kind,
+        version,
+        content,
+        chrono::Utc::now().to_rfc3339(),
+    ))
+    .unwrap_or_default();
+    if let Some(o) = rec.as_object_mut() {
+        o.insert("backfilled".into(), serde_json::json!(true));
+    }
+
+    let mut ok = append(&base, catalog_id, &rec.to_string()).await;
+    // Liveness is derived from the sequence, so an archived row needs its
+    // archive event too — otherwise the fold reports a retired entry as live and
+    // `get_latest` resolves to a version the source would not serve.
+    if ok && archived {
+        let tomb = serde_json::json!({
+            "record_version": RECORD_VERSION,
+            "event_type": EVENT_ARCHIVED,
+            "catalog_id": catalog_id.to_string(),
+            "path": path,
+            "version": version,
+            "backfilled": true,
+            "registered_at": chrono::Utc::now().to_rfc3339(),
+        });
+        ok = append(&base, catalog_id, &tomb.to_string()).await;
+    }
+    crate::metrics::record_catalog_log(
+        mode.as_str(),
+        if ok { "recorded" } else { "append_failed" },
+    );
+    ok
+}
+
+/// `catalog.archived` — emitted by the backfill for a retired row.
+pub const EVENT_ARCHIVED: &str = "catalog.archived";
+
+/// The relay base, or `None` when unconfigured.
+fn relay_base() -> Option<String> {
+    std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// POST one record and report whether it actually landed.
+async fn append(base: &str, key: i64, payload: &str) -> bool {
+    let body = serde_json::json!({ "execution_id": key.to_string(), "records": [payload] });
+    let url = format!("{}/ehdb/tiers/{TIER}", base.trim_end_matches('/'));
+    match reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .timeout(APPEND_TIMEOUT)
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => {
+            classify_append_reply(&r.text().await.unwrap_or_default()) == "recorded"
+        }
+        _ => false,
+    }
+}
+
 /// Classify a tier-append reply body.
 ///
 /// The relay answers **200 with the outcome in the body**, so the HTTP status
@@ -451,6 +545,185 @@ pub async fn verify_endpoint(
         "missing_in_source": missing_in_source,
         "agrees": fold_agrees(compared, mismatched) && missing_in_source == 0,
         "mismatches": mismatches,
+    })))
+}
+
+/// `POST /api/catalog-log/backfill` — bring the catalog log to full coverage.
+///
+/// # Why this exists
+///
+/// 2,518 catalog rows predate the log, so the relation's coverage is a strict
+/// subset of the catalog — and a fold-served read on a missing entry would be
+/// **wrong**, not merely stale, while `list_by_kind` would silently
+/// under-report. Full coverage is the gate for serving.
+///
+/// # Idempotent by diffing, not by hoping
+///
+/// It folds the log **first** and emits only rows the fold is missing or
+/// disagrees with. A second run emits nothing. That is a stronger property than
+/// "re-running is harmless": the log is append-only, so an emit-everything
+/// backfill would keep appending duplicates forever even though the folded
+/// relation stayed the same.
+///
+/// # Cursor
+///
+/// `after_catalog_id` makes it resumable, so a 2,518-row backfill is a sequence
+/// of bounded calls rather than one request that must not fail.
+pub async fn backfill_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> crate::error::AppResult<axum::Json<serde_json::Value>> {
+    let limit: i64 = q
+        .get("limit")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200)
+        .clamp(1, 1000);
+    let after: i64 = q
+        .get("after_catalog_id")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let dry_run = q.get("dry_run").map(|v| v == "true").unwrap_or(false);
+
+    if !mode().enabled() {
+        return Ok(axum::Json(serde_json::json!({
+            "action": "catalog.log.backfill",
+            "outcome": "disabled",
+            "hint": format!("set {MODE_ENV}=shadow"),
+        })));
+    }
+
+    // Fold what the log already has, so this run only emits the difference.
+    let existing = match read_and_fold(2000).await {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(axum::Json(serde_json::json!({
+                "action": "catalog.log.backfill",
+                "outcome": "unavailable",
+                "error": e,
+            })))
+        }
+    };
+
+    let archived_sel = if crate::db::queries::catalog::archived_column_present() {
+        "archived_at IS NOT NULL"
+    } else {
+        "false"
+    };
+    let sql = format!(
+        "SELECT catalog_id, path, kind, version, COALESCE(content, ''), {archived_sel} \
+         FROM noetl.catalog WHERE catalog_id > $1 ORDER BY catalog_id ASC LIMIT $2"
+    );
+    let rows: Vec<(i64, String, String, i16, String, bool)> = sqlx::query_as(&sql)
+        .bind(after)
+        .bind(limit)
+        .fetch_all(state.pools.cluster())
+        .await?;
+
+    let scanned = rows.len();
+    let (mut emitted, mut already, mut failed) = (0usize, 0usize, 0usize);
+    let mut next = after;
+    for (cid, path, kind, version, content, archived) in rows {
+        next = cid;
+        let digest = crate::handlers::catalog_snapshot::sha256_hex(content.as_bytes());
+        // Covered means the fold has this key with the SAME digest AND the same
+        // liveness. Digest-only would let an archived row read as covered while
+        // the fold still served it as live.
+        let covered = existing
+            .get(&path, version as i32)
+            .is_some_and(|e| e.content_sha256 == digest && e.archived == archived);
+        if covered {
+            already += 1;
+            continue;
+        }
+        if dry_run {
+            emitted += 1;
+            continue;
+        }
+        if record_backfill(cid, &path, &kind, version, &content, archived).await {
+            emitted += 1;
+        } else {
+            failed += 1;
+        }
+    }
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "catalog.log.backfill",
+        "outcome": "ok",
+        "dry_run": dry_run,
+        "scanned": scanned,
+        "already_covered": already,
+        "emitted": emitted,
+        "failed": failed,
+        "next_after_catalog_id": next,
+        // `scanned < limit` is the only honest "done" signal; a caller that
+        // stopped on `emitted == 0` would stop at the first fully-covered page.
+        "done": (scanned as i64) < limit,
+    })))
+}
+
+/// Read the catalog tier and fold it.
+pub async fn read_and_fold(
+    limit: usize,
+) -> Result<crate::handlers::catalog_relation::CatalogRelation, String> {
+    let base = relay_base().ok_or_else(|| {
+        format!("{} is unset", crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+    })?;
+    let url = format!("{}/ehdb/tiers/{TIER}?limit={limit}", base.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "tier read {}: {}",
+            resp.status(),
+            resp.text().await.unwrap_or_default().chars().take(200).collect::<String>()
+        ));
+    }
+    let body: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    let records: Vec<serde_json::Value> = body
+        .get("records")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default();
+    Ok(crate::handlers::catalog_relation::CatalogRelation::fold(&records))
+}
+
+/// `GET /api/catalog-log/coverage` — is the relation complete enough to serve?
+///
+/// The blocker for the read cutover is coverage, so it gets its own answer
+/// rather than being inferred from the verifier's counts.
+pub async fn coverage_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+) -> crate::error::AppResult<axum::Json<serde_json::Value>> {
+    let rel = match read_and_fold(5000).await {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(axum::Json(serde_json::json!({
+                "action": "catalog.log.coverage",
+                "outcome": "unavailable",
+                "error": e,
+            })))
+        }
+    };
+    let (source_rows,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM noetl.catalog")
+        .fetch_one(state.pools.cluster())
+        .await?;
+    let folded = rel.len() as i64;
+    Ok(axum::Json(serde_json::json!({
+        "action": "catalog.log.coverage",
+        "outcome": "ok",
+        "source_rows": source_rows,
+        "folded_entries": folded,
+        "fold_missing": (source_rows - folded).max(0),
+        "records_seen": rel.records_seen,
+        "records_applied": rel.records_applied,
+        // Serving is permissible only at FULL coverage. Under-reporting is the
+        // failure mode nobody notices, so this is stated rather than left to a
+        // reader comparing two numbers.
+        "full_coverage": folded >= source_rows && source_rows > 0,
     })))
 }
 

--- a/src/handlers/catalog_log.rs
+++ b/src/handlers/catalog_log.rs
@@ -1,0 +1,535 @@
+//! The catalog's log (noetl/ai-meta#311 step 2, `docs/rfc/ehdb-catalog-relation.md`).
+//!
+//! `noetl.catalog` is **not event-sourced**: `POST /api/catalog/register`
+//! performs a direct `INSERT` and there is no emit site anywhere in the catalog
+//! service or handler. A relation is by definition a fold of a log, so the
+//! catalog relation had nothing to fold. This module is the producer that gives
+//! it one.
+//!
+//! # Where the records go, and why not the event log
+//!
+//! Into [`StoreTier::Catalog`](../../../worker) — its own store. A catalog record
+//! carries no `execution_id` and has no row in `noetl.event`, so appending one to
+//! the event-log tier would make the cross-store parity comparator report
+//! `extra_event` — a tier record with no authoritative row — which **pages**.
+//! Giving the new log its own store is what keeps it from setting off the alarm
+//! that guards the old one.
+//!
+//! # Dual-write, not a cutover
+//!
+//! The `INSERT` into `noetl.catalog` is untouched and remains the source every
+//! read resolves from. This only *also* records the registration, so the fold
+//! can be built and compared before anything depends on it.
+
+use serde::Serialize;
+
+/// `NOETL_CATALOG_LOG` — whether registrations are also recorded to the tier.
+pub const MODE_ENV: &str = "NOETL_CATALOG_LOG";
+
+/// The tier path segment. Must match the worker's `StoreTier::Catalog::as_str`.
+pub const TIER: &str = "catalog";
+
+/// The record shape's own version, so a reader can tell a v1 record from a
+/// future shape without inferring it from which keys happen to be present.
+pub const RECORD_VERSION: i64 = 1;
+
+/// Event type recorded for a registration.
+pub const EVENT_REGISTERED: &str = "catalog.registered";
+
+/// How long an append may take. Short: registration must not wait on a mirror.
+const APPEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Outcomes, pinned as metric labels.
+pub const OUTCOMES: [&str; 5] = [
+    "recorded",
+    "disabled",
+    "unconfigured",
+    "append_failed",
+    "serialise_failed",
+];
+
+/// Whether registrations are mirrored into the catalog log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Not recorded. Default, so this lands inert.
+    Off,
+    /// Recorded to the tier. Nothing reads it yet — the fold is verified against
+    /// `noetl.catalog`, and catalog reads still resolve from Postgres.
+    Shadow,
+}
+
+pub const MODES: [&str; 2] = ["off", "shadow"];
+
+impl Mode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Shadow => "shadow",
+        }
+    }
+    pub fn enabled(self) -> bool {
+        matches!(self, Self::Shadow)
+    }
+}
+
+pub fn mode() -> Mode {
+    parse_mode(std::env::var(MODE_ENV).ok().as_deref())
+}
+
+/// The parse, without the environment — testable without `set_var`, which would
+/// race (`cargo test` does not serialise tests).
+///
+/// Unrecognised resolves to `Off`. A typo must not start writing to a tier.
+pub fn parse_mode(raw: Option<&str>) -> Mode {
+    match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("shadow") => Mode::Shadow,
+        _ => Mode::Off,
+    }
+}
+
+/// One catalog-log record.
+#[derive(Debug, Clone, Serialize)]
+pub struct CatalogRecord {
+    pub record_version: i64,
+    pub event_type: &'static str,
+    pub catalog_id: String,
+    pub path: String,
+    pub kind: String,
+    pub version: i16,
+    /// Pins the exact registered bytes. The fold compares on this rather than on
+    /// the content itself, so a comparison is cheap and a mismatch is exact.
+    pub content_sha256: String,
+    pub content_bytes: usize,
+    /// The registered content. The catalog log is the *only* event-sourced record
+    /// of catalog content, so unlike the per-execution snapshot it carries the
+    /// bytes — there is one record per registration, not one per run.
+    pub content: String,
+    pub registered_at: String,
+}
+
+/// Build a record. Pure, so the shape is asserted by a test rather than by a
+/// running server.
+pub fn build(
+    catalog_id: i64,
+    path: &str,
+    kind: &str,
+    version: i16,
+    content: &str,
+    registered_at: String,
+) -> CatalogRecord {
+    CatalogRecord {
+        record_version: RECORD_VERSION,
+        event_type: EVENT_REGISTERED,
+        catalog_id: catalog_id.to_string(),
+        path: path.to_string(),
+        kind: kind.to_string(),
+        version,
+        content_sha256: crate::handlers::catalog_snapshot::sha256_hex(content.as_bytes()),
+        content_bytes: content.len(),
+        content: content.to_string(),
+        registered_at,
+    }
+}
+
+/// Record one registration into the catalog log.
+///
+/// # Fail-safe
+///
+/// Returns `()`. Registration has already committed to `noetl.catalog` by the
+/// time this runs; failing the request now would report a failure for work that
+/// succeeded, and the caller would re-register, creating a second version of an
+/// identical playbook.
+pub async fn record_registration(
+    catalog_id: i64,
+    path: &str,
+    kind: &str,
+    version: i16,
+    content: &str,
+) {
+    let mode = mode();
+    if !mode.enabled() {
+        crate::metrics::record_catalog_log(mode.as_str(), "disabled");
+        return;
+    }
+    let Some(base) = std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        // Asked to record with nowhere to record to. A misconfiguration, not a
+        // quiet no-op: without this the tier stays empty while the mode says it
+        // is on, and the fold would later report "no records" for a cause two
+        // hops away.
+        crate::metrics::record_catalog_log(mode.as_str(), "unconfigured");
+        tracing::warn!(
+            target: "noetl_server::catalog_log",
+            "{MODE_ENV}=shadow but {} is unset — registration was NOT recorded",
+            crate::handlers::ehdb::WORKER_QUERY_URL_ENV
+        );
+        return;
+    };
+
+    let rec = build(
+        catalog_id,
+        path,
+        kind,
+        version,
+        content,
+        chrono::Utc::now().to_rfc3339(),
+    );
+    let Ok(payload) = serde_json::to_string(&rec) else {
+        crate::metrics::record_catalog_log(mode.as_str(), "serialise_failed");
+        return;
+    };
+
+    // The relay keys records by an opaque partition string. `catalog_id` is the
+    // natural one: unique per record, and it makes a keyed read return exactly
+    // the registration asked for.
+    let body = serde_json::json!({
+        "execution_id": catalog_id.to_string(),
+        "records": [payload],
+    });
+    let url = format!("{}/ehdb/tiers/{TIER}", base.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .timeout(APPEND_TIMEOUT)
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) if r.status().is_success() => {
+            crate::metrics::record_catalog_log(mode.as_str(), "recorded");
+        }
+        Ok(r) => {
+            crate::metrics::record_catalog_log(mode.as_str(), "append_failed");
+            tracing::warn!(
+                target: "noetl_server::catalog_log",
+                status = %r.status(), path, version,
+                "catalog log append refused; the catalog row is committed regardless"
+            );
+        }
+        Err(e) => {
+            crate::metrics::record_catalog_log(mode.as_str(), "append_failed");
+            tracing::warn!(
+                target: "noetl_server::catalog_log",
+                error = %e, path, version,
+                "catalog log append failed; the catalog row is committed regardless"
+            );
+        }
+    }
+}
+
+/// One folded catalog entry, keyed by `(path, version)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoldedEntry {
+    pub catalog_id: String,
+    pub kind: String,
+    pub content_sha256: String,
+}
+
+/// Fold catalog-log records into the relation's shape.
+///
+/// Pure, and the whole point of step 2: this is the function that turns a log
+/// into a relation. Later records for the same `(path, version)` win, which
+/// matters only for a duplicate append — `(path, version)` is immutable in the
+/// source, so two records for one key must agree, and the verifier is what says
+/// whether they do.
+///
+/// Returns a `BTreeMap` so the ordering is deterministic and two folds of the
+/// same log compare equal.
+pub fn fold_records(
+    records: &[serde_json::Value],
+) -> std::collections::BTreeMap<(String, i64), FoldedEntry> {
+    let mut out = std::collections::BTreeMap::new();
+    for r in records {
+        // A tier record may arrive as `{payload: "<json>"}` or inline.
+        let p = match r.get("payload").and_then(|p| p.as_str()) {
+            Some(s) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => v,
+                Err(_) => continue,
+            },
+            None => r.clone(),
+        };
+        if p.get("event_type").and_then(|v| v.as_str()) != Some(EVENT_REGISTERED) {
+            continue;
+        }
+        let (Some(path), Some(version)) = (
+            p.get("path").and_then(|v| v.as_str()),
+            p.get("version").and_then(|v| v.as_i64()),
+        ) else {
+            continue;
+        };
+        let Some(digest) = p.get("content_sha256").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        out.insert(
+            (path.to_string(), version),
+            FoldedEntry {
+                catalog_id: p
+                    .get("catalog_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                kind: p
+                    .get("kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                content_sha256: digest.to_string(),
+            },
+        );
+    }
+    out
+}
+
+/// Does the fold agree with the source?
+///
+/// **Both conditions, and the first is the one that matters.** A fold that
+/// covered nothing has zero mismatches, so `mismatched == 0` alone would report
+/// an empty log as agreeing with the catalog — the vacuous pass this codebase
+/// keeps refusing.
+pub fn fold_agrees(compared: usize, mismatched: usize) -> bool {
+    compared > 0 && mismatched == 0
+}
+
+/// `GET /api/catalog-log/verify?limit=N` — fold the catalog log and compare it
+/// against `noetl.catalog`.
+///
+/// Read-only, and independent of the mode, so evidence can be gathered while
+/// registration reads still resolve entirely from Postgres.
+pub async fn verify_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> crate::error::AppResult<axum::Json<serde_json::Value>> {
+    let limit: usize = q
+        .get("limit")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200)
+        .clamp(1, 2000);
+
+    let base = std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let Some(base) = base else {
+        return Ok(axum::Json(serde_json::json!({
+            "action": "catalog.log.verify",
+            "outcome": "unconfigured",
+            "error": format!("{} is unset", crate::handlers::ehdb::WORKER_QUERY_URL_ENV),
+        })));
+    };
+
+    let url = format!("{}/ehdb/tiers/{TIER}?limit={limit}", base.trim_end_matches('/'));
+    let body: serde_json::Value = match reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(20))
+        .send()
+        .await
+    {
+        Ok(r) => match r.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                return Ok(axum::Json(serde_json::json!({
+                    "action": "catalog.log.verify",
+                    "outcome": "unavailable",
+                    "error": e.to_string(),
+                })))
+            }
+        },
+        Err(e) => {
+            return Ok(axum::Json(serde_json::json!({
+                "action": "catalog.log.verify",
+                "outcome": "unavailable",
+                "error": e.to_string(),
+            })))
+        }
+    };
+
+    let records: Vec<serde_json::Value> = body
+        .get("records")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let folded = fold_records(&records);
+
+    // Compare each folded entry against the authoritative row.
+    let pool = state.pools.cluster();
+    let (mut compared, mut mismatched, mut missing_in_source) = (0usize, 0usize, 0usize);
+    let mut mismatches: Vec<serde_json::Value> = Vec::new();
+    for ((path, version), e) in &folded {
+        let row: Option<(String, String, i16)> = sqlx::query_as(
+            "SELECT COALESCE(content, ''), kind, version FROM noetl.catalog \
+             WHERE path = $1 AND version = $2",
+        )
+        .bind(path)
+        .bind(*version as i16)
+        .fetch_optional(pool)
+        .await?;
+        let Some((content, kind, _)) = row else {
+            missing_in_source += 1;
+            continue;
+        };
+        compared += 1;
+        let src = crate::handlers::catalog_snapshot::sha256_hex(content.as_bytes());
+        if src != e.content_sha256 || kind != e.kind {
+            mismatched += 1;
+            if mismatches.len() < 10 {
+                mismatches.push(serde_json::json!({
+                    "path": path, "version": version,
+                    "source_sha256": &src[..16.min(src.len())],
+                    "folded_sha256": &e.content_sha256[..16.min(e.content_sha256.len())],
+                    "source_kind": kind, "folded_kind": e.kind,
+                }));
+            }
+        }
+    }
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "catalog.log.verify",
+        "outcome": "ok",
+        "mode": mode().as_str(),
+        "records_read": records.len(),
+        "folded_entries": folded.len(),
+        "compared": compared,
+        "mismatched": mismatched,
+        // A folded entry with no row is a real fault: the log claims a
+        // registration the catalog does not have.
+        "missing_in_source": missing_in_source,
+        "agrees": fold_agrees(compared, mismatched) && missing_in_source == 0,
+        "mismatches": mismatches,
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recording_is_off_unless_asked_for() {
+        assert_eq!(parse_mode(None), Mode::Off);
+        assert_eq!(parse_mode(Some("")), Mode::Off);
+        assert!(!Mode::Off.enabled());
+    }
+
+    #[test]
+    fn a_typo_does_not_start_writing_to_a_tier() {
+        for junk in ["shadwo", "SHADOW!", "on", "true", "1", "tier", "serve"] {
+            assert_eq!(parse_mode(Some(junk)), Mode::Off, "{junk} must not enable writes");
+        }
+        assert_eq!(parse_mode(Some(" Shadow ")), Mode::Shadow);
+    }
+
+    /// The record pins the registered CONTENT, not just its version.
+    #[test]
+    fn the_record_pins_content_not_just_the_version() {
+        let a = build(1, "p", "playbook", 3, "steps: [a]", "t".into());
+        let b = build(2, "p", "playbook", 3, "steps: [b]", "t".into());
+        assert_eq!(a.version, b.version);
+        assert_ne!(
+            a.content_sha256, b.content_sha256,
+            "two different registrations at the same version must not pin identically"
+        );
+        assert_eq!(a.content, "steps: [a]", "the log must carry the bytes");
+    }
+
+    /// The digest is over the content, and matches the snapshot module's — the
+    /// two are compared against each other by the verifier, so a divergence in
+    /// hashing would read as a divergence in data.
+    #[test]
+    fn the_digest_agrees_with_the_execution_snapshots() {
+        let c = "apiVersion: noetl.io/v2\nkind: Playbook\n";
+        let r = build(1, "p", "playbook", 1, c, "t".into());
+        assert_eq!(
+            r.content_sha256,
+            crate::handlers::catalog_snapshot::sha256_hex(c.as_bytes()),
+            "the catalog log and the execution snapshot must hash content the same \
+             way, or comparing them reports data divergence for a hashing difference"
+        );
+    }
+
+    fn rec(path: &str, version: i64, sha: &str) -> serde_json::Value {
+        serde_json::json!({
+            "record_version": 1, "event_type": EVENT_REGISTERED,
+            "catalog_id": "7", "path": path, "kind": "playbook",
+            "version": version, "content_sha256": sha,
+        })
+    }
+
+    /// ⭐ The fold turns a log into the relation's shape, keyed by (path, version).
+    #[test]
+    fn the_fold_keys_by_path_and_version() {
+        let f = fold_records(&[rec("a", 1, "d1"), rec("a", 2, "d2"), rec("b", 1, "d3")]);
+        assert_eq!(f.len(), 3);
+        assert_eq!(f[&("a".into(), 2)].content_sha256, "d2");
+        assert_eq!(f[&("b".into(), 1)].content_sha256, "d3");
+    }
+
+    /// Records arriving wrapped in a tier `payload` string fold identically.
+    #[test]
+    fn a_wrapped_payload_folds_the_same_as_an_inline_one() {
+        let inline = rec("a", 1, "d1");
+        let wrapped = serde_json::json!({ "payload": inline.to_string() });
+        assert_eq!(fold_records(&[inline]), fold_records(&[wrapped]));
+    }
+
+    /// Foreign record types are ignored rather than folded into nonsense.
+    #[test]
+    fn records_of_another_type_are_skipped() {
+        let mut other = rec("a", 1, "d1");
+        other["event_type"] = serde_json::json!("catalog.archived");
+        assert!(
+            fold_records(&[other]).is_empty(),
+            "an unrecognised record type must not be folded as a registration"
+        );
+    }
+
+    /// A malformed record is skipped, not folded with defaults.
+    #[test]
+    fn a_record_missing_its_key_is_skipped() {
+        let mut bad = rec("a", 1, "d1");
+        bad.as_object_mut().unwrap().remove("version");
+        assert!(fold_records(&[bad]).is_empty());
+        let mut nodigest = rec("a", 1, "d1");
+        nodigest.as_object_mut().unwrap().remove("content_sha256");
+        assert!(
+            fold_records(&[nodigest]).is_empty(),
+            "a record with no digest must not fold to an empty digest that then \
+             compares as a mismatch against every source row"
+        );
+    }
+
+    /// The verifier must be able to FAIL, including on the shape most like success.
+    #[test]
+    fn a_fold_that_compared_nothing_is_not_agreement() {
+        assert!(
+            !fold_agrees(0, 0),
+            "an empty log has zero mismatches; calling that agreement is the \
+             vacuous pass"
+        );
+        assert!(!fold_agrees(0, 3));
+        assert!(!fold_agrees(9, 1));
+        assert!(fold_agrees(9, 0));
+    }
+
+    #[test]
+    fn every_label_is_pinned() {
+        for m in [Mode::Off, Mode::Shadow] {
+            let expect = match m {
+                Mode::Off => "off",
+                Mode::Shadow => "shadow",
+            };
+            assert_eq!(m.as_str(), expect);
+            assert!(MODES.contains(&m.as_str()));
+        }
+        assert_eq!(MODES.len(), 2);
+        assert_eq!(OUTCOMES.len(), 5);
+    }
+
+    #[test]
+    fn the_tier_segment_matches_the_workers_store_tier_name() {
+        // If these drift, appends 400 with "unknown tier" and the log stays
+        // silently empty while the mode says it is on.
+        assert_eq!(TIER, "catalog");
+    }
+}

--- a/src/handlers/catalog_log.rs
+++ b/src/handlers/catalog_log.rs
@@ -428,8 +428,13 @@ pub fn fold_agrees(compared: usize, mismatched: usize) -> bool {
 /// `GET /api/catalog-log/verify?limit=N` — fold the catalog log and compare it
 /// against `noetl.catalog`.
 ///
-/// Read-only, and independent of the mode, so evidence can be gathered while
-/// registration reads still resolve entirely from Postgres.
+/// Read-only and independent of the mode, so evidence can be gathered while
+/// catalog reads still resolve entirely from Postgres.
+///
+/// Goes through [`read_and_fold`] rather than reading the tier itself: this
+/// endpoint originally did its own single unpaged read and answered
+/// `unavailable` once the log outgrew a 1 MiB frame — a verifier that stops
+/// working at exactly the coverage it exists to confirm.
 pub async fn verify_endpoint(
     axum::extract::State(state): axum::extract::State<crate::state::AppState>,
     axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
@@ -437,83 +442,32 @@ pub async fn verify_endpoint(
     let limit: usize = q
         .get("limit")
         .and_then(|v| v.parse().ok())
-        .unwrap_or(200)
-        .clamp(1, 2000);
+        .unwrap_or(FOLD_READ_CAP)
+        .clamp(1, FOLD_READ_CAP);
 
-    let base = std::env::var(crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-    let Some(base) = base else {
-        return Ok(axum::Json(serde_json::json!({
-            "action": "catalog.log.verify",
-            "outcome": "unconfigured",
-            "error": format!("{} is unset", crate::handlers::ehdb::WORKER_QUERY_URL_ENV),
-        })));
-    };
-
-    let url = format!("{}/ehdb/tiers/{TIER}?limit={limit}", base.trim_end_matches('/'));
-    let body: serde_json::Value = match reqwest::Client::new()
-        .get(&url)
-        .timeout(std::time::Duration::from_secs(20))
-        .send()
-        .await
-    {
-        // ⚠ Status FIRST. A 502 from the relay carries a JSON error body with no
-        // `records` key, so parsing it without checking the status reported
-        // `records_read: 0` — an unreachable tier reading exactly like an empty
-        // one. That is the absent-vs-error conflation, and it hid a real failure
-        // for a full gate round.
-        Ok(r) if !r.status().is_success() => {
-            let st = r.status();
-            let text = r.text().await.unwrap_or_default();
-            return Ok(axum::Json(serde_json::json!({
-                "action": "catalog.log.verify",
-                "outcome": "unavailable",
-                "status": st.as_u16(),
-                "error": text.chars().take(400).collect::<String>(),
-            })));
-        }
-        Ok(r) => match r.json().await {
-            Ok(v) => v,
-            Err(e) => {
-                return Ok(axum::Json(serde_json::json!({
-                    "action": "catalog.log.verify",
-                    "outcome": "unavailable",
-                    "error": e.to_string(),
-                })))
-            }
-        },
+    let folded = match read_and_fold(limit).await {
+        Ok(r) => r,
         Err(e) => {
             return Ok(axum::Json(serde_json::json!({
                 "action": "catalog.log.verify",
                 "outcome": "unavailable",
-                "error": e.to_string(),
+                "error": e,
             })))
         }
     };
 
-    let records: Vec<serde_json::Value> = body
-        .get("records")
-        .and_then(|r| r.as_array())
-        .cloned()
-        .unwrap_or_default();
-    let folded = fold_records(&records);
-
-    // Compare each folded entry against the authoritative row.
     let pool = state.pools.cluster();
     let (mut compared, mut mismatched, mut missing_in_source) = (0usize, 0usize, 0usize);
     let mut mismatches: Vec<serde_json::Value> = Vec::new();
-    for ((path, version), e) in &folded {
-        let row: Option<(String, String, i16)> = sqlx::query_as(
-            "SELECT COALESCE(content, ''), kind, version FROM noetl.catalog \
-             WHERE path = $1 AND version = $2",
+    for e in folded.entries() {
+        let row: Option<(String, String)> = sqlx::query_as(
+            "SELECT COALESCE(content, ''), kind FROM noetl.catalog WHERE path = $1 AND version = $2",
         )
-        .bind(path)
-        .bind(*version as i16)
+        .bind(&e.path)
+        .bind(e.version as i16)
         .fetch_optional(pool)
         .await?;
-        let Some((content, kind, _)) = row else {
+        let Some((content, kind)) = row else {
             missing_in_source += 1;
             continue;
         };
@@ -523,7 +477,7 @@ pub async fn verify_endpoint(
             mismatched += 1;
             if mismatches.len() < 10 {
                 mismatches.push(serde_json::json!({
-                    "path": path, "version": version,
+                    "path": e.path, "version": e.version,
                     "source_sha256": &src[..16.min(src.len())],
                     "folded_sha256": &e.content_sha256[..16.min(e.content_sha256.len())],
                     "source_kind": kind, "folded_kind": e.kind,
@@ -536,17 +490,107 @@ pub async fn verify_endpoint(
         "action": "catalog.log.verify",
         "outcome": "ok",
         "mode": mode().as_str(),
-        "records_read": records.len(),
+        "records_read": folded.records_seen,
+        "records_applied": folded.records_applied,
         "folded_entries": folded.len(),
         "compared": compared,
         "mismatched": mismatched,
-        // A folded entry with no row is a real fault: the log claims a
-        // registration the catalog does not have.
         "missing_in_source": missing_in_source,
         "agrees": fold_agrees(compared, mismatched) && missing_in_source == 0,
         "mismatches": mismatches,
     })))
 }
+
+pub async fn read_and_fold(
+    limit: usize,
+) -> Result<crate::handlers::catalog_relation::CatalogRelation, String> {
+    let base = relay_base().ok_or_else(|| {
+        format!("{} is unset", crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
+    })?;
+    let client = reqwest::Client::new();
+    let mut all: Vec<serde_json::Value> = Vec::new();
+    let mut after: u64 = 0;
+    let mut page = FOLD_PAGE;
+
+    // ⚠⚠ Paged AND adaptive, and both are forced by the store rather than
+    // chosen. A tier-service frame is capped at 1 MiB; catalog records carry
+    // playbook content, and a single entry can be 267 KB. So neither a whole-log
+    // scan nor a fixed page size works — a page of 25 measured 1,311,308 bytes
+    // because a few large entries landed together. On a frame-cap refusal the
+    // page halves and retries; a page that cannot be made to fit is reported,
+    // not silently skipped, because a fold missing records is a WRONG answer and
+    // not a smaller one.
+    for _ in 0..MAX_FOLD_PAGES {
+        // The FIRST page must omit `after`: the store rejects `after=0` with
+        // "stream sequence must be greater than zero" — starting from the
+        // beginning is the ABSENCE of a cursor, not a zero one.
+        let url = if after == 0 {
+            format!("{}/ehdb/tiers/{TIER}?limit={page}", base.trim_end_matches('/'))
+        } else {
+            format!(
+                "{}/ehdb/tiers/{TIER}?limit={page}&after={after}",
+                base.trim_end_matches('/')
+            )
+        };
+        let resp = client
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(60))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            if text.contains("exceeds the") && text.contains("cap") && page > 1 {
+                page = (page / 2).max(1);
+                continue;
+            }
+            return Err(format!(
+                "tier read failed at page size {page} after={after}: {}",
+                text.chars().take(240).collect::<String>()
+            ));
+        }
+
+        let body: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+        let recs: Vec<serde_json::Value> = body
+            .get("records")
+            .and_then(|r| r.as_array())
+            .cloned()
+            .unwrap_or_default();
+        if recs.is_empty() {
+            break;
+        }
+        let next = recs
+            .iter()
+            .filter_map(|r| r.get("global_sequence").and_then(|v| v.as_u64()))
+            .max()
+            .unwrap_or(0);
+        let short = recs.len() < page;
+        all.extend(recs);
+        // A cursor that did not advance would re-read the same page forever.
+        if short || next <= after {
+            break;
+        }
+        after = next;
+        if all.len() >= limit {
+            break;
+        }
+    }
+    Ok(crate::handlers::catalog_relation::CatalogRelation::fold(&all))
+}
+
+/// Upper bound on records a single fold will accumulate.
+///
+/// Generous, because a partial fold is a WRONG answer rather than a smaller one;
+/// bounded anyway so a caller cannot ask for unbounded work.
+pub const FOLD_READ_CAP: usize = 50_000;
+
+/// Records per fold page. Small on purpose: one catalog entry can be 267 KB, and
+/// the tier-service frame cap is 1 MiB.
+const FOLD_PAGE: usize = 16;
+
+/// Page walk bound, so a stalled cursor cannot spin.
+const MAX_FOLD_PAGES: usize = 4000;
 
 /// `POST /api/catalog-log/backfill` — bring the catalog log to full coverage.
 ///
@@ -661,36 +705,6 @@ pub async fn backfill_endpoint(
     })))
 }
 
-/// Read the catalog tier and fold it.
-pub async fn read_and_fold(
-    limit: usize,
-) -> Result<crate::handlers::catalog_relation::CatalogRelation, String> {
-    let base = relay_base().ok_or_else(|| {
-        format!("{} is unset", crate::handlers::ehdb::WORKER_QUERY_URL_ENV)
-    })?;
-    let url = format!("{}/ehdb/tiers/{TIER}?limit={limit}", base.trim_end_matches('/'));
-    let resp = reqwest::Client::new()
-        .get(&url)
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "tier read {}: {}",
-            resp.status(),
-            resp.text().await.unwrap_or_default().chars().take(200).collect::<String>()
-        ));
-    }
-    let body: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
-    let records: Vec<serde_json::Value> = body
-        .get("records")
-        .and_then(|r| r.as_array())
-        .cloned()
-        .unwrap_or_default();
-    Ok(crate::handlers::catalog_relation::CatalogRelation::fold(&records))
-}
-
 /// `GET /api/catalog-log/coverage` — is the relation complete enough to serve?
 ///
 /// The blocker for the read cutover is coverage, so it gets its own answer
@@ -698,7 +712,7 @@ pub async fn read_and_fold(
 pub async fn coverage_endpoint(
     axum::extract::State(state): axum::extract::State<crate::state::AppState>,
 ) -> crate::error::AppResult<axum::Json<serde_json::Value>> {
-    let rel = match read_and_fold(5000).await {
+    let rel = match read_and_fold(FOLD_READ_CAP).await {
         Ok(r) => r,
         Err(e) => {
             return Ok(axum::Json(serde_json::json!({
@@ -723,7 +737,10 @@ pub async fn coverage_endpoint(
         // Serving is permissible only at FULL coverage. Under-reporting is the
         // failure mode nobody notices, so this is stated rather than left to a
         // reader comparing two numbers.
-        "full_coverage": folded >= source_rows && source_rows > 0,
+        "full_coverage": folded >= source_rows && source_rows > 0
+            && rel.records_seen < FOLD_READ_CAP,
+        // Full coverage computed from a truncated read is not full coverage.
+        "fold_read_capped": rel.records_seen >= FOLD_READ_CAP,
     })))
 }
 

--- a/src/handlers/catalog_relation.rs
+++ b/src/handlers/catalog_relation.rs
@@ -345,6 +345,57 @@ mod tests {
         assert_eq!(r.records_applied, 0);
     }
 
+    /// ⭐ A BACKFILL record folds identically to a live registration.
+    ///
+    /// The whole point of the backfill emitting through the same record shape:
+    /// an entry must be indistinguishable in the relation whether it arrived
+    /// live or was seeded from an existing row. Only its provenance differs.
+    #[test]
+    fn a_backfilled_record_folds_the_same_as_a_live_one() {
+        let live = reg("a", 7, "d7", "playbook", 77);
+        let mut back = live.clone();
+        back["backfilled"] = serde_json::json!(true);
+        assert_eq!(
+            CatalogRelation::fold(&[live]).get("a", 7),
+            CatalogRelation::fold(&[back]).get("a", 7),
+            "a backfilled entry must fold identically; only provenance differs"
+        );
+    }
+
+    /// ⭐ The backfill must NOT bump versions.
+    ///
+    /// Re-registering the existing catalog through the normal path would run
+    /// MAX(version)+1 and create a second version of every entry — describing a
+    /// 2,518-row catalog by doubling it. This pins the property the backfill
+    /// preserves: the folded version is the SOURCE version.
+    #[test]
+    fn the_backfill_preserves_the_source_version() {
+        let r = CatalogRelation::fold(&[
+            reg("a", 3, "d3", "playbook", 33),
+            reg("a", 4, "d4", "playbook", 44),
+        ]);
+        assert_eq!(
+            r.list_versions("a").iter().map(|e| e.version).collect::<Vec<_>>(),
+            vec![3, 4],
+            "backfilled versions must be the source's own, not 1..n"
+        );
+        assert_eq!(r.get_latest("a").unwrap().version, 4);
+        assert!(r.get("a", 1).is_none(), "no phantom version was invented");
+    }
+
+    /// Re-folding a log that already contains an entry leaves the relation
+    /// unchanged — the property the backfill's diff relies on.
+    #[test]
+    fn re_emitting_an_identical_record_does_not_change_the_relation() {
+        let one = CatalogRelation::fold(&[reg("a", 1, "d1", "playbook", 1)]);
+        let twice = CatalogRelation::fold(&[
+            reg("a", 1, "d1", "playbook", 1),
+            reg("a", 1, "d1", "playbook", 1),
+        ]);
+        assert_eq!(one.get("a", 1), twice.get("a", 1));
+        assert_eq!(one.len(), twice.len(), "a duplicate must not create a second entry");
+    }
+
     /// Records wrapped in a tier `payload` string fold identically to inline ones.
     #[test]
     fn wrapped_and_inline_records_fold_identically() {

--- a/src/handlers/catalog_relation.rs
+++ b/src/handlers/catalog_relation.rs
@@ -1,0 +1,358 @@
+//! The catalog relation — the read side of `docs/rfc/ehdb-catalog-relation-step3.md`.
+//!
+//! A relation is a **fold of a log**. This module is that fold: it takes catalog
+//! log records and answers the five reads the catalog surface actually uses.
+//!
+//! # Pure on purpose
+//!
+//! Construction takes records and the reads take `&self`. No IO, no clock, no
+//! environment. Every rule below is therefore reachable by a unit test rather
+//! than only by a running server against a live tier — which is how the rules in
+//! step 2 ended up asserted by nothing until they were extracted.
+//!
+//! # Serving nothing
+//!
+//! Nothing calls this on a read path. It exists to be folded and **compared**
+//! against `noetl.catalog`; the flip to serving is a separate decision
+//! (RFC §5).
+
+use std::collections::BTreeMap;
+
+/// Record types the fold understands.
+pub const EVENT_REGISTERED: &str = "catalog.registered";
+pub const EVENT_ARCHIVED: &str = "catalog.archived";
+pub const EVENT_RESTORED: &str = "catalog.restored";
+
+/// One entry in the relation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub catalog_id: i64,
+    pub path: String,
+    pub kind: String,
+    /// `i32`, not the source's `smallint`. 32,767 versions per path is a real
+    /// ceiling and an agent-driven registration loop is what finds it; widening
+    /// here costs nothing and does not require touching the source column.
+    pub version: i32,
+    pub content_sha256: String,
+    /// Derived from `catalog.archived` / `catalog.restored` applied in order —
+    /// **not** a stored flag. That is what makes re-archiving idempotent by
+    /// construction rather than by a `WHERE archived_at IS NULL` predicate
+    /// happening to be written that way.
+    pub archived: bool,
+}
+
+/// The folded catalog.
+#[derive(Debug, Default, Clone)]
+pub struct CatalogRelation {
+    by_key: BTreeMap<(String, i32), Entry>,
+    /// How many records the fold consumed, including ones it skipped. Reported
+    /// so "the log was empty" and "the log was unparseable" are distinguishable.
+    pub records_seen: usize,
+    pub records_applied: usize,
+}
+
+impl CatalogRelation {
+    /// Fold records **in the order given**.
+    ///
+    /// Order is the caller's responsibility and it is load-bearing: archive and
+    /// restore are last-write-wins over the same key, so folding them out of
+    /// sequence yields a different liveness answer. The tier returns records in
+    /// `global_sequence` order.
+    pub fn fold(records: &[serde_json::Value]) -> Self {
+        let mut r = Self::default();
+        for rec in records {
+            r.records_seen += 1;
+            let p = match rec.get("payload").and_then(|p| p.as_str()) {
+                Some(s) => match serde_json::from_str::<serde_json::Value>(s) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                },
+                None => rec.clone(),
+            };
+            if r.apply(&p) {
+                r.records_applied += 1;
+            }
+        }
+        r
+    }
+
+    fn apply(&mut self, p: &serde_json::Value) -> bool {
+        let Some(t) = p.get("event_type").and_then(|v| v.as_str()) else {
+            return false;
+        };
+        let path = p.get("path").and_then(|v| v.as_str()).unwrap_or_default();
+        if path.is_empty() {
+            return false;
+        }
+        let version = p.get("version").and_then(|v| v.as_i64()).map(|v| v as i32);
+
+        match t {
+            EVENT_REGISTERED => {
+                let (Some(version), Some(digest)) =
+                    (version, p.get("content_sha256").and_then(|v| v.as_str()))
+                else {
+                    // A registration with no version or no digest is not a
+                    // registration this fold can represent. Skipped rather than
+                    // defaulted: an empty digest would compare as a mismatch
+                    // against every source row.
+                    return false;
+                };
+                self.by_key.insert(
+                    (path.to_string(), version),
+                    Entry {
+                        catalog_id: p
+                            .get("catalog_id")
+                            .and_then(|v| {
+                                v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                            })
+                            .unwrap_or(0),
+                        path: path.to_string(),
+                        kind: p
+                            .get("kind")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        version,
+                        content_sha256: digest.to_string(),
+                        archived: false,
+                    },
+                );
+                true
+            }
+            EVENT_ARCHIVED | EVENT_RESTORED => {
+                let archived = t == EVENT_ARCHIVED;
+                match version {
+                    // A version-scoped archive touches exactly that entry.
+                    Some(v) => match self.by_key.get_mut(&(path.to_string(), v)) {
+                        Some(e) => {
+                            e.archived = archived;
+                            true
+                        }
+                        None => false,
+                    },
+                    // An absent version means EVERY version of the path — the
+                    // same semantics `CatalogDeleteRequest` documents, and the
+                    // reason there is deliberately no "latest" shorthand.
+                    None => {
+                        let mut hit = false;
+                        for ((p2, _), e) in self.by_key.iter_mut() {
+                            if p2 == path {
+                                e.archived = archived;
+                                hit = true;
+                            }
+                        }
+                        hit
+                    }
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Highest **non-archived** version of `path`.
+    ///
+    /// The archived filter is the whole subtlety: resolution by path is what
+    /// every execution does, and an archived entry is retired.
+    pub fn get_latest(&self, path: &str) -> Option<&Entry> {
+        self.by_key
+            .range((path.to_string(), i32::MIN)..=(path.to_string(), i32::MAX))
+            .filter(|((p, _), e)| p == path && !e.archived)
+            .next_back()
+            .map(|(_, e)| e)
+    }
+
+    pub fn get(&self, path: &str, version: i32) -> Option<&Entry> {
+        self.by_key.get(&(path.to_string(), version))
+    }
+
+    /// By surrogate key. Returns archived entries too — deliberately, matching
+    /// `resolve_catalog`, so a historical version can be re-run on purpose.
+    pub fn get_by_id(&self, catalog_id: i64) -> Option<&Entry> {
+        self.by_key.values().find(|e| e.catalog_id == catalog_id)
+    }
+
+    /// Every version of `path`, ascending, archived included.
+    pub fn list_versions(&self, path: &str) -> Vec<&Entry> {
+        self.by_key
+            .range((path.to_string(), i32::MIN)..=(path.to_string(), i32::MAX))
+            .filter(|((p, _), _)| p == path)
+            .map(|(_, e)| e)
+            .collect()
+    }
+
+    /// Live entries, optionally filtered by kind.
+    pub fn list_by_kind(&self, kind: Option<&str>) -> Vec<&Entry> {
+        self.by_key
+            .values()
+            .filter(|e| !e.archived && kind.is_none_or(|k| e.kind == k))
+            .collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_key.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.by_key.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reg(path: &str, v: i64, sha: &str, kind: &str, id: i64) -> serde_json::Value {
+        serde_json::json!({
+            "event_type": EVENT_REGISTERED, "path": path, "version": v,
+            "content_sha256": sha, "kind": kind, "catalog_id": id.to_string(),
+        })
+    }
+    fn arch(path: &str, v: Option<i64>) -> serde_json::Value {
+        let mut j = serde_json::json!({"event_type": EVENT_ARCHIVED, "path": path});
+        if let Some(v) = v {
+            j["version"] = serde_json::json!(v);
+        }
+        j
+    }
+    fn rest(path: &str, v: Option<i64>) -> serde_json::Value {
+        let mut j = serde_json::json!({"event_type": EVENT_RESTORED, "path": path});
+        if let Some(v) = v {
+            j["version"] = serde_json::json!(v);
+        }
+        j
+    }
+
+    #[test]
+    fn get_latest_is_the_highest_version() {
+        let r = CatalogRelation::fold(&[
+            reg("a", 1, "d1", "playbook", 1),
+            reg("a", 3, "d3", "playbook", 3),
+            reg("a", 2, "d2", "playbook", 2),
+        ]);
+        assert_eq!(r.get_latest("a").unwrap().version, 3);
+        assert_eq!(r.get("a", 2).unwrap().content_sha256, "d2");
+        assert_eq!(r.get_by_id(1).unwrap().version, 1);
+        assert_eq!(
+            r.list_versions("a").iter().map(|e| e.version).collect::<Vec<_>>(),
+            vec![1, 2, 3],
+            "list_versions must be ascending"
+        );
+    }
+
+    /// ⭐ get_latest must SKIP archived entries.
+    ///
+    /// Resolution by path is what every execution does, and an archived entry is
+    /// retired. A fold that agreed on every content digest while disagreeing
+    /// about liveness would pass a digest-only comparator and then resolve
+    /// get_latest to the wrong version — the exact trap the RFC names.
+    #[test]
+    fn get_latest_skips_archived_versions() {
+        let r = CatalogRelation::fold(&[
+            reg("a", 1, "d1", "playbook", 1),
+            reg("a", 2, "d2", "playbook", 2),
+            arch("a", Some(2)),
+        ]);
+        assert_eq!(
+            r.get_latest("a").unwrap().version,
+            1,
+            "archiving v2 must make v1 the latest, not leave v2 resolving"
+        );
+        assert!(r.get("a", 2).is_some(), "the archived entry still EXISTS by key");
+        assert!(r.get("a", 2).unwrap().archived);
+    }
+
+    /// An archive with no version retires every version of the path.
+    #[test]
+    fn a_versionless_archive_retires_the_whole_path() {
+        let r = CatalogRelation::fold(&[
+            reg("a", 1, "d1", "playbook", 1),
+            reg("a", 2, "d2", "playbook", 2),
+            reg("b", 1, "d3", "playbook", 3),
+            arch("a", None),
+        ]);
+        assert!(r.get_latest("a").is_none(), "every version of `a` is retired");
+        assert!(r.get_latest("b").is_some(), "a sibling path is untouched");
+    }
+
+    /// Archiving is idempotent, and restore is its inverse — by construction,
+    /// because liveness is derived from the sequence rather than stored.
+    #[test]
+    fn archive_is_idempotent_and_restore_inverts_it() {
+        let base = vec![reg("a", 1, "d1", "playbook", 1)];
+        let twice = CatalogRelation::fold(
+            &[base.clone(), vec![arch("a", Some(1)), arch("a", Some(1))]].concat(),
+        );
+        let once = CatalogRelation::fold(&[base.clone(), vec![arch("a", Some(1))]].concat());
+        assert_eq!(twice.get("a", 1), once.get("a", 1));
+
+        let restored =
+            CatalogRelation::fold(&[base, vec![arch("a", Some(1)), rest("a", Some(1))]].concat());
+        assert_eq!(restored.get_latest("a").unwrap().version, 1);
+    }
+
+    /// ⚠ ORDER is load-bearing: archive-then-restore and restore-then-archive
+    /// are different states, so folding out of sequence changes the answer.
+    #[test]
+    fn order_decides_liveness() {
+        let r1 = CatalogRelation::fold(&[
+            reg("a", 1, "d", "playbook", 1),
+            arch("a", Some(1)),
+            rest("a", Some(1)),
+        ]);
+        let r2 = CatalogRelation::fold(&[
+            reg("a", 1, "d", "playbook", 1),
+            rest("a", Some(1)),
+            arch("a", Some(1)),
+        ]);
+        assert!(r1.get_latest("a").is_some(), "restore last => live");
+        assert!(r2.get_latest("a").is_none(), "archive last => retired");
+    }
+
+    #[test]
+    fn list_by_kind_filters_and_excludes_archived() {
+        let r = CatalogRelation::fold(&[
+            reg("a", 1, "d1", "playbook", 1),
+            reg("b", 1, "d2", "agent", 2),
+            reg("c", 1, "d3", "playbook", 3),
+            arch("c", Some(1)),
+        ]);
+        let pbs: Vec<_> = r.list_by_kind(Some("playbook")).iter().map(|e| e.path.clone()).collect();
+        assert_eq!(pbs, vec!["a"], "archived `c` must not be listed");
+        assert_eq!(r.list_by_kind(None).len(), 2);
+        assert_eq!(r.list_by_kind(Some("agent")).len(), 1);
+    }
+
+    /// A malformed registration is SKIPPED, and the counters say so — "the log
+    /// was empty" and "the log was unparseable" must not read the same.
+    #[test]
+    fn malformed_records_are_skipped_and_counted() {
+        let mut nodigest = reg("a", 1, "d", "playbook", 1);
+        nodigest.as_object_mut().unwrap().remove("content_sha256");
+        let r = CatalogRelation::fold(&[nodigest, serde_json::json!({"nonsense": true})]);
+        assert!(r.is_empty());
+        assert_eq!(r.records_seen, 2);
+        assert_eq!(
+            r.records_applied, 0,
+            "seen != applied is what distinguishes an unparseable log from an empty one"
+        );
+    }
+
+    /// An archive for a path the fold has never seen changes nothing and is not
+    /// counted as applied — it is a gap in coverage, not a state transition.
+    #[test]
+    fn an_archive_for_an_unknown_path_is_not_applied() {
+        let r = CatalogRelation::fold(&[arch("ghost", Some(1))]);
+        assert!(r.is_empty());
+        assert_eq!(r.records_applied, 0);
+    }
+
+    /// Records wrapped in a tier `payload` string fold identically to inline ones.
+    #[test]
+    fn wrapped_and_inline_records_fold_identically() {
+        let inline = reg("a", 1, "d1", "playbook", 1);
+        let wrapped = serde_json::json!({"payload": inline.to_string()});
+        assert_eq!(
+            CatalogRelation::fold(&[inline]).get("a", 1),
+            CatalogRelation::fold(&[wrapped]).get("a", 1)
+        );
+    }
+}

--- a/src/handlers/catalog_relation.rs
+++ b/src/handlers/catalog_relation.rs
@@ -188,6 +188,11 @@ impl CatalogRelation {
             .collect()
     }
 
+    /// Every entry, in key order.
+    pub fn entries(&self) -> impl Iterator<Item = &Entry> {
+        self.by_key.values()
+    }
+
     pub fn len(&self) -> usize {
         self.by_key.len()
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -5,6 +5,7 @@
 pub mod auth;
 pub mod auth_verify;
 pub mod catalog;
+pub mod catalog_log;
 pub mod catalog_snapshot;
 pub mod cells;
 pub mod container_callback;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod auth_verify;
 pub mod catalog;
 pub mod catalog_log;
+pub mod catalog_relation;
 pub mod catalog_snapshot;
 pub mod cells;
 pub mod container_callback;

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,10 @@ fn build_router(
     // Catalog routes
     let catalog_routes = Router::new()
         .route("/api/catalog/register", post(handlers::catalog::register))
+        .route(
+            "/api/catalog/register/batch",
+            post(handlers::catalog::register_batch),
+        )
         .route("/api/catalog/delete", post(handlers::catalog::delete))
         .route("/api/catalog/list", post(handlers::catalog::list))
         .route("/api/catalog/restore", post(handlers::catalog::restore))
@@ -380,6 +384,14 @@ fn build_router(
         .route(
             "/api/catalog-log/verify",
             get(handlers::catalog_log::verify_endpoint),
+        )
+        .route(
+            "/api/catalog-log/coverage",
+            get(handlers::catalog_log::coverage_endpoint),
+        )
+        .route(
+            "/api/catalog-log/backfill",
+            post(handlers::catalog_log::backfill_endpoint),
         )
         .with_state(state.clone());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,6 +373,14 @@ fn build_router(
             "/api/ehdb/projection-recovery/equivalence",
             get(handlers::ehdb_projection_fold::equivalence_endpoint),
         )
+        // ai-meta#311 step 2 — the catalog log's fold-vs-source verifier. Same
+        // router, so it inherits the #303 gate for the same reason: it
+        // enumerates catalog content rather than answering about one id the
+        // caller already holds.
+        .route(
+            "/api/catalog-log/verify",
+            get(handlers::catalog_log::verify_endpoint),
+        )
         .with_state(state.clone());
 
     let ehdb_parity_routes = Router::new()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3572,6 +3572,11 @@ pub fn init_ehdb_projection_series() {
                 .inc_by(0);
         }
     }
+    for m in crate::handlers::catalog_log::MODES {
+        for o in crate::handlers::catalog_log::OUTCOMES {
+            catalog_log_total().with_label_values(&[m, o]).inc_by(0);
+        }
+    }
     for m in crate::handlers::catalog_snapshot::MODES {
         for o in crate::handlers::catalog_snapshot::OUTCOMES {
             catalog_snapshot_total().with_label_values(&[m, o]).inc_by(0);
@@ -4179,6 +4184,30 @@ pub fn ehdb_recovery_source_info() -> &'static IntGaugeVec {
             .expect("register ehdb_recovery_source_info");
         m
     })
+}
+
+/// Catalog-log records, by mode and outcome (noetl/ai-meta#311 step 2).
+pub fn catalog_log_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_catalog_log_total",
+                "Catalog registrations recorded to the catalog tier, by mode and outcome.",
+            ),
+            &["mode", "outcome"],
+        )
+        .expect("catalog_log_total metric");
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register catalog_log_total");
+        m
+    })
+}
+
+/// Record one catalog-log attempt.
+pub fn record_catalog_log(mode: &str, outcome: &str) {
+    catalog_log_total().with_label_values(&[mode, outcome]).inc();
 }
 
 /// Execution-start catalog snapshots, by mode and outcome.

--- a/src/services/catalog.rs
+++ b/src/services/catalog.rs
@@ -104,6 +104,24 @@ impl CatalogService {
         )
         .await?;
 
+        // Step 2 of the catalog relation: give the catalog a LOG.
+        //
+        // After the INSERT, never instead of it — the row is the source every
+        // read still resolves from, and this only *also* records the
+        // registration so the fold can be built and compared before anything
+        // depends on it.
+        //
+        // Returns `()` and swallows every failure: the row is already committed,
+        // and failing the request now would report a failure for work that
+        // succeeded — the caller would re-register and create a second version
+        // of an identical playbook.
+        //
+        // No-op unless `NOETL_CATALOG_LOG=shadow`.
+        crate::handlers::catalog_log::record_registration(
+            catalog_id, &path, &kind, version, &content,
+        )
+        .await;
+
         Ok(CatalogRegisterResponse {
             status: "success".to_string(),
             message: format!("Resource '{}' version '{}' registered.", path, version),


### PR DESCRIPTION
feat(catalog): give catalog registration a log

Step 2 of docs/rfc/ehdb-catalog-relation.md.  Additive and INERT:
NOETL_CATALOG_LOG defaults to off, the INSERT into noetl.catalog is untouched,
and every catalog read still resolves from Postgres.

noetl.catalog is not event-sourced -- register is a direct INSERT with no emit
site anywhere in the catalog service or handler.  A relation is by definition a
fold of a log, so the catalog relation had nothing to fold.  This is the producer
that gives it one, writing into the worker's new StoreTier::Catalog.

⚠ Deliberately NOT the event log.  A catalog record carries no execution_id and
has no row in noetl.event, so appending one to the eventlog tier would make the
cross-store parity comparator report extra_event -- a tier record with no
authoritative row -- which PAGES.  The new log gets its own store so it cannot
set off the alarm guarding the old one.

Dual-write, not a cutover: the record is written AFTER the row commits, never
instead of it, and record_registration returns unit and swallows every failure.
Failing the request at that point would report a failure for work that succeeded,
and the caller would re-register -- creating a second version of an identical
playbook.

fold_records is the function that turns the log into the relation's shape, keyed
by (path, version) in a BTreeMap so two folds of the same log compare equal.  It
skips foreign event types and records missing a key rather than folding defaults:
a record with no digest folding to an empty string would then compare as a
mismatch against every source row, reporting a parse gap as data divergence.

GET /api/catalog-log/verify folds the log and compares each entry against
noetl.catalog on content digest and kind.  Agreement requires compared > 0, since
an empty log has zero mismatches and calling that agreement is the vacuous pass.
A folded entry with no source row is counted separately as missing_in_source --
the log claiming a registration the catalog does not have is a different fault
from a digest disagreement.  The route sits in the #303-gated router because it
enumerates catalog content rather than answering about one id the caller holds.

Mutation-proven four ways, each restored: dropping the denominator makes an empty
log agree; accepting any event_type folds archives as registrations; defaulting a
missing digest to empty makes it mismatch everything; and hashing content even
slightly differently from the execution-snapshot module fails on "comparing them
reports data divergence for a hashing difference" -- the two are compared against
each other, so their hashing must not drift.

909 tests pass, no new clippy warnings.

Refs noetl/ai-meta#307