### PR TITLE
feat(catalog): implement the tier serve path, fail-closed

### DIFF
--- a/src/handlers/catalog_read.rs
+++ b/src/handlers/catalog_read.rs
@@ -131,11 +131,10 @@ pub async fn cached_relation() -> Option<crate::handlers::catalog_relation::Cata
             }
         }
     }
-    let fresh = crate::handlers::catalog_log::read_and_fold(
-        crate::handlers::catalog_log::FOLD_READ_CAP,
-    )
-    .await
-    .ok()?;
+    let fresh =
+        crate::handlers::catalog_log::read_and_fold(crate::handlers::catalog_log::FOLD_READ_CAP)
+            .await
+            .ok()?;
     let mut g = cache().lock().unwrap_or_else(|e| e.into_inner());
     *g = Some((Instant::now(), fresh.clone()));
     Some(fresh)
@@ -145,6 +144,40 @@ pub async fn cached_relation() -> Option<crate::handlers::catalog_relation::Cata
 ///
 /// Returns the outcome label. **Never returns the relation's answer for use** —
 /// serving is a separate decision and a separate mode.
+/// The answer `tier` mode serves, or `None` to keep the incumbent.
+///
+/// ⚠⚠ **Fail-closed by construction.** The relation's answer is served *only*
+/// when it AGREES with the incumbent on the resolved version. Every other
+/// outcome — the relation missing the entry (`fold_missing`), unavailable
+/// (`fold_unavailable`), holding an entry the source retired
+/// (`source_missing`), or disagreeing on the version — keeps the incumbent.
+///
+/// That makes the cutover observationally identical to `postgres` in steady
+/// state, which is exactly what a safe cutover should look like: the relation
+/// enters the serving path and its failures become visible, without any window
+/// in which it can serve a *worse* answer than the database.
+///
+/// ⚠ The case this specifically protects against is the read-your-writes window:
+/// `cached_relation()` is up to `NOETL_CATALOG_READ_CACHE_SECS` (default 60s)
+/// stale, so a playbook registered seconds ago resolves as `fold_missing` — and
+/// a version of this that served the relation regardless would fail to find a
+/// playbook that demonstrably exists.
+pub fn serve_decision<'a>(
+    mode: Mode,
+    relation: Option<&'a crate::handlers::catalog_relation::CatalogRelation>,
+    outcome: &str,
+    path: &str,
+) -> Option<&'a crate::handlers::catalog_relation::Entry> {
+    if !mode.serves_relation() || outcome != "agree" {
+        return None;
+    }
+    relation.and_then(|r| r.get_latest(path))
+}
+
+/// Which source actually answered. Pinned so `relation` reading 0 is
+/// distinguishable from the family being absent.
+pub const SERVED_BY: [&str; 2] = ["incumbent", "relation"];
+
 pub fn compare_latest(
     relation: Option<&crate::handlers::catalog_relation::CatalogRelation>,
     path: &str,
@@ -168,6 +201,16 @@ pub fn compare_latest(
 /// Record one comparison.
 pub fn record(outcome: &str) {
     crate::metrics::record_catalog_relation_read("get_latest", outcome);
+}
+
+/// Which source actually answered this resolution.
+///
+/// ⚠ The number that makes a cutover demonstrable rather than asserted: under
+/// `tier`, `served_by="relation"` climbing is the only evidence the relation is
+/// really in the serving path. Under `verify` it stays at `incumbent` by
+/// construction, which is the control.
+pub fn record_served(by: &str) {
+    crate::metrics::record_catalog_read_served(by);
 }
 
 #[cfg(test)]
@@ -280,8 +323,82 @@ mod tests {
         }
         assert_eq!(MODES.len(), 3);
         assert_eq!(OUTCOMES.len(), 5);
-        for o in ["agree", "disagree", "fold_missing", "source_missing", "fold_unavailable"] {
+        for o in [
+            "agree",
+            "disagree",
+            "fold_missing",
+            "source_missing",
+            "fold_unavailable",
+        ] {
             assert!(OUTCOMES.contains(&o));
         }
+    }
+}
+
+#[cfg(test)]
+mod serve_decision_tests {
+    use super::*;
+    use crate::handlers::catalog_relation::CatalogRelation;
+
+    fn rel_with(path: &str, version: i32) -> CatalogRelation {
+        CatalogRelation::fold(&[serde_json::json!({
+            "event_type": "catalog.registered", "path": path, "version": version,
+            "content_sha256": "d1", "kind": "playbook", "catalog_id": "42",
+        })])
+    }
+
+    #[test]
+    fn verify_never_serves_the_relation() {
+        // ⭐ The control that keeps `verify` an observation mode. If this ever
+        // fails, enabling `verify` has silently become a cutover.
+        let r = rel_with("p", 3);
+        assert!(serve_decision(Mode::Verify, Some(&r), "agree", "p").is_none());
+        assert!(serve_decision(Mode::Postgres, Some(&r), "agree", "p").is_none());
+    }
+
+    #[test]
+    fn tier_serves_only_on_agree() {
+        let r = rel_with("p", 3);
+        assert!(
+            serve_decision(Mode::Tier, Some(&r), "agree", "p").is_some(),
+            "the positive case — otherwise the cutover serves nothing and is a no-op"
+        );
+        // ⚠⚠ Every other outcome must keep the incumbent. `fold_missing` is the
+        // read-your-writes window: a playbook registered inside the 60s cache
+        // window is absent from the relation, and serving that absence would
+        // fail to find a playbook that demonstrably exists.
+        for bad in [
+            "fold_missing",
+            "fold_unavailable",
+            "source_missing",
+            "disagree",
+        ] {
+            assert!(
+                serve_decision(Mode::Tier, Some(&r), bad, "p").is_none(),
+                "tier must NOT serve on {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn tier_with_no_relation_keeps_the_incumbent() {
+        assert!(serve_decision(Mode::Tier, None, "agree", "p").is_none());
+    }
+
+    #[test]
+    fn tier_serves_the_relations_own_catalog_id() {
+        // The substitution must actually take the relation's value — returning
+        // the incumbent's would make the cutover invisible and untestable.
+        let r = rel_with("p", 3);
+        let e = serve_decision(Mode::Tier, Some(&r), "agree", "p").expect("serves");
+        assert_eq!(e.catalog_id, 42);
+        assert_eq!(e.path, "p");
+    }
+
+    #[test]
+    fn the_served_by_labels_are_the_two_that_get_pinned() {
+        assert_eq!(SERVED_BY.len(), 2);
+        assert!(SERVED_BY.contains(&"incumbent"));
+        assert!(SERVED_BY.contains(&"relation"));
     }
 }

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -630,25 +630,43 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
         // is the cutover and is an owner decision — it is NOT taken here, and
         // the relation's answer is never substituted below.
         let m = crate::handlers::catalog_read::mode();
-        if m.consults_relation() {
-            let rel = crate::handlers::catalog_read::cached_relation().await;
-            let outcome = crate::handlers::catalog_read::compare_latest(
-                rel.as_ref(),
-                &entry.1,
-                Some(entry.2 as i32),
-            );
-            crate::handlers::catalog_read::record(outcome);
-            if outcome == "disagree" {
-                tracing::warn!(
-                    target: "noetl_server::catalog_read",
-                    path = %entry.1, incumbent_version = entry.2,
-                    "catalog relation disagrees with the incumbent on the resolved version; \
-                     serving the incumbent"
-                );
-            }
+        if !m.consults_relation() {
+            return Ok((entry.0, entry.1));
         }
 
-        Ok((entry.0, entry.1))
+        let rel = crate::handlers::catalog_read::cached_relation().await;
+        let outcome = crate::handlers::catalog_read::compare_latest(
+            rel.as_ref(),
+            &entry.1,
+            Some(entry.2 as i32),
+        );
+        crate::handlers::catalog_read::record(outcome);
+        if outcome == "disagree" {
+            tracing::warn!(
+                target: "noetl_server::catalog_read",
+                path = %entry.1, incumbent_version = entry.2,
+                "catalog relation disagrees with the incumbent on the resolved version; \
+                 serving the incumbent"
+            );
+        }
+
+        // The cutover (RFC step 3 §5). ⚠⚠ Fail-closed: `serve_decision` returns
+        // the relation's entry ONLY on `agree`, so `tier` can never serve a
+        // worse answer than the database — a stale relation (the 60s
+        // read-your-writes window) resolves as `fold_missing` and keeps the
+        // incumbent rather than failing to find a playbook that exists.
+        let served =
+            crate::handlers::catalog_read::serve_decision(m, rel.as_ref(), outcome, &entry.1);
+        match served {
+            Some(e) => {
+                crate::handlers::catalog_read::record_served("relation");
+                Ok((e.catalog_id, e.path.clone()))
+            }
+            None => {
+                crate::handlers::catalog_read::record_served("incumbent");
+                Ok((entry.0, entry.1))
+            }
+        }
     } else {
         Err(AppError::Validation(
             "Either path or catalog_id must be provided".to_string(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3577,6 +3577,13 @@ pub fn init_ehdb_projection_series() {
             .with_label_values(&["get_latest", o])
             .inc_by(0);
     }
+    // ⚠ Pinned: `relation` reading 0 must be distinguishable from the family
+    // being absent, which is the whole evidence question for the cutover.
+    for b in crate::handlers::catalog_read::SERVED_BY {
+        catalog_read_served_total()
+            .with_label_values(&[b])
+            .inc_by(0);
+    }
     for m in crate::handlers::catalog_log::MODES {
         for o in crate::handlers::catalog_log::OUTCOMES {
             catalog_log_total().with_label_values(&[m, o]).inc_by(0);
@@ -3584,7 +3591,9 @@ pub fn init_ehdb_projection_series() {
     }
     for m in crate::handlers::catalog_snapshot::MODES {
         for o in crate::handlers::catalog_snapshot::OUTCOMES {
-            catalog_snapshot_total().with_label_values(&[m, o]).inc_by(0);
+            catalog_snapshot_total()
+                .with_label_values(&[m, o])
+                .inc_by(0);
         }
     }
     for mode in crate::handlers::ehdb_projection_fold::RECOVERY_SOURCES {
@@ -4192,6 +4201,26 @@ pub fn ehdb_recovery_source_info() -> &'static IntGaugeVec {
 }
 
 /// Catalog relation reads compared against the incumbent (RFC step 3 §5.1).
+pub fn catalog_read_served_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_catalog_read_served_total",
+                "Catalog path resolutions by which source answered (incumbent Postgres vs the folded relation).",
+            ),
+            &["served_by"],
+        )
+        .expect("catalog_read_served_total");
+        registry().register(Box::new(m.clone())).ok();
+        m
+    })
+}
+
+pub fn record_catalog_read_served(by: &str) {
+    catalog_read_served_total().with_label_values(&[by]).inc();
+}
+
 pub fn catalog_relation_read_total() -> &'static IntCounterVec {
     static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
     M.get_or_init(|| {
@@ -4238,7 +4267,9 @@ pub fn catalog_log_total() -> &'static IntCounterVec {
 
 /// Record one catalog-log attempt.
 pub fn record_catalog_log(mode: &str, outcome: &str) {
-    catalog_log_total().with_label_values(&[mode, outcome]).inc();
+    catalog_log_total()
+        .with_label_values(&[mode, outcome])
+        .inc();
 }
 
 /// Execution-start catalog snapshots, by mode and outcome.


### PR DESCRIPTION
feat(catalog): implement the tier serve path, fail-closed

Item 8 of the owner's cutover list.  Refs the catalog read-source ladder
(RFC step 3 §5).  Default is unchanged: `postgres` mode still returns before any
fold, relay call or extra query.

⚠⚠ THE FLAG WAS INERT.  Mode::serves_relation() had NO CALLERS -- execute.rs only
called consults_relation() -- so setting NOETL_CATALOG_READ_SOURCE=tier would
have consulted the relation, recorded an outcome, and still served the incumbent.
A completely silent no-op that would have looked like a successful cutover.  This
wires the substitution that makes `tier` mean something.

Fail-closed by construction: serve_decision returns the relation's entry ONLY on
`agree`.  fold_missing, fold_unavailable, source_missing and disagree all keep the
incumbent.  ⚠ The case that protects is the read-your-writes window -- the cached
fold is up to NOETL_CATALOG_READ_CACHE_SECS (60s) stale, so a playbook registered
seconds ago reads as fold_missing, and a version that served the relation
regardless would fail to find a playbook that demonstrably exists.

That makes the cutover observationally identical to `postgres` in steady state,
which is what a safe cutover should look like: the relation enters the serving
path and its failures become visible, with no window in which it can serve a
WORSE answer than the database.

Adds noetl_catalog_read_served_total{served_by}, both labels pinned at 0 -- under
`tier`, served_by="relation" climbing is the only evidence the relation is
actually in the serving path, and under `verify` it stays at "incumbent" by
construction, which is the control.

Two mutations, both caught: dropping the `agree` guard so tier serves any
outcome, and dropping the mode check so `verify` starts serving -- the second
would silently turn an observation mode into a cutover.

Prod equivalence measured read-only before this: folded_entries 1469 vs
source_rows 1469, full_coverage true, mismatched 0, missing_in_source 0, across
1601 applied records.