### PR TITLE
fix(ehdb): retry mirror deliveries, and count the ones that are lost

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -102,7 +102,7 @@
 use std::time::{Duration, Instant};
 
 use serde_json::json;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::handlers::event_write::EventRow;
 use crate::state::AppState;
@@ -120,6 +120,95 @@ pub const MIRROR_SOURCE_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_SOURCE";
 /// Short on purpose. This sits inline on the event-write path, so the cost of a
 /// hung worker is bounded latency on event emission, not an unbounded stall.
 const APPEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How many times a failed delivery is retried before the batch is declared
+/// lost (noetl/ai-meta#320). Default 4, i.e. up to 5 attempts.
+///
+/// Retrying is only safe because the tier deduplicates on `event_id`
+/// (noetl/ehdb#352 + noetl/worker#309, shipped in worker v5.131.0): an
+/// *ambiguous* failure — request applied, response lost — is the common
+/// shape here, and before the dedupe a retry of one would have written the
+/// record twice. `mirror_payload` emits `event_id` as a JSON number and the
+/// worker's `event_id_from_payload` reads both spellings, so the key is
+/// present on every record this path sends.
+///
+/// **`0` restores the pre-fix behaviour exactly** (one attempt, then the batch
+/// is dropped) and is the no-redeploy rollback.
+pub const MAX_RETRIES_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_MAX_RETRIES";
+
+/// Base delay for the retry backoff, doubled each attempt. Default 250 ms.
+///
+/// Sized against the measured outage: the observed failure bursts lasted
+/// ~1.5 s (a liveness kill of the single relay endpoint), and 250 ms doubling
+/// over 4 retries spans 250+500+1000+2000 = 3.75 s of waiting.
+pub const RETRY_BACKOFF_MS_ENV: &str = "NOETL_EHDB_EVENTLOG_MIRROR_RETRY_BACKOFF_MS";
+
+fn max_retries() -> u32 {
+    std::env::var(MAX_RETRIES_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(4)
+        .min(10)
+}
+
+fn retry_backoff() -> Duration {
+    let ms = std::env::var(RETRY_BACKOFF_MS_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(250);
+    Duration::from_millis(ms.min(10_000))
+}
+
+/// What one delivery attempt concluded.
+///
+/// Split from the metric label on purpose: the label says what to *count*, this
+/// says what to *do next*, and conflating them is how a 501 ends up retried 5
+/// times against a worker that will refuse it every time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttemptOutcome {
+    Delivered,
+    /// Worth another attempt: transport failure, or a 5xx/429 from the relay.
+    Retryable(&'static str),
+    /// Retrying cannot help — the worker is not rolled, or is in `worker` mode.
+    Fatal(&'static str),
+}
+
+/// Classify an HTTP status into a retry decision.
+///
+/// Pure so the decision is testable without a relay; the mutation that made
+/// 501 retryable is caught by a gate rather than by an operator watching a
+/// rollout spam five attempts per batch.
+pub(crate) fn classify_status(status: u16) -> AttemptOutcome {
+    match status {
+        200..=299 => AttemptOutcome::Delivered,
+        // 501 — rolled, but still in `worker` mode. 405 — not rolled at all.
+        // Both are a rollout state, not an outage, and both are permanent
+        // until someone deploys. Retrying just multiplies the log noise.
+        501 | 405 => AttemptOutcome::Fatal("unconfigured"),
+        // 408/429 and every 5xx are the relay being transiently unable.
+        408 | 429 | 500..=599 => AttemptOutcome::Retryable("degraded"),
+        // Any other 4xx is a request this server will keep getting wrong.
+        _ => AttemptOutcome::Fatal("degraded"),
+    }
+}
+
+/// The `event_id`s in a batch, for the drop log.
+///
+/// A dropped batch is repairable only if someone can find out *which* events
+/// went missing. Before noetl/ai-meta#320 the warn logged the count and not the
+/// ids, so the only way to discover a loss was to diff both stores afterwards.
+pub(crate) fn batch_event_ids(records: &[String]) -> Vec<i64> {
+    records
+        .iter()
+        .filter_map(|r| {
+            serde_json::from_str::<serde_json::Value>(r)
+                .ok()?
+                .get("event_id")?
+                .as_i64()
+        })
+        .collect()
+}
 
 /// Which component mirrors into the event-log tier. Mirror of the worker's
 /// `ehdb::mirror_source::MirrorSource`.
@@ -377,58 +466,90 @@ pub(crate) async fn deliver(batch: &MirrorBatch) {
     let url = format!("{}/ehdb/tiers/eventlog", batch.base.trim_end_matches('/'));
     let body = json!({ "execution_id": execution_id.to_string(), "records": batch.records });
 
-    let resp = relay_client()
-        .post(&url)
-        .json(&body)
-        .timeout(APPEND_TIMEOUT)
-        .send()
-        .await;
+    let retries = max_retries();
+    let mut backoff = retry_backoff();
+    let mut last_detail = String::new();
 
-    match resp {
-        Err(e) => {
-            crate::metrics::record_ehdb_eventlog_mirror("unavailable", count);
-            warn!(
-                target: "noetl_server::ehdb_eventlog_mirror",
-                execution_id, events = count, error = %e,
-                "event-log tier mirror relay failed"
-            );
-        }
-        Ok(r) => {
-            let status = r.status();
-            if status == reqwest::StatusCode::NOT_IMPLEMENTED
-                || status == reqwest::StatusCode::METHOD_NOT_ALLOWED
-            {
-                // Two distinct causes, one meaning: this worker cannot accept
-                // server-authored appends, and the fix is a rollout rather than
-                // an outage.
-                //
-                //   501 — rolled, but still in `worker` mode.
-                //   405 — NOT rolled. The GET route exists on every worker back
-                //         to the query interface, so axum answers a POST to it
-                //         with "method not allowed" rather than 404. Counting
-                //         that as `degraded` would file the single most likely
-                //         operational state — server rolled ahead of worker —
-                //         under a label meaning "the append was refused", and
-                //         send an operator looking at the tier instead of at
-                //         the rollout.
-                crate::metrics::record_ehdb_eventlog_mirror("unconfigured", count);
+    for attempt in 0..=retries {
+        let outcome = match relay_client()
+            .post(&url)
+            .json(&body)
+            .timeout(APPEND_TIMEOUT)
+            .send()
+            .await
+        {
+            Err(e) => {
+                last_detail = e.to_string();
+                AttemptOutcome::Retryable("unavailable")
+            }
+            Ok(r) => {
+                let status = r.status().as_u16();
+                let decided = classify_status(status);
+                if !matches!(decided, AttemptOutcome::Delivered) {
+                    let detail = r.text().await.unwrap_or_default();
+                    last_detail = format!(
+                        "status {status}: {}",
+                        detail.chars().take(400).collect::<String>()
+                    );
+                }
+                decided
+            }
+        };
+
+        match outcome {
+            AttemptOutcome::Delivered => {
+                // `recovered` rather than `mirrored` when it took more than one
+                // attempt, so a pool that flaps and a pool that is healthy do
+                // not read identically. Suppressing that would hide the very
+                // instability the retry exists to survive.
+                crate::metrics::record_ehdb_eventlog_mirror(
+                    if attempt == 0 { "mirrored" } else { "recovered" },
+                    count,
+                );
+                if attempt > 0 {
+                    warn!(
+                        target: "noetl_server::ehdb_eventlog_mirror",
+                        execution_id, events = count, attempts = attempt + 1,
+                        "event-log tier mirror recovered on retry"
+                    );
+                }
+                return;
+            }
+            AttemptOutcome::Fatal(label) => {
+                crate::metrics::record_ehdb_eventlog_mirror(label, count);
                 warn!(
                     target: "noetl_server::ehdb_eventlog_mirror",
-                    execution_id, events = count, status = status.as_u16(),
-                    "worker cannot accept server-authored appends — is it rolled, and is \
+                    execution_id, events = count, detail = %last_detail,
+                    "event-log tier mirror refused permanently — is the worker rolled, and is \
                      {MIRROR_SOURCE_ENV}=server set on it?"
                 );
-            } else if status.is_success() {
-                crate::metrics::record_ehdb_eventlog_mirror("mirrored", count);
-            } else {
-                let detail = r.text().await.unwrap_or_default();
-                crate::metrics::record_ehdb_eventlog_mirror("degraded", count);
-                warn!(
-                    target: "noetl_server::ehdb_eventlog_mirror",
-                    execution_id, events = count, status = status.as_u16(),
-                    detail = %detail.chars().take(400).collect::<String>(),
-                    "event-log tier mirror was refused"
-                );
+                return;
+            }
+            AttemptOutcome::Retryable(label) => {
+                if attempt == retries {
+                    // Terminal. This is the loss, and it gets its own counter and
+                    // its own level, because noetl/ai-meta#320 ran for days while
+                    // every queue metric read healthy and this path filed its
+                    // discards under `unavailable`, which no alert watched.
+                    crate::metrics::record_ehdb_eventlog_mirror("dropped", count);
+                    error!(
+                        target: "noetl_server::ehdb_eventlog_mirror",
+                        execution_id,
+                        events = count,
+                        attempts = attempt + 1,
+                        event_ids = ?batch_event_ids(&batch.records),
+                        detail = %last_detail,
+                        "event-log tier mirror DROPPED events after exhausting retries — these \
+                         event_ids are absent from the tier and need POST \
+                         /api/ehdb/repair/executions/{execution_id}"
+                    );
+                    return;
+                }
+                // A failed attempt that will be retried is counted separately, so
+                // the terminal counter keeps meaning "one per batch".
+                crate::metrics::record_ehdb_eventlog_mirror_attempt(label, count);
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2);
             }
         }
     }
@@ -436,6 +557,244 @@ pub(crate) async fn deliver(batch: &MirrorBatch) {
 
 #[cfg(test)]
 mod tests {
+
+    // ---- noetl/ai-meta#320: the mirror must not lose events silently -------
+    //
+    // These drive the REAL `deliver` against a controllable relay, because the
+    // defect being fixed was never in a pure function: `deliver` POSTed once and
+    // returned `()`, so no test of a decision helper could have seen it. The
+    // assertions are on the terminal metric and on the number of requests the
+    // relay actually received.
+
+    use super::{
+        batch_event_ids, classify_status, deliver, max_retries, AttemptOutcome, MirrorBatch,
+        MAX_RETRIES_ENV, RETRY_BACKOFF_MS_ENV,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    fn outcome_count(outcome: &str) -> u64 {
+        crate::metrics::ehdb_eventlog_mirror_total()
+            .with_label_values(&[outcome])
+            .get()
+    }
+    fn attempt_count(outcome: &str) -> u64 {
+        crate::metrics::ehdb_eventlog_mirror_attempt_total()
+            .with_label_values(&[outcome])
+            .get()
+    }
+
+    /// A relay that answers the first `fail_times` requests with `code`, then 200.
+    /// Returns (base_url, hits).
+    async fn fake_relay(fail_times: usize, code: u16) -> (String, Arc<AtomicUsize>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let h = hits.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let h = h.clone();
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = vec![0u8; 65536];
+                    let _ = sock.read(&mut buf).await;
+                    let n = h.fetch_add(1, Ordering::SeqCst);
+                    let status = if n < fail_times { code } else { 200 };
+                    let body = b"{}";
+                    let resp = format!(
+                        "HTTP/1.1 {status} X\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.write_all(body).await;
+                    let _ = sock.flush().await;
+                });
+            }
+        });
+        (format!("http://{addr}"), hits)
+    }
+
+    fn batch(base: &str, ids: &[i64]) -> MirrorBatch {
+        MirrorBatch {
+            base: base.to_string(),
+            execution_id: 4242,
+            records: ids
+                .iter()
+                .map(|i| format!(r#"{{"event_id":{i},"event_type":"t"}}"#))
+                .collect(),
+            enqueued_at: Instant::now(),
+        }
+    }
+
+    /// **The gate the whole fix exists for.** A batch the relay never accepts
+    /// must land on `dropped` — never on nothing, and never only on a label no
+    /// alert watches.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn an_undeliverable_batch_is_counted_as_dropped_not_silently_discarded() {
+        std::env::set_var(MAX_RETRIES_ENV, "2");
+        std::env::set_var(RETRY_BACKOFF_MS_ENV, "1");
+        let (base, hits) = fake_relay(usize::MAX, 503).await;
+
+        let before_dropped = outcome_count("dropped");
+        let before_attempt = attempt_count("degraded");
+        deliver(&batch(&base, &[11, 22, 33])).await;
+
+        assert_eq!(
+            outcome_count("dropped") - before_dropped,
+            3,
+            "a batch that was never accepted must increment the `dropped` counter by its event \
+             count — this is the only signal that authoritative events will never reach the tier"
+        );
+        assert_eq!(
+            attempt_count("degraded") - before_attempt,
+            6,
+            "the two retried attempts must be counted per-attempt (2 attempts x 3 events)"
+        );
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            3,
+            "max_retries=2 means 3 attempts total"
+        );
+        std::env::remove_var(MAX_RETRIES_ENV);
+        std::env::remove_var(RETRY_BACKOFF_MS_ENV);
+    }
+
+    /// Retrying has to actually recover, or the fix is only better logging.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_transient_failure_is_retried_and_recovers() {
+        std::env::set_var(MAX_RETRIES_ENV, "4");
+        std::env::set_var(RETRY_BACKOFF_MS_ENV, "1");
+        let (base, hits) = fake_relay(2, 503).await;
+
+        let before_rec = outcome_count("recovered");
+        let before_drop = outcome_count("dropped");
+        deliver(&batch(&base, &[7, 8])).await;
+
+        assert_eq!(
+            outcome_count("recovered") - before_rec,
+            2,
+            "a delivery that succeeded on attempt 3 must be counted as `recovered`, so a flapping \
+             relay is still visible"
+        );
+        assert_eq!(
+            outcome_count("dropped") - before_drop,
+            0,
+            "nothing was lost, so `dropped` must not move"
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 3, "two failures then success");
+        std::env::remove_var(MAX_RETRIES_ENV);
+        std::env::remove_var(RETRY_BACKOFF_MS_ENV);
+    }
+
+    /// `max_retries=0` must reproduce the pre-fix behaviour exactly — that is the
+    /// no-redeploy rollback, and a rollback that changes the request count is not
+    /// a rollback.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn zero_retries_is_one_attempt_and_still_reports_the_loss() {
+        std::env::set_var(MAX_RETRIES_ENV, "0");
+        let (base, hits) = fake_relay(usize::MAX, 503).await;
+
+        let before = outcome_count("dropped");
+        deliver(&batch(&base, &[1])).await;
+
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "no retries means one POST");
+        assert_eq!(
+            outcome_count("dropped") - before,
+            1,
+            "even with retries disabled the loss must be counted — the pre-fix behaviour was to \
+             file it under `unavailable`, which is why it went unnoticed"
+        );
+        std::env::remove_var(MAX_RETRIES_ENV);
+    }
+
+    /// A rollout state must not be retried: 501/405 mean "deploy something",
+    /// and five attempts per batch against them is pure noise.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_rollout_state_is_not_retried() {
+        std::env::set_var(MAX_RETRIES_ENV, "4");
+        std::env::set_var(RETRY_BACKOFF_MS_ENV, "1");
+        let (base, hits) = fake_relay(usize::MAX, 501).await;
+
+        let before_unconf = outcome_count("unconfigured");
+        let before_drop = outcome_count("dropped");
+        deliver(&batch(&base, &[5])).await;
+
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "501 is permanent until a deploy; retrying it multiplies log noise without a chance \
+             of succeeding"
+        );
+        assert_eq!(outcome_count("unconfigured") - before_unconf, 1);
+        assert_eq!(
+            outcome_count("dropped") - before_drop,
+            0,
+            "`unconfigured` is a rollout state, not data loss; conflating them would make the \
+             loss counter unreadable during any rollout"
+        );
+        std::env::remove_var(MAX_RETRIES_ENV);
+        std::env::remove_var(RETRY_BACKOFF_MS_ENV);
+    }
+
+    #[test]
+    fn status_classification_separates_retryable_from_permanent() {
+        assert_eq!(classify_status(200), AttemptOutcome::Delivered);
+        assert_eq!(classify_status(501), AttemptOutcome::Fatal("unconfigured"));
+        assert_eq!(classify_status(405), AttemptOutcome::Fatal("unconfigured"));
+        assert_eq!(classify_status(503), AttemptOutcome::Retryable("degraded"));
+        assert_eq!(classify_status(500), AttemptOutcome::Retryable("degraded"));
+        assert_eq!(classify_status(429), AttemptOutcome::Retryable("degraded"));
+        assert_eq!(
+            classify_status(400),
+            AttemptOutcome::Fatal("degraded"),
+            "a malformed request will be malformed on every retry"
+        );
+    }
+
+    /// The drop log is the only thing that makes a loss repairable without
+    /// diffing both stores, so the ids have to actually come out.
+    #[test]
+    fn the_drop_log_can_name_the_lost_events() {
+        let b = batch("http://x", &[900, 901]);
+        assert_eq!(batch_event_ids(&b.records), vec![900, 901]);
+        assert!(
+            batch_event_ids(&["not json".to_string()]).is_empty(),
+            "an unparseable record must not panic the drop path"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn retry_count_defaults_and_is_bounded() {
+        std::env::remove_var(MAX_RETRIES_ENV);
+        assert_eq!(max_retries(), 4, "default");
+        std::env::set_var(MAX_RETRIES_ENV, "0");
+        assert_eq!(max_retries(), 0, "0 is honoured — it is the rollback");
+        std::env::set_var(MAX_RETRIES_ENV, "banana");
+        assert_eq!(max_retries(), 4, "junk falls back to the default");
+        std::env::set_var(MAX_RETRIES_ENV, "9999");
+        assert_eq!(max_retries(), 10, "clamped");
+        std::env::remove_var(MAX_RETRIES_ENV);
+    }
+
+    /// `dropped` must be in the pinned label set, or a server that has never
+    /// dropped and a server built before the counter existed look identical.
+    #[test]
+    fn the_loss_label_is_pinned_so_absent_is_not_zero() {
+        assert!(
+            crate::metrics::EHDB_EVENTLOG_MIRROR_OUTCOMES.contains(&"dropped"),
+            "the loss counter must be pinned at 0 like every other closed label set"
+        );
+        assert!(crate::metrics::EHDB_EVENTLOG_MIRROR_OUTCOMES.contains(&"recovered"));
+    }
 
     /// The fold reads `context`; the payload must therefore carry it.
     ///
@@ -633,10 +992,26 @@ mod tests {
     fn there_is_exactly_one_deliverer() {
         let me = include_str!("ehdb_eventlog_mirror.rs");
         let queue = include_str!("ehdb_eventlog_mirror_queue.rs");
+        // Whitespace-insensitive on purpose. The first spelling of this guard
+        // pinned the exact indentation (`relay_client()\n` + eight spaces +
+        // `.post(`), so moving the POST inside the noetl/ai-meta#320 retry loop
+        // made it report ZERO call sites — a guard against a second deliverer
+        // that would have passed if the only deliverer were deleted. It must
+        // count the code, not one layout of it.
+        let squashed: String = me.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            squashed.len() > 20_000,
+            "the guard extracted an implausibly small source — it is not measuring this file"
+        );
+        // Assembled rather than written out, because `include_str!` includes THIS
+        // line: the literal spelling of the needle would match itself and the
+        // guard would report 2 call sites in a file that has 1.
+        let needle = format!("relay_client(){} .post(", "");
         assert_eq!(
-            me.matches("relay_client()\n        .post(").count(),
+            squashed.matches(&needle).count(),
             1,
-            "the relay POST must exist once, in `deliver`"
+            "the relay POST must exist exactly once, in `deliver` — 0 means this guard stopped \
+             measuring, >1 means a second failure posture was added"
         );
         assert!(
             !queue.contains(".post("),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3359,9 +3359,57 @@ pub fn ehdb_eventlog_mirror_total() -> &'static IntCounterVec {
     })
 }
 
-/// Every outcome label the server-side mirror can emit. Closed set, pinned at 0.
-pub const EHDB_EVENTLOG_MIRROR_OUTCOMES: [&str; 4] =
-    ["mirrored", "unconfigured", "unavailable", "degraded"];
+/// Every **terminal** outcome label the server-side mirror can emit, one per
+/// batch. Closed set, pinned at 0.
+///
+/// `dropped` is the one that matters: it is the count of authoritative events
+/// that will never reach the tier, and before noetl/ai-meta#320 there was no
+/// such label — a discarded batch was filed under `unavailable`, which reads
+/// like a transport blip rather than data loss, and which no alert watched.
+///
+/// `unavailable` and `degraded` are still emitted here when retries are
+/// disabled (`NOETL_EHDB_EVENTLOG_MIRROR_MAX_RETRIES=0`), because with no
+/// retry the first failure *is* terminal. When retries are on, a failing
+/// attempt is counted on
+/// [`record_ehdb_eventlog_mirror_attempt`] instead and only the exhausted
+/// batch lands here, as `dropped`.
+pub const EHDB_EVENTLOG_MIRROR_OUTCOMES: [&str; 6] = [
+    "mirrored",
+    "recovered",
+    "dropped",
+    "unconfigured",
+    "unavailable",
+    "degraded",
+];
+
+/// Per-**attempt** failure labels, so a retry that eventually succeeds is still
+/// visible. Without this the fix would hide the very instability it works
+/// around: a pool flapping every ten minutes and a perfectly healthy one would
+/// both read `mirrored`.
+pub const EHDB_EVENTLOG_MIRROR_ATTEMPT_OUTCOMES: [&str; 2] = ["unavailable", "degraded"];
+
+pub fn ehdb_eventlog_mirror_attempt_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let c = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_eventlog_mirror_attempt_total",
+                "Individual failed mirror delivery attempts by outcome; a batch that \
+                 succeeds on a retry increments this and then `mirror_total{outcome=\"recovered\"}`.",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric");
+        registry().register(Box::new(c.clone())).ok();
+        c
+    })
+}
+
+pub fn record_ehdb_eventlog_mirror_attempt(outcome: &str, events: usize) {
+    ehdb_eventlog_mirror_attempt_total()
+        .with_label_values(&[outcome])
+        .inc_by(events as u64);
+}
 
 pub fn record_ehdb_eventlog_mirror(outcome: &str, events: usize) {
     ehdb_eventlog_mirror_total()
@@ -3379,6 +3427,11 @@ pub fn record_ehdb_eventlog_mirror(outcome: &str, events: usize) {
 pub fn init_ehdb_eventlog_mirror_series() {
     for outcome in EHDB_EVENTLOG_MIRROR_OUTCOMES {
         ehdb_eventlog_mirror_total()
+            .with_label_values(&[outcome])
+            .inc_by(0);
+    }
+    for outcome in EHDB_EVENTLOG_MIRROR_ATTEMPT_OUTCOMES {
+        ehdb_eventlog_mirror_attempt_total()
             .with_label_values(&[outcome])
             .inc_by(0);
     }


### PR DESCRIPTION
Closes the residual event loss in noetl/ai-meta#320.

## The defect

`deliver` POSTed **once** and returned `()`. All three failure arms ended in a `warn!` and a return — no retry, no re-queue, no dead-letter — and it was structurally incapable of telling the drain it had failed.

Lowering `DRAIN_CONCURRENCY` to 1 did not stop it, because **concurrency was never the mechanism**; it was a rate multiplier on a drop path that was always there. Measured on prod over six hours with the queue completely idle:

```
queue:    enqueued 144 = drained 144 | queue_full_inline 0 | pending 0
delivery: mirrored 135 | unavailable 9      <-- 6.25% dropped
```

Trigger: `NOETL_EHDB_WORKER_QUERY_URL` resolves to **exactly one endpoint** (`noetl-worker-system-pool-metrics`; the shard1 pool has a different `app` label and is not a fallback), and that pod was killed by liveness **14 times in one day** (tracked separately as noetl/ai-meta#322). 8 of 8 logged failures are connection-level, 0 are timeouts, bursts last ~1.5 s.

## The fix

- **Bounded retry** with doubling backoff (default 4 retries / 250 ms — sized against the measured 1.5 s bursts). Safe **only because the tier deduplicates on `event_id`** (noetl/ehdb#352 + noetl/worker#309, live in worker v5.131.0): the common failure here is *ambiguous* — request applied, response lost — and before the dedupe a retry would have duplicated the record.
- **`dropped`** — a terminal counter meaning *these authoritative events will never reach the tier*.
- **`recovered`** — delivered on a retry, so a flapping relay stays visible instead of reading healthy.
- Drops log at **`error`** with the **`event_ids`**, so a loss is repairable via `POST /api/ehdb/repair/executions/{id}` rather than only discoverable by diffing both stores.
- **501/405 are not retried** — a rollout state is permanent until someone deploys.

### Why `dropped` had to exist

The discards were filed under `unavailable`, which reads like a transport blip. **None of the 18 prod alert policies referenced it.** All four mirror alerts watch `..._mirror_queue_total` or the lag histogram — **the enqueue ladder whose own module header says "never a drop"** — and not the delivery step that drops. The queue read perfectly healthy for days while events were being lost.

## Gates

Five mutations, each caught by its intended gate. The gates drive the **real `deliver`** against a local relay and assert **request counts**, because the defect was never in a pure function — no test of a decision helper could have seen it.

| mutation | gate that caught it |
| :-- | :-- |
| exhausted retries record `unavailable` again | `an_undeliverable_batch_is_counted_as_dropped_...` |
| retries forced to 0 | `a_transient_failure_is_retried_and_recovers` |
| 501 made retryable | `a_rollout_state_is_not_retried` |
| `dropped` removed from the pinned label set | `the_loss_label_is_pinned_so_absent_is_not_zero` |
| a second POST site added | `there_is_exactly_one_deliverer` |

Suite **1048 passed / 0 failed**, clippy 0 errors.

### A guard that had stopped guarding

`there_is_exactly_one_deliverer` pinned the POST's exact indentation, so moving the POST inside the retry loop made it report **zero** call sites — a guard against a second deliverer that would have passed if the only deliverer were deleted. It now counts whitespace-normalised code, asserts it extracted a plausible amount of source, and **assembles its needle** so `include_str!` cannot match it against itself (it was matching its own pattern literal, reporting 2 sites in a file with 1).

## Rollback

`NOETL_EHDB_EVENTLOG_MIRROR_MAX_RETRIES=0` reproduces the pre-fix behaviour exactly — one attempt, then drop — with no redeploy. The loss is still counted as `dropped` there, so it can never be silent again.

Wiki: server wiki `deployment-specification` @c2a0597 (Rule 2a — both env vars + the outcome set).

Refs noetl/ai-meta#320
Refs noetl/ai-meta#322