### PR TITLE
fix(metrics): the giveup counter was registered on the wrong registry

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -218,8 +218,15 @@ pub fn reconcile_giveup_total() -> &'static prometheus::IntCounterVec {
             ),
             &["reason"],
         )
-        .expect("valid metric");
-        let _ = prometheus::default_registry().register(Box::new(m.clone()));
+        .expect("static counter spec must be valid");
+        // ⚠ `registry()`, NOT `prometheus::default_registry()`. `gather_text()`
+        // gathers from this crate's own registry, so a metric registered on the
+        // default one is never scraped — it exists, it increments, and it is
+        // invisible. Shipped that way in v3.99.3 (noetl/ai-meta#315): the cap
+        // worked while the counter proving it could not appear.
+        registry()
+            .register(Box::new(m.clone()))
+            .expect("counter registration must succeed");
         m
     })
 }
@@ -236,6 +243,34 @@ pub fn init_reconcile_giveup_series() {
 
 pub fn record_reconcile_giveup(reason: &str) {
     reconcile_giveup_total().with_label_values(&[reason]).inc();
+}
+
+#[cfg(test)]
+mod reconcile_giveup_registry_tests {
+    /// The metric must be on the registry `/metrics` actually gathers.
+    ///
+    /// ⚠ This is the test that was missing. v3.99.3 shipped the giveup counter
+    /// registered on `prometheus::default_registry()` while `gather_text()`
+    /// gathers from this crate's own `registry()`, so the series could never
+    /// appear on the scrape — the cap worked and the counter proving it was
+    /// invisible. Every test written for it was a pure-function test of the
+    /// decision logic, which is exactly why none of them caught it.
+    #[test]
+    fn the_giveup_series_reaches_the_scrape() {
+        super::init_reconcile_giveup_series();
+        let text = super::gather_text().expect("gather");
+        assert!(
+            text.contains("noetl_reconcile_giveup_total"),
+            "the giveup counter is not on the registry gather_text() reads, so it can \
+             never be scraped — registering it is not the same as exposing it"
+        );
+        assert!(
+            text.contains(r#"noetl_reconcile_giveup_total{reason="max_noops"} 0"#),
+            "the series must be PINNED at 0: a labelled family is pruned while empty, so \
+             without the pin a healthy server and one too old to carry the metric serve \
+             the same nothing"
+        );
+    }
 }
 
 pub fn init_orphan_sweep_series() {


### PR DESCRIPTION
Refs noetl/ai-meta#315

⚠️ **NOT for merge without a decision** — merging fires semantic-release and a
publish. Raising it because I introduced the defect in the change that shipped
an hour ago.

## What I got wrong

`v3.99.3` registered `noetl_reconcile_giveup_total` on
`prometheus::default_registry()`. `gather_text()` gathers from **this crate's own
`registry()`**. So the series can never appear on `/metrics` — it exists, it
increments, and it is invisible.

Confirmed on prod right after the roll: `/metrics` serves **555** `noetl_` series
from the new binary (`noetl_server_build_info{version="3.99.3"}`), and
`noetl_reconcile_giveup_total` is **absent**.

## Why it matters more than a missing gauge usually would

The cap itself is fine — the logic never reads the metric, and the deployed
default (225) is in force.

But a **restart clears `orch_cache` anyway**. That is what cleared the 43 stale
executions the last two times, before the cap existed. So without the counter
there is no way to distinguish *"the cap bounded the re-drive"* from *"the
restart cleared the cache"* — which is precisely the ambiguity #315 was opened
about. The metric is the only thing that separates them.

## Why the existing tests couldn't catch it

Every test written for #387 was a **pure-function test of `reconcile_decision`**.
They are good tests and they all still pass. They are also structurally incapable
of catching a registration mistake, because none of them touches the registry.

The new test asserts the series reaches `gather_text()` **and** is pinned at 0 —
a labelled family is pruned while empty, so without the pin a healthy server and
one too old to carry the metric serve the same nothing.

⚠️ Verified by mutation: putting `default_registry()` back **fails** the new test.

## Verification

- `cargo test --lib` — **971 pass, 0 fail**
- `grep default_registry src/metrics.rs` — only my explanatory comment remains