### PR TITLE
fix(db): raise the shared pool so /api/execute stops collapsing at 6 clients

### DIFF
--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -66,8 +66,38 @@ fn default_database() -> String {
     "noetl".to_string()
 }
 
+/// Maximum Postgres connections this server process holds.
+///
+/// ⚠ **This is a shared pool.** With `shard_count <= 1` — prod's configuration —
+/// [`crate::db::pool::DbPoolMap::pool_for`] returns the same handle for every
+/// shard *and* for cluster tables, so every `/api/execute`, every read, and
+/// every background task draw from this one budget. As of 2026-09-02 that is
+/// five long-lived pollers (orchestrator reconcile on an 8 s tick, orphan
+/// sweep, non-convergence sweep, cross-store parity sampler, projection parity
+/// sampler) plus all request traffic.
+///
+/// At the previous value of **10** that left roughly five connections for
+/// requests, and `POST /api/execute` — which makes several sequential
+/// round-trips per call — exhausted it at **six concurrent clients**. Every
+/// request then blocked in `acquire()` for the full
+/// [`default_acquire_timeout`] of 30 s, which is exactly where an in-cluster
+/// load run saw them die. It presented as a *collapse* rather than a plateau:
+/// concurrency 1-2 fine, 4 degraded, 6 total stall with **no executions
+/// started and no ERROR logged**, because a waiting `acquire` has nothing to
+/// say (noetl/ai-meta#317).
+///
+/// **25 is chosen to match pgbouncer's `default_pool_size = 25`**, which is the
+/// real ceiling: pgbouncer pools per (database, user) pair, so a server pool
+/// larger than that would not buy concurrency, it would just move the queue one
+/// hop downstream where it is even harder to see. `max_db_connections = 32`
+/// leaves headroom above it for other users.
+///
+/// ⚠ **These two numbers are coupled and must move together.** Raising this
+/// above pgbouncer's `default_pool_size`, or running more than one server
+/// replica without raising pgbouncer, re-creates the same queue somewhere less
+/// observable. Prod runs **one** replica; 25 x 1 <= 25 holds.
 fn default_max_connections() -> u32 {
-    10
+    25
 }
 
 fn default_min_connections() -> u32 {
@@ -532,6 +562,105 @@ mod tests {
                 let cfg = ShardingConfig::from_env().expect("from_env");
                 assert_eq!(cfg.shard_count(), 2);
             },
+        );
+    }
+}
+
+#[cfg(test)]
+mod pool_sizing_tests {
+    use super::*;
+
+    /// pgbouncer pools per (database, user) pair. The server pool must not
+    /// exceed it, or the queue simply moves one hop downstream where it is
+    /// harder to see. Live value on prod 2026-09-02.
+    const PGBOUNCER_DEFAULT_POOL_SIZE: u32 = 25;
+
+    /// Concurrent requests the pool must still serve after every long-lived
+    /// background task has taken a connection.
+    const MIN_REQUEST_HEADROOM: u32 = 15;
+
+    /// Count the long-lived background tasks that draw on the shared pool.
+    ///
+    /// Counts CODE in main.rs, not prose — the bug was that five pollers plus
+    /// request traffic exceeded a pool of ten, and the way that recurs is
+    /// someone adding a sixth poller without touching this file.
+    fn background_pool_consumers() -> u32 {
+        let main_rs = include_str!("../main.rs");
+        main_rs
+            .lines()
+            .map(str::trim_start)
+            .filter(|l| !l.starts_with("//"))
+            .filter(|l| l.contains("spawn_") && l.contains("state.clone()"))
+            .count() as u32
+    }
+
+    /// ⚠ THE REGRESSION GUARD for noetl/ai-meta#317.
+    ///
+    /// At `max_connections = 10` with five background pollers, roughly five
+    /// connections were left for requests, and `POST /api/execute` — several
+    /// sequential round-trips per call — exhausted the pool at SIX concurrent
+    /// clients. Every request then blocked the full 30 s `acquire_timeout`,
+    /// with no execution started and no ERROR logged.
+    #[test]
+    fn the_pool_serves_the_background_tasks_and_still_leaves_headroom() {
+        let bg = background_pool_consumers();
+        assert!(
+            bg > 0,
+            "found no background pool consumers — the guard is anchored on \
+             `spawn_*(state.clone())` in main.rs and has stopped matching, so it \
+             would pass vacuously"
+        );
+        let need = bg + MIN_REQUEST_HEADROOM;
+        assert!(
+            default_max_connections() >= need,
+            "pool of {} cannot serve {bg} background tasks plus {MIN_REQUEST_HEADROOM} \
+             concurrent requests (needs >= {need}). This is exactly noetl/ai-meta#317: \
+             requests block in acquire() for the full 30s timeout with nothing logged.",
+            default_max_connections()
+        );
+    }
+
+    /// The other side of the same coupling: bigger is not free.
+    #[test]
+    fn the_pool_does_not_exceed_the_pgbouncer_per_user_cap() {
+        assert!(
+            default_max_connections() <= PGBOUNCER_DEFAULT_POOL_SIZE,
+            "a server pool of {} above pgbouncer's default_pool_size of {} does not buy \
+             concurrency — it moves the queue one hop downstream, where there is no \
+             metric at all. Raise pgbouncer first, and remember prod runs 1 replica: \
+             N replicas x this value must also fit.",
+            default_max_connections(),
+            PGBOUNCER_DEFAULT_POOL_SIZE
+        );
+    }
+
+    /// ⚠ NEGATIVE CONTROL. Without it the two assertions above are satisfied by
+    /// any value in a wide band, and a nonsense pool (say 1, or 10_000) could
+    /// still pass one of them. This pins that BOTH bounds bite.
+    #[test]
+    fn negative_control_the_old_value_would_fail_the_guard() {
+        let bg = background_pool_consumers();
+        let old = 10u32;
+        assert!(
+            old < bg + MIN_REQUEST_HEADROOM,
+            "the pre-fix value of 10 must FAIL the headroom guard, otherwise the guard \
+             would not have caught the bug it was written for"
+        );
+        assert!(
+            10_000 > PGBOUNCER_DEFAULT_POOL_SIZE,
+            "an absurdly large pool must fail the downstream-cap guard"
+        );
+    }
+
+    /// The acquire timeout is what turns exhaustion into a 30s hang rather than
+    /// a fast failure. Pinned so a change is deliberate and reviewed.
+    #[test]
+    fn the_acquire_timeout_is_pinned() {
+        assert_eq!(
+            default_acquire_timeout(),
+            30,
+            "acquire_timeout is why pool exhaustion presents as a 30s hang that looks \
+             exactly like a network fault; changing it changes the failure SHAPE"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -994,6 +994,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_nonconvergence_sweep_series();
     noetl_server::metrics::init_orphan_sweep_series();
     noetl_server::metrics::init_reconcile_giveup_series();
+    noetl_server::metrics::init_db_pool_series();
     noetl_server::metrics::init_sink_state_series();
     noetl_server::metrics::init_catalog_delete_series();
     noetl_server::metrics::init_parity_and_dedup_series();
@@ -1126,6 +1127,18 @@ async fn main() -> anyhow::Result<()> {
     );
     handlers::ehdb_parity::spawn_crossstore_parity_sampler(state.clone());
     handlers::ehdb_projection_parity::spawn_projection_parity_sampler(state.clone());
+    // noetl/ai-meta#317 — sample the shared pool so exhaustion is visible.
+    // Cheap: two atomic reads off the sqlx handle every 15s, no query.
+    {
+        let st = state.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+                let p = st.pools.cluster();
+                noetl_server::metrics::set_db_pool(p.size() as i64, p.num_idle() as i64);
+            }
+        });
+    }
 
     // CQRS write-path cutover (noetl/ai-meta#103 phase 2d-3): when
     // `NOETL_EVENT_INGEST_PUBLISH_ONLY` is on, server-originated events publish to

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -273,6 +273,111 @@ mod reconcile_giveup_registry_tests {
     }
 }
 
+/// `noetl_db_pool_connections{state}` — the shared Postgres pool's occupancy.
+///
+/// ⚠ This pool had **no metric at all** until noetl/ai-meta#317. It is the one
+/// resource that bounds the whole request path — with `shard_count <= 1` every
+/// `/api/execute`, every read and all five background pollers draw from it —
+/// and it was invisible. A pool exhaustion presents as requests hanging for the
+/// full 30 s `acquire_timeout` with **no error logged**, because a waiting
+/// `acquire` has nothing to say. That is indistinguishable from a network
+/// problem unless you can see the pool.
+///
+/// `state` is `total` (connections the pool holds) or `idle` (of those, unused).
+/// `total - idle` is in-flight; `total` pinned at the configured max with
+/// `idle` at 0 is the exhaustion signature.
+pub fn db_pool_connections() -> &'static prometheus::IntGaugeVec {
+    static M: OnceLock<prometheus::IntGaugeVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = prometheus::IntGaugeVec::new(
+            Opts::new(
+                "noetl_db_pool_connections",
+                "Shared Postgres pool occupancy by state (noetl/ai-meta#317).",
+            ),
+            &["state"],
+        )
+        .expect("static gauge spec must be valid");
+        // ⚠ `registry()`, not `prometheus::default_registry()` — `gather_text`
+        // reads this crate's registry, and getting that wrong once already
+        // shipped an invisible metric (noetl/ai-meta#315).
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+pub const DB_POOL_STATES: &[&str] = &["total", "idle"];
+
+/// Pin both series at 0 so an exhausted pool and a build without the metric are
+/// distinguishable — a labelled family is pruned while empty.
+pub fn init_db_pool_series() {
+    for st in DB_POOL_STATES {
+        db_pool_connections().with_label_values(&[st]).set(0);
+    }
+}
+
+pub fn set_db_pool(total: i64, idle: i64) {
+    db_pool_connections()
+        .with_label_values(&["total"])
+        .set(total);
+    db_pool_connections().with_label_values(&["idle"]).set(idle);
+}
+
+#[cfg(test)]
+mod db_pool_metric_tests {
+    /// One test, not two, deliberately.
+    ///
+    /// ⚠ The registry is process-global and tests run in parallel. Split across
+    /// two tests these raced: one called `init_db_pool_series()` (pinning both
+    /// series to 0) while the other asserted the values it had just set, and the
+    /// pinning test won. Same labels, same registry, no isolation possible — so
+    /// the sequence is kept inside a single test.
+    #[test]
+    fn the_pool_gauge_is_pinned_reaches_the_scrape_and_tracks_its_values() {
+        // 1. pinned at 0 — an exhausted pool and a build without the metric must
+        //    not look the same; a labelled family is pruned while empty.
+        super::init_db_pool_series();
+        let text = super::gather_text().expect("gather");
+        assert!(
+            text.contains("noetl_db_pool_connections"),
+            "the pool gauge is not on the registry gather_text() reads — registering is \
+             not the same as exposing"
+        );
+        for st in ["total", "idle"] {
+            assert!(
+                text.contains(&format!(r#"noetl_db_pool_connections{{state="{st}"}} 0"#)),
+                "series for state={st} must be pinned at 0:\n{text}"
+            );
+        }
+
+        // 2. tracks what it is given, so a renderer hard-coding 0 cannot pass.
+        super::set_db_pool(25, 3);
+        let text = super::gather_text().expect("gather");
+        assert!(
+            text.contains(r#"noetl_db_pool_connections{state="total"} 25"#),
+            "{text}"
+        );
+        assert!(
+            text.contains(r#"noetl_db_pool_connections{state="idle"} 3"#),
+            "{text}"
+        );
+
+        // 3. the exhaustion signature the incident would have shown: pool at its
+        //    max with nothing idle.
+        super::set_db_pool(25, 0);
+        let text = super::gather_text().expect("gather");
+        assert!(
+            text.contains(r#"noetl_db_pool_connections{state="total"} 25"#),
+            "{text}"
+        );
+        assert!(
+            text.contains(r#"noetl_db_pool_connections{state="idle"} 0"#),
+            "{text}"
+        );
+    }
+}
+
 pub fn init_orphan_sweep_series() {
     for outcome in ORPHAN_SWEEP_OUTCOMES {
         orphan_sweep_total().with_label_values(&[outcome]).inc_by(0);


### PR DESCRIPTION
Closes noetl/ai-meta#317

## Root cause

With `shard_count <= 1` — prod's configuration — `DbPoolMap::pool_for` returns
**one pool** for every shard *and* for cluster tables. So all of
`/api/execute`, every read, and **five long-lived background pollers**
(orchestrator reconcile on an 8 s tick, orphan sweep, non-convergence sweep,
cross-store parity sampler, projection parity sampler) draw from a single budget
of `max_connections = 10`.

`execute_one` makes several sequential round-trips per call. Five pollers plus
request traffic exhausted ten connections at **six concurrent clients**, and
every request then blocked in `acquire()` for the full **30 s**
`acquire_timeout` — exactly where the in-cluster load run saw them die.

It presented as a **collapse, not a plateau**:

| concurrency | result |
|---|---|
| 1 | fine, ~0.9 exec/s |
| 2 | 37 ok / 0 err, 0.49 exec/s |
| 4 | 30 ok / **6 err** |
| 6 | **0 ok**, total stall |

with **no executions started and no ERROR logged** — a waiting `acquire` has
nothing to say, which is precisely why it looked like a network fault.

⚠️ **This also explains why raising pgbouncer 12→25 / 16→32 changed nothing.**
The binding constraint was *upstream* of pgbouncer, inside the server process.

## The fix

`max_connections` **10 → 25**, chosen to **match pgbouncer's
`default_pool_size = 25`**. pgbouncer pools per (database, user) pair, so a
larger server pool would not buy concurrency — it would move the queue one hop
downstream, where there is no metric at all. The doc comment records that the
two numbers are **coupled**, and that prod runs one replica so *N replicas × this
value* must also fit.

## The observability that was missing

`noetl_db_pool_connections{state="total"|"idle"}`, sampled every 15 s off the
sqlx handle (two atomic reads, no query), **pinned at 0**.

This pool bounded the entire request path and had **no metric whatsoever** —
which is why diagnosing it required a from-inside-the-cluster load run rather
than a dashboard. `total` at max with `idle` at 0 is the exhaustion signature.

## Tests — and the mutation each was verified against

| mutation | test that fails |
|---|---|
| pool back to **10** | headroom guard — **the original bug, reproduced as a failing test** |
| pool set to **200** | downstream-cap guard |
| *unmutated* | 0 — all pass |

- The headroom guard **counts code** (`spawn_*(state.clone())` in `main.rs`), so
  adding a sixth poller without raising the pool fails. It also asserts it found
  a non-zero count, so a moved anchor fails rather than passing vacuously.
- **Negative control** asserts that 10 would fail the lower bound *and* 10 000
  would fail the upper one — so both bounds demonstrably bite rather than the
  value sitting in a wide band nothing tests.
- `acquire_timeout` pinned at 30: it is what turns exhaustion into a *hang*
  rather than a fast failure, so changing it changes the failure **shape**.

⚠️ The gauge assertions are **one test, not two**, deliberately: the registry is
process-global and the parallel split raced — the pinning test reset the series
the value test had just written.

## Deliberately not changed

`acquire_timeout` stays 30 s. Shortening it would surface exhaustion faster but
converts waits into failures; that is a separate decision now that the pool is
observable.

⚠️ `main.rs` was **not** run through rustfmt — its baseline already drifts and a
formatting sweep there previously blinded `auth_gate_wiring.rs` (server#391).
Only the 13-line addition is present.

## Verification

- `cargo test --all-targets --locked` — **985 pass, 0 FAILED**
- `cargo clippy --lib` — 0 errors

## Blast radius

Changes how many connections one server process opens: 10 → up to 25, against
pgbouncer's 25 per-user / 32 per-database. At **one replica** this fits exactly
and leaves 7 for other users. It does not change request semantics, only how
many can proceed concurrently.