### PR TITLE
fix(metrics): publish the shutdown-flush budget on the ARMED line

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror_queue.rs
+++ b/src/handlers/ehdb_eventlog_mirror_queue.rs
@@ -210,6 +210,7 @@ pub fn init() {
         capacity,
         drain_max,
         enqueue_timeout_ms = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS).as_millis() as u64,
+        flush_timeout_ms = env_millis(FLUSH_TIMEOUT_ENV, DEFAULT_FLUSH_TIMEOUT_MS).as_millis() as u64,
         drain_concurrency = configured_drain_concurrency(),
         "async event-log mirror queue ARMED — the mirror is off the event-write path"
     );

--- a/src/handlers/ehdb_projection_mirror_queue.rs
+++ b/src/handlers/ehdb_projection_mirror_queue.rs
@@ -221,6 +221,7 @@ pub fn init(lag_tolerance_secs: u64) {
         target: "noetl_server::ehdb_projection_mirror",
         capacity, drain_max, lag_tolerance_secs,
         enqueue_timeout_ms = env_millis(ENQUEUE_TIMEOUT_ENV, DEFAULT_ENQUEUE_TIMEOUT_MS).as_millis() as u64,
+        flush_timeout_ms = env_millis(FLUSH_TIMEOUT_ENV, DEFAULT_FLUSH_TIMEOUT_MS).as_millis() as u64,
         "async projection mirror queue ARMED — the mirror is off the orchestrator write path"
     );
     tokio::spawn(drain_loop(rx, drain_max));


### PR DESCRIPTION
Found by the `knob-observability` drift-audit check added in ai-meta@378efef — **its first real finding.**

`NOETL_EHDB_{EVENTLOG,PROJECTION}_MIRROR_FLUSH_TIMEOUT_MS` is read but its value appeared **nowhere on a running process**. It was logged only inside `flush_on_shutdown`, which runs at SIGTERM and returns early when the queue is empty — so the budget was invisible until the moment it mattered, and often not even then.

That budget decides how long shutdown waits before abandoning queued mirror events and counting them `shutdown_abandoned`. An operator diagnosing lost events at shutdown could not see what bound was applied without reading the Deployment spec — a *different representation* of the running process.

Adds `flush_timeout_ms` alongside `capacity` / `drain_max` / `enqueue_timeout_ms` on both ARMED lines, matching how the other three knobs are already published. `drift-audit knob-observability` now reports OK (verified before: DRIFT on both modules; after: OK).

## ⚠️ Not built locally

This checkout cannot resolve the server's current lock (the registry cache lacks `memo-map 0.3.4`) and `vendor/` is untracked and stale, so `--offline` resolution fails for reasons unrelated to this change. **CI builds from the network and is the verification** — this will not be merged unless it is green.

## ⚠️ Two of my own edits misfired first

The first anchored on a region truncated at the first `"ARMED"` match — a doc comment hundreds of lines above the real log line. The second used the wrong indentation. Both **asserted** rather than silently no-op'ing, which is why they were caught rather than shipped as a false green.