### PR TITLE
feat(catalog): stage the read-cutover and a gated dead-data survey

### DIFF
--- a/src/handlers/catalog_read.rs
+++ b/src/handlers/catalog_read.rs
@@ -1,0 +1,287 @@
+//! Where a catalog `get_latest` resolves from (`docs/rfc/ehdb-catalog-relation-step3.md` §5).
+//!
+//! **Staged, not flipped.** The default is `postgres`, which is byte-identical
+//! to today and costs a single branch. The cutover is a flag flip, and it is an
+//! owner decision.
+//!
+//! # The ladder
+//!
+//! | mode | behaviour |
+//! | :-- | :-- |
+//! | `postgres` *(default)* | today. No fold, no relay call, no extra query. |
+//! | `verify` | answer from Postgres **and** the relation, compare, record — serve **Postgres**. |
+//! | `tier` | serve the relation, falling back to Postgres when it has no answer. |
+//!
+//! Same shape as `ehdb_projection_read`'s ladder, deliberately: that one is
+//! live on prod and the discipline it encodes — measure before serving — is
+//! what made noetl/ai-meta#307 safe to enable.
+//!
+//! # Why the relation is cached
+//!
+//! A fold is over the whole catalog log — 1,601 records on prod, read in pages
+//! because the tier-service frame caps at 1 MiB. Folding that per execution
+//! would make `verify` far more expensive than the read it is checking, and an
+//! observability mode that degrades the thing it observes gets switched off and
+//! learns nothing. The fold is cached with a TTL, so `verify` costs at most one
+//! fold per interval.
+//!
+//! ⚠ The cache is the reason `tier` is not simply "flip it and go": a cached
+//! relation is **stale by construction** for up to the TTL, which is exactly the
+//! read-your-writes problem the RFC names (register-then-run). Serving from a
+//! cached fold without a read barrier would sometimes run the previous version —
+//! and that looks exactly like a successful run.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// `NOETL_CATALOG_READ_SOURCE` — where `get_latest` resolves from.
+pub const MODE_ENV: &str = "NOETL_CATALOG_READ_SOURCE";
+
+/// `NOETL_CATALOG_READ_CACHE_SECS` — how long a fold is reused.
+pub const CACHE_SECS_ENV: &str = "NOETL_CATALOG_READ_CACHE_SECS";
+
+pub const DEFAULT_CACHE_SECS: u64 = 60;
+
+/// Modes, pinned as metric labels.
+pub const MODES: [&str; 3] = ["postgres", "verify", "tier"];
+
+/// Comparison outcomes, pinned as metric labels.
+///
+/// `fold_missing` is deliberately distinct from `disagree`: "the relation does
+/// not have this path yet" and "the relation has a different answer" want
+/// opposite responses — the first is a coverage gap, the second is a fault.
+pub const OUTCOMES: [&str; 5] = [
+    "agree",
+    "disagree",
+    "fold_missing",
+    "source_missing",
+    "fold_unavailable",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Postgres,
+    Verify,
+    Tier,
+}
+
+impl Mode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Postgres => "postgres",
+            Self::Verify => "verify",
+            Self::Tier => "tier",
+        }
+    }
+    /// Whether the relation is consulted at all.
+    pub fn consults_relation(self) -> bool {
+        !matches!(self, Self::Postgres)
+    }
+    /// Whether the relation's answer may be **served**.
+    pub fn serves_relation(self) -> bool {
+        matches!(self, Self::Tier)
+    }
+}
+
+pub fn mode() -> Mode {
+    parse_mode(std::env::var(MODE_ENV).ok().as_deref())
+}
+
+/// The parse, without the environment — testable without `set_var`, which races.
+///
+/// Unrecognised resolves to `Postgres`, never forward to `tier`: a typo must not
+/// silently move catalog resolution onto an unproven path.
+pub fn parse_mode(raw: Option<&str>) -> Mode {
+    match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("verify") => Mode::Verify,
+        Some("tier") => Mode::Tier,
+        _ => Mode::Postgres,
+    }
+}
+
+fn cache_ttl() -> Duration {
+    Duration::from_secs(
+        std::env::var(CACHE_SECS_ENV)
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(DEFAULT_CACHE_SECS),
+    )
+}
+
+type Cached = Option<(Instant, crate::handlers::catalog_relation::CatalogRelation)>;
+
+fn cache() -> &'static Mutex<Cached> {
+    static C: OnceLock<Mutex<Cached>> = OnceLock::new();
+    C.get_or_init(|| Mutex::new(None))
+}
+
+/// The folded relation, refreshed at most once per TTL.
+///
+/// `None` when the fold could not be produced — which is reported as
+/// `fold_unavailable` rather than as an empty relation, because an unreachable
+/// log and an empty one must not read the same. That conflation cost a full gate
+/// round on the catalog-log verifier.
+pub async fn cached_relation() -> Option<crate::handlers::catalog_relation::CatalogRelation> {
+    {
+        let g = cache().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((at, rel)) = g.as_ref() {
+            if at.elapsed() < cache_ttl() {
+                return Some(rel.clone());
+            }
+        }
+    }
+    let fresh = crate::handlers::catalog_log::read_and_fold(
+        crate::handlers::catalog_log::FOLD_READ_CAP,
+    )
+    .await
+    .ok()?;
+    let mut g = cache().lock().unwrap_or_else(|e| e.into_inner());
+    *g = Some((Instant::now(), fresh.clone()));
+    Some(fresh)
+}
+
+/// Compare the relation's `get_latest` against the incumbent answer.
+///
+/// Returns the outcome label. **Never returns the relation's answer for use** —
+/// serving is a separate decision and a separate mode.
+pub fn compare_latest(
+    relation: Option<&crate::handlers::catalog_relation::CatalogRelation>,
+    path: &str,
+    incumbent_version: Option<i32>,
+) -> &'static str {
+    let Some(rel) = relation else {
+        return "fold_unavailable";
+    };
+    match (rel.get_latest(path), incumbent_version) {
+        (Some(e), Some(v)) if e.version == v => "agree",
+        (Some(_), Some(_)) => "disagree",
+        // The relation has an answer the source does not — the log claims a
+        // registration the catalog has retired or never had.
+        (Some(_), None) => "source_missing",
+        // The source has an answer the relation does not: a coverage gap, which
+        // the backfill exists to close. Not a fault.
+        (None, _) => "fold_missing",
+    }
+}
+
+/// Record one comparison.
+pub fn record(outcome: &str) {
+    crate::metrics::record_catalog_relation_read("get_latest", outcome);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::catalog_relation::CatalogRelation;
+
+    fn rel(path: &str, versions: &[(i64, bool)]) -> CatalogRelation {
+        let mut recs = Vec::new();
+        for (v, archived) in versions {
+            recs.push(serde_json::json!({
+                "event_type": "catalog.registered", "path": path, "version": v,
+                "content_sha256": format!("d{v}"), "kind": "playbook", "catalog_id": "1",
+            }));
+            if *archived {
+                recs.push(serde_json::json!({
+                    "event_type": "catalog.archived", "path": path, "version": v
+                }));
+            }
+        }
+        CatalogRelation::fold(&recs)
+    }
+
+    /// The default is postgres, so this lands without changing resolution.
+    #[test]
+    fn the_default_is_postgres() {
+        assert_eq!(parse_mode(None), Mode::Postgres);
+        assert_eq!(parse_mode(Some("")), Mode::Postgres);
+        assert!(!Mode::Postgres.consults_relation());
+        assert!(!Mode::Postgres.serves_relation());
+    }
+
+    /// A typo must not move catalog resolution onto the relation.
+    #[test]
+    fn an_unrecognised_mode_does_not_move_resolution() {
+        for junk in ["teir", "TIER!", "relation", "on", "true", "1"] {
+            assert_eq!(parse_mode(Some(junk)), Mode::Postgres, "{junk}");
+        }
+        assert_eq!(parse_mode(Some(" Verify ")), Mode::Verify);
+        assert_eq!(parse_mode(Some("TIER")), Mode::Tier);
+    }
+
+    /// ⭐ `verify` observes; only `tier` serves.
+    #[test]
+    fn verify_never_serves() {
+        assert!(Mode::Verify.consults_relation());
+        assert!(
+            !Mode::Verify.serves_relation(),
+            "verify is the measure-before-serving rung; if it serves, the rung does not exist"
+        );
+        assert!(Mode::Tier.serves_relation());
+    }
+
+    #[test]
+    fn agreement_is_on_the_resolved_version() {
+        let r = rel("a", &[(1, false), (2, false)]);
+        assert_eq!(compare_latest(Some(&r), "a", Some(2)), "agree");
+        assert_eq!(compare_latest(Some(&r), "a", Some(1)), "disagree");
+    }
+
+    /// ⚠ An archived latest changes the answer, and the comparison must see it.
+    ///
+    /// This is the trap the RFC names: a comparison on content alone would agree
+    /// while the two disagreed about which version resolves.
+    #[test]
+    fn archiving_the_latest_changes_what_agreement_means() {
+        let r = rel("a", &[(1, false), (2, true)]);
+        assert_eq!(
+            compare_latest(Some(&r), "a", Some(1)),
+            "agree",
+            "with v2 archived, v1 is the latest — agreeing with a source that says v1"
+        );
+        assert_eq!(
+            compare_latest(Some(&r), "a", Some(2)),
+            "disagree",
+            "a source still resolving to the archived v2 is a real disagreement"
+        );
+    }
+
+    /// A coverage gap is NOT a fault, and must not be reported as one.
+    #[test]
+    fn a_missing_path_is_a_coverage_gap_not_a_disagreement() {
+        let r = rel("a", &[(1, false)]);
+        assert_eq!(
+            compare_latest(Some(&r), "unknown", Some(1)),
+            "fold_missing",
+            "the relation not having a path yet is what the backfill closes, not a fault"
+        );
+        assert_ne!(compare_latest(Some(&r), "unknown", Some(1)), "disagree");
+    }
+
+    /// An unreachable fold is not an empty one.
+    #[test]
+    fn an_unavailable_fold_is_distinguishable_from_an_empty_one() {
+        assert_eq!(compare_latest(None, "a", Some(1)), "fold_unavailable");
+        let empty = CatalogRelation::fold(&[]);
+        assert_eq!(compare_latest(Some(&empty), "a", Some(1)), "fold_missing");
+    }
+
+    #[test]
+    fn every_label_is_pinned() {
+        for m in [Mode::Postgres, Mode::Verify, Mode::Tier] {
+            let e = match m {
+                Mode::Postgres => "postgres",
+                Mode::Verify => "verify",
+                Mode::Tier => "tier",
+            };
+            assert_eq!(m.as_str(), e);
+            assert!(MODES.contains(&m.as_str()));
+        }
+        assert_eq!(MODES.len(), 3);
+        assert_eq!(OUTCOMES.len(), 5);
+        for o in ["agree", "disagree", "fold_missing", "source_missing", "fold_unavailable"] {
+            assert!(OUTCOMES.contains(&o));
+        }
+    }
+}

--- a/src/handlers/dead_data.rs
+++ b/src/handlers/dead_data.rs
@@ -1,0 +1,326 @@
+//! Dead-data survey and archive rehearsal (noetl/ai-meta#308 / cleanup track).
+//!
+//! Read-only reporting plus a **rehearsal** that proves an archive-then-restore
+//! round trip works, without touching a single live row.
+//!
+//! # Why this exists as a typed endpoint
+//!
+//! The obvious way to answer "how big is the dead data" is arbitrary SQL through
+//! `POST /api/postgres/execute`. That endpoint takes any statement, is not
+//! auth-gated, and is [noetl/ai-meta#312](https://github.com/noetl/ai-meta/issues/312).
+//! A cleanup that begins by reaching for it would be using the very thing the
+//! cleanup is supposed to make unnecessary. This is the narrow, gated,
+//! read-only alternative: fixed queries, no caller-supplied SQL.
+//!
+//! # Nothing here deletes anything
+//!
+//! `report` reads counts. `rehearse` creates a scratch table, round-trips **one
+//! synthetic row** through it, and drops the scratch table. Neither reads a live
+//! row's contents nor writes to a live table. The destructive steps stay in the
+//! runbook, owner-run.
+
+use serde::Serialize;
+
+/// Tables the cleanup track is about.
+///
+/// A closed list, in code, because the alternative is a caller naming a table —
+/// which is `/api/postgres/execute` again with extra steps.
+pub const SURVEYED: [&str; 3] = ["outbox", "projection", "execution"];
+
+/// The scratch table the rehearsal uses. Named so it is obviously disposable and
+/// obviously not a real archive.
+pub const REHEARSAL_TABLE: &str = "noetl.__archive_rehearsal";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TableSurvey {
+    pub table: String,
+    pub exists: bool,
+    pub rows: Option<i64>,
+    /// `pg_total_relation_size`, which includes indexes and TOAST.
+    ///
+    /// ⚠ Returns 0 for a **partitioned parent**; the size lives on the
+    /// partitions. Reported as-is rather than silently summed, so a 0 here is
+    /// read as "ask the partitions", not "empty".
+    pub total_bytes: Option<i64>,
+    pub total_pretty: Option<String>,
+    /// Set only where the table has a meaningful liveness column.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live_rows: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// `GET /api/admin/dead-data/report` — the cleanup dry run.
+///
+/// Read-only. Counts and sizes only; no row contents leave the database.
+pub async fn report_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+) -> crate::error::AppResult<axum::Json<serde_json::Value>> {
+    let pool = state.pools.cluster();
+    let mut out: Vec<TableSurvey> = Vec::new();
+
+    for t in SURVEYED {
+        let full = format!("noetl.{t}");
+        let exists: Option<(bool,)> = sqlx::query_as(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+             WHERE table_schema = 'noetl' AND table_name = $1)",
+        )
+        .bind(t)
+        .fetch_optional(pool)
+        .await?;
+        let exists = exists.map(|(b,)| b).unwrap_or(false);
+        if !exists {
+            out.push(TableSurvey {
+                table: full,
+                exists: false,
+                rows: None,
+                total_bytes: None,
+                total_pretty: None,
+                live_rows: None,
+                note: Some("table not present".into()),
+            });
+            continue;
+        }
+
+        // Fixed identifiers from SURVEYED, never from the request.
+        let rows: Option<(i64,)> = sqlx::query_as(&format!("SELECT COUNT(*) FROM {full}"))
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten();
+        let size: Option<(i64, String)> = sqlx::query_as(
+            "SELECT pg_total_relation_size($1::regclass)::bigint, \
+             pg_size_pretty(pg_total_relation_size($1::regclass))",
+        )
+        .bind(&full)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+
+        // Per-table liveness, where the table has a column that expresses it.
+        let (live_rows, note) = match t {
+            "outbox" => {
+                let unpublished: Option<(i64,)> = sqlx::query_as(&format!(
+                    "SELECT COUNT(*) FROM {full} WHERE published_at IS NULL"
+                ))
+                .fetch_optional(pool)
+                .await
+                .ok()
+                .flatten();
+                (
+                    unpublished.map(|(n,)| n),
+                    Some(
+                        "live_rows = unpublished. A non-zero value means the outbox is \
+                         NOT dead and nothing may be dropped."
+                            .into(),
+                    ),
+                )
+            }
+            "projection" => (
+                None,
+                Some(
+                    "the DEAD table: noetl/ai-meta#265 found it has no Rust writer. The \
+                     live store is noetl.projection_snapshot — do not confuse them."
+                        .into(),
+                ),
+            ),
+            "execution" => (
+                None,
+                Some(
+                    "⚠ NOT dead. noetl/ai-meta#235 records that `status` is a frozen \
+                     Python-era column, which is a different claim from the table being \
+                     unused. Survey only."
+                        .into(),
+                ),
+            ),
+            _ => (None, None),
+        };
+
+        out.push(TableSurvey {
+            table: full,
+            exists: true,
+            rows: rows.map(|(n,)| n),
+            total_bytes: size.as_ref().map(|(b, _)| *b),
+            total_pretty: size.map(|(_, p)| p),
+            live_rows,
+            note,
+        });
+    }
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "admin.dead_data.report",
+        "outcome": "ok",
+        "read_only": true,
+        "tables": out,
+        "reminder": "This endpoint deletes nothing. The archive-then-drop steps are \
+                     owner-run and live in playbooks/dead-data-cleanup/.",
+    })))
+}
+
+/// `POST /api/admin/dead-data/rehearse` — prove the archive round trip is real.
+///
+/// Creates a scratch table, writes **one synthetic row**, reads it back, compares
+/// it, and drops the scratch table. It does not read or write a live row.
+///
+/// # What this actually establishes
+///
+/// That the server's role can `CREATE TABLE` in the `noetl` schema, write, read
+/// back byte-identically, and `DROP`. That is the whole archive-before-drop
+/// mechanism, exercised end to end. Without it, "we will archive first" is a
+/// plan whose first step has never been run — and the server's role is known to
+/// lack ownership on some tables (`must be owner of table event` appears in the
+/// boot log), so this is a real question rather than a formality.
+pub async fn rehearse_endpoint(
+    axum::extract::State(state): axum::extract::State<crate::state::AppState>,
+) -> crate::error::AppResult<axum::Json<serde_json::Value>> {
+    let pool = state.pools.cluster();
+    let mut steps: Vec<serde_json::Value> = Vec::new();
+    let mut ok = true;
+    let token = format!("rehearsal-{}", chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0));
+
+    macro_rules! step {
+        ($name:expr, $res:expr) => {{
+            match $res {
+                Ok(v) => {
+                    steps.push(serde_json::json!({"step": $name, "ok": true}));
+                    Some(v)
+                }
+                Err(e) => {
+                    ok = false;
+                    steps.push(serde_json::json!({
+                        "step": $name, "ok": false, "error": e.to_string()
+                    }));
+                    None
+                }
+            }
+        }};
+    }
+
+    // Always drop first: a leftover from a failed run must not make this pass by
+    // finding a table that already exists.
+    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {REHEARSAL_TABLE}"))
+        .execute(pool)
+        .await;
+
+    step!(
+        "create_archive_table",
+        sqlx::query(&format!(
+            "CREATE TABLE {REHEARSAL_TABLE} (id BIGINT PRIMARY KEY, payload TEXT NOT NULL)"
+        ))
+        .execute(pool)
+        .await
+    );
+    if ok {
+        step!(
+            "write_sample",
+            sqlx::query(&format!(
+                "INSERT INTO {REHEARSAL_TABLE} (id, payload) VALUES (1, $1)"
+            ))
+            .bind(&token)
+            .execute(pool)
+            .await
+        );
+    }
+    let mut round_trip = false;
+    if ok {
+        let read: Result<Option<(String,)>, _> =
+            sqlx::query_as(&format!("SELECT payload FROM {REHEARSAL_TABLE} WHERE id = 1"))
+                .fetch_optional(pool)
+                .await;
+        if let Some(v) = step!("read_back", read) {
+            // The comparison is the point. A rehearsal that created a table and
+            // never checked what came out would pass on a store that silently
+            // dropped the write.
+            round_trip = v.map(|(p,)| p) == Some(token.clone());
+            steps.push(serde_json::json!({
+                "step": "compare", "ok": round_trip,
+                "detail": if round_trip { "byte-identical" } else { "MISMATCH — the restore path is not real" }
+            }));
+            if !round_trip {
+                ok = false;
+            }
+        }
+    }
+    // Always attempt cleanup, even on failure: a rehearsal that leaves debris
+    // behind is a cleanup task of its own.
+    let dropped = sqlx::query(&format!("DROP TABLE IF EXISTS {REHEARSAL_TABLE}"))
+        .execute(pool)
+        .await
+        .is_ok();
+    steps.push(serde_json::json!({"step": "drop_scratch", "ok": dropped}));
+
+    Ok(axum::Json(serde_json::json!({
+        "action": "admin.dead_data.rehearse",
+        "outcome": if ok && round_trip && dropped { "ok" } else { "failed" },
+        "archive_path_writable": ok,
+        "round_trip_verified": round_trip,
+        "scratch_removed": dropped,
+        "touched_live_rows": false,
+        "steps": steps,
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The surveyed set is fixed in code, so no caller can name a table.
+    #[test]
+    fn the_surveyed_tables_are_a_closed_set() {
+        assert_eq!(SURVEYED, ["outbox", "projection", "execution"]);
+        for t in SURVEYED {
+            assert!(
+                !t.contains(';') && !t.contains(' ') && !t.contains('"'),
+                "{t} is interpolated into SQL; it must be a bare identifier"
+            );
+        }
+    }
+
+    /// The scratch table is obviously disposable and clearly not a real archive.
+    #[test]
+    fn the_rehearsal_table_is_obviously_scratch() {
+        assert!(REHEARSAL_TABLE.starts_with("noetl.__"));
+        assert!(REHEARSAL_TABLE.contains("rehearsal"));
+        for t in SURVEYED {
+            assert_ne!(
+                REHEARSAL_TABLE,
+                format!("noetl.{t}"),
+                "the rehearsal must never name a surveyed table"
+            );
+        }
+    }
+
+    /// ⚠ Nothing in this module deletes from a surveyed table.
+    ///
+    /// Counts CODE with `//` comments stripped, so the prose above cannot
+    /// satisfy the guard and deleting the prose cannot break it.
+    #[test]
+    fn this_module_never_deletes_from_a_live_table() {
+        let src = include_str!("dead_data.rs");
+        let code = src
+            .split_once("\n#[cfg(test)]")
+            .map(|(above, _)| above)
+            .unwrap_or(src);
+        let code: String = code
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for t in SURVEYED {
+            for verb in ["DELETE FROM", "TRUNCATE", "DROP TABLE"] {
+                let needle = format!("{verb} noetl.{t}");
+                assert!(
+                    !code.to_uppercase().contains(&needle.to_uppercase()),
+                    "this module must never `{verb}` a surveyed table, found: {needle}"
+                );
+            }
+        }
+        // Positive control: the guard can see a destructive statement, and does
+        // — the scratch table is dropped, on purpose.
+        assert!(
+            code.contains("DROP TABLE IF EXISTS"),
+            "the guard is not reading the code it thinks it is"
+        );
+    }
+}

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -594,7 +594,7 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
         Ok(entry)
     } else if let Some(path) = &request.path {
         // Lookup by path (latest version; Phase F R4-3: cluster-wide)
-        let entry = sqlx::query_as::<_, (i64, String)>(
+        let entry = sqlx::query_as::<_, (i64, String, i16)>(
             // noetl/ai-meta#237 — an archived entry is retired: it must not
             // resolve by PATH, which is how everything normally runs.
             // Resolution by explicit `catalog_id` (above) deliberately still
@@ -606,7 +606,10 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
             // it every execute-by-path returned 500. When absent this is the
             // empty string and the query is byte-identical to pre-soft-delete.
             &format!(
-                "SELECT catalog_id, path FROM noetl.catalog \
+                // `version` is selected for the catalog read-source
+                // comparison (RFC step 3 §5). Same query plan; the column is
+                // ignored entirely under the default `postgres` mode.
+                "SELECT catalog_id, path, version FROM noetl.catalog \
                      WHERE path = $1{archived} \
                      ORDER BY version DESC LIMIT 1",
                 archived = crate::db::queries::catalog::archived_filter()
@@ -617,7 +620,35 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Playbook not found: {}", path)))?;
 
-        Ok(entry)
+        // Catalog read-source ladder (RFC step 3 §5). Under the default
+        // `postgres` mode this is a single branch and returns immediately: no
+        // fold, no relay call, no extra query. A mode that is switched off must
+        // cost nothing, or "switched off" is not a real rollback.
+        //
+        // `verify` compares the relation's answer with the one just resolved and
+        // records the outcome; it serves the Postgres answer either way. `tier`
+        // is the cutover and is an owner decision — it is NOT taken here, and
+        // the relation's answer is never substituted below.
+        let m = crate::handlers::catalog_read::mode();
+        if m.consults_relation() {
+            let rel = crate::handlers::catalog_read::cached_relation().await;
+            let outcome = crate::handlers::catalog_read::compare_latest(
+                rel.as_ref(),
+                &entry.1,
+                Some(entry.2 as i32),
+            );
+            crate::handlers::catalog_read::record(outcome);
+            if outcome == "disagree" {
+                tracing::warn!(
+                    target: "noetl_server::catalog_read",
+                    path = %entry.1, incumbent_version = entry.2,
+                    "catalog relation disagrees with the incumbent on the resolved version; \
+                     serving the incumbent"
+                );
+            }
+        }
+
+        Ok((entry.0, entry.1))
     } else {
         Err(AppError::Validation(
             "Either path or catalog_id must be provided".to_string(),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -6,6 +6,8 @@ pub mod auth;
 pub mod auth_verify;
 pub mod catalog;
 pub mod catalog_log;
+pub mod dead_data;
+pub mod catalog_read;
 pub mod catalog_relation;
 pub mod catalog_snapshot;
 pub mod cells;

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,6 +393,18 @@ fn build_router(
             "/api/catalog-log/backfill",
             post(handlers::catalog_log::backfill_endpoint),
         )
+        // ai-meta#308 cleanup track. In the gated router deliberately: it
+        // enumerates table sizes and can create/drop a scratch table, so it is
+        // not the shape of thing to leave open — which is the whole point of it
+        // existing rather than reaching for /api/postgres/execute (#312).
+        .route(
+            "/api/admin/dead-data/report",
+            get(handlers::dead_data::report_endpoint),
+        )
+        .route(
+            "/api/admin/dead-data/rehearse",
+            post(handlers::dead_data::rehearse_endpoint),
+        )
         .with_state(state.clone());
 
     let ehdb_parity_routes = Router::new()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3572,6 +3572,11 @@ pub fn init_ehdb_projection_series() {
                 .inc_by(0);
         }
     }
+    for o in crate::handlers::catalog_read::OUTCOMES {
+        catalog_relation_read_total()
+            .with_label_values(&["get_latest", o])
+            .inc_by(0);
+    }
     for m in crate::handlers::catalog_log::MODES {
         for o in crate::handlers::catalog_log::OUTCOMES {
             catalog_log_total().with_label_values(&[m, o]).inc_by(0);
@@ -4184,6 +4189,32 @@ pub fn ehdb_recovery_source_info() -> &'static IntGaugeVec {
             .expect("register ehdb_recovery_source_info");
         m
     })
+}
+
+/// Catalog relation reads compared against the incumbent (RFC step 3 §5.1).
+pub fn catalog_relation_read_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_catalog_relation_read_total",
+                "Catalog relation reads by operation and outcome (agree/disagree/fold_missing/...).",
+            ),
+            &["operation", "outcome"],
+        )
+        .expect("catalog_relation_read_total metric");
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("register catalog_relation_read_total");
+        m
+    })
+}
+
+/// Record one relation-vs-incumbent comparison.
+pub fn record_catalog_relation_read(operation: &str, outcome: &str) {
+    catalog_relation_read_total()
+        .with_label_values(&[operation, outcome])
+        .inc();
 }
 
 /// Catalog-log records, by mode and outcome (noetl/ai-meta#311 step 2).

--- a/tests/catalog_snapshot_wiring.rs
+++ b/tests/catalog_snapshot_wiring.rs
@@ -76,3 +76,49 @@ fn the_snapshot_is_given_the_parsed_content_and_effective_workload() {
          for, not what ran:\n{call}"
     );
 }
+
+// ---- catalog read-source ladder (RFC step 3 §5) ----
+
+/// The ladder must be WIRED, or flipping the flag would do nothing.
+///
+/// An unreachable mode is the failure this codebase keeps finding: a flag that
+/// is set, documented, and read by nothing. `NOETL_CATALOG_READ_SOURCE=tier`
+/// must be a cutover, not a no-op.
+#[test]
+fn the_catalog_read_ladder_is_wired_into_resolution() {
+    assert!(
+        EXECUTE.contains("catalog_read::mode()"),
+        "resolve_catalog does not consult the read-source mode; the flag would be inert"
+    );
+    assert!(
+        EXECUTE.contains("catalog_read::compare_latest("),
+        "the comparison is never performed, so `verify` would measure nothing"
+    );
+}
+
+/// ⭐ The relation's answer is NOT served here.
+///
+/// This is the held decision. `verify` must resolve from Postgres, and the
+/// cutover must be a deliberate, separate change — not something that arrives
+/// by accident in a refactor.
+#[test]
+fn resolution_still_returns_the_incumbent_answer() {
+    let at = EXECUTE
+        .find("catalog_read::mode()")
+        .expect("the ladder must be wired");
+    let tail = &EXECUTE[at..];
+    let end = tail.find("} else {").expect("the by-path branch must end");
+    let block = &tail[..end];
+    assert!(
+        block.contains("Ok((entry.0, entry.1))"),
+        "resolution no longer returns the incumbent tuple — the read-cutover may \
+         have been taken by accident:\n{block}"
+    );
+    for forbidden in ["rel.get_latest", "relation.get_latest", "e.version)"] {
+        assert!(
+            !block.contains(forbidden),
+            "the relation's answer is being used to resolve; that is the held \
+             read-cutover, not a staging step: found `{forbidden}`"
+        );
+    }
+}


### PR DESCRIPTION
feat(catalog): stage the read-cutover and a gated dead-data survey

Two staged changes.  Both default to today's behaviour and neither takes a held
decision.

CATALOG READ-SOURCE LADDER (RFC step 3 section 5).
NOETL_CATALOG_READ_SOURCE = postgres (default) | verify | tier.  Under postgres
this is a single branch that returns immediately -- no fold, no relay call, no
extra query -- because a mode that is switched off must cost nothing or
"switched off" is not a real rollback.  verify compares the relation's
get_latest with the answer just resolved and records the outcome, serving the
incumbent either way.  tier is the cutover and is NOT taken.

It is WIRED, deliberately.  An unwired flag is the inert-and-unreachable failure
this codebase keeps finding: set, documented, and read by nothing.  A structural
guard asserts both halves -- that the ladder is consulted, and that resolution
still returns the incumbent tuple -- so the cutover cannot arrive by accident in
a refactor.  Mutation-proven: making it serve the relation's answer fails on
"the read-cutover may have been taken by accident".

The relation is cached with a TTL because a fold spans the whole catalog log --
1,601 records on prod, read in pages against a 1 MiB frame cap -- and folding
that per execution would make verify more expensive than the read it checks.  An
observability mode that degrades what it observes gets switched off and teaches
nothing.  The cache is also why tier is not merely a flip: a cached relation is
stale by construction for up to the TTL, which is the read-your-writes problem
the RFC names.

fold_missing is a distinct outcome from disagree.  "The relation does not have
this path yet" is a coverage gap the backfill closes; "the relation has a
different answer" is a fault.  They want opposite responses, and collapsing them
would have made the backfill's own progress look like divergence.  Likewise an
unreachable fold reports fold_unavailable rather than reading as an empty one.

DEAD-DATA SURVEY.  GET /api/admin/dead-data/report counts rows and sizes for
outbox, projection and execution over a closed, in-code table list; POST
.../rehearse proves an archive round trip by creating a scratch table, writing
ONE synthetic row, reading it back, comparing it, and dropping the table.
Neither reads nor writes a live row, and a guard counts CODE to assert this
module never DELETEs, TRUNCATEs or DROPs a surveyed table -- with a positive
control so the guard is known to be reading what it thinks.

The rehearsal earns its place: "we will archive first" is otherwise a plan whose
first step has never been run, and the server's role is known to lack ownership
on some tables ("must be owner of table event" appears in the boot log), so
whether it can create and drop an archive table is a real question.

Both endpoints sit in the #303-gated router.  They exist partly because the
obvious alternative -- arbitrary SQL through POST /api/postgres/execute -- is
unauthenticated and unrestricted (noetl/ai-meta#312), and a cleanup that began by
reaching for it would be using the thing the cleanup should make unnecessary.

933 tests pass.  Eight mutations across the two modules, each restored.

Refs noetl/ai-meta#307, noetl/ai-meta#308, noetl/ai-meta#312