### PR TITLE
perf(execute): read the catalog row once per execution, not four times

### DIFF
--- a/src/handlers/catalog_snapshot.rs
+++ b/src/handlers/catalog_snapshot.rs
@@ -237,7 +237,7 @@ pub fn build(
 pub async fn record(
     state: &crate::state::AppState,
     execution_id: i64,
-    catalog_id: i64,
+    item: &CatalogItem,
     content: &str,
     workload: &serde_json::Value,
 ) {
@@ -247,38 +247,24 @@ pub async fn record(
         return;
     }
 
-    // One small read for the two fields `resolve_catalog` does not return.
-    // Deliberately its own query rather than widening `get_playbook_yaml`: that
-    // helper is on the hot path for every execution, and this must cost exactly
-    // nothing when the mode is off.
-    // `path` is read back here rather than threaded in from the caller, so the
-    // snapshot names the path as the CATALOG holds it, not as the request spelled
-    // it — the two can differ, and the catalog's is the one that identifies the
-    // row.
-    let row: Result<Option<(String, String, i16)>, _> =
-        sqlx::query_as::<_, (String, String, i16)>(
-            "SELECT path, kind, version FROM noetl.catalog WHERE catalog_id = $1",
-        )
-        .bind(catalog_id)
-        .fetch_optional(state.pools.cluster())
-        .await;
+    let catalog_id = item.catalog_id;
 
-    let (path, kind, version) = match row {
-        Ok(Some(v)) => v,
-        Ok(None) | Err(_) => {
-            crate::metrics::record_catalog_snapshot(mode.as_str(), "catalog_read_failed");
-            tracing::warn!(
-                target: "noetl_server::catalog_snapshot",
-                execution_id, catalog_id,
-                "catalog snapshot skipped: could not read path/kind/version"
-            );
-            return;
-        }
-    };
+    // The path/kind/version this snapshot names come from the caller's single
+    // catalog read (noetl/ai-meta#319 P2), not from a re-read here.
+    //
+    // The re-read existed so the mode would cost exactly nothing when off — but
+    // `digest` is what production runs, so in practice it was a FOURTH read of a
+    // row already in memory, on every execution. The property it protected still
+    // holds, and now holds more strongly: the snapshot names the path as the
+    // CATALOG holds it (the `path` column, not the request's spelling), and it is
+    // now provably the SAME read the execution resolved through — so the snapshot
+    // cannot name a different row than the one that ran. Two reads could disagree
+    // if the catalog changed between them; one cannot.
+    //
+    // Off-mode still costs nothing: this function returns above, and the caller
+    // builds its `CatalogItem` from values it already holds.
 
-    let item = CatalogItem { catalog_id, path, kind, version };
-
-    let snap = build(&item, execution_id, content, workload, mode, max_bytes());
+    let snap = build(item, execution_id, content, workload, mode, max_bytes());
     let outcome = if snap.content_included || !mode.carries_content() {
         "recorded"
     } else {

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -239,6 +239,23 @@ static SYSTEM_CATALOG: std::sync::LazyLock<
 /// must be **exempt** from the publish gate: if their own events published, they
 /// could never bootstrap (the drainer would deadlock waiting for itself to
 /// drain). So they always write synchronously, even under the gate.
+/// Record `catalog_id -> is_system` from a path the caller has ALREADY read.
+///
+/// [`is_system_execution`] below memoises the same fact, but only after paying a
+/// `SELECT path FROM noetl.catalog` to learn it. `execute_one` has that path in
+/// hand from resolution, so it seeds the memo directly and the read never happens
+/// (noetl/ai-meta#319 P2).
+///
+/// ⚠ The caller must pass the catalog's `path` COLUMN, not the path the request
+/// spelled. `is_system_path` is a `system/` prefix test and this memo is what the
+/// publish gate consults, so seeding a request-supplied string would let a caller
+/// choose which side of that gate its execution lands on.
+pub(crate) fn memoize_system_path(catalog_id: i64, path: &str) {
+    if let Ok(mut m) = SYSTEM_CATALOG.write() {
+        m.insert(catalog_id, is_system_path(path));
+    }
+}
+
 async fn is_system_execution(state: &AppState, catalog_id: i64) -> bool {
     if let Some(v) = SYSTEM_CATALOG
         .read()

--- a/src/handlers/execute.rs
+++ b/src/handlers/execute.rs
@@ -357,16 +357,30 @@ pub(crate) async fn execute_one(
         }
     }
 
-    // Resolve catalog entry
-    let (catalog_id, path) = resolve_catalog(state, &request).await?;
+    // Resolve catalog entry — ONE read, carrying every column the rest of this
+    // function needs (noetl/ai-meta#319 P2).
+    let catalog = resolve_catalog(state, &request).await?;
+    let catalog_id = catalog.catalog_id;
+    let path = catalog.path.clone();
 
     info!(
         "Starting execution for path={}, catalog_id={}",
         path, catalog_id
     );
 
-    // Get playbook from catalog
-    let playbook_yaml = get_playbook_yaml(state, catalog_id).await?;
+    // Seed the publish-gate's system-path memo from the path we just read, so
+    // `should_publish` does not spend a THIRD read of this same row deciding
+    // whether `system/` owns it.
+    //
+    // ⚠ Seeded with the CATALOG's path, not the request's spelling. The two can
+    // differ (case, a redirected alias), and it is the catalog's that identifies
+    // the row — memoising the request's would let a request spell its way past
+    // the system-pool gate. `resolve_catalog` returns the `path` COLUMN, which is
+    // the same value `is_system_execution`'s own query would have returned.
+    crate::handlers::event_write::memoize_system_path(catalog_id, &path);
+
+    // Get playbook from the row already in hand — no second query.
+    let playbook_yaml = playbook_yaml_from(&catalog)?;
 
     // Parse playbook
     let playbook = crate::playbook::parser::parse_playbook(&playbook_yaml)?;
@@ -440,7 +454,12 @@ pub(crate) async fn execute_one(
     crate::handlers::catalog_snapshot::record(
         state,
         execution_id,
-        catalog_id,
+        &crate::handlers::catalog_snapshot::CatalogItem {
+            catalog_id,
+            path: path.clone(),
+            kind: catalog.kind.clone(),
+            version: catalog.version,
+        },
         &playbook_yaml,
         &workload,
     )
@@ -580,21 +599,74 @@ async fn emit_deduplicated_event(
 }
 
 /// Resolve catalog entry from path or catalog_id.
-async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResult<(i64, String)> {
+/// Everything `execute_one` needs from `noetl.catalog`, read **once**.
+///
+/// Before noetl/ai-meta#319 P2 the same catalog row was read **four times** on
+/// every `/api/execute`: `resolve_catalog` (id/path/version), `get_playbook_yaml`
+/// (content/payload), `is_system_execution` (path), and `catalog_snapshot::record`
+/// (path/kind/version). Each was individually reasonable and each cost a full
+/// pgbouncer → cloud-sql-proxy → Cloud SQL round-trip, measured at **13-20 ms**
+/// from inside the server pod — so the redundancy was ~45-60 ms of a ~150 ms
+/// request.
+///
+/// ⚠ This is **not a cache**. The row is still read fresh on every request, from
+/// the same query with the same predicate; only the *repeats* are gone. A newly
+/// registered version, an archive, or an out-of-band content edit is therefore
+/// picked up on the very next request exactly as before — there is no window in
+/// which a stale definition can be served, because nothing is retained.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedCatalog {
+    pub catalog_id: i64,
+    pub path: String,
+    pub kind: String,
+    pub version: i16,
+    pub content: Option<String>,
+    pub payload: Option<serde_json::Value>,
+}
+
+async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResult<ResolvedCatalog> {
     if let Some(catalog_id) = request.catalog_id {
         // Lookup by catalog_id (Phase F R4-3: noetl.catalog is cluster-wide)
-        let entry = sqlx::query_as::<_, (i64, String)>(
-            "SELECT catalog_id, path FROM noetl.catalog WHERE catalog_id = $1",
+        let entry = sqlx::query_as::<
+            _,
+            (
+                i64,
+                String,
+                String,
+                i16,
+                Option<String>,
+                Option<serde_json::Value>,
+            ),
+        >(
+            "SELECT catalog_id, path, kind, version, content, payload \
+                 FROM noetl.catalog WHERE catalog_id = $1",
         )
         .bind(catalog_id)
         .fetch_optional(state.pools.cluster())
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Catalog entry not found: {}", catalog_id)))?;
 
-        Ok(entry)
+        Ok(ResolvedCatalog {
+            catalog_id: entry.0,
+            path: entry.1,
+            kind: entry.2,
+            version: entry.3,
+            content: entry.4,
+            payload: entry.5,
+        })
     } else if let Some(path) = &request.path {
         // Lookup by path (latest version; Phase F R4-3: cluster-wide)
-        let entry = sqlx::query_as::<_, (i64, String, i16)>(
+        let entry = sqlx::query_as::<
+            _,
+            (
+                i64,
+                String,
+                i16,
+                String,
+                Option<String>,
+                Option<serde_json::Value>,
+            ),
+        >(
             // noetl/ai-meta#237 — an archived entry is retired: it must not
             // resolve by PATH, which is how everything normally runs.
             // Resolution by explicit `catalog_id` (above) deliberately still
@@ -609,7 +681,8 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
                 // `version` is selected for the catalog read-source
                 // comparison (RFC step 3 §5). Same query plan; the column is
                 // ignored entirely under the default `postgres` mode.
-                "SELECT catalog_id, path, version FROM noetl.catalog \
+                "SELECT catalog_id, path, version, kind, content, payload \
+                     FROM noetl.catalog \
                      WHERE path = $1{archived} \
                      ORDER BY version DESC LIMIT 1",
                 archived = crate::db::queries::catalog::archived_filter()
@@ -629,9 +702,18 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
         // records the outcome; it serves the Postgres answer either way. `tier`
         // is the cutover and is an owner decision — it is NOT taken here, and
         // the relation's answer is never substituted below.
+        let resolved = ResolvedCatalog {
+            catalog_id: entry.0,
+            path: entry.1.clone(),
+            kind: entry.3.clone(),
+            version: entry.2,
+            content: entry.4.clone(),
+            payload: entry.5.clone(),
+        };
+
         let m = crate::handlers::catalog_read::mode();
         if !m.consults_relation() {
-            return Ok((entry.0, entry.1));
+            return Ok(resolved);
         }
 
         let rel = crate::handlers::catalog_read::cached_relation().await;
@@ -658,13 +740,25 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
         let served =
             crate::handlers::catalog_read::serve_decision(m, rel.as_ref(), outcome, &entry.1);
         match served {
-            Some(e) => {
+            // ⚠ The relation may name a DIFFERENT row than the incumbent, and the
+            // one-read widening above loaded the INCUMBENT's content. Serving the
+            // relation's id with the incumbent's YAML would run one playbook while
+            // claiming to run another — the exact silent-substitution failure the
+            // fail-closed `serve_decision` exists to prevent. So when the ids
+            // differ, pay a second read for the row actually being served. This
+            // costs nothing under `postgres`/`verify` (the modes that ship): both
+            // return the incumbent, whose content is already in hand.
+            Some(e) if e.catalog_id != resolved.catalog_id => {
                 crate::handlers::catalog_read::record_served("relation");
-                Ok((e.catalog_id, e.path.clone()))
+                load_catalog_by_id(state, e.catalog_id).await
+            }
+            Some(_) => {
+                crate::handlers::catalog_read::record_served("relation");
+                Ok(resolved)
             }
             None => {
                 crate::handlers::catalog_read::record_served("incumbent");
-                Ok((entry.0, entry.1))
+                Ok(resolved)
             }
         }
     } else {
@@ -674,30 +768,57 @@ async fn resolve_catalog(state: &AppState, request: &ExecuteRequest) -> AppResul
     }
 }
 
-/// Get playbook YAML from catalog.
-async fn get_playbook_yaml(state: &AppState, catalog_id: i64) -> AppResult<String> {
-    // Try to get content first (raw YAML), fall back to payload (JSON)
-    // Phase F R4-3: noetl.catalog is cluster-wide.
-    let row: (Option<String>, Option<serde_json::Value>) =
-        sqlx::query_as::<_, (Option<String>, Option<serde_json::Value>)>(
-            "SELECT content, payload FROM noetl.catalog WHERE catalog_id = $1",
-        )
-        .bind(catalog_id)
-        .fetch_optional(state.pools.cluster())
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("Catalog entry not found: {}", catalog_id)))?;
+/// Load one catalog row by id, as `ResolvedCatalog`.
+///
+/// Only reached when the read-source ladder elects to serve a row OTHER than the
+/// incumbent — see the call site. Not on the shipping path.
+async fn load_catalog_by_id(state: &AppState, catalog_id: i64) -> AppResult<ResolvedCatalog> {
+    let entry = sqlx::query_as::<
+        _,
+        (
+            i64,
+            String,
+            String,
+            i16,
+            Option<String>,
+            Option<serde_json::Value>,
+        ),
+    >(
+        "SELECT catalog_id, path, kind, version, content, payload \
+             FROM noetl.catalog WHERE catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_optional(state.pools.cluster())
+    .await?
+    .ok_or_else(|| AppError::NotFound(format!("Catalog entry not found: {}", catalog_id)))?;
 
-    match row {
-        (Some(content), _) if !content.is_empty() => Ok(content),
-        (_, Some(payload)) => {
-            // Convert JSON payload to YAML string
-            serde_yaml::to_string(&payload).map_err(|e| {
-                AppError::Internal(format!("Failed to convert payload to YAML: {}", e))
-            })
-        }
+    Ok(ResolvedCatalog {
+        catalog_id: entry.0,
+        path: entry.1,
+        kind: entry.2,
+        version: entry.3,
+        content: entry.4,
+        payload: entry.5,
+    })
+}
+
+/// The playbook YAML carried by an already-read catalog row.
+///
+/// Raw `content` wins; a row that stores the definition as a JSON `payload`
+/// instead is converted. Was a second `SELECT content, payload FROM noetl.catalog`
+/// (noetl/ai-meta#319 P2) — the columns now arrive with the resolution, so this is
+/// a **pure function**: same inputs, same result, no I/O, unit-testable without a
+/// database. The row it reads is the row resolution just read, so "the YAML the
+/// parser consumed" and "the row this execution resolved to" cannot drift apart —
+/// with two reads they could, if the catalog changed between them.
+pub(crate) fn playbook_yaml_from(entry: &ResolvedCatalog) -> AppResult<String> {
+    match (&entry.content, &entry.payload) {
+        (Some(content), _) if !content.is_empty() => Ok(content.clone()),
+        (_, Some(payload)) => serde_yaml::to_string(payload)
+            .map_err(|e| AppError::Internal(format!("Failed to convert payload to YAML: {}", e))),
         _ => Err(AppError::NotFound(format!(
             "No playbook content found for catalog_id: {}",
-            catalog_id
+            entry.catalog_id
         ))),
     }
 }

--- a/tests/catalog_snapshot_wiring.rs
+++ b/tests/catalog_snapshot_wiring.rs
@@ -61,7 +61,15 @@ fn the_snapshot_call_cannot_fail_the_execution() {
 #[test]
 fn the_snapshot_is_given_the_parsed_content_and_effective_workload() {
     let at = EXECUTE.find("catalog_snapshot::record(").unwrap();
-    let call = &EXECUTE[at..at + 260];
+    // Window widened for noetl/ai-meta#319 P2: the call now passes an inline
+    // `CatalogItem` built from the single resolution, so the argument list is
+    // longer than the old 260 bytes. Cut at the call's own terminator instead of
+    // a byte count, so the window tracks the call rather than needing a bump
+    // every time an argument is added.
+    let call = {
+        let tail = &EXECUTE[at..];
+        &tail[..tail.find(")\n    .await;").expect("the call is awaited")]
+    };
     assert!(
         call.contains("&playbook_yaml"),
         "snapshot must receive the resolved content parse_playbook consumed:\n{call}"
@@ -109,10 +117,20 @@ fn resolution_still_returns_the_incumbent_answer() {
     let tail = &EXECUTE[at..];
     let end = tail.find("} else {").expect("the by-path branch must end");
     let block = &tail[..end];
+    // The incumbent answer is the `ResolvedCatalog` built from the Postgres row
+    // (`entry`), and it is what BOTH the `None` arm and the same-id `Some` arm
+    // return. It used to be spelled `Ok((entry.0, entry.1))`; noetl/ai-meta#319
+    // P2 widened the read into a struct, so the guard pins the property — the
+    // value returned is the one built from `entry` — rather than the old tuple.
     assert!(
-        block.contains("Ok((entry.0, entry.1))"),
-        "resolution no longer returns the incumbent tuple — the read-cutover may \
-         have been taken by accident:\n{block}"
+        EXECUTE.contains("let resolved = ResolvedCatalog {")
+            && EXECUTE.contains("catalog_id: entry.0,"),
+        "the incumbent answer is no longer built from the Postgres row `entry`"
+    );
+    assert!(
+        block.contains("record_served(\"incumbent\");\n                Ok(resolved)"),
+        "the `incumbent` arm no longer returns the row Postgres resolved — the \
+         read-cutover may have been taken by accident:\n{block}"
     );
     for forbidden in ["rel.get_latest", "relation.get_latest", "e.version)"] {
         assert!(

--- a/tests/one_catalog_read_per_execute.rs
+++ b/tests/one_catalog_read_per_execute.rs
@@ -1,0 +1,137 @@
+//! Guards for noetl/ai-meta#319 P2 — the catalog row is read ONCE per execute.
+//!
+//! The defect these guard against is not a bug in any one function. Every one of
+//! the four reads was locally reasonable; the cost was only visible by counting
+//! them together, on a path where a Postgres round-trip measures 13-20 ms. So the
+//! guards are about the *call graph*, which no unit test on a single function can
+//! see — the same reason `catalog_snapshot_wiring.rs` exists.
+
+const EXECUTE: &str = include_str!("../src/handlers/execute.rs");
+const SNAPSHOT: &str = include_str!("../src/handlers/catalog_snapshot.rs");
+const EVENT_WRITE: &str = include_str!("../src/handlers/event_write.rs");
+
+fn non_test(src: &str) -> &str {
+    src.split_once("\n#[cfg(test)]").map_or(src, |(b, _)| b)
+}
+
+/// Count the reads of `noetl.catalog` a source file performs.
+///
+/// ⚠ Comment lines are excluded. The first version of this counter matched the
+/// phrase anywhere and scored 4 against a file with 3 queries, because a doc
+/// comment mentioning the removed query counted as one — the same
+/// comments-as-callers idiom that has produced false readings in this repo
+/// before. A guard whose count includes prose measures the prose.
+fn catalog_reads(src: &str) -> usize {
+    non_test(src)
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .filter(|l| l.contains("FROM noetl.catalog"))
+        .count()
+}
+
+/// The execute path performs exactly the reads it needs and no repeats.
+///
+/// **Two** in `execute.rs`: the by-`catalog_id` resolution and the by-`path`
+/// resolution — mutually exclusive branches of one request — plus
+/// `load_catalog_by_id`, which is reached only when the read-source ladder elects
+/// to serve a row other than the incumbent (not a shipping mode).
+///
+/// **Zero** in `catalog_snapshot.rs` and, on the execute path, zero in
+/// `event_write.rs`: both used to re-read a row the caller already held.
+#[test]
+fn the_catalog_row_is_read_once_per_execution() {
+    // resolve by id, resolve by path, and the ladder's non-incumbent loader.
+    assert_eq!(
+        catalog_reads(EXECUTE),
+        3,
+        "execute.rs reads noetl.catalog a different number of times than the \
+         two resolution branches plus the ladder's loader — a re-read has been \
+         added back, or a branch has been lost"
+    );
+
+    assert_eq!(
+        catalog_reads(SNAPSHOT),
+        0,
+        "catalog_snapshot re-reads noetl.catalog; it is handed the CatalogItem \
+         the caller already resolved, and a fourth read of that row was ~15 ms \
+         on every production execute (NOETL_CATALOG_SNAPSHOT=digest is live)"
+    );
+}
+
+/// The publish gate's memo is seeded BEFORE any event is emitted.
+///
+/// `should_publish` consults `is_system_execution`, which reads
+/// `SELECT path FROM noetl.catalog` on a memo miss. Seeding after the first
+/// `emit_event` would let that read fire once per cold catalog_id — the memo
+/// would still fill, so the query would be rare and the regression invisible in
+/// aggregate latency while being a full round-trip for the request that pays it.
+#[test]
+fn the_system_path_memo_is_seeded_before_the_first_event() {
+    let seed = EXECUTE
+        .find("memoize_system_path(")
+        .expect("execute_one must seed the system-path memo from the resolved row");
+    let emit = EXECUTE
+        .find("emit_playbook_started_event(")
+        .expect("execute_one must still emit playbook_started");
+    assert!(
+        seed < emit,
+        "the system-path memo is seeded AFTER the first event is emitted, so \
+         should_publish still pays a catalog read on a cold catalog_id"
+    );
+}
+
+/// The memo is seeded from the catalog's `path` COLUMN, never a request string.
+///
+/// `is_system_path` is a `system/` prefix test and the memo is what the publish
+/// gate consults. Seeding it from `request.path` would let a caller pick which
+/// side of that gate its execution lands on by how it spells the path — the
+/// request's spelling and the stored one can differ.
+#[test]
+fn the_memo_is_seeded_from_the_catalog_path_not_the_request() {
+    let at = EXECUTE.find("memoize_system_path(").unwrap();
+    let call = &EXECUTE[at..at + 60];
+    assert!(
+        !call.contains("request"),
+        "the system-path memo is seeded from the request rather than the \
+         resolved catalog row:\n{call}"
+    );
+    assert!(
+        EVENT_WRITE.contains("is_system_path(path)"),
+        "memoize_system_path must classify with the same predicate \
+         is_system_execution uses, or the two disagree on the same row"
+    );
+}
+
+/// ⚠ NEGATIVE CONTROL for the invalidation gate: nothing is cached.
+///
+/// The round-trips were removed by not *repeating* a read, not by retaining its
+/// result. That is what makes "a changed definition is picked up on the next
+/// request" true by construction rather than by a TTL.
+///
+/// Without this test the suite would pass just as happily on an implementation
+/// that memoised catalog content in a static — which would be faster still, and
+/// would serve a stale playbook after a re-register. `SYSTEM_CATALOG` is the one
+/// permitted memo (a `system/` prefix on an immutable path column) and predates
+/// this change.
+#[test]
+fn no_playbook_content_is_retained_between_requests() {
+    let src = non_test(EXECUTE);
+    // ⚠ `static ` alone is not the pattern: every `&'static str` in a signature
+    // matches it, and the first version of this test failed on the `entry:
+    // &'static str` metrics label rather than on any retained state.
+    for retainer in ["\nstatic ", "LazyLock", "OnceLock", "thread_local"] {
+        assert!(
+            !src.contains(retainer),
+            "execute.rs now holds process-wide state (`{retainer}`). If that \
+             caches catalog content or a parsed playbook, a re-registered \
+             definition is served stale — the one property this change promises \
+             it does not touch."
+        );
+    }
+    assert!(
+        src.contains("let catalog = resolve_catalog(state, &request).await?;"),
+        "execute_one no longer resolves the catalog unconditionally on every \
+         request; if resolution became conditional on a cache hit, freshness is \
+         no longer guaranteed"
+    );
+}


### PR DESCRIPTION
noetl/ai-meta#319 **P2**.

## The defect

Every `/api/execute` read the **same `noetl.catalog` row four times**:

| # | caller | columns | why it existed |
|---|---|---|---|
| 1 | `resolve_catalog` | `catalog_id, path, version` | resolution |
| 2 | `get_playbook_yaml` | `content, payload` | the definition |
| 3 | `is_system_execution` (publish gate) | `path` | `system/` prefix test |
| 4 | `catalog_snapshot::record` | `path, kind, version` | audit record |

Each is locally reasonable — #4's comment even explains that it is deliberately
its own query "so it costs exactly nothing when the mode is off". But
`NOETL_CATALOG_SNAPSHOT=digest` is what **production runs**, so it was never off.

The redundancy is only visible by counting them together. One round-trip through
pgbouncer → cloud-sql-proxy → Cloud SQL measures **13–20 ms** from inside the
server pod, so three needless reads were **~45–60 ms** of a ~150 ms request.

## The fix

Resolution selects every column the request needs, once. `get_playbook_yaml`
becomes the **pure function** `playbook_yaml_from`. The publish gate's memo is
seeded from the path already resolved. The snapshot is handed the `CatalogItem`
the caller holds.

## ⚠️ This is not a cache

The row is still read **fresh on every request**, from the same query with the
same predicate — only the *repeats* are gone. A re-registered version, an
archive, or an out-of-band content edit is picked up on the very next request
exactly as before, because **nothing is retained**.

`no_playbook_content_is_retained_between_requests` is the negative control that
keeps it that way. Without it the suite passes just as happily on an
implementation that memoises catalog content in a static — faster still, and
serving a stale playbook after a re-register.

**One property got stronger.** The snapshot's path and the resolution's path now
provably come from the same read, so the snapshot cannot name a different row
than the one that ran. With two reads they could disagree if the catalog changed
between them.

**Fail-closed on the read-source ladder.** When the ladder elects to serve a row
other than the incumbent, that row's content is loaded rather than the
incumbent's reused — otherwise the server would run one playbook while reporting
another. Costs nothing under `postgres`/`verify`, the modes that ship.

## Mutations, each verified to fail the intended guard

| mutation | guard that fails |
|---|---|
| snapshot re-reads the catalog | read-count |
| memo seeded from `request.path` | memo-provenance |
| incumbent arm reloads by id | held-cutover |
| *unmutated* | 0 — all pass |

⚠️ Both new scan idioms were **wrong on the first run and said so loudly**: a doc
comment mentioning the removed query counted as a query, and `&'static str`
matched a search for retained `static` state. Both are fixed and documented in
the test; a guard whose count includes prose measures the prose.

Two existing `catalog_snapshot_wiring` guards fired correctly on the shape change
and were updated to pin the **property** rather than the old spelling.

## Verification

- `cargo test --all-targets --locked` — **0 FAILED**, 1029 tests pass
- `cargo clippy --all-targets` — 0 errors
- fmt: these files are not rustfmt-clean on `main`; baselines measured before and
  after, and this change does not increase them. **`cargo fmt` was deliberately
  not run** — it rewrites `main.rs` into a shape `auth_gate_wiring` cannot parse,
  which is what went wrong in server#390.