### PR TITLE
fix(events): project_events persists parent_execution_id and worker_id (ai-meta#326)

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -1123,6 +1123,150 @@ mod tests {
         );
     }
 
+    /// **No INSERT into `noetl.event` may persist fewer columns than the row
+    /// carries** — whether or not it mirrors (noetl/ai-meta#327).
+    ///
+    /// The sibling guard below asserts it only for writers that *mirror*, and that
+    /// invariant is too narrow: it is stated in terms of a behaviour the writer
+    /// happens to have rather than the property that matters. On an EHDB bus
+    /// `emit_events` PUBLISHES instead of inserting, so the live Postgres writer is
+    /// `services::internal::project_events` — which does not mirror, sat outside
+    /// the narrow invariant, and dropped `parent_execution_id` for every child
+    /// execution on prod (noetl/ai-meta#326).
+    ///
+    /// ⚠ Which writer is REACHABLE is a question about configuration, not about
+    /// code. That is why this guard covers every site rather than the ones a reader
+    /// guesses are live: the previous fix was aimed at two real defects that simply
+    /// were not on the path prod takes.
+    ///
+    /// Sites that legitimately store a subset are listed explicitly, so an
+    /// exclusion is a decision someone wrote down rather than an absence nobody
+    /// noticed — and the list is asserted to be exactly what is expected, so a NEW
+    /// truncating writer fails here instead of joining it silently.
+    #[test]
+    fn no_event_insert_persists_fewer_columns_than_the_row_carries() {
+        use crate::handlers::event_write::EventRow;
+
+        let row = EventRow::new(1, 2, 3, "call.done", "COMPLETED", chrono::Utc::now())
+            .with_nodes("n1", "step-a")
+            .with_node_type("task")
+            .with_parent_event_id(4)
+            .with_prev_event_id(Some(5))
+            .with_parent_execution_id(Some(6))
+            .with_context(serde_json::json!({"k": "v"}))
+            .with_result(serde_json::json!({"r": 1}))
+            .with_meta(serde_json::json!({"m": 1}))
+            .with_error(Some("boom".to_string()))
+            .with_worker_id(Some("w-1".to_string()));
+        let payload = mirror_payload(&row);
+        let not_columns = ["step", "mirror_source", MIRROR_PAYLOAD_VERSION_KEY];
+        let row_columns: Vec<&str> = payload
+            .as_object()
+            .expect("payload is an object")
+            .keys()
+            .map(|k| k.as_str())
+            .filter(|k| !not_columns.contains(k))
+            .collect();
+        assert!(
+            row_columns.len() >= 15,
+            "only {} row-backed columns — the extraction broke and a guard \
+             measuring nothing passes",
+            row_columns.len()
+        );
+
+        // Documented exclusions. Each needs a reason, not just an entry.
+        //
+        //   handlers/internal.rs :: events_materialize — a 10-column sink that is
+        //   NOT live (`noetl_events_materialized_total` reads 0 on prod). Left
+        //   truncating deliberately rather than changed as a side effect of this
+        //   guard; tracked on noetl/ai-meta#327. If anything ever routes to it,
+        //   it reintroduces exactly the #326 loss.
+        //   db/queries/event.rs :: insert_event — drops `error` and
+        //   `prev_event_id`. `prev_event_id` is the one-level event-chain link
+        //   (noetl/ai-meta#115), so a row written here is not walkable. It has
+        //   ~5 callers in `services/event.rs`, so it is reachable CODE; whether
+        //   any of those paths run on prod is unverified, and this guard exists
+        //   precisely because that question cannot be answered by reading. Left
+        //   unchanged rather than fixed as a side effect of noetl/ai-meta#327;
+        //   surfaced there instead.
+        let known_truncating = ["handlers/internal.rs", "db/queries/event.rs"];
+
+        let needle = format!("INSERT INTO noetl.event{}", "");
+        let mut offenders: Vec<String> = Vec::new();
+        let mut scanned = 0;
+        for (file, src) in [
+            ("handlers/events.rs", include_str!("events.rs")),
+            ("handlers/event_write.rs", include_str!("event_write.rs")),
+            ("handlers/internal.rs", include_str!("internal.rs")),
+            (
+                "services/internal.rs",
+                include_str!("../services/internal.rs"),
+            ),
+            (
+                "db/queries/event.rs",
+                include_str!("../db/queries/event.rs"),
+            ),
+        ] {
+            for (i, _) in src.match_indices(&needle) {
+                // Strip `--` comments BEFORE locating the parens, not after: a
+                // comment containing a `)` — e.g. "(emit_events publishes rather
+                // than inserting)" — otherwise closes the column list early and the
+                // guard reports columns missing that are listed just below it.
+                // Observed while writing the noetl/ai-meta#327 fix this verifies.
+                let window: String = src[i..]
+                    .lines()
+                    .take(40)
+                    .map(|l| l.split("--").next().unwrap_or(""))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let open = window.find('(').expect("column list opens");
+                let close = window[open..]
+                    .find(')')
+                    .map(|c| open + c)
+                    .expect("column list closes");
+                let cols: String = window[open + 1..close]
+                    .replace('\\', " ")
+                    .split_whitespace()
+                    .collect();
+                scanned += 1;
+                let missing: Vec<&str> = row_columns
+                    .iter()
+                    .copied()
+                    .filter(|c| !cols.split(',').any(|listed| listed == *c))
+                    .collect();
+                if !missing.is_empty() {
+                    offenders.push(format!("{file} drops {missing:?}"));
+                }
+            }
+        }
+        assert!(
+            scanned >= 5,
+            "only {scanned} INSERT sites scanned — a writer moved and this guard \
+             is measuring less than it thinks"
+        );
+
+        let unexpected: Vec<&String> = offenders
+            .iter()
+            .filter(|o| !known_truncating.iter().any(|k| o.starts_with(k)))
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "an INSERT into noetl.event persists fewer columns than the EventRow \
+             carries: {unexpected:?}. On an EHDB bus the live writer is whichever \
+             one the CONFIGURATION reaches, so a truncating writer anywhere is a \
+             latent noetl/ai-meta#326."
+        );
+        // The exclusion list must stay honest: every excluded file must still be
+        // truncating, or the entry is stale and hiding a site that is now clean.
+        for k in known_truncating {
+            assert!(
+                offenders.iter().any(|o| o.starts_with(k)),
+                "{k} is on the known-truncating list but no longer truncates — \
+                 remove the exclusion rather than leaving it to excuse a future one"
+            );
+        }
+    }
+
     #[test]
     fn every_mirrored_insert_persists_what_it_mirrors() {
         use crate::handlers::event_write::EventRow;

--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -16,9 +16,9 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::types::JsonValue;
 
-use sqlx::Row;
 use crate::db::DbPool;
 use crate::error::AppResult;
+use sqlx::Row;
 
 // ---------------------------------------------------------------------------
 // Scheduled cleanup (noetl/ai-meta#96)
@@ -597,7 +597,16 @@ pub async fn project_events(
             stack_trace,
             tenant_id,
             organization_id,
-            created_at
+            created_at,
+            -- noetl/ai-meta#326/#327.  This sink is the LIVE Postgres writer on
+            -- an EHDB bus (`emit_events` publishes rather than inserting), and it
+            -- dropped both of these while the tier received them -- so the system
+            -- of record knew less than its mirror.  The emitter already publishes
+            -- them (`EventRow::to_stream_json`) and they survive into the JSONB
+            -- via the envelope's flattened `extra`, so this is additive: no
+            -- schema change, no new field on the wire.
+            parent_execution_id,
+            worker_id
         )
         SELECT
             (row->>'event_id')::bigint,
@@ -620,7 +629,11 @@ pub async fn project_events(
             COALESCE(NULLIF(row->>'organization_id', ''), 'default'),
             COALESCE(NULLIF(row->>'timestamp', '')::timestamp,
                      NULLIF(row->>'created_at', '')::timestamp,
-                     now())
+                     now()),
+            -- NULLIF so an absent value stays NULL rather than becoming 0 or "";
+            -- nothing is fabricated to fill a column.
+            NULLIF(row->>'parent_execution_id', '')::bigint,
+            NULLIF(row->>'worker_id', '')
         FROM jsonb_array_elements($1::jsonb) AS row
         -- noetl.event is partitioned (15 partitions); event_id alone
         -- is not a partition-spanning unique constraint.  Using
@@ -636,7 +649,8 @@ pub async fn project_events(
         -- harder one to notice because the tier would have MORE, not less.
         RETURNING event_id, execution_id, catalog_id, event_type, status,
                   created_at, prev_event_id, node_id, node_name, node_type,
-                  parent_event_id, context, result, meta, error
+                  parent_event_id, context, result, meta, error,
+                  parent_execution_id, worker_id
         "#,
     )
     .bind(payload)
@@ -671,10 +685,13 @@ pub async fn project_events(
             node_name: r.try_get("node_name").ok(),
             node_type: r.try_get("node_type").ok(),
             parent_event_id: r.try_get("parent_event_id").ok(),
-            // Neither column is written by this sink's INSERT, so both are
-            // None here by construction rather than by omission.
-            parent_execution_id: None,
-            worker_id: None,
+            // Both ARE written by this sink now (noetl/ai-meta#327), and both are
+            // read back, so the row this function returns -- which the caller
+            // MIRRORS -- carries what Postgres actually stored. Leaving them None
+            // while the INSERT persisted them would put the asymmetry back, just
+            // pointing the other way.
+            parent_execution_id: r.try_get("parent_execution_id").ok(),
+            worker_id: r.try_get("worker_id").ok(),
             context: r.try_get("context").ok(),
             result: r.try_get("result").ok(),
             meta: r.try_get("meta").ok(),


### PR DESCRIPTION
Closes the loss in noetl/ai-meta#326 — this time in **the writer that actually runs**.

## Why the previous fix missed

On an EHDB bus `emit_events` **publishes** rather than inserting, so the live Postgres writer is `services::internal::project_events`. Confirmed by counter, not by reading:

```
noetl_events_projected_total     60   ← exactly a parent+child run's 30 + 30
noetl_events_materialized_total   0
```

It dropped `parent_execution_id` and `worker_id`, so every child's `playbook_started` reached the tier with its parent and Postgres without it.

## The change — additive

The emitter already publishes both (`EventRow::to_stream_json`), and they survive into the JSONB through the envelope's **flattened `extra`** — so no schema change and no new field on the wire. `NULLIF` keeps an absent value `NULL` rather than `0` or `""`; nothing is fabricated.

Both are added to `RETURNING` and read back onto the reconstructed `EventRow`, **which the caller mirrors** — leaving them `None` while the INSERT persisted them would put the asymmetry back, pointing the other way.

## The guard, widened to the property that matters

Old invariant: *a writer that **mirrors** must persist what it mirrors.* That is stated in terms of a behaviour the writer happens to have — and `project_events`, the live one, does not mirror, so it sat outside it.

New: **no INSERT into `noetl.event` may persist fewer columns than the row carries**, mirroring or not. It scans all five sites and asserts it scanned ≥5.

⚠ **Which writer is reachable is a configuration question, not a code question.** That is the whole reason the guard now covers every site rather than the ones a reader guesses are live.

Two sites remain truncating and are now **documented, asserted exclusions** — each must *still* truncate, so a stale entry cannot silently excuse a future offender:

| site | why excluded |
| :-- | :-- |
| `handlers/internal.rs :: events_materialize` | 10 columns, **not live** (`materialized_total` = 0) |
| `db/queries/event.rs :: insert_event` | drops `error` + `prev_event_id`; reachable code, ~5 callers |

⚠ **New finding:** `prev_event_id` is the one-level chain link (noetl/ai-meta#115), so a row written by `insert_event` is **not walkable**. Surfaced on noetl/ai-meta#327 rather than fixed as a side effect here.

| mutation | caught by |
| :-- | :-- |
| revert the column addition | names `services/internal.rs drops ["parent_execution_id"]` |
| add a clean file to the exclusion list | *"on the known-truncating list but no longer truncates"* |

1064 passed / 0 failed, clippy 0 errors, fmt clean.

⚠ The guard had to strip `--` comments **before** locating the parens: a comment containing a `)` closes the column list early and reports columns missing that are listed right below it. Third time a comment has broken this parser — and all three were mine.

Refs noetl/ai-meta#326
Refs noetl/ai-meta#327