### PR TITLE
fix(metrics): pin deferred_exhausted, which was absent rather than zero

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -699,8 +699,25 @@ pub fn ehdb_command_publish_failed_total() -> &'static IntCounterVec {
 /// any signal.  `no_writers` is the severe one: with `NOETL_COMMAND_BUS=ehdb`
 /// and no writer routes resolved, EVERY command is silently not delivered and
 /// every execution stalls — previously visible only as a `tracing::warn!`.
-pub const EHDB_COMMAND_PUBLISH_FAILED_REASONS: [&str; 4] =
-    ["gave_up", "attempt", "no_writers", "shadow_failed"];
+/// ⚠ Every reason the code can record must be listed here.
+///
+/// A reason that is recorded but not pinned stays **ABSENT** from `/metrics`
+/// until the first time it fires, while its siblings read 0 — so "it has never
+/// happened" and "this build has no such metric" are the same scrape. That is
+/// the absent-is-not-zero shape this repo keeps finding, and
+/// `drift-audit.sh metric-pins` compares this list against the literals
+/// `record_ehdb_command_publish_failed` is actually called with.
+///
+/// `deferred_exhausted` was missing here from the day the deferred publish path
+/// shipped (noetl/ai-meta#319 P3) — the one outcome an operator would go looking
+/// for after a writer outage, and the one that would have shown nothing.
+pub const EHDB_COMMAND_PUBLISH_FAILED_REASONS: [&str; 5] = [
+    "gave_up",
+    "attempt",
+    "no_writers",
+    "shadow_failed",
+    "deferred_exhausted",
+];
 
 pub fn init_ehdb_command_publish_failed_series() {
     for reason in EHDB_COMMAND_PUBLISH_FAILED_REASONS {


### PR DESCRIPTION
Found by `drift-audit pinned-sets`. **The defect is mine** — it shipped with the deferred publish path (noetl/ai-meta#319 P3).

`record_ehdb_command_publish_failed("deferred_exhausted")` fires when a deferred publish burns its whole remaining deadline off the request path. But `deferred_exhausted` was not in `EHDB_COMMAND_PUBLISH_FAILED_REASONS`, so the series stayed **ABSENT** from `/metrics` until the first time it fired, while its four siblings read 0.

That makes *"it has never happened"* and *"this build has no such metric"* the same scrape. It is also **the one outcome an operator would go looking for after a writer outage** — and the one that would have shown nothing.

The array is now multi-line with a comment stating the rule: every reason the code can record must be listed here, and `pinned-sets` compares this list against the literals the recorder is actually called with.

## Verification

- `cargo test --all-targets --locked` — **1034 passed, 0 FAILED**
- `cargo clippy --all-targets` — 0 errors
- ⓘ `drift-audit pinned-sets` reads `origin/main`, not the working tree, so it will keep reporting SHORT until this merges — that is the check auditing what is *shipped*, working as intended.