### PR TITLE
fix(publish): move the retry budget off the request path

### DIFF
--- a/src/command_bus.rs
+++ b/src/command_bus.rs
@@ -137,6 +137,23 @@ pub fn parse_writer_addrs(spec: &str) -> BTreeMap<u32, String> {
 /// dominant term in command dispatch latency (noetl/ai-meta#205); it also kept
 /// the writer from ever seeing two records at once, so it could never
 /// group-commit them.
+/// What a bounded publish did (noetl/ai-meta#319 P3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishOutcome {
+    /// The writer acked within the on-path budget; the sort key is durable.
+    Landed(u64),
+    /// The on-path budget elapsed and the remaining
+    /// [`PUBLISH_DEADLINE`](EhdbCommandPublisher::PUBLISH_DEADLINE) is being spent
+    /// by a background task.
+    ///
+    /// ⚠ This is **not** fire-and-forget. The same retry loop, the same total
+    /// deadline, and the same at-least-once guarantee — only the waiter changed.
+    /// `command.issued` is already durable in the event log before any publish is
+    /// attempted, so the record is not at risk; what is deferred is the bus
+    /// notification, which is exactly what the retry has always been protecting.
+    Deferred,
+}
+
 pub struct EhdbCommandPublisher {
     shard_count: u32,
     addrs: BTreeMap<u32, String>,
@@ -188,6 +205,23 @@ impl EhdbCommandPublisher {
     /// is what actually ends the loop.
     const PUBLISH_ATTEMPTS: u32 = 32;
 
+    /// How long the **request thread** may spend retrying before the remaining
+    /// budget is continued off-path (noetl/ai-meta#319 P3).
+    ///
+    /// [`PUBLISH_DEADLINE`](Self::PUBLISH_DEADLINE) is 10s because it must span a
+    /// writer pod restart (~2.7s measured) — that window is correct and is NOT
+    /// reduced here. What was wrong is *who waits for it*: the whole 10s sat on
+    /// `POST /api/execute`, so one writer hiccup became a 10s user-visible stall.
+    /// Measured consequence: p50 180ms with a **p95 of 17s** at concurrency 1, and
+    /// a bistable collapse — once publishes start failing, every request burns 10s,
+    /// crosses the client timeout, and the run falls from 18 successes to 0.
+    ///
+    /// 500ms covers the common case the doc above describes (a broken socket the
+    /// writer has already recovered, ~100ms). Anything longer is a real outage of
+    /// the writer, and waiting for that on the request path buys the caller
+    /// nothing it cannot get from the retry continuing in the background.
+    const PUBLISH_ONPATH_DEADLINE: std::time::Duration = std::time::Duration::from_millis(500);
+
     /// Publish one command notification onto the EHDB bus. `execution_id` routes
     /// the shard; `event_id` is the sort key; `payload` is the notification JSON.
     /// Returns the writer-assigned sort key. Lazily (re)connects the router.
@@ -214,11 +248,115 @@ impl EhdbCommandPublisher {
     /// dedupes it (the second claimer is told the command is already claimed).
     /// Losing the command has no such safety net, so at-least-once is the right
     /// trade here.
+    /// Bounded publish (noetl/ai-meta#319 P3): wait at most
+    /// [`PUBLISH_ONPATH_DEADLINE`](Self::PUBLISH_ONPATH_DEADLINE) on the caller's
+    /// thread, then continue the remaining
+    /// [`PUBLISH_DEADLINE`](Self::PUBLISH_DEADLINE) in the background.
+    ///
+    /// The delivery guarantee is unchanged — same loop, same total window,
+    /// still at-least-once. Only the waiter moves.
+    pub async fn publish_bounded(
+        self: &std::sync::Arc<Self>,
+        execution_id: i64,
+        event_id: i64,
+        payload: &[u8],
+    ) -> Result<PublishOutcome, String> {
+        let started = std::time::Instant::now();
+        match self
+            .publish_until(
+                execution_id,
+                event_id,
+                payload,
+                Self::PUBLISH_ONPATH_DEADLINE,
+                started,
+            )
+            .await
+        {
+            Ok(seq) => Ok(PublishOutcome::Landed(seq)),
+            Err(e) => {
+                // Budget elapsed (or the attempt cap hit) without an ack. Hand the
+                // REMAINING window to a background task rather than making the
+                // caller wait it out.
+                if started.elapsed() >= Self::PUBLISH_DEADLINE {
+                    return Err(e);
+                }
+                let me = std::sync::Arc::clone(self);
+                let payload = payload.to_vec();
+                crate::metrics::record_ehdb_command_publish_deferred();
+                tracing::warn!(
+                    execution_id,
+                    event_id,
+                    on_path_ms = started.elapsed().as_millis() as u64,
+                    error = %e,
+                    "EHDB publish did not ack within the on-path budget; continuing the retry \
+                     in the background (noetl/ai-meta#319). command.issued is already durable."
+                );
+                tokio::spawn(async move {
+                    match me
+                        .publish_until(
+                            execution_id,
+                            event_id,
+                            &payload,
+                            Self::PUBLISH_DEADLINE,
+                            started,
+                        )
+                        .await
+                    {
+                        Ok(seq) => {
+                            crate::metrics::record_ehdb_command_publish_deferred_landed();
+                            tracing::info!(
+                                execution_id,
+                                event_id,
+                                ehdb_sort_key = seq,
+                                waited_ms = started.elapsed().as_millis() as u64,
+                                "EHDB publish landed off the request path"
+                            );
+                        }
+                        Err(e) => {
+                            crate::metrics::record_ehdb_command_publish_failed(
+                                "deferred_exhausted",
+                            );
+                            tracing::error!(
+                                execution_id,
+                                event_id,
+                                error = %e,
+                                "EHDB publish EXHAUSTED its deadline off the request path — the \
+                                 command was never delivered to the bus. command.issued is durable, \
+                                 so recovery is the reconcile/guardrail path."
+                            );
+                        }
+                    }
+                });
+                Ok(PublishOutcome::Deferred)
+            }
+        }
+    }
+
     pub async fn publish(
         &self,
         execution_id: i64,
         event_id: i64,
         payload: &[u8],
+    ) -> Result<u64, String> {
+        let started = std::time::Instant::now();
+        self.publish_until(
+            execution_id,
+            event_id,
+            payload,
+            Self::PUBLISH_DEADLINE,
+            started,
+        )
+        .await
+    }
+
+    /// The retry loop, parameterised by how long it may run.
+    async fn publish_until(
+        &self,
+        execution_id: i64,
+        event_id: i64,
+        payload: &[u8],
+        deadline: std::time::Duration,
+        started: std::time::Instant,
     ) -> Result<u64, String> {
         let record = EventRecord::new(
             event_id as u64,
@@ -226,7 +364,6 @@ impl EhdbCommandPublisher {
             String::new(),
             String::from_utf8_lossy(payload).into_owned(),
         );
-        let started = std::time::Instant::now();
         let mut last_err = String::new();
         let mut backoff = Self::RETRY_BACKOFF_INITIAL;
         for attempt in 1..=Self::PUBLISH_ATTEMPTS {
@@ -234,7 +371,7 @@ impl EhdbCommandPublisher {
                 Ok(r) => r,
                 Err(e) => {
                     last_err = e;
-                    if !Self::sleep_before_retry(started, &mut backoff).await {
+                    if !Self::sleep_before_retry(started, deadline, &mut backoff).await {
                         break;
                     }
                     continue;
@@ -273,7 +410,7 @@ impl EhdbCommandPublisher {
                         error = %last_err,
                         "EHDB publish failed; redialing the writer and retrying"
                     );
-                    if !Self::sleep_before_retry(started, &mut backoff).await {
+                    if !Self::sleep_before_retry(started, deadline, &mut backoff).await {
                         break;
                     }
                 }
@@ -301,9 +438,10 @@ impl EhdbCommandPublisher {
     /// budget.
     async fn sleep_before_retry(
         started: std::time::Instant,
+        deadline: std::time::Duration,
         backoff: &mut std::time::Duration,
     ) -> bool {
-        let remaining = match Self::PUBLISH_DEADLINE.checked_sub(started.elapsed()) {
+        let remaining = match deadline.checked_sub(started.elapsed()) {
             Some(r) => r,
             None => return false,
         };

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -1787,8 +1787,24 @@ async fn publish_command_notification(
     // `shadow` mode NATS is authoritative, so a failure is logged and swallowed.
     if mode.publishes_ehdb() {
         match state.ehdb_command_publisher.as_ref() {
-            Some(publisher) => match publisher.publish(execution_id, event_id, &payload).await {
-                Ok(seq) => {
+            // noetl/ai-meta#319 P3 — bounded on-path wait. The retry budget and the
+            // at-least-once guarantee are unchanged; only the waiter moved, so a
+            // writer restart no longer becomes a 10s user-visible stall.
+            Some(publisher) => match publisher
+                .publish_bounded(execution_id, event_id, &payload)
+                .await
+            {
+                Ok(crate::command_bus::PublishOutcome::Deferred) => {
+                    crate::metrics::record_command_publish(publish_route, pool_segment);
+                    tracing::info!(
+                        execution_id,
+                        event_id,
+                        command_id = %command_id,
+                        "Command publish deferred off the request path; retry continues in the \
+                         background (noetl/ai-meta#319)"
+                    );
+                }
+                Ok(crate::command_bus::PublishOutcome::Landed(seq)) => {
                     // The publish metric used to live only in the NATS arm, so
                     // removing that arm dropped it entirely — a dispatch-rate
                     // signal that would have gone quiet without anything

--- a/src/main.rs
+++ b/src/main.rs
@@ -995,6 +995,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_orphan_sweep_series();
     noetl_server::metrics::init_reconcile_giveup_series();
     noetl_server::metrics::init_db_pool_series();
+    noetl_server::metrics::init_ehdb_publish_deferred_series();
     noetl_server::metrics::init_sink_state_series();
     noetl_server::metrics::init_catalog_delete_series();
     noetl_server::metrics::init_parity_and_dedup_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -311,6 +311,50 @@ pub const DB_POOL_STATES: &[&str] = &["total", "idle"];
 
 /// Pin both series at 0 so an exhausted pool and a build without the metric are
 /// distinguishable — a labelled family is pruned while empty.
+/// Publishes whose retry moved off the request path, and how many later landed
+/// (noetl/ai-meta#319 P3). `deferred - deferred_landed` is the number still
+/// in flight or exhausted; pinned at 0 so absence is not mistaken for health.
+pub fn ehdb_command_publish_deferred_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let c = prometheus::IntCounter::new(
+            "noetl_ehdb_command_publish_deferred_total",
+            "Publishes whose retry budget continued off the request path (noetl/ai-meta#319).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(c.clone()))
+            .expect("registration must succeed");
+        c
+    })
+}
+
+pub fn ehdb_command_publish_deferred_landed_total() -> &'static prometheus::IntCounter {
+    static M: OnceLock<prometheus::IntCounter> = OnceLock::new();
+    M.get_or_init(|| {
+        let c = prometheus::IntCounter::new(
+            "noetl_ehdb_command_publish_deferred_landed_total",
+            "Deferred publishes that subsequently landed (noetl/ai-meta#319).",
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(c.clone()))
+            .expect("registration must succeed");
+        c
+    })
+}
+
+pub fn record_ehdb_command_publish_deferred() {
+    ehdb_command_publish_deferred_total().inc();
+}
+pub fn record_ehdb_command_publish_deferred_landed() {
+    ehdb_command_publish_deferred_landed_total().inc();
+}
+pub fn init_ehdb_publish_deferred_series() {
+    ehdb_command_publish_deferred_total().inc_by(0);
+    ehdb_command_publish_deferred_landed_total().inc_by(0);
+}
+
 pub fn init_db_pool_series() {
     for st in DB_POOL_STATES {
         db_pool_connections().with_label_values(&[st]).set(0);

--- a/tests/publish_off_request_path.rs
+++ b/tests/publish_off_request_path.rs
@@ -1,0 +1,133 @@
+//! **The publish retry budget must not sit on the request path** (noetl/ai-meta#319 P3).
+//!
+//! `PUBLISH_DEADLINE` is 10s for a good reason (#208): it spans a writer pod
+//! restart, measured at ~2.7s, and a dropped publish is *lost* — `command.issued`
+//! is durable but nothing reaches the bus, and after T5 there is no NATS to fall
+//! back to. That window is correct and is **not** shortened here.
+//!
+//! What was wrong is *who waits for it*. The whole 10s sat on `POST /api/execute`,
+//! so one writer hiccup became a 10s user-visible stall: p50 180ms with a **p95 of
+//! 17s** at concurrency 1, and a bistable collapse from 18 successes to 0 once
+//! publishes began failing.
+//!
+//! These tests pin both halves of the fix: the caller stops waiting, **and** the
+//! append still lands.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use noetl_server::command_bus::{EhdbCommandPublisher, PublishOutcome};
+
+fn unused_addr() -> String {
+    // Bind, read the port, drop the listener — nothing is listening there now.
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let a = l.local_addr().unwrap();
+    drop(l);
+    format!("127.0.0.1:{}", a.port())
+}
+
+fn publisher_at(addr: &str) -> Arc<EhdbCommandPublisher> {
+    let mut addrs = BTreeMap::new();
+    addrs.insert(0u32, addr.to_string());
+    Arc::new(EhdbCommandPublisher::new(1, addrs))
+}
+
+/// The request thread must be released in ~the on-path budget, not the full
+/// deadline.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_caller_is_released_within_the_on_path_budget() {
+    let p = publisher_at(&unused_addr());
+    let t0 = Instant::now();
+    let out = p.publish_bounded(1, 1, b"{}").await;
+    let waited = t0.elapsed();
+
+    assert!(
+        matches!(out, Ok(PublishOutcome::Deferred)),
+        "an unreachable writer must defer, not fail the caller: {out:?}"
+    );
+    assert!(
+        waited < Duration::from_secs(3),
+        "the caller waited {waited:?} — the on-path budget is 500ms; anything near the \
+         10s PUBLISH_DEADLINE means the retry is still on the request path, which is \
+         exactly the 17s p95 this fixes"
+    );
+}
+
+/// ⚠ THE NEGATIVE CONTROL. Without it, the test above passes trivially on any
+/// implementation that returns fast — including one that never retries at all.
+/// This pins that the FULL budget still exists on the unbounded path, so the
+/// 10s window (#208's writer-restart cover) has not been quietly deleted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_full_deadline_still_exists_on_the_unbounded_path() {
+    let p = publisher_at(&unused_addr());
+    let t0 = Instant::now();
+    let r = p.publish(2, 2, b"{}").await;
+    let waited = t0.elapsed();
+
+    assert!(r.is_err(), "an unreachable writer must eventually fail the unbounded call");
+    assert!(
+        waited >= Duration::from_secs(8),
+        "the unbounded publish returned after {waited:?} — the 10s PUBLISH_DEADLINE that \
+         covers a writer pod restart (noetl/ai-meta#208) must NOT have been shortened; \
+         P3 moves the wait, it does not remove it"
+    );
+}
+
+/// ⚠ THE CORRECTNESS GATE. A transient failure must still land the append —
+/// deferring is not dropping.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_transient_failure_still_lands_the_append_exactly_once() {
+    use ehdb_feed::{serve_ingest, FeedWriter};
+    use ehdb_l0::substrate::DurableSubstrate;
+    use ehdb_l0::{D1EventLog, L0Config, L0Engine, LocalFsSubstrate};
+
+    // Reserve a port, leave it closed so the first attempts fail.
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = l.local_addr().unwrap();
+    drop(l);
+    let p = publisher_at(&format!("127.0.0.1:{}", addr.port()));
+
+    let t0 = Instant::now();
+    let out = p.publish_bounded(4242, 7, b"{\"hello\":\"world\"}").await;
+    assert!(
+        matches!(out, Ok(PublishOutcome::Deferred)),
+        "writer down at call time must defer: {out:?}"
+    );
+    assert!(
+        t0.elapsed() < Duration::from_secs(3),
+        "caller must not have waited for the writer to come back"
+    );
+
+    // Writer arrives late — the same shape as a pod restart completing.
+    let dir = std::env::temp_dir().join(format!("p3-late-writer-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let store: Arc<dyn DurableSubstrate> = Arc::new(LocalFsSubstrate::new(&dir).unwrap());
+    let engine =
+        L0Engine::<D1EventLog>::open(L0Config::d1(&dir).with_shard_count(1), store).unwrap();
+    let writer = Arc::new(FeedWriter::new(engine));
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", addr.port())).await.unwrap();
+    tokio::spawn(serve_ingest(listener, writer.clone()));
+
+    // The deferred retry should find it within the remaining deadline.
+    let mut found = 0usize;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let eng = writer.engine();
+        let g = eng.lock().unwrap();
+        found = g.read_execution_after("4242", 0).map(|v| v.len()).unwrap_or(0);
+        drop(g);
+        if found > 0 {
+            break;
+        }
+    }
+
+    assert_eq!(
+        found, 1,
+        "the deferred publish must land EXACTLY ONCE once the writer returns — {found} \
+         records found. 0 means deferring silently dropped the command (the loss bug \
+         noetl/ai-meta#208 exists to prevent); >1 means the background retry duplicated \
+         beyond the at-least-once contract within a single deferral."
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
noetl/ai-meta#319 **P3**.

## What is NOT changing

`PUBLISH_DEADLINE` stays **10 s**. It exists for a documented reason (#208): it
spans a **writer pod restart, measured at ~2.7 s**, and a dropped publish is
**lost** — `command.issued` is durable but nothing reaches the bus, and after T5
there is no NATS to fall back to. Shortening it would reintroduce that bug.

## What was actually wrong: who waits

The whole 10 s sat on `POST /api/execute`. One writer hiccup became a 10 s
user-visible stall — measured **p50 180 ms with a p95 of 17 s at concurrency 1**,
and a **bistable collapse**: once publishes start failing every request burns
10 s, crosses the client's 30 s timeout, and a run drops from 18 successes to 0.

## The fix

`PUBLISH_ONPATH_DEADLINE = 500 ms`. The caller waits at most that; if no ack has
arrived, the **remaining** budget is continued by a background task running the
**identical retry loop against the identical total deadline**.

Same at-least-once contract, same window, different waiter.

⚠️ **Not fire-and-forget.** `command.issued` is already durable in the event log
before any publish is attempted, so the record is never at risk — what defers is
the bus *notification*, which is precisely what the retry has always been
protecting. A deferral that exhausts its deadline logs at **ERROR** and
increments a counter rather than vanishing.

## Tests — and the mutation each was verified against

| mutation | test that fails |
|---|---|
| on-path budget set back to the full deadline | caller-released, and the landing test |
| **background spawn dropped (the loss bug)** | **exactly-once landing** |
| *unmutated* | 0 — 3 pass |

- **Correctness gate**: writer absent at call time, arriving late, and the
  deferred retry finds it and lands **exactly once**. Dropping the spawn makes
  this fail — it catches real command loss, which is the bug #208 exists to
  prevent.
- ⚠️ **Negative control**: the full 10 s deadline still exists on the unbounded
  path. Without it the first test passes trivially on an implementation that
  never retries at all, and the writer-restart cover would have been deleted
  silently.

## Observability

`noetl_ehdb_command_publish_deferred_total` and `..._deferred_landed_total`, both
pinned at 0. Their difference is what is in flight or exhausted.

## Verification

- `cargo test --all-targets --locked` — **0 FAILED**, 985 lib tests pass
- `cargo clippy --lib` — 0 errors
- fmt clean on touched files (baselines checked; `execute.rs` untouched by fmt)

## Expected effect

p95 at concurrency 1 collapses from ~17 s toward the p50, and the bistability
(18 ok / 0 ok across repeats) goes away — validated on the fixed rig after deploy.