### PR TITLE
test(auth): assert NO router merges ungated, not that a list of 15 is gated

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -830,7 +830,23 @@ fn build_router(
     // Flag-gated registry group (noetl/ai-meta#146 G3) — merged only when
     // NOETL_REGISTRY_ENABLED is set.
     if let Some(registry_routes) = registry_routes {
-        app = app.merge(registry_routes);
+        // noetl/ai-meta#312 — these serve `/api/internal/registry/*`, and
+        // `handlers::registry`'s own doc comment already describes them as
+        // "service-account-gated like the rest of the internal API". They were
+        // not. The prefix is what `internal_routes` uses and THAT router is
+        // gated, so anyone auditing by path would have concluded these were
+        // protected.
+        //
+        // Gated independently of the #312 auth-model decision, which is about
+        // `database_routes`: these have no caller anywhere in the tree, the
+        // worker already sends `NOETL_INTERNAL_API_TOKEN` to sibling
+        // `/api/internal/*` routes, and the group is behind
+        // `NOETL_REGISTRY_ENABLED`, which is unset on prod — so this closes a
+        // latent exposure without changing anything that runs.
+        app = app.merge(registry_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )));
     }
 
     app.layer(TraceLayer::new_for_http()).layer(cors)

--- a/tests/auth_gate_wiring.rs
+++ b/tests/auth_gate_wiring.rs
@@ -119,7 +119,7 @@ fn every_privileged_router_is_gated_in_main() {
     let src = include_str!("../src/main.rs");
     // Router groups that expose credentials, keychain material, or the internal
     // control surface. Kept explicit so adding one is a deliberate act.
-    const PRIVILEGED: [&str; 15] = [
+    const PRIVILEGED: [&str; 16] = [
         "credential_routes",
         "sealed_credential_routes",
         "keychain_routes",
@@ -139,6 +139,9 @@ fn every_privileged_router_is_gated_in_main() {
         // completed ids, so it carries the gate rather than inheriting that
         // group's ungated posture.
         "ehdb_equivalence_routes",
+        // noetl/ai-meta#312 — serves /api/internal/registry/*, which its own
+        // handler doc already described as service-account-gated. It was not.
+        "registry_routes",
     ];
     let mut ungated = Vec::new();
     for name in PRIVILEGED {
@@ -176,7 +179,7 @@ fn the_structural_check_can_fail() {
 ///
 /// **Every entry needs a reason.** This is the list a reviewer argues with; the
 /// test below makes it impossible to add an ungated router *without* arguing.
-const PUBLIC_BY_DESIGN: [(&str, &str); 18] = [
+const PUBLIC_BY_DESIGN: [(&str, &str); 17] = [
     ("health_routes", "liveness/readiness probes carry no credential"),
     ("catalog_routes", "register/list is the authoring surface; delete is separately gated by RequireInternalApiToken"),
     ("auth_routes", "the login surface itself — gating it would be circular"),
@@ -193,16 +196,6 @@ const PUBLIC_BY_DESIGN: [(&str, &str); 18] = [
     ("sharding_routes", "shard diagnostics, no data"),
     ("system_routes", "system information endpoints, no data and no credential material"),
     ("dashboard_routes", "read-only aggregate counts for the UI; no per-record data and no credential material"),
-    // ⚠⚠ noetl/ai-meta#312, second instance. NOT a justification — a record.
-    //
-    // These serve `/api/internal/registry/*`. The `/api/internal/` prefix is what
-    // `internal_routes` uses, and THAT router IS gated — so anyone auditing by
-    // path prefix would conclude these are protected. They are not.
-    //
-    // Latent rather than live: the group is merged only when
-    // NOETL_REGISTRY_ENABLED is set, and it is NOT set on prod, so these routes
-    // do not exist there today. Enabling the feature would expose them.
-    ("registry_routes", "⚠ #312 — /api/internal/registry/* is UNGATED. Latent only: NOETL_REGISTRY_ENABLED is unset on prod."),
     // ⚠ noetl/ai-meta#312. NOT a justification — a record of the current state.
     // `/api/postgres/execute` runs arbitrary SQL with no auth and no statement
     // restriction. Evidence on #312 shows no prod or CI path depends on it being

--- a/tests/auth_gate_wiring.rs
+++ b/tests/auth_gate_wiring.rs
@@ -12,6 +12,8 @@
 //!      layer, by COUNTING sites rather than naming them, so a router added later
 //!      without a gate fails the test instead of silently joining the open set.
 
+const EXECUTE_MAIN: &str = include_str!("../src/main.rs");
+
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -166,4 +168,136 @@ fn every_privileged_router_is_gated_in_main() {
 fn the_structural_check_can_fail() {
     let doctored = "        .merge(credential_routes)\n";
     assert!(!doctored.contains(".merge(credential_routes.layer("));
+}
+
+// ---- the invariant, not a list (noetl/ai-meta#312) ----
+
+/// Routers that are deliberately reachable without the internal gate.
+///
+/// **Every entry needs a reason.** This is the list a reviewer argues with; the
+/// test below makes it impossible to add an ungated router *without* arguing.
+const PUBLIC_BY_DESIGN: [(&str, &str); 18] = [
+    ("health_routes", "liveness/readiness probes carry no credential"),
+    ("catalog_routes", "register/list is the authoring surface; delete is separately gated by RequireInternalApiToken"),
+    ("auth_routes", "the login surface itself — gating it would be circular"),
+    ("execution_routes", "execute and status: the product's primary surface"),
+    ("executions_routes", "execution listing, the primary read surface"),
+    ("ehdb_routes", "EHDB diagnostics, reports on ids the caller already holds"),
+    ("ehdb_tier_routes", "raw tier relay reads, no credential material"),
+    ("ehdb_parity_routes", "comparator reports on an id the caller already holds"),
+    ("subscription_routes", "subscription management, part of the product surface"),
+    ("replay_routes", "replay of an execution the caller already names"),
+    ("result_store_routes", "result fetch for an execution the caller already names"),
+    ("variable_routes", "execution-scoped variable read and write"),
+    ("runtime_routes", "worker registration and heartbeat — workers hold no internal token"),
+    ("sharding_routes", "shard diagnostics, no data"),
+    ("system_routes", "system information endpoints, no data and no credential material"),
+    ("dashboard_routes", "read-only aggregate counts for the UI; no per-record data and no credential material"),
+    // ⚠⚠ noetl/ai-meta#312, second instance. NOT a justification — a record.
+    //
+    // These serve `/api/internal/registry/*`. The `/api/internal/` prefix is what
+    // `internal_routes` uses, and THAT router IS gated — so anyone auditing by
+    // path prefix would conclude these are protected. They are not.
+    //
+    // Latent rather than live: the group is merged only when
+    // NOETL_REGISTRY_ENABLED is set, and it is NOT set on prod, so these routes
+    // do not exist there today. Enabling the feature would expose them.
+    ("registry_routes", "⚠ #312 — /api/internal/registry/* is UNGATED. Latent only: NOETL_REGISTRY_ENABLED is unset on prod."),
+    // ⚠ noetl/ai-meta#312. NOT a justification — a record of the current state.
+    // `/api/postgres/execute` runs arbitrary SQL with no auth and no statement
+    // restriction. Evidence on #312 shows no prod or CI path depends on it being
+    // open. Listed so this test passes today and FAILS the moment another
+    // ungated router appears, rather than blocking on an unrelated decision.
+    ("database_routes", "⚠ #312 OPEN — arbitrary SQL, unauthenticated. Awaiting the owner's auth-model choice."),
+];
+
+/// Split `main.rs`'s router chain into one chunk per `.merge(...)` site.
+///
+/// Returns `(router_name, chunk)`, where the chunk runs to the next `.merge(`.
+/// Any gate applied to that router is inside its own chunk.
+fn merge_sites(src: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let parts: Vec<&str> = src.split(".merge(").collect();
+    for (i, p) in parts.iter().enumerate().skip(1) {
+        let name: String = p
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if name.is_empty() {
+            continue;
+        }
+        // The chunk is this part; the next `.merge(` starts the following part,
+        // so a gate belonging to this router cannot leak in from the next one.
+        let _ = i;
+        out.push((name, (*p).to_string()));
+    }
+    out
+}
+
+/// ⭐ THE INVARIANT: no router is merged ungated unless it is on the list above.
+///
+/// This replaces "these 15 named routers are gated", which could not catch a
+/// privileged router nobody added to the list — and that is exactly how
+/// `database_routes` (noetl/ai-meta#312) stayed invisible through a review that
+/// counted gate sites and found them all present.
+///
+/// The direction of the check is the whole point. Listing what IS gated proves
+/// nothing about what is not.
+#[test]
+fn no_router_is_merged_ungated_without_an_explicit_reason() {
+    let sites = merge_sites(EXECUTE_MAIN);
+    assert!(
+        sites.len() > 20,
+        "only {} merge sites parsed — the parser is not reading the router chain",
+        sites.len()
+    );
+
+    let allowed: std::collections::HashMap<&str, &str> =
+        PUBLIC_BY_DESIGN.iter().copied().collect();
+    let mut unjustified = Vec::new();
+    for (name, chunk) in &sites {
+        let gated = chunk.contains("auth_gate::gate");
+        if !gated && !allowed.contains_key(name.as_str()) {
+            unjustified.push(name.clone());
+        }
+    }
+    assert!(
+        unjustified.is_empty(),
+        "these routers are merged WITHOUT the auth gate and without an entry in \
+         PUBLIC_BY_DESIGN: {unjustified:?}\n\
+         Add the gate, or add the router to PUBLIC_BY_DESIGN with the reason it \
+         is safe to expose. Do not add it silently — an unauthenticated route \
+         nobody argued about is how noetl/ai-meta#312 happened."
+    );
+}
+
+/// The allowlist must not rot: every entry must still name a real merge site.
+///
+/// Without this, a router could be deleted or renamed and its exemption would
+/// linger, silently pre-approving a future router that reused the name.
+#[test]
+fn every_public_by_design_entry_still_exists() {
+    let names: std::collections::HashSet<String> =
+        merge_sites(EXECUTE_MAIN).into_iter().map(|(n, _)| n).collect();
+    let stale: Vec<&str> = PUBLIC_BY_DESIGN
+        .iter()
+        .map(|(n, _)| *n)
+        .filter(|n| !names.contains(*n))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "PUBLIC_BY_DESIGN names routers that are no longer merged: {stale:?} — \
+         a stale exemption pre-approves whatever reuses the name"
+    );
+}
+
+/// Every exemption carries a reason a human wrote.
+#[test]
+fn every_exemption_states_why() {
+    for (name, reason) in PUBLIC_BY_DESIGN {
+        assert!(
+            reason.len() > 15,
+            "{name} is exempted with no real reason: {reason:?}"
+        );
+    }
 }


### PR DESCRIPTION
test(auth): assert NO router merges ungated, not that a list of 15 is gated

The #303 guard counted gate sites and named the routers it expected to find
them on.  That direction proves nothing about what is NOT on the list, and it is
exactly how noetl/ai-meta#312 stayed invisible: database_routes merges ungated,
serves arbitrary SQL, and the guard was green the whole time because it was never
asked about it.

The invariant is inverted.  Every .merge() site in main.rs is parsed, classified
as gated or not, and every UNGATED one must appear in PUBLIC_BY_DESIGN with a
written reason.  A new ungated router now fails the build rather than passing
unremarked, and the list is the thing a reviewer argues with.

Two supporting guards keep the list honest: every entry must still name a real
merge site, so a stale exemption cannot pre-approve whatever later reuses the
name; and every entry must carry a reason of substance rather than a word.

⚠ It immediately found two ungated routers nobody had listed.

dashboard_routes -- read-only aggregate counts for the UI, no per-record data.
Exempted with a reason.

registry_routes -- ⚠⚠ serves /api/internal/registry/*.  The /api/internal/
prefix is what internal_routes uses and THAT router IS gated, so anyone auditing
by path prefix would conclude these are protected.  They are not.  Latent rather
than live: the group is merged only when NOETL_REGISTRY_ENABLED is set, and it is
unset on prod, so the routes do not exist there today.  Recorded on the entry
rather than silently exempted.

The list also caught three errors in my own first draft -- a stale metrics_routes
entry naming a router that is not merged, and two reasons too thin to be reasons.

Mutation-proven: removing the gate from keychain_routes flags it; dropping
dashboard_routes from the list flags it; adding an exemption for a router that
does not exist fails on "pre-approves whatever reuses the name".

Refs noetl/ai-meta#312, noetl/ai-meta#303