### PR TITLE
fix(mirror): drain independent executions concurrently

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror_queue.rs
+++ b/src/handlers/ehdb_eventlog_mirror_queue.rs
@@ -105,6 +105,25 @@ const DEFAULT_ENQUEUE_TIMEOUT_MS: u64 = 5_000;
 pub const DRAIN_MAX_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_DRAIN_MAX_BATCHES";
 const DEFAULT_DRAIN_MAX: usize = 64;
 
+/// How many executions one drain pass delivers **concurrently**. Default 8.
+///
+/// The drain used to POST strictly one batch at a time. Throughput was therefore
+/// `1 / relay-round-trip` no matter how many independent executions were waiting,
+/// and on production that was not close to enough: the mean queue lag reached
+/// **170 s**, the queue sat full, and **24.6% of batches** fell through to inline
+/// delivery on the request path — which is the whole p95 tail and the whole
+/// run-to-run bistability on `/api/execute` (noetl/ai-meta#319).
+///
+/// ⚠ Concurrency here is safe for a reason specific to this queue's shape, not
+/// because ordering does not matter. `deliver_pass` coalesces to **at most one
+/// batch per `execution_id`**, and pass *N+1* does not begin until pass *N* has
+/// fully completed. So two requests in flight together are always for two
+/// DIFFERENT executions, and the per-execution order this module exists to
+/// guarantee is untouched. Setting this to 1 restores the old serial behaviour
+/// exactly.
+pub const DRAIN_CONCURRENCY_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_DRAIN_CONCURRENCY";
+const DEFAULT_DRAIN_CONCURRENCY: usize = 8;
+
 /// How long the shutdown flush waits for the queue to empty. Default 10 s, to
 /// match the graceful-shutdown budget in `main`.
 pub const FLUSH_TIMEOUT_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_FLUSH_TIMEOUT_MS";
@@ -346,21 +365,62 @@ async fn deliver_pass(pass: Vec<MirrorBatch>) {
         }
     }
 
+    // Deliver up to `concurrency` executions at once, as a sliding window: spawn
+    // until the window is full, then retire one before spawning the next.
+    //
+    // `order` is first-seen execution order and is preserved as the SPAWN order.
+    // Completion order is not, and does not need to be — see the note on
+    // `DRAIN_CONCURRENCY_ENV`: one batch per execution per pass, and passes do
+    // not overlap.
+    let concurrency = env_usize(DRAIN_CONCURRENCY_ENV, DEFAULT_DRAIN_CONCURRENCY).max(1);
+    let mut inflight: tokio::task::JoinSet<(usize, f64)> = tokio::task::JoinSet::new();
+
     for execution_id in order {
         let Some(batch) = merged.remove(&execution_id) else {
             continue;
         };
-        let n = batch.records.len();
-        let waited = batch.enqueued_at.elapsed();
-        super::ehdb_eventlog_mirror::deliver(&batch).await;
-        // Observed once per event, so the histogram's count is an event count
-        // and lines up with the mirror counter it is read beside.
-        let secs = waited.as_secs_f64();
-        for _ in 0..n {
-            crate::metrics::observe_ehdb_eventlog_mirror_lag(secs);
+        while inflight.len() >= concurrency {
+            retire(inflight.join_next().await);
         }
-        crate::metrics::record_ehdb_eventlog_mirror_queue("drained", n);
-        settled(n);
+        inflight.spawn(async move {
+            let n = batch.records.len();
+            let waited = batch.enqueued_at.elapsed();
+            super::ehdb_eventlog_mirror::deliver(&batch).await;
+            (n, waited.as_secs_f64())
+        });
+    }
+    while let Some(joined) = inflight.join_next().await {
+        retire(Some(joined));
+    }
+}
+
+/// Account one finished delivery.
+///
+/// ⚠ A task that panicked still has to be accounted. `settled(n)` is what
+/// `flush_on_shutdown` waits on, so a lost accounting would leave the shutdown
+/// flush waiting out its full deadline on events that are no longer coming —
+/// and would report them as `shutdown_abandoned`, blaming the queue for a panic
+/// somewhere else. The `deliver` path catches its own errors, so this is the
+/// unexpected case, not the routine one.
+fn retire(joined: Option<Result<(usize, f64), tokio::task::JoinError>>) {
+    let Some(result) = joined else { return };
+    match result {
+        Ok((n, secs)) => {
+            // Observed once per event, so the histogram's count is an event count
+            // and lines up with the mirror counter it is read beside.
+            for _ in 0..n {
+                crate::metrics::observe_ehdb_eventlog_mirror_lag(secs);
+            }
+            crate::metrics::record_ehdb_eventlog_mirror_queue("drained", n);
+            settled(n);
+        }
+        Err(e) => {
+            warn!(
+                target: "noetl_server::ehdb_eventlog_mirror",
+                error = %e,
+                "a mirror delivery task did not complete; its events are unaccounted"
+            );
+        }
     }
 }
 

--- a/tests/mirror_drain_concurrency.rs
+++ b/tests/mirror_drain_concurrency.rs
@@ -1,0 +1,175 @@
+//! The drain delivers independent executions CONCURRENTLY — measured, not declared.
+//!
+//! **noetl/ai-meta#319.** The drain used to POST one batch at a time. Throughput
+//! was `1 / relay-round-trip` regardless of how many independent executions were
+//! waiting, and on production that was nowhere near enough: mean queue lag
+//! **170 s**, the queue permanently full, and **24.6%** of batches falling
+//! through to inline delivery *on the `/api/execute` request path* — the whole
+//! p95 tail and the whole run-to-run bistability.
+//!
+//! # Why this test measures wall-clock
+//!
+//! A concurrency knob is exactly the kind of thing that is set, documented, and
+//! **reached by nothing**. `DRAIN_CONCURRENCY_ENV` could be read, parsed and
+//! logged while the deliveries still serialise behind a shared lock, a `&mut`,
+//! or an accidental `.await` in the spawn loop — and every structural check
+//! would pass. The only claim worth asserting is the one the production defect
+//! is about: **N slow deliveries take about one delivery's time, not N.**
+//!
+//! # Its own binary, one test function
+//!
+//! The queue is a process-global (`OnceLock` + one drain task) configured from
+//! process env, and `cargo test` does **not** serialise tests within a binary.
+//! `mirror_queue.rs` settled on one function for that reason; this needs a
+//! *different* queue configuration, so it needs a different process.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::{extract::State, routing::post, Json, Router};
+use noetl_server::handlers::ehdb_eventlog_mirror::MirrorBatch;
+use noetl_server::handlers::ehdb_eventlog_mirror_queue as queue;
+use serde_json::Value;
+
+/// Each delivery costs this much at the relay. Long enough that serial and
+/// concurrent are unmistakable, short enough that the test is quick.
+const RELAY_DELAY: Duration = Duration::from_millis(200);
+const EXECUTIONS: usize = 8;
+
+#[derive(Clone)]
+struct Relay {
+    seen: Arc<AtomicUsize>,
+    /// Highest number of requests in flight at the relay at any instant. This is
+    /// the direct observation of concurrency, independent of any timing margin.
+    peak: Arc<Mutex<usize>>,
+    inflight: Arc<Mutex<usize>>,
+}
+
+async fn accept(State(r): State<Relay>, Json(_body): Json<Value>) -> &'static str {
+    {
+        let mut n = r.inflight.lock().unwrap();
+        *n += 1;
+        let mut p = r.peak.lock().unwrap();
+        if *n > *p {
+            *p = *n;
+        }
+    }
+    tokio::time::sleep(RELAY_DELAY).await;
+    *r.inflight.lock().unwrap() -= 1;
+    r.seen.fetch_add(1, Ordering::SeqCst);
+    "ok"
+}
+
+async fn drain_all(seen: &Arc<AtomicUsize>, what: &str) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(30) {
+        if seen.load(Ordering::SeqCst) >= EXECUTIONS {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!(
+        "{what}: only {} of {EXECUTIONS} deliveries arrived in 30s",
+        seen.load(Ordering::SeqCst)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn independent_executions_are_delivered_concurrently() {
+    let seen = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(Mutex::new(0usize));
+    let relay = Relay {
+        seen: seen.clone(),
+        peak: peak.clone(),
+        inflight: Arc::new(Mutex::new(0)),
+    };
+    let app = Router::new()
+        .route("/ehdb/tiers/eventlog", post(accept))
+        .with_state(relay);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://{addr}");
+
+    std::env::set_var(queue::ASYNC_ENV, "true");
+    std::env::set_var(queue::CAPACITY_ENV, "64");
+    std::env::set_var(queue::ENQUEUE_TIMEOUT_ENV, "5000");
+    // Larger than EXECUTIONS, so one pass can pick all of them up: this test is
+    // about concurrency WITHIN a pass, and a drain_max below EXECUTIONS would
+    // split them across passes and serialise them for an unrelated reason.
+    std::env::set_var(queue::DRAIN_MAX_ENV, "64");
+    std::env::set_var(queue::DRAIN_CONCURRENCY_ENV, "8");
+    queue::init();
+    assert!(queue::enabled(), "the queue must arm from the flag");
+
+    // ---- the measurement ---------------------------------------------------
+    let started = Instant::now();
+    for i in 0..EXECUTIONS {
+        queue::submit(MirrorBatch {
+            base: base.clone(),
+            execution_id: 1000 + i as i64,
+            records: vec![format!("{{\"n\":{i}}}")],
+            enqueued_at: Instant::now(),
+        })
+        .await;
+    }
+    drain_all(&seen, "concurrent").await;
+    let concurrent = started.elapsed();
+    let observed_peak = *peak.lock().unwrap();
+
+    let serial_floor = RELAY_DELAY * EXECUTIONS as u32;
+    assert!(
+        concurrent < serial_floor / 2,
+        "{EXECUTIONS} independent executions took {concurrent:?}; serial would be \
+         about {serial_floor:?}. The drain is still delivering one at a time — \
+         which is the production defect, not a slow test."
+    );
+    assert!(
+        observed_peak > 1,
+        "the relay never saw more than one request in flight, so nothing was \
+         actually concurrent regardless of how long the pass took"
+    );
+
+    // ---- ⚠ NEGATIVE CONTROL ------------------------------------------------
+    //
+    // Without this the assertions above pass on a machine fast enough to make
+    // any implementation look quick, and the test would be measuring the host
+    // rather than the drain. Concurrency is read per pass, so setting it to 1
+    // restores the serial shape in the SAME process, against the SAME relay —
+    // and the timing must flip.
+    std::env::set_var(queue::DRAIN_CONCURRENCY_ENV, "1");
+    seen.store(0, Ordering::SeqCst);
+    *peak.lock().unwrap() = 0;
+
+    let started = Instant::now();
+    for i in 0..EXECUTIONS {
+        queue::submit(MirrorBatch {
+            base: base.clone(),
+            execution_id: 2000 + i as i64,
+            records: vec![format!("{{\"n\":{i}}}")],
+            enqueued_at: Instant::now(),
+        })
+        .await;
+    }
+    drain_all(&seen, "serial").await;
+    let serial = started.elapsed();
+
+    assert!(
+        serial >= serial_floor - RELAY_DELAY,
+        "with concurrency 1 the same work took {serial:?}, under the {serial_floor:?} \
+         a serial drain must cost. The knob is not being honoured, so the \
+         concurrent measurement above proves nothing about it."
+    );
+    assert_eq!(
+        *peak.lock().unwrap(),
+        1,
+        "concurrency 1 still put more than one request in flight"
+    );
+    assert!(
+        concurrent < serial,
+        "concurrent ({concurrent:?}) was not faster than serial ({serial:?})"
+    );
+}


### PR DESCRIPTION
noetl/ai-meta#319 — **the actual cause of the p95 tail on `/api/execute`**, and
a correction to my own earlier diagnosis.

## What I got wrong first

server#393 bounded the on-path command publish, on the theory that a 10 s retry
budget was the tail. It shipped as **v3.100.3**, is live, and the counter it
added reads:

```
noetl_ehdb_command_publish_deferred_total 0
```

**Zero.** The publish always succeeded inside 500 ms; that budget was never
being spent. p95 at concurrency 1 stayed at **14.9 s / 16.6 s** and the
bistability stayed. §4 of #319 described a real hazard but not the observed cost.

## What it actually is

`emit_mirror` is **1.68 s mean** on the request path (6209 s / 3696 calls), and
every other phase is noise — `emit_publish` 50 ms, `emit_should_publish` 2 µs.

`MIRROR_ASYNC=true` is set and the queue **is** armed. That is not enough:

```
queue_total{outcome="enqueued"}             2463
queue_total{outcome="enqueued_after_wait"}   327
queue_total{outcome="queue_full_inline"}     908   <- 24.6%
```

**A quarter of all batches were delivered inline, on the request path.** An
inline batch first waits out the 5 s enqueue timeout, then POSTs with a 5 s
timeout — up to 10 s — and a request emits three events.

And the queue was not marginally behind:

```
mirror_lag_seconds_sum    475512
mirror_lag_seconds_count    2790     -> 170 s mean
```

Only **56 of 2790** drained within 10 s.

### Cause

`deliver_pass` coalesced per execution and then POSTed strictly **one at a
time**. Throughput was `1 / relay-round-trip` no matter how many independent
executions were waiting — while the function's own comment already said:

> Different executions are independent, so their relative order is not a
> property anything checks.

### It also explains the bistability, better than #319 §5 did

queue fills → submits wait 5 s then go inline → requests slow → more in flight →
queue stays full. A run stays under the knee or falls through it.

## The change

Up to `NOETL_EHDB_EVENTLOG_MIRROR_DRAIN_CONCURRENCY` (default **8**) executions
deliver at once, as a sliding window.

⚠️ **Ordering is untouched** — for a reason specific to this queue's shape, not
an assumption that order does not matter. A pass holds **at most one batch per
`execution_id`**, and pass *N+1* does not begin until pass *N* completes, so two
in-flight requests are always for two *different* executions. Setting the knob to
1 restores the old serial behaviour exactly.

Panicked tasks are still accounted: `settled(n)` is what the shutdown flush waits
on, and losing it would make the flush burn its deadline and report
`shutdown_abandoned` for a panic somewhere else entirely.

## Tests

The existing end-to-end ordering test is the **positive control**, and I checked
it can fail: a mutation delivering raw batches concurrently *without* coalescing
trips it on execution 11.

The new test **measures wall-clock** rather than asserting the knob exists — a
concurrency knob is precisely the sort of thing that gets set, documented, and
reached by nothing.

| mutation | result |
|---|---|
| `await` inside the spawn loop (silently serial) | 1.64 s vs a 1.6 s serial floor — timing assertion fires |
| hard-code 8, ignore the env | **negative control** fires: concurrency 1 finishes in 212 ms, not 1.6 s |
| *unmutated* | passes; relay peak in-flight > 1 |

⚠️ The negative control is what keeps the first measurement honest: on a fast
host any implementation looks quick, so the test also proves the serial shape is
still reachable in the same process against the same relay.

## Verification

- `cargo test --all-targets --locked` — **0 FAILED**, 1026 tests
- `cargo clippy --all-targets` — 0 errors
- rustfmt baseline on the touched file was 0 and is still 0