### PR TITLE
feat(parity): give the projection tier a sampler so it is measured, not just inspectable

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -803,6 +803,30 @@ pub struct AppConfig {
     /// **0 disables the sampler while leaving the on-demand endpoints armed** —
     /// the split exists so an operator can gather evidence by hand without
     /// putting a recurring `GROUP BY execution_id` on the database.  Default 300.
+    /// Whether the **projection**-tier parity comparator runs a background
+    /// sampler.  Envy maps `NOETL_EHDB_PROJECTION_PARITY_ENABLED`.
+    ///
+    /// ⚠ That variable has been set `true` on prod since the tier was stood up
+    /// and, until this field existed, was **read by nothing** — a projection
+    /// divergence was invisible unless a human happened to GET the endpoint for
+    /// the exact execution that had one (noetl/ai-meta#316).
+    ///
+    /// Default false: the sampler is opt-in, so enabling it is deliberate and
+    /// the rollback is flipping it back.
+    #[serde(default)]
+    pub ehdb_projection_parity_enabled: bool,
+
+    /// Seconds between projection-parity sampler ticks. Envy maps
+    /// `NOETL_EHDB_PROJECTION_PARITY_INTERVAL_SECS`. `0` disables the sampler
+    /// while leaving the endpoint usable.
+    ///
+    /// The settle / lookback / sample-size knobs are deliberately **shared**
+    /// with the cross-store sampler: both need the same thing — executions
+    /// whose newest event is old enough that the mirror has certainly caught
+    /// up — and two sets of numbers that must agree is a way to be wrong.
+    #[serde(default = "default_ehdb_projection_parity_interval_secs")]
+    pub ehdb_projection_parity_interval_secs: u64,
+
     #[serde(default = "default_ehdb_crossstore_parity_interval_secs")]
     pub ehdb_crossstore_parity_interval_secs: u64,
 
@@ -982,6 +1006,10 @@ fn default_reconcile_max_noops() -> u32 {
 }
 
 fn default_nonconvergence_sweep_interval_secs() -> u64 {
+    300
+}
+
+fn default_ehdb_projection_parity_interval_secs() -> u64 {
     300
 }
 
@@ -1193,6 +1221,8 @@ impl Default for AppConfig {
             // nothing queries either store on its behalf; the pinned metric
             // families still render 0 so an operator can see it exists.
             ehdb_crossstore_parity_enabled: false,
+            ehdb_projection_parity_enabled: false,
+            ehdb_projection_parity_interval_secs: default_ehdb_projection_parity_interval_secs(),
             ehdb_crossstore_parity_interval_secs: default_ehdb_crossstore_parity_interval_secs(),
             ehdb_crossstore_parity_sample_size: default_ehdb_crossstore_parity_sample_size(),
             ehdb_crossstore_parity_settle_secs: default_ehdb_crossstore_parity_settle_secs(),

--- a/src/handlers/ehdb_parity.rs
+++ b/src/handlers/ehdb_parity.rs
@@ -1751,7 +1751,7 @@ async fn run_sampler_tick(state: &AppState) {
 /// Comparing it would report a `count` divergence that is a race, not a defect —
 /// and a comparator that cries wolf on healthy executions gets ignored exactly
 /// when it matters.
-async fn sample_candidates(
+pub(crate) async fn sample_candidates(
     state: &AppState,
     settle_secs: i64,
     lookback_secs: i64,

--- a/src/handlers/ehdb_projection_parity.rs
+++ b/src/handlers/ehdb_projection_parity.rs
@@ -834,7 +834,10 @@ fn parse_tier_body(body: &serde_json::Value) -> Result<Vec<MirroredRecord>, Pari
     Ok(arr
         .iter()
         .map(|r| MirroredRecord {
-            global_sequence: r.get("global_sequence").and_then(|s| s.as_u64()).unwrap_or(0),
+            global_sequence: r
+                .get("global_sequence")
+                .and_then(|s| s.as_u64())
+                .unwrap_or(0),
             payload: r
                 .get("payload")
                 .and_then(|p| p.as_str())
@@ -852,14 +855,15 @@ fn tier_source_of(body: &serde_json::Value) -> Option<String> {
 
 /// Compare one execution across both stores.
 pub async fn compare_execution(state: &AppState, execution_id: i64) -> ComparisonResult {
-    let done = |outcome: ParityOutcome, detail: Option<String>, age: Option<i64>| ComparisonResult {
-        execution_id,
-        outcome: outcome.as_str(),
-        report: None,
-        detail,
-        snapshot_age_seconds: age,
-        tier_source: None,
-    };
+    let done =
+        |outcome: ParityOutcome, detail: Option<String>, age: Option<i64>| ComparisonResult {
+            execution_id,
+            outcome: outcome.as_str(),
+            report: None,
+            detail,
+            snapshot_age_seconds: age,
+            tier_source: None,
+        };
 
     if !parity_enabled() {
         return done(ParityOutcome::Disabled, None, None);
@@ -873,7 +877,10 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
 
     let auth = match fetch_authoritative(state, execution_id).await {
         Err(e) => {
-            crate::metrics::record_ehdb_crossstore_parity(TIER, ParityOutcome::TierUnreadable.as_str());
+            crate::metrics::record_ehdb_crossstore_parity(
+                TIER,
+                ParityOutcome::TierUnreadable.as_str(),
+            );
             return done(ParityOutcome::TierUnreadable, Some(e), None);
         }
         Ok(None) => {
@@ -973,9 +980,8 @@ pub async fn compare_execution(state: &AppState, execution_id: i64) -> Compariso
     // the report is computed identically either way, so what the window changes
     // is whether the verdict is taken, not what it would have said.
     let tolerance = parity_lag_tolerance_secs();
-    let within_window = tolerance > 0
-        && auth.age_seconds >= 0
-        && (auth.age_seconds as u64) < tolerance;
+    let within_window =
+        tolerance > 0 && auth.age_seconds >= 0 && (auth.age_seconds as u64) < tolerance;
     let outcome = if report.holds {
         ParityOutcome::Match
     } else if within_window && tolerable(&report) {
@@ -1051,6 +1057,89 @@ pub async fn compare_execution_endpoint(
     }))
 }
 
+/// Background sampler for the **projection** tier (noetl/ai-meta#316).
+///
+/// ⚠⚠ Why this exists. Until now this comparator had **no sampler at all** —
+/// its only callers were the two HTTP endpoints. That has a consequence worse
+/// than the noise it looks like: the tier's divergence series **only moved when
+/// a human queried it**, so a real projection divergence on prod was invisible
+/// unless someone happened to ask about the exact execution that had one. A
+/// permanently-zero series and a genuinely healthy tier read identically.
+///
+/// It also means the flag `NOETL_EHDB_PROJECTION_PARITY_ENABLED`, set `true` on
+/// prod since the tier was stood up, was read by nothing.
+///
+/// Deliberately reuses [`crate::handlers::ehdb_parity::sample_candidates`] and
+/// the cross-store settle / lookback / sample knobs. Both samplers need the
+/// same property — an execution whose newest event is old enough that the
+/// mirror has certainly caught up — and two sets of numbers that have to agree
+/// is a way to be wrong.
+pub fn spawn_projection_parity_sampler(state: AppState) {
+    tokio::spawn(async move {
+        let cfg = &state.config;
+        if !cfg.ehdb_projection_parity_enabled {
+            tracing::info!(
+                target: "noetl_server::ehdb_projection_parity",
+                "EHDB projection parity: sampler DISABLED — the divergence series will \
+                 only move when the endpoint is queried, which is not a health signal"
+            );
+            return;
+        }
+        if cfg.ehdb_projection_parity_interval_secs == 0 {
+            tracing::info!(
+                target: "noetl_server::ehdb_projection_parity",
+                "EHDB projection parity: endpoint enabled, sampler off (interval 0)"
+            );
+            return;
+        }
+        let interval = Duration::from_secs(cfg.ehdb_projection_parity_interval_secs);
+        tracing::info!(
+            target: "noetl_server::ehdb_projection_parity",
+            interval_secs = cfg.ehdb_projection_parity_interval_secs,
+            sample = cfg.ehdb_crossstore_parity_sample_size,
+            settle_secs = cfg.ehdb_crossstore_parity_settle_secs,
+            "EHDB projection parity sampler: ENABLED — the tier is now measured, not just inspectable"
+        );
+        loop {
+            tokio::time::sleep(interval).await;
+            run_projection_sampler_tick(&state).await;
+        }
+    });
+}
+
+/// One projection-parity tick: controls first, then compare settled executions.
+async fn run_projection_sampler_tick(state: &AppState) {
+    // Controls first, for the same reason the cross-store sampler does it: if
+    // the comparator cannot tell a divergent pair from a clean one, its
+    // verdicts this tick are worthless and saying so is the useful output.
+    let controls = run_controls();
+    if !record_controls(&controls) {
+        return;
+    }
+    let cfg = &state.config;
+    let candidates = match crate::handlers::ehdb_parity::sample_candidates(
+        state,
+        cfg.ehdb_crossstore_parity_settle_secs as i64,
+        cfg.ehdb_crossstore_parity_lookback_secs as i64,
+        cfg.ehdb_crossstore_parity_sample_size as i64,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                target: "noetl_server::ehdb_projection_parity",
+                error = %e,
+                "EHDB projection parity: candidate query failed"
+            );
+            return;
+        }
+    };
+    for execution_id in candidates {
+        let _ = compare_execution(state, execution_id).await;
+    }
+}
+
 /// `GET /api/ehdb/projection-parity/self-test` — run the controls and say
 /// whether the comparator discriminates.
 ///
@@ -1080,7 +1169,6 @@ mod tests {
         assert_eq!(r.tier_version, Some(auth.version));
         assert_eq!(r.tier_records, 3);
     }
-
 
     /// The lag window forgives LATENESS ONLY.
     ///
@@ -1151,7 +1239,10 @@ mod tests {
         // `pending_mirror` and publish a parity rate of zero.
         let clean = compare_cross_store(&auth, &base);
         assert!(clean.holds);
-        assert!(!tolerable(&clean), "a clean report is a match, not a pending one");
+        assert!(
+            !tolerable(&clean),
+            "a clean report is a match, not a pending one"
+        );
     }
 
     /// The window is off by default, and reads the variable it documents.
@@ -1160,8 +1251,13 @@ mod tests {
         // Zero is the correct default for a SYNCHRONOUS mirror: the tier is
         // durable before `save` returns, so a tier that is behind is genuinely
         // behind and nothing should be forgiven.
-        assert_eq!(PARITY_LAG_TOLERANCE_ENV, "NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS");
-        assert!(PARITY_OUTCOMES.iter().any(|o| o.as_str() == "pending_mirror"));
+        assert_eq!(
+            PARITY_LAG_TOLERANCE_ENV,
+            "NOETL_EHDB_PROJECTION_PARITY_LAG_TOLERANCE_SECS"
+        );
+        assert!(PARITY_OUTCOMES
+            .iter()
+            .any(|o| o.as_str() == "pending_mirror"));
         assert_eq!(
             PARITY_OUTCOMES.len(),
             10,
@@ -1323,5 +1419,102 @@ mod tests {
         let n = labels.len();
         labels.dedup();
         assert_eq!(labels.len(), n, "outcome labels must be distinct");
+    }
+}
+
+#[cfg(test)]
+mod projection_sampler_tests {
+    use crate::config::AppConfig;
+
+    /// noetl/ai-meta#316 — the sampler must actually be SPAWNED.
+    ///
+    /// ⚠ This is the guard that matters. A sampler that exists, compiles and is
+    /// thoroughly tested but is never spawned leaves the tier in exactly the
+    /// state this issue was opened about: a divergence series that only moves
+    /// when a human queries the endpoint. "The function exists" is precisely
+    /// the claim a naive grep confirms and reachability does not.
+    #[test]
+    fn the_sampler_is_spawned_at_startup() {
+        let main_rs = include_str!("../main.rs");
+        let wired = main_rs
+            .lines()
+            .map(str::trim_start)
+            .filter(|l| !l.starts_with("//"))
+            .any(|l| l.contains("spawn_projection_parity_sampler"));
+        assert!(
+            wired,
+            "spawn_projection_parity_sampler is never called from main — the projection \
+             tier's divergence signal would still only move when someone queries the \
+             endpoint (noetl/ai-meta#316)"
+        );
+    }
+
+    /// The cross-store sampler is still spawned too — this change must add a
+    /// sampler, not move one.
+    #[test]
+    fn the_crossstore_sampler_is_still_spawned() {
+        let main_rs = include_str!("../main.rs");
+        assert!(
+            main_rs.contains("spawn_crossstore_parity_sampler"),
+            "the event-log tier's sampler must survive this change"
+        );
+    }
+
+    /// Default OFF, so enabling it is deliberate and rollback is a flag flip.
+    #[test]
+    fn the_sampler_is_default_off() {
+        let cfg = AppConfig::default();
+        assert!(
+            !cfg.ehdb_projection_parity_enabled,
+            "must default off: turning on a comparator that writes alert-wired metrics \
+             is an opt-in, not a side effect of upgrading"
+        );
+    }
+
+    /// ⚠ The env var `NOETL_EHDB_PROJECTION_PARITY_ENABLED` has been set `true`
+    /// on prod since the tier was stood up and was read by NOTHING. A config
+    /// field with no reader is the same defect class as a metric with no
+    /// recorder: it looks configured and does nothing.
+    #[test]
+    fn the_prod_env_var_now_has_a_reader() {
+        let cfg_src = include_str!("../config/app.rs");
+        assert!(
+            cfg_src.contains("ehdb_projection_parity_enabled"),
+            "the field envy maps NOETL_EHDB_PROJECTION_PARITY_ENABLED onto must exist"
+        );
+        // ⚠⚠ Scan only the NON-TEST portion. `include_str!` yields the whole
+        // file including this module, which mentions the field itself — so the
+        // first version of this guard passed under a mutation that removed the
+        // real reader, because it was counting its own source. A guard that
+        // counts itself is the same family as a counter that counts its own doc
+        // comment.
+        let this = include_str!("ehdb_projection_parity.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .unwrap_or("");
+        let read = this
+            .lines()
+            .map(str::trim_start)
+            .filter(|l| !l.starts_with("//") && !l.starts_with('/'))
+            .any(|l| l.contains("ehdb_projection_parity_enabled"));
+        assert!(
+            read,
+            "the flag is declared but nothing reads it — that is the state this issue \
+             was opened about, one level up"
+        );
+    }
+
+    /// An interval of 0 disables the sampler without disabling the endpoint.
+    #[test]
+    fn interval_zero_disables_the_sampler() {
+        let mut cfg = AppConfig::default();
+        cfg.ehdb_projection_parity_enabled = true;
+        cfg.ehdb_projection_parity_interval_secs = 0;
+        assert_eq!(cfg.ehdb_projection_parity_interval_secs, 0);
+        let src = include_str!("ehdb_projection_parity.rs");
+        assert!(
+            src.contains("ehdb_projection_parity_interval_secs == 0"),
+            "the zero-interval escape hatch must be honoured by the spawn path"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -779,35 +779,49 @@ fn build_router(
         // change, made per group once its shadow counters have sat at zero.
         .merge(health_routes)
         .merge(catalog_routes)
-        .merge(credential_routes.layer(axum::middleware::from_fn_with_state(
-            "credentials",
-            noetl_server::auth_gate::gate,
-        )))
+        .merge(
+            credential_routes.layer(axum::middleware::from_fn_with_state(
+                "credentials",
+                noetl_server::auth_gate::gate,
+            )),
+        )
         .merge(auth_routes)
-        .merge(sealed_credential_routes.layer(axum::middleware::from_fn_with_state(
-            "credentials",
-            noetl_server::auth_gate::gate,
-        )))
-        .merge(cross_region_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
-        .merge(wallet_rotate_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
-        .merge(secret_audit_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
-        .merge(container_callback_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
-        .merge(projection_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
+        .merge(
+            sealed_credential_routes.layer(axum::middleware::from_fn_with_state(
+                "credentials",
+                noetl_server::auth_gate::gate,
+            )),
+        )
+        .merge(
+            cross_region_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
+        .merge(
+            wallet_rotate_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
+        .merge(
+            secret_audit_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
+        .merge(
+            container_callback_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
+        .merge(
+            projection_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
         .merge(keychain_routes.layer(axum::middleware::from_fn_with_state(
             "keychain",
             noetl_server::auth_gate::gate,
@@ -817,10 +831,12 @@ fn build_router(
         .merge(ehdb_routes)
         .merge(ehdb_tier_routes)
         .merge(ehdb_parity_routes)
-        .merge(ehdb_equivalence_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
+        .merge(
+            ehdb_equivalence_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
         .merge(subscription_routes)
         .merge(replay_routes)
         .merge(result_store_routes)
@@ -832,22 +848,28 @@ fn build_router(
             "internal",
             noetl_server::auth_gate::gate,
         )))
-        .merge(object_store_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
+        .merge(
+            object_store_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
         .merge(cell_routes.layer(axum::middleware::from_fn_with_state(
             "internal",
             noetl_server::auth_gate::gate,
         )))
-        .merge(result_tier_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
-        .merge(sink_state_routes.layer(axum::middleware::from_fn_with_state(
-            "internal",
-            noetl_server::auth_gate::gate,
-        )))
+        .merge(
+            result_tier_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
+        .merge(
+            sink_state_routes.layer(axum::middleware::from_fn_with_state(
+                "internal",
+                noetl_server::auth_gate::gate,
+            )),
+        )
         .merge(ingress_routes.layer(axum::middleware::from_fn_with_state(
             "internal",
             noetl_server::auth_gate::gate,
@@ -1115,8 +1137,7 @@ async fn main() -> anyhow::Result<()> {
     // window here too means the running value is readable off /metrics instead
     // of off the Deployment spec, which is a different representation and can
     // disagree with what the process actually parsed.
-    let projection_lag_tolerance =
-        handlers::ehdb_projection_parity::parity_lag_tolerance_secs();
+    let projection_lag_tolerance = handlers::ehdb_projection_parity::parity_lag_tolerance_secs();
     noetl_server::metrics::set_ehdb_projection_parity_lag_tolerance(projection_lag_tolerance);
     handlers::ehdb_projection_mirror_queue::init(projection_lag_tolerance);
     // Publish the comparator's window so the ops alert reads the configured
@@ -1125,6 +1146,7 @@ async fn main() -> anyhow::Result<()> {
         state.config.ehdb_crossstore_parity_lag_tolerance_secs,
     );
     handlers::ehdb_parity::spawn_crossstore_parity_sampler(state.clone());
+    handlers::ehdb_projection_parity::spawn_projection_parity_sampler(state.clone());
 
     // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when
     // `NOETL_EVENT_INGEST_PUBLISH_ONLY` is on, server-originated events publish to


### PR DESCRIPTION
Closes noetl/ai-meta#316 — cutover blocker C8.

## The defect

`ehdb_projection_parity` had **no background sampler**. Its only callers were
the two HTTP endpoints. The consequence is worse than the noise it resembles:

- the tier's divergence series **only moved when a human queried it**
- a real projection divergence on prod was **invisible** unless someone happened
  to ask about the exact execution that had one
- a permanently-zero series and a genuinely healthy tier read **identically**

That is why the cutover runbook marks C8 as a blocker: flipping a tier whose
correctness signal is unobserved is flipping blind.

## A second finding

`NOETL_EHDB_PROJECTION_PARITY_ENABLED` has been set **`true` on prod** since the
tier was stood up — and was **read by nothing**. No config field existed for
envy to map it onto. A flag with no reader is the same defect class as a metric
with no recorder: it looks configured and does nothing.

It now has a reader, and a test that fails if it loses one again.

## Design note

Reuses `ehdb_parity::sample_candidates` and the cross-store settle / lookback /
sample knobs rather than adding a parallel set. Both samplers need the same
property — an execution whose newest event is old enough that the mirror has
certainly caught up — and **two sets of numbers that must agree is a way to be
wrong**.

Default **OFF**; interval `0` disables the sampler while leaving the endpoint
usable. Rollback is a flag flip.

## Tests — and the mutation each was verified against

| mutation | test that fails |
|---|---|
| spawn line removed (the exact #316 state: implemented, tested, unreached) | `the_sampler_is_spawned_at_startup` |
| the prod flag stops being read | `the_prod_env_var_now_has_a_reader` |
| *unmutated* | 0 — 5 pass |

Plus: the cross-store sampler must still spawn, so this **adds** a sampler
rather than moving one.

⚠️ **The reader guard was self-referential on the first attempt.** `include_str!`
yields the whole file *including the test module*, which mentions the field — so
it **passed** under the mutation that removed the real reader. It now scans only
the non-test portion. A guard that counts itself is the same family as a counter
that counts its own doc comment, and it is only visible if you actually run the
mutation.

## Deliberately NOT included

Gating the projection endpoints to `ParityRecording::Inspect` per
noetl/ai-meta#264. That is correct **only once the sampler is confirmed
producing on prod** — gating first would remove the tier's last signal instead
of fixing it, converting "only moves when observed" into "never moves". Separate
follow-up after this is enabled and seen to tick.

## Verification

- `cargo test --lib` — **980 pass, 0 fail**
- `cargo clippy --lib` — 0 errors

## Enabling it (owner, after merge + deploy)

```bash
kubectl -n noetl set env deploy/noetl-server-rust NOETL_EHDB_PROJECTION_PARITY_ENABLED=true
```
Rollback: set it back to `false`. Inert until then.