### PR TITLE
fix(metrics): make the mirror drain concurrency observable

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror_queue.rs
+++ b/src/handlers/ehdb_eventlog_mirror_queue.rs
@@ -166,6 +166,14 @@ static PENDING_EVENTS: AtomicI64 = AtomicI64::new(0);
 static QUEUE: OnceLock<Option<mpsc::Sender<MirrorBatch>>> = OnceLock::new();
 
 /// Is the async queue armed in this process?
+/// The configured drain concurrency, for pinning the gauge and for the ARMED log.
+///
+/// Reads the same env the drain reads, through the same helper, so the published
+/// value cannot drift from the applied one.
+pub fn configured_drain_concurrency() -> usize {
+    env_usize(DRAIN_CONCURRENCY_ENV, DEFAULT_DRAIN_CONCURRENCY).max(1)
+}
+
 pub fn enabled() -> bool {
     queue().is_some()
 }
@@ -202,6 +210,7 @@ pub fn init() {
         capacity,
         drain_max,
         enqueue_timeout_ms = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS).as_millis() as u64,
+        drain_concurrency = configured_drain_concurrency(),
         "async event-log mirror queue ARMED — the mirror is off the event-write path"
     );
     tokio::spawn(drain_loop(rx, drain_max));
@@ -372,7 +381,12 @@ async fn deliver_pass(pass: Vec<MirrorBatch>) {
     // Completion order is not, and does not need to be — see the note on
     // `DRAIN_CONCURRENCY_ENV`: one batch per execution per pass, and passes do
     // not overlap.
-    let concurrency = env_usize(DRAIN_CONCURRENCY_ENV, DEFAULT_DRAIN_CONCURRENCY).max(1);
+    let concurrency = configured_drain_concurrency();
+    // Published from the value this pass ACTUALLY used, not from a startup read.
+    // The knob is per-pass, so a gauge set only at init could disagree with the
+    // running behaviour — which is precisely the drift that left the #320
+    // mitigation unobservable.
+    crate::metrics::ehdb_eventlog_mirror_drain_concurrency().set(concurrency as i64);
     let mut inflight: tokio::task::JoinSet<(usize, f64)> = tokio::task::JoinSet::new();
 
     for execution_id in order {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3532,6 +3532,34 @@ pub fn ehdb_eventlog_mirror_async_enabled() -> &'static IntGauge {
     })
 }
 
+/// Gauge: how many executions one drain pass delivers concurrently.
+///
+/// ⚠ This exists because I shipped the knob without it. `DRAIN_CONCURRENCY` is
+/// read **per pass** rather than at startup, and the ARMED log line reports
+/// `capacity` / `drain_max` / `enqueue_timeout_ms` but not this — so after the
+/// noetl/ai-meta#320 mitigation was applied there was **no runtime evidence
+/// anywhere** that the serial drain was actually in effect. The value could only
+/// be inferred from the Deployment spec, which is a different representation and
+/// one that can disagree with the running process.
+///
+/// A rollback knob whose engagement cannot be observed is the same defect class
+/// as the incident it mitigates.
+pub fn ehdb_eventlog_mirror_drain_concurrency() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_eventlog_mirror_drain_concurrency",
+            "Executions one async event-log mirror drain pass delivers concurrently; 1 is the \
+             serial drain (noetl/ai-meta#320).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
 /// Pin the async-mirror label set and gauges at 0.
 ///
 /// Unconditional, and not inside the flag check: a pin behind the flag would be
@@ -3546,6 +3574,12 @@ pub fn init_ehdb_eventlog_mirror_queue_series() {
     ehdb_eventlog_mirror_pending_events().set(0);
     ehdb_eventlog_mirror_queue_depth().set(0);
     ehdb_eventlog_mirror_async_enabled().set(0);
+    // Pinned to the CONFIGURED value, not 0: unlike the others this is not a
+    // count that starts empty — 0 is not a legal concurrency, so pinning it at 0
+    // would publish a value the drain can never use and make an un-armed process
+    // look misconfigured rather than idle.
+    ehdb_eventlog_mirror_drain_concurrency()
+        .set(crate::handlers::ehdb_eventlog_mirror_queue::configured_drain_concurrency() as i64);
     // An unlabelled Histogram is still a family with one child, so it is not
     // pruned — but observing nothing leaves every bucket at 0, which is what we
     // want it to read as.

--- a/tests/drain_concurrency_observable.rs
+++ b/tests/drain_concurrency_observable.rs
@@ -1,0 +1,134 @@
+//! The #320 mitigation's engagement must be observable at runtime.
+//!
+//! **noetl/ai-meta#320.** `NOETL_EHDB_EVENTLOG_MIRROR_DRAIN_CONCURRENCY=1` was
+//! applied to production as the mitigation for a 99% mirror failure rate — and
+//! there was **no runtime evidence anywhere that it had taken effect**. The knob
+//! is read per drain pass rather than at startup, and the ARMED log line reported
+//! `capacity` / `drain_max` / `enqueue_timeout_ms` but not this one.
+//!
+//! The only way to check was the Deployment spec, which is a *different
+//! representation* of the running process and can disagree with it. A rollback
+//! knob whose engagement cannot be observed is the same defect class as the
+//! incident it mitigates.
+
+const QUEUE: &str = include_str!("../src/handlers/ehdb_eventlog_mirror_queue.rs");
+const METRICS: &str = include_str!("../src/metrics.rs");
+
+fn non_test(src: &str) -> &str {
+    src.split_once("\n#[cfg(test)]").map_or(src, |(b, _)| b)
+}
+
+/// ⭐ The ARMED line reports the concurrency alongside the other three knobs.
+///
+/// ⚠ Mutation verified: removing `drain_concurrency` from the `info!` fails this.
+#[test]
+fn the_armed_log_line_reports_the_drain_concurrency() {
+    let src = non_test(QUEUE);
+    let at = src
+        .find("async event-log mirror queue ARMED")
+        .expect("the ARMED line must exist");
+    // The fields precede the message in a tracing macro, so look back from it.
+    let head = &src[at.saturating_sub(600)..at];
+    for field in [
+        "capacity",
+        "drain_max",
+        "enqueue_timeout_ms",
+        "drain_concurrency",
+    ] {
+        assert!(
+            head.contains(field),
+            "the ARMED line omits `{field}`. Every knob that changes drain \
+             behaviour has to be in it, or an operator reading the log cannot \
+             tell what the process is actually doing:\n{head}"
+        );
+    }
+}
+
+/// ⭐ The gauge is published from the value the pass ACTUALLY used.
+///
+/// Setting it only at startup would let it disagree with the running behaviour,
+/// because the knob is re-read per pass. That gap is exactly what left the
+/// mitigation unobservable.
+///
+/// ⚠ Mutation verified: moving the `.set(..)` out of `deliver_pass` and into
+/// `init` fails this.
+#[test]
+fn the_gauge_is_set_from_the_value_the_pass_used() {
+    let src = non_test(QUEUE);
+    let at = src
+        .find("async fn deliver_pass")
+        .expect("deliver_pass must exist");
+    let body = &src[at..];
+    let end = body.find("\n}\n").unwrap_or(body.len());
+    let body = &body[..end];
+    assert!(
+        body.contains("ehdb_eventlog_mirror_drain_concurrency().set("),
+        "deliver_pass does not publish the concurrency it used, so the gauge can \
+         disagree with the running drain"
+    );
+    let set_at = body.find("drain_concurrency().set(").unwrap();
+    let conc_at = body
+        .find("let concurrency = configured_drain_concurrency();")
+        .expect("the pass must resolve the concurrency");
+    assert!(
+        conc_at < set_at,
+        "the gauge is published before the value is resolved, so it cannot be \
+         reporting what this pass used"
+    );
+}
+
+/// ⚠ The gauge and the drain must read the SAME source.
+///
+/// Two independent `env_usize` reads would let the published value and the
+/// applied value drift — a gauge that is confidently wrong is worse than none,
+/// because it ends an investigation early.
+#[test]
+fn the_published_value_and_the_applied_value_share_one_reader() {
+    let src = non_test(QUEUE);
+    assert_eq!(
+        src.matches("env_usize(DRAIN_CONCURRENCY_ENV").count(),
+        1,
+        "DRAIN_CONCURRENCY is read from the env in more than one place; the \
+         published value can then drift from the applied one"
+    );
+    assert!(
+        src.contains("pub fn configured_drain_concurrency() -> usize {"),
+        "the single reader must be a named, shared helper"
+    );
+}
+
+/// ⚠ Pinned at the CONFIGURED value, not 0.
+///
+/// Unlike the counters beside it this is not a tally that starts empty: 0 is not
+/// a legal concurrency. Pinning it at 0 would publish a value the drain can never
+/// use, making an idle process look misconfigured.
+#[test]
+fn the_gauge_is_pinned_to_the_configured_value_not_zero() {
+    // ⚠ Deliberately NOT `non_test` here. That helper cuts at the FIRST
+    // `#[cfg(test)]`, which in `metrics.rs` is at line 248 — thousands of lines
+    // before this function. Using it made this test search an empty tail and fail
+    // for a reason that had nothing to do with the code. A file with inline test
+    // modules needs the function extracted, not the file truncated.
+    let at = METRICS
+        .find("pub fn init_ehdb_eventlog_mirror_queue_series()")
+        .expect("the pin fn must exist");
+    let rest = &METRICS[at..];
+    let end = rest.find("\n}\n").map(|e| e + 2).unwrap_or(rest.len());
+    let body = &rest[..end];
+    assert!(
+        body.len() > 200,
+        "extracted an implausibly short function body ({} bytes) — the extraction \
+         is broken and any pass below would be vacuous",
+        body.len()
+    );
+    assert!(
+        body.contains("ehdb_eventlog_mirror_drain_concurrency()"),
+        "the drain-concurrency gauge is not pinned, so it is ABSENT until the \
+         first drain pass — and absent reads as 'no such metric', which is the \
+         same silence this fixes"
+    );
+    assert!(
+        !body.contains("ehdb_eventlog_mirror_drain_concurrency()\n        .set(0)"),
+        "pinned at 0, which is not a legal concurrency"
+    );
+}


### PR DESCRIPTION
noetl/ai-meta#320. **I shipped the knob without this, and it mattered.**

`NOETL_EHDB_EVENTLOG_MIRROR_DRAIN_CONCURRENCY=1` was applied to production as the mitigation for a **99% mirror failure rate** — and there was **no runtime evidence anywhere that it had taken effect**.

The value is read *per drain pass* rather than at startup, and the ARMED log line reported `capacity` / `drain_max` / `enqueue_timeout_ms` but not this one. The only way to check was the Deployment spec — a *different representation* of the running process, and one that can disagree with it.

⚠️ **A rollback knob whose engagement cannot be observed is the same defect class as the incident it mitigates.**

## What

- `noetl_ehdb_eventlog_mirror_drain_concurrency`, published from the value **each pass actually used** — not a startup read, which could drift from the running behaviour.
- The field added to the ARMED log line.
- Both go through **one shared helper**, so the published value cannot drift from the applied one.
- **Pinned at the configured value, not 0.** Unlike the counters beside it this is not a tally that starts empty: 0 is not a legal concurrency, so pinning at 0 would publish a value the drain can never use and make an idle process look misconfigured.

## Mutations, each verified

| mutation | gate that fails |
|---|---|
| drop the field from the ARMED line (**the original defect**) | armed-line |
| publish at init instead of per pass | per-pass |
| remove the pin | pin |

## ⚠️ One of my own gates was a false negative first

It used a `non_test()` helper that cuts at the **first** `#[cfg(test)]` — which in `metrics.rs` is line 248, thousands of lines before the function under test. It searched an empty tail and failed for a reason unrelated to the code. The test now extracts the function body and **asserts the extraction is non-trivial before asserting anything about it**.

## Verification

- `cargo test --all-targets --locked` — **1034 passed, 0 FAILED**
- `cargo clippy --all-targets` — 0 errors
- fmt baselines unchanged on touched files