### PR TITLE
feat(ehdb): embed the engine in SHADOW at N=1, default-off (#332 step 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "ehdb-core"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=e4572492b8373bd3bf8e347d09f2f3fbd9808dd5#e4572492b8373bd3bf8e347d09f2f3fbd9808dd5"
+source = "git+https://github.com/noetl/ehdb?tag=v0.2.0#24e63b8d88adbd0bbc1c95448380193a495b473e"
 dependencies = [
  "arrow-schema",
  "serde",
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "ehdb-feed"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=e4572492b8373bd3bf8e347d09f2f3fbd9808dd5#e4572492b8373bd3bf8e347d09f2f3fbd9808dd5"
+source = "git+https://github.com/noetl/ehdb?tag=v0.2.0#24e63b8d88adbd0bbc1c95448380193a495b473e"
 dependencies = [
  "ehdb-core",
  "ehdb-l0",
@@ -547,12 +547,13 @@ dependencies = [
  "serde_json",
  "socket2 0.5.10",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "ehdb-l0"
 version = "0.1.0"
-source = "git+https://github.com/noetl/ehdb?rev=e4572492b8373bd3bf8e347d09f2f3fbd9808dd5#e4572492b8373bd3bf8e347d09f2f3fbd9808dd5"
+source = "git+https://github.com/noetl/ehdb?tag=v0.2.0#24e63b8d88adbd0bbc1c95448380193a495b473e"
 dependencies = [
  "ehdb-core",
  "serde",
@@ -614,6 +615,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -1234,6 +1241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1414,7 @@ dependencies = [
  "sqlx",
  "subtle",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.20",
  "time",
  "tokio",
@@ -1981,6 +1995,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2604,6 +2631,19 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,15 @@ gcp_auth = "0.12"
 
 # NATS messaging
 # EHDB command bus (L1 T4, flag-gated behind NOETL_COMMAND_BUS; default off).
-# The networked publish path to the per-shard writer (noetl/ehdb ehdb-feed).
-ehdb-feed = { git = "https://github.com/noetl/ehdb", rev = "e4572492b8373bd3bf8e347d09f2f3fbd9808dd5" }
-ehdb-l0 = { git = "https://github.com/noetl/ehdb", rev = "e4572492b8373bd3bf8e347d09f2f3fbd9808dd5" }
+# noetl/ai-meta#332 — GIT-TAG SEMVER, not a rev pin.
+#
+# The rev pins let two consumers drift 70 commits apart on the same engine.
+# Tolerable while they talked over a wire protocol; a corruption vector once both
+# open engines against one on-disk layout.  A tag is a decision someone made;
+# a rev is wherever a branch happened to be.  ehdb-l0's FORMAT_VERSION gate is
+# the belt to this braces: it refuses a layout it cannot read.
+ehdb-feed = { git = "https://github.com/noetl/ehdb", tag = "v0.2.0" }
+ehdb-l0 = { git = "https://github.com/noetl/ehdb", tag = "v0.2.0" }
 # Value type for the JetStream KV puts in `src/coherence.rs` (multi-replica
 # watermark/descriptor coherence, RFC #115 program-scale).  Matches the version
 # async-nats already pulls in transitively.
@@ -177,6 +183,7 @@ prometheus = "0.13"
 twox-hash = "1.6"
 
 [dev-dependencies]
+tempfile = "3"
 tokio-test = "0.4"
 # Process-global env var tests serialise via #[serial] so concurrent
 # test threads don't race on NOETL_INTERNAL_API_TOKEN; see

--- a/src/handlers/ehdb_embedded.rs
+++ b/src/handlers/ehdb_embedded.rs
@@ -1,0 +1,309 @@
+//! **The embedded engine, in shadow** (noetl/ai-meta#332 step 5).
+//!
+//! # What this is, and what it deliberately is not
+//!
+//! The server opens an `ehdb-l0` event-log engine **in-process** and appends to
+//! it in parallel with the authoritative write, then compares. That is the whole
+//! of it.
+//!
+//! It does **not** serve any read or write from the embedded engine. Postgres
+//! remains the system of record; nothing here can change what a caller sees.
+//! Flipping the serve path is a separate, later checkpoint.
+//!
+//! # Why shadow first
+//!
+//! The embedded design rests on the claim that a local engine holds the same
+//! events as the authoritative path. That claim is checkable *without depending
+//! on it* — append to both, compare, emit a metric. If it disagrees at N=1,
+//! where ownership is trivially true and nothing forwards, it would disagree
+//! worse everywhere else.
+//!
+//! # Default OFF
+//!
+//! `NOETL_EHDB_EMBEDDED` defaults to false, so the deploy is **inert on
+//! arrival**: with the flag off, not a byte of this module runs and the server's
+//! behaviour is identical to the release before it. That is what makes the
+//! rollout reversible by configuration rather than by redeploy.
+
+use std::sync::Arc;
+
+use ehdb_l0::dataset::D1EventLog;
+use ehdb_l0::engine::{L0Config, L0Engine};
+use ehdb_l0::substrate::{DurableSubstrate, LocalFsSubstrate};
+
+/// Env flag. Absent or anything but `true` means the whole module is inert.
+pub const EMBEDDED_ENV: &str = "NOETL_EHDB_EMBEDDED";
+/// Where the embedded engine keeps its local root.
+pub const EMBEDDED_DIR_ENV: &str = "NOETL_EHDB_EMBEDDED_DIR";
+/// Default local root. Under `/data` so it lands on a mounted volume when one
+/// exists and fails loudly at open when it does not.
+pub const DEFAULT_EMBEDDED_DIR: &str = "/data/ehdb-embedded";
+
+/// Is the embedded shadow armed?
+///
+/// ⚠ Strict `== "true"`. A flag that accepts `1`, `yes`, `TRUE` and `on` is a
+/// flag whose state nobody can read off a manifest with confidence.
+pub fn embedded_enabled() -> bool {
+    std::env::var(EMBEDDED_ENV)
+        .map(|v| v == "true")
+        .unwrap_or(false)
+}
+
+/// The local root for the embedded engine.
+pub fn embedded_dir() -> String {
+    std::env::var(EMBEDDED_DIR_ENV).unwrap_or_else(|_| DEFAULT_EMBEDDED_DIR.to_string())
+}
+
+/// Open the embedded engine, or `None` when the flag is off.
+///
+/// ⚠ Returns `None` rather than erroring when disabled, and logs-and-returns
+/// `None` when an *enabled* open fails. A shadow that could take the server down
+/// on a storage problem would be a liability rather than evidence — the whole
+/// point is that it cannot affect serving.
+pub fn open_embedded() -> Option<Arc<std::sync::Mutex<L0Engine<D1EventLog>>>> {
+    if !embedded_enabled() {
+        return None;
+    }
+    let dir = embedded_dir();
+    let substrate: Arc<dyn DurableSubstrate> =
+        match LocalFsSubstrate::new(format!("{dir}/substrate")) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(target: "noetl_server::ehdb_embedded", dir = %dir, error = %e,
+                "embedded substrate could not be opened; shadow stays off");
+                crate::metrics::record_embedded_shadow("open_failed");
+                return None;
+            }
+        };
+    // ⚠ This is where ehdb-l0's FORMAT_VERSION gate fires: an on-disk layout
+    // written by a different build refuses here rather than being misread.
+    match L0Engine::<D1EventLog>::open(
+        L0Config::for_dataset("d1_event_log", format!("{dir}/local")),
+        substrate,
+    ) {
+        Ok(engine) => {
+            tracing::info!(target: "noetl_server::ehdb_embedded", dir = %dir,
+                "embedded EHDB engine open in SHADOW — not serving reads or writes");
+            crate::metrics::record_embedded_shadow("opened");
+            Some(Arc::new(std::sync::Mutex::new(engine)))
+        }
+        Err(e) => {
+            tracing::error!(target: "noetl_server::ehdb_embedded", dir = %dir, error = %e,
+                "embedded engine open failed; shadow stays off");
+            crate::metrics::record_embedded_shadow("open_failed");
+            None
+        }
+    }
+}
+
+/// The verdict of one shadow comparison.
+///
+/// ⚠ `Skipped` is distinct from `Agreed`. A shadow that reports agreement when it
+/// compared nothing is the "clean result computed over zero rows" failure this
+/// codebase keeps producing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShadowVerdict {
+    /// Embedded and authoritative agree on the count for this batch.
+    Agreed,
+    /// They disagree — the number the whole shadow exists to surface.
+    Diverged {
+        embedded: usize,
+        authoritative: usize,
+    },
+    /// Nothing was compared (flag off, engine absent, or an empty batch).
+    Skipped,
+}
+
+/// Compare what the shadow appended against what the authoritative path wrote.
+///
+/// Pure, so the verdict logic is testable without an engine or a database.
+pub fn verdict(embedded: usize, authoritative: usize, compared: bool) -> ShadowVerdict {
+    if !compared {
+        return ShadowVerdict::Skipped;
+    }
+    if embedded == authoritative {
+        ShadowVerdict::Agreed
+    } else {
+        ShadowVerdict::Diverged {
+            embedded,
+            authoritative,
+        }
+    }
+}
+
+impl ShadowVerdict {
+    /// The metric label. Closed set, pinned at 0 in `metrics`, so "never
+    /// diverged" reads as `0` rather than as an absent series.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Agreed => "agreed",
+            Self::Diverged { .. } => "diverged",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+/// The process-wide embedded engine, opened once on first use.
+///
+/// `OnceLock` rather than eager construction in `main`: with the flag off this
+/// never allocates, so the disabled path costs nothing at startup either.
+static EMBEDDED: std::sync::OnceLock<Option<Arc<std::sync::Mutex<L0Engine<D1EventLog>>>>> =
+    std::sync::OnceLock::new();
+
+fn engine() -> Option<&'static Arc<std::sync::Mutex<L0Engine<D1EventLog>>>> {
+    EMBEDDED.get_or_init(open_embedded).as_ref()
+}
+
+/// Append the rows Postgres accepted to the embedded engine, and record whether
+/// the two agree.
+///
+/// ⚠ Never returns an error and never panics on a poisoned lock. This runs on
+/// the live write path; a shadow that can fail a real write is a liability, not
+/// evidence.
+pub fn shadow_append(rows: &[crate::handlers::event_write::EventRow]) {
+    let Some(engine) = engine() else {
+        // Flag off, or the open failed and already recorded why.
+        return;
+    };
+    if rows.is_empty() {
+        crate::metrics::record_embedded_shadow(ShadowVerdict::Skipped.label());
+        return;
+    }
+    let mut guard = match engine.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut appended = 0usize;
+    for row in rows {
+        // Same construction the command bus uses (`command_bus.rs:361`), so the
+        // shadow's records are shaped exactly like the ones the networked path
+        // publishes — a shadow that stored a different shape would prove nothing
+        // about the embedded engine's fitness to replace it.
+        let record = ehdb_l0::dataset::EventRecord::new(
+            row.event_id as u64,
+            row.execution_id.to_string(),
+            String::new(),
+            row.to_stream_json().to_string(),
+        );
+        match guard.append_record(record) {
+            Ok(_) => appended += 1,
+            Err(e) => {
+                tracing::warn!(target: "noetl_server::ehdb_embedded", error = %e,
+                    "embedded shadow append failed");
+                crate::metrics::record_embedded_shadow("append_failed");
+            }
+        }
+    }
+    let v = verdict(appended, rows.len(), true);
+    if let ShadowVerdict::Diverged {
+        embedded,
+        authoritative,
+    } = v
+    {
+        tracing::warn!(target: "noetl_server::ehdb_embedded", embedded, authoritative,
+            "embedded shadow DIVERGED from the authoritative write");
+    }
+    crate::metrics::record_embedded_shadow(v.label());
+}
+
+#[cfg(test)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ⚠ `cargo test` does NOT serialise tests — two tests mutating the same env
+    /// var race, and the failure is intermittent rather than loud. The same
+    /// pattern is used in `config::database` and `secrets::broker` for the same
+    /// reason.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn agreement_and_divergence_are_distinguished() {
+        assert_eq!(verdict(5, 5, true), ShadowVerdict::Agreed);
+        assert_eq!(
+            verdict(4, 5, true),
+            ShadowVerdict::Diverged {
+                embedded: 4,
+                authoritative: 5
+            }
+        );
+    }
+
+    /// ⚠ The one that matters. A shadow that compared nothing must not report
+    /// agreement — that is a clean result computed over zero rows, which reads
+    /// exactly like a healthy one.
+    #[test]
+    fn comparing_nothing_is_skipped_not_agreed() {
+        assert_eq!(verdict(0, 0, false), ShadowVerdict::Skipped);
+        assert_ne!(verdict(0, 0, false), ShadowVerdict::Agreed);
+        // And zero-vs-zero WITH a comparison is genuinely agreement.
+        assert_eq!(verdict(0, 0, true), ShadowVerdict::Agreed);
+    }
+
+    /// ⚠⚠ Default OFF. This is what makes the deploy inert on arrival; a flag
+    /// that defaults on turns a shadow into a change.
+    #[test]
+    fn the_flag_defaults_off_and_is_strict() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Not set at all.
+        std::env::remove_var(EMBEDDED_ENV);
+        assert!(!embedded_enabled(), "absent must mean off");
+        for v in ["", "1", "yes", "TRUE", "on", "false"] {
+            std::env::set_var(EMBEDDED_ENV, v);
+            assert!(
+                !embedded_enabled(),
+                "{v:?} must not arm the shadow — a flag that accepts many \
+                 spellings is one nobody can read off a manifest"
+            );
+        }
+        std::env::set_var(EMBEDDED_ENV, "true");
+        assert!(embedded_enabled());
+        std::env::remove_var(EMBEDDED_ENV);
+    }
+
+    /// With the flag off, no engine is opened — so the flag-off path touches no
+    /// storage at all.
+    ///
+    /// ⚠ The directory is pointed at a WRITABLE temp dir on purpose. The first
+    /// version left it at the `/data` default, where the open fails anyway — so
+    /// `None` came back for the wrong reason and a mutation deleting the flag
+    /// check passed. A test that cannot tell "disabled" from "broken" is not
+    /// testing the flag.
+    #[test]
+    fn nothing_opens_when_the_flag_is_off() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var(EMBEDDED_DIR_ENV, tmp.path().to_str().unwrap());
+
+        std::env::remove_var(EMBEDDED_ENV);
+        assert!(
+            open_embedded().is_none(),
+            "flag-off must open nothing — even where opening WOULD succeed"
+        );
+
+        // Positive control: the same directory DOES open once the flag is on, so
+        // the None above is the flag's doing and not a broken fixture.
+        std::env::set_var(EMBEDDED_ENV, "true");
+        assert!(
+            open_embedded().is_some(),
+            "the fixture must be openable, or the assertion above proves nothing"
+        );
+
+        std::env::remove_var(EMBEDDED_ENV);
+        std::env::remove_var(EMBEDDED_DIR_ENV);
+    }
+
+    #[test]
+    fn labels_are_a_closed_set() {
+        assert_eq!(ShadowVerdict::Agreed.label(), "agreed");
+        assert_eq!(ShadowVerdict::Skipped.label(), "skipped");
+        assert_eq!(
+            ShadowVerdict::Diverged {
+                embedded: 1,
+                authoritative: 2
+            }
+            .label(),
+            "diverged"
+        );
+    }
+}

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -205,7 +205,11 @@ impl EventRow {
     /// posts it to `/api/internal/events/project`.  Keep the DB column names +
     /// `created_at` (NOT `timestamp`) so the materialized row is byte-identical
     /// to the synchronous INSERT.
-    fn to_stream_json(&self) -> Value {
+    // noetl/ai-meta#332 step 5: the embedded shadow serialises rows with the
+    // SAME function the networked publish path uses, so a shadow record is shaped
+    // exactly like a published one.  A shadow storing a different shape would
+    // prove nothing about the engine's fitness to replace that path.
+    pub(crate) fn to_stream_json(&self) -> Value {
         json!({
             "event_id": self.event_id,
             "execution_id": self.execution_id,
@@ -582,14 +586,19 @@ mod tests {
     fn both_producers_reduce_created_at_identically() {
         use chrono::TimeZone;
 
-        fn truncates(ns: i64) -> i64 { ns.div_euclid(1_000) }
-        fn rounds(ns: i64) -> i64 { (ns + 500).div_euclid(1_000) }
+        fn truncates(ns: i64) -> i64 {
+            ns.div_euclid(1_000)
+        }
+        fn rounds(ns: i64) -> i64 {
+            (ns + 500).div_euclid(1_000)
+        }
 
         // Real sub-microsecond remainders seen on prod 2026-08-31, spanning
         // both halves of the boundary: a rule that only works below 500 ns
         // must fail here.
-        let remainders: [u32; 14] =
-            [0, 1, 27, 88, 206, 449, 499, 500, 501, 681, 798, 867, 891, 999];
+        let remainders: [u32; 14] = [
+            0, 1, 27, 88, 206, 449, 499, 500, 501, 681, 798, 867, 891, 999,
+        ];
 
         let mut unreduced_disagreements = 0;
         let mut still_disagree = Vec::new();

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -18,6 +18,7 @@ pub mod cross_region;
 pub mod dashboard;
 pub mod database;
 pub mod ehdb;
+pub mod ehdb_embedded;
 pub mod ehdb_eventlog_mirror;
 pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1012,6 +1012,8 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_catalog_delete_series();
     noetl_server::metrics::init_parity_and_dedup_series();
     noetl_server::metrics::init_ehdb_crossstore_series();
+    // noetl/ai-meta#332 step 5 — pinned so an unrun shadow reads 0, not absent.
+    noetl_server::metrics::init_embedded_shadow_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_queue_series();
     noetl_server::metrics::init_ehdb_projection_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3210,6 +3210,50 @@ pub fn ehdb_crossstore_parity_total() -> &'static IntCounterVec {
     })
 }
 
+/// Counter: embedded-engine shadow outcomes (noetl/ai-meta#332 step 5).
+///
+/// ⚠ Labels are a closed set pinned at 0 in [`init_embedded_shadow_series`], so
+/// "never diverged" reads as `0` rather than as an absent series — and "the
+/// shadow never ran" is visible as `opened` staying 0 rather than as silence.
+pub fn embedded_shadow_total() -> &'static prometheus::IntCounterVec {
+    static M: std::sync::OnceLock<prometheus::IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = prometheus::IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_ehdb_embedded_shadow_total",
+                "Embedded EHDB engine shadow outcomes (open/append/compare)",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric");
+        registry().register(Box::new(m.clone())).ok();
+        m
+    })
+}
+
+/// The closed label set. Adding an outcome means adding it here, or its series
+/// is absent until it first fires.
+pub const EMBEDDED_SHADOW_OUTCOMES: [&str; 6] = [
+    "opened",
+    "open_failed",
+    "agreed",
+    "diverged",
+    "skipped",
+    "append_failed",
+];
+
+/// Record one embedded-shadow outcome.
+pub fn record_embedded_shadow(outcome: &str) {
+    embedded_shadow_total().with_label_values(&[outcome]).inc();
+}
+
+/// Pin every embedded-shadow label at 0.
+pub fn init_embedded_shadow_series() {
+    for o in EMBEDDED_SHADOW_OUTCOMES {
+        embedded_shadow_total().with_label_values(&[o]).inc_by(0);
+    }
+}
+
 /// Record one cross-store parity verdict.
 pub fn record_ehdb_crossstore_parity(tier: &str, outcome: &str) {
     ehdb_crossstore_parity_total()

--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -660,7 +660,7 @@ pub async fn project_events(
     let projected = result.len() as i64;
     let duplicates = (events.len() as i64 - projected).max(0);
 
-    let inserted = result
+    let inserted: Vec<crate::handlers::event_write::EventRow> = result
         .iter()
         .map(|r| crate::handlers::event_write::EventRow {
             event_id: r.try_get("event_id").unwrap_or(0),
@@ -698,6 +698,20 @@ pub async fn project_events(
             error: r.try_get("error").ok(),
         })
         .collect();
+
+    // noetl/ai-meta#332 step 5 — SHADOW ONLY.
+    //
+    // Append what Postgres just accepted to the embedded engine and compare the
+    // counts.  Nothing downstream reads this: `inserted` is returned unchanged,
+    // Postgres remains the system of record, and the flag defaults OFF so this
+    // whole block is unreachable until someone arms it.
+    //
+    // ⚠ Errors are recorded and swallowed ON PURPOSE.  A shadow that can fail a
+    // real write is a liability, not evidence — the point is to learn whether the
+    // embedded engine agrees, at zero risk to serving.  The `append_failed`
+    // counter is how a silently-degraded shadow stays visible; a bare swallow
+    // here would be the `serve_ingest` mistake again.
+    crate::handlers::ehdb_embedded::shadow_append(inserted.as_slice());
 
     Ok((projected, duplicates, inserted))
 }


### PR DESCRIPTION
The server opens an `ehdb-l0` event-log engine **in-process**, appends to it in parallel with the authoritative write, and compares counts. That is all it does.

**It serves nothing.** Postgres remains the system of record; `inserted` is returned unchanged and nothing downstream reads the embedded engine. Flipping the serve path is a **separate, later checkpoint**.

**Default OFF.** `NOETL_EHDB_EMBEDDED` defaults to `false`, so the deploy is **inert on arrival** — with the flag off, the engine is never opened and behaviour is identical to the release before it. The rollout is reversible **by configuration**, not by redeploy.

## Dependency: git rev → git **tag** (ehdb `v0.2.0`)

The rev pins let two consumers drift **70 commits apart** on the same engine — tolerable over a wire protocol, a corruption vector once both open one on-disk layout. `ehdb-l0`'s `FORMAT_VERSION` gate is the belt to this braces, and fires at exactly this open.

## Shadow shape

Rows are serialised with the **same `to_stream_json`** the networked publish path uses, so a shadow record is shaped like a published one. Storing a different shape would prove nothing about the engine's fitness to replace that path.

⚠ Shadow errors are recorded and **swallowed on purpose** — a shadow that can fail a real write is a liability, not evidence. `append_failed` plus a pinned label set keep a silently-degraded shadow visible; a bare swallow would be the `serve_ingest` mistake again.

## Four mutations, each verified applied and caught

| mutation | why it matters |
| :-- | :-- |
| flag defaults **on** | turns a shadow into a change |
| lenient flag (`1`/`yes`/`on`) | a flag whose state can't be read off a manifest |
| "compared nothing" → "agreed" | a clean result over zero rows reads like a healthy one |
| delete the flag check from `open_embedded()` | ⚠ see below |

⚠⚠ **The last one was not caught on first run.** The test left the directory at the `/data` default, where the open fails anyway — so `None` came back for the *wrong reason* and deleting the flag check passed. **A test that cannot tell "disabled" from "broken" is not testing the flag.** Now pointed at a writable temp dir, with a positive control proving the same directory *does* open when the flag is on.

1042 tests pass; clippy clean.

Refs noetl/ai-meta#332