### PR TITLE
fix(main): restore the merge-chain formatting my rustfmt run broke

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -779,49 +779,35 @@ fn build_router(
         // change, made per group once its shadow counters have sat at zero.
         .merge(health_routes)
         .merge(catalog_routes)
-        .merge(
-            credential_routes.layer(axum::middleware::from_fn_with_state(
-                "credentials",
-                noetl_server::auth_gate::gate,
-            )),
-        )
+        .merge(credential_routes.layer(axum::middleware::from_fn_with_state(
+            "credentials",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(auth_routes)
-        .merge(
-            sealed_credential_routes.layer(axum::middleware::from_fn_with_state(
-                "credentials",
-                noetl_server::auth_gate::gate,
-            )),
-        )
-        .merge(
-            cross_region_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
-        .merge(
-            wallet_rotate_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
-        .merge(
-            secret_audit_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
-        .merge(
-            container_callback_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
-        .merge(
-            projection_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
+        .merge(sealed_credential_routes.layer(axum::middleware::from_fn_with_state(
+            "credentials",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(cross_region_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(wallet_rotate_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(secret_audit_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(container_callback_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(projection_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(keychain_routes.layer(axum::middleware::from_fn_with_state(
             "keychain",
             noetl_server::auth_gate::gate,
@@ -831,12 +817,10 @@ fn build_router(
         .merge(ehdb_routes)
         .merge(ehdb_tier_routes)
         .merge(ehdb_parity_routes)
-        .merge(
-            ehdb_equivalence_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
+        .merge(ehdb_equivalence_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(subscription_routes)
         .merge(replay_routes)
         .merge(result_store_routes)
@@ -848,28 +832,22 @@ fn build_router(
             "internal",
             noetl_server::auth_gate::gate,
         )))
-        .merge(
-            object_store_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
+        .merge(object_store_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(cell_routes.layer(axum::middleware::from_fn_with_state(
             "internal",
             noetl_server::auth_gate::gate,
         )))
-        .merge(
-            result_tier_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
-        .merge(
-            sink_state_routes.layer(axum::middleware::from_fn_with_state(
-                "internal",
-                noetl_server::auth_gate::gate,
-            )),
-        )
+        .merge(result_tier_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
+        .merge(sink_state_routes.layer(axum::middleware::from_fn_with_state(
+            "internal",
+            noetl_server::auth_gate::gate,
+        )))
         .merge(ingress_routes.layer(axum::middleware::from_fn_with_state(
             "internal",
             noetl_server::auth_gate::gate,
@@ -1137,7 +1115,8 @@ async fn main() -> anyhow::Result<()> {
     // window here too means the running value is readable off /metrics instead
     // of off the Deployment spec, which is a different representation and can
     // disagree with what the process actually parsed.
-    let projection_lag_tolerance = handlers::ehdb_projection_parity::parity_lag_tolerance_secs();
+    let projection_lag_tolerance =
+        handlers::ehdb_projection_parity::parity_lag_tolerance_secs();
     noetl_server::metrics::set_ehdb_projection_parity_lag_tolerance(projection_lag_tolerance);
     handlers::ehdb_projection_mirror_queue::init(projection_lag_tolerance);
     // Publish the comparator's window so the ops alert reads the configured


### PR DESCRIPTION
Fixes red CI on `main` introduced by noetl/server#390.

## What happened

#390 ran `rustfmt` over `src/main.rs` as a tidy-up. That reformatted the router
merge chain, splitting `.merge(x.layer(...))` across lines — and
`tests/auth_gate_wiring.rs` matches that as a **single-line literal**.

The guard went from passing to reporting **eleven** privileged routers as
ungated. And the merge landed anyway, because I read the check result in the
same command that issued the merge rather than before it. My error, twice over.

## The gating was never broken

```
auth_gate::gate occurrences in main.rs   before: 18   after: 18
```

Credentials, keychain, and the internal control surface stayed gated the whole
time. What broke was the guard's ability to **see** that — a guard blinded by
formatting, which is its own kind of bad, but not a security regression. Worth
stating precisely rather than letting "11 routers ungated" stand.

## The fix

`main.rs` restored to its pre-#390 content, with only the one line #390 actually
needed re-applied — the projection-parity sampler spawn. **46 insertions / 67
deletions, all of it undoing churn.**

## Verification

- `cargo test --all-targets --locked` — **0 FAILED** across every suite
- `auth_gate_wiring` — **9/9**
- the sampler's own 5 tests still pass, so #390's actual change is preserved

## Lesson

Don't run `rustfmt` over a file whose baseline is already drifting, and never
over one a source-scanning guard reads. I checked that baseline deliberately for
`ehdb_parity.rs` and `events.rs` earlier in this session and skipped the check
here.

⚠️ Note: semantic-release already cut **v3.100.0** from the broken commit. The
released binary is functionally fine (the gating is intact); only the test guard
was red. This PR will produce the next patch.