### PR TITLE
fix(event): insert_event can record the chain link and the error (#327)

### DIFF
--- a/src/db/queries/event.rs
+++ b/src/db/queries/event.rs
@@ -25,15 +25,26 @@ pub async fn insert_event(
     result: Option<&serde_json::Value>,
     worker_id: Option<&str>,
     attempt: Option<i32>,
+    // noetl/ai-meta#327.  `prev_event_id` is the RFC #115 §4.1 chain link: a row
+    // written without it is NOT WALKABLE, so a log assembled through this path
+    // cannot be traversed one hop at a time even though every row is present.
+    // `error` is the other column the row can carry and this INSERT could not.
+    //
+    // ⚠ Added as parameters rather than defaulted, so a caller that has the
+    // values cannot silently fail to pass them.
+    prev_event_id: Option<i64>,
+    error: Option<&str>,
 ) -> AppResult<i64> {
     let row: (i64,) = sqlx::query_as(
         r#"
         INSERT INTO noetl.event (
             event_id, execution_id, catalog_id, parent_event_id, parent_execution_id,
             event_type, node_id, node_name, node_type, status,
-            context, meta, result, worker_id, attempt, created_at
+            context, meta, result, worker_id, attempt, created_at,
+            prev_event_id, error
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+                $17, $18)
         RETURNING id
         "#,
     )
@@ -53,6 +64,8 @@ pub async fn insert_event(
     .bind(worker_id)
     .bind(attempt)
     .bind(Utc::now())
+    .bind(prev_event_id)
+    .bind(error)
     .fetch_one(pool)
     .await?;
 

--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -1181,15 +1181,19 @@ mod tests {
         //   truncating deliberately rather than changed as a side effect of this
         //   guard; tracked on noetl/ai-meta#327. If anything ever routes to it,
         //   it reintroduces exactly the #326 loss.
-        //   db/queries/event.rs :: insert_event — drops `error` and
-        //   `prev_event_id`. `prev_event_id` is the one-level event-chain link
-        //   (noetl/ai-meta#115), so a row written here is not walkable. It has
-        //   ~5 callers in `services/event.rs`, so it is reachable CODE; whether
-        //   any of those paths run on prod is unverified, and this guard exists
-        //   precisely because that question cannot be answered by reading. Left
-        //   unchanged rather than fixed as a side effect of noetl/ai-meta#327;
-        //   surfaced there instead.
-        let known_truncating = ["handlers/internal.rs", "db/queries/event.rs"];
+        //
+        // ⚠ `db/queries/event.rs :: insert_event` WAS on this list and has been
+        // removed, because it no longer truncates (noetl/ai-meta#327): it now
+        // takes and binds `prev_event_id` and `error`. The honesty assertion
+        // below is what forced the removal — leaving a stale entry here is how an
+        // exclusion list comes to excuse a site nobody re-examined.
+        //
+        // Its callers are all methods on `EventService`, which is **never
+        // constructed** anywhere in the binary (`ExecutionService::new` at
+        // main.rs is the working control for that search idiom). So the path is
+        // latent like the one above; the fix is a landmine removal, not a live
+        // repair, and it is deliberately NOT claimed as live-validated.
+        let known_truncating = ["handlers/internal.rs"];
 
         let needle = format!("INSERT INTO noetl.event{}", "");
         let mut offenders: Vec<String> = Vec::new();

--- a/src/services/event.rs
+++ b/src/services/event.rs
@@ -23,6 +23,12 @@ pub struct EmitEventRequest {
     pub parent_event_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_execution_id: Option<i64>,
+    /// RFC #115 §4.1 chain link. Without it the row is present but **not
+    /// walkable** — noetl/ai-meta#327.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev_event_id: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -112,6 +118,8 @@ impl EventService {
             sanitized_result.as_ref(),
             request.worker_id.as_deref(),
             request.attempt,
+            request.prev_event_id,
+            request.error.as_deref(),
         )
         .await?;
 
@@ -183,6 +191,12 @@ impl EventService {
             None,
             None,
             None,
+            // noetl/ai-meta#327: these wrappers have no chain link to pass.
+            // ⚠ Explicit `None`, not a defaulted parameter — if this path is
+            // ever revived, the caller must be made to supply `prev_event_id`
+            // or the rows it writes will be present but not walkable.
+            None,
+            None,
         )
         .await?;
 
@@ -224,6 +238,12 @@ impl EventService {
             Some(&context),
             Some(&meta),
             None,
+            None,
+            None,
+            // noetl/ai-meta#327: these wrappers have no chain link to pass.
+            // ⚠ Explicit `None`, not a defaulted parameter — if this path is
+            // ever revived, the caller must be made to supply `prev_event_id`
+            // or the rows it writes will be present but not walkable.
             None,
             None,
         )
@@ -272,6 +292,12 @@ impl EventService {
             None,
             None,
             None,
+            // noetl/ai-meta#327: these wrappers have no chain link to pass.
+            // ⚠ Explicit `None`, not a defaulted parameter — if this path is
+            // ever revived, the caller must be made to supply `prev_event_id`
+            // or the rows it writes will be present but not walkable.
+            None,
+            None,
         )
         .await?;
 
@@ -314,6 +340,12 @@ impl EventService {
             Some(&sanitized_command),
             Some(&meta),
             None,
+            None,
+            None,
+            // noetl/ai-meta#327: these wrappers have no chain link to pass.
+            // ⚠ Explicit `None`, not a defaulted parameter — if this path is
+            // ever revived, the caller must be made to supply `prev_event_id`
+            // or the rows it writes will be present but not walkable.
             None,
             None,
         )
@@ -473,6 +505,8 @@ mod tests {
             event_type: "playbook_started".to_string(),
             parent_event_id: None,
             parent_execution_id: None,
+            prev_event_id: Some(999),
+            error: None,
             node_id: Some("playbook".to_string()),
             node_name: Some("test-playbook".to_string()),
             node_type: Some("execution".to_string()),


### PR DESCRIPTION
Two of the three things #327 named turned out not to be defects on measurement. Reporting that, and fixing the one that was.

## Fixed

`insert_event` could not persist `prev_event_id` (the RFC #115 §4.1 chain link) or `error` — neither was a parameter. A row written through it is present but **not walkable**. Both are now parameters and both are bound; parameters rather than defaults, so a caller holding the values cannot silently fail to pass them.

## Not fixed, and why — both measured with working controls

| claim | measurement |
| :-- | :-- |
| `insert_event` is a live truncating writer | **Dead code.** Its 5 callers are all `EventService` methods, and `EventService` is **never constructed**. Control: the same idiom finds `ExecutionService::new` at main.rs:1280. |
| `noetl.command` inserts drop `parent_execution_id` | **Vestigial, not truncated.** No INSERT binds it *and* no query selects it. Control: the same idiom finds `step_name`/`tool_kind` being selected. |

So this fix is a **landmine removal, not a live repair** — there is no live path to validate it on, and it is deliberately not claimed as live-validated.

Plumbing `parent_execution_id` through four call layers into a column no reader consumes would be work with no consumer. Left alone and reported.

## The guard forced its own update

The exclusion list asserts every excluded file must **still** truncate. Fixing `insert_event` made that assertion fail — the guard working as intended, since a stale exclusion is how a list comes to excuse a site nobody re-examined. `db/queries/event.rs` removed; `events_materialize` stays as the one asserted-latent sink (`noetl_events_materialized_total` reads 0 on prod).

Mutation-gated: reverting the SQL fails the guard. ⚠ An earlier attempt at that mutation did not compile and produced **no test-result line at all** — not a pass — and was redone.

Full suite 1027 passed; clippy adds no warnings.

Refs noetl/ai-meta#327