### PR TITLE
fix: move the embedded shadow hook to the emit_events chokepoint

### DIFF
--- a/src/handlers/ehdb_embedded.rs
+++ b/src/handlers/ehdb_embedded.rs
@@ -154,8 +154,21 @@ fn engine() -> Option<&'static Arc<std::sync::Mutex<L0Engine<D1EventLog>>>> {
     EMBEDDED.get_or_init(open_embedded).as_ref()
 }
 
-/// Append the rows Postgres accepted to the embedded engine, and record whether
-/// the two agree.
+/// Append the batch that is about to become authoritative to the embedded
+/// engine, and record whether the engine accepted all of it.
+///
+/// Called from `handlers::event_write::emit_events` — the one chokepoint every
+/// server-originated event passes through, on both sides of the CQRS gate
+/// (noetl/ai-meta#332). ⚠ Not from `services::internal::project_events`, where
+/// it lived until 2026-09-08: that is the materializer, and prod's scheduled
+/// traffic is system executions, which `should_publish` excludes by design and
+/// which therefore never reach it. The shadow sat armed and unexercised for a
+/// full window, reporting the same all-zero series a healthy shadow reports.
+///
+/// ⚠ The comparison is `appended` vs `rows.len()` — *"did the engine accept
+/// every record the log is about to take"*. It is **not** a comparison against
+/// what Postgres ultimately stored: at this call site the write has not happened
+/// yet. A batch whose subsequent write fails is counted here and not in the log.
 ///
 /// ⚠ Never returns an error and never panics on a poisoned lock. This runs on
 /// the live write path; a shadow that can fail a real write is a liability, not
@@ -206,7 +219,6 @@ pub fn shadow_append(rows: &[crate::handlers::event_write::EventRow]) {
     crate::metrics::record_embedded_shadow(v.label());
 }
 
-#[cfg(test)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/handlers/event_write.rs
+++ b/src/handlers/event_write.rs
@@ -470,6 +470,34 @@ pub async fn emit_events(state: &AppState, pool: &DbPool, rows: &[EventRow]) -> 
     crate::handlers::ehdb_eventlog_mirror::mirror_rows(state, rows).await;
     crate::metrics::record_event_ingest_phase("emit_mirror", __t.elapsed().as_secs_f64());
 
+    // noetl/ai-meta#332 — embedded EHDB engine, SHADOW ONLY.
+    //
+    // Deliberately HERE, sharing the mirror's position for the same reasons: it
+    // is after terminal dedup and chain stamping, so `rows` is exactly the set
+    // that becomes authoritative, and it is *before* the publish/insert fork, so
+    // one call site covers both branches.
+    //
+    // ⚠ It used to live in `services::internal::project_events` — the
+    // materializer — and that made it unreachable in production. `should_publish`
+    // excludes system executions by design, and prod's scheduled traffic is
+    // `system/orchestrate`, so those events never reached the materializer at
+    // all: measured 2026-09-08, 25 minutes and a full execution with every shadow
+    // series at 0. The failure was invisible because an unreachable shadow
+    // reports `agreed=0, diverged=0` — indistinguishable from a healthy one on a
+    // quiet system. `opened` is the only series that tells them apart.
+    //
+    // ⚠ Pre-fork means the shadow appends before the authoritative write is
+    // known to have succeeded, so a batch whose INSERT/publish then fails is
+    // counted by the shadow and not by the log. That is the same property
+    // `mirror_rows` has one line above, accepted for the same reason: covering
+    // both branches from one site is worth more than exactness on a path that
+    // returns `Err` to the caller anyway.
+    //
+    // ⚠ Errors are recorded and swallowed ON PURPOSE. A shadow that can fail a
+    // real write is a liability, not evidence. `append_failed` is how a
+    // silently-degraded shadow stays visible.
+    crate::handlers::ehdb_embedded::shadow_append(rows);
+
     // All rows in a batch share the same execution + catalog, so one decision
     // covers the batch.
     let __t = std::time::Instant::now();
@@ -789,6 +817,181 @@ mod tests {
         let r = EventRow::new(1, 1, 1, "step.enter", "ENTERED", Utc::now()).with_node("s");
         assert_eq!(r.node_id.as_deref(), Some("s"));
         assert_eq!(r.node_name.as_deref(), Some("s"));
+    }
+
+    // ---------------------------------------------------------------------
+    // noetl/ai-meta#332 — the embedded shadow must be REACHABLE from here.
+    // ---------------------------------------------------------------------
+
+    /// Strip `//` comment lines before searching source.
+    ///
+    /// ⚠ Without this a guard can match its own doc comment and stay green
+    /// while the code it guards is gone — a mistake already made once on this
+    /// repo (noetl/ai-meta#332, the `#[non_exhaustive]` guard).
+    fn code_only(src: &str) -> String {
+        src.lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The body of `emit_events`, comments removed.
+    ///
+    /// ⚠ Asserts its own extraction. A slice that silently came back empty
+    /// would make every assertion below pass over zero bytes — the shape that
+    /// produced three false green results in one session.
+    fn emit_events_body() -> String {
+        let src = include_str!("event_write.rs");
+        let non_test = src.split("#[cfg(test)]").next().unwrap();
+        let start = non_test
+            .find("pub async fn emit_events")
+            .expect("emit_events not found — the extraction broke");
+        let region = &non_test[start..];
+        let end = region.find("\n}\n").map(|i| i + 3).unwrap_or(region.len());
+        let body = code_only(&region[..end]);
+        assert!(
+            body.len() > 1500,
+            "emit_events body extracted as {} bytes — implausibly small; a guard \
+             measuring nothing passes",
+            body.len()
+        );
+        assert!(
+            body.contains("should_publish") && body.contains("insert_rows"),
+            "the extracted region is missing the publish/insert fork, so it is not \
+             the whole function and the ordering assertion below would be vacuous"
+        );
+        body
+    }
+
+    /// ⚠⚠ THE wiring, gated at the source — `emit_events` needs an `AppState`
+    /// and a live pool, so it cannot be driven from a unit test.
+    ///
+    /// The tempting test (call `shadow_append` directly and assert it appends)
+    /// is the noetl/ai-meta#326 mistake exactly: it passes whether or not
+    /// anything on the write path ever calls it. This asserts the call site.
+    #[test]
+    fn shadow_append_is_called_from_the_emit_chokepoint() {
+        let body = emit_events_body();
+        assert!(
+            body.contains("ehdb_embedded::shadow_append("),
+            "emit_events does not call shadow_append. The embedded shadow is then \
+             unreachable on the production path, and — this is why it went \
+             unnoticed for a full window — an unreachable shadow reports \
+             `agreed=0, diverged=0, append_failed=0`, which is byte-identical to \
+             a healthy shadow on a quiet system (noetl/ai-meta#332)."
+        );
+    }
+
+    /// The call must sit BEFORE the publish/insert fork.
+    ///
+    /// After the fork it would have to be duplicated into both branches, and the
+    /// gate-off branch is the one prod does not exercise — the classic place for
+    /// the second copy to rot. Same argument the mirror one line above makes.
+    #[test]
+    fn shadow_append_precedes_the_publish_insert_fork() {
+        let body = emit_events_body();
+        let shadow = body
+            .find("ehdb_embedded::shadow_append(")
+            .expect("shadow_append call missing — see the previous test");
+        let fork = body
+            .find("should_publish(state")
+            .expect("publish/insert fork not found — extraction broke");
+        assert!(
+            shadow < fork,
+            "shadow_append is called AFTER the publish/insert decision, so it \
+             covers only one branch of the gate. It belongs beside `mirror_rows`, \
+             which is placed pre-fork for this same reason."
+        );
+    }
+
+    /// The shadow must not be able to fail the authoritative write.
+    ///
+    /// A `?` on this call would turn a storage problem in a diagnostic into a
+    /// 5xx on a real event — the liability the whole design forbids. Pinned at
+    /// the source because the type system permits it the moment someone changes
+    /// `shadow_append`'s return type.
+    #[test]
+    fn the_shadow_cannot_fail_the_serving_path() {
+        let body = emit_events_body();
+        let at = body
+            .find("ehdb_embedded::shadow_append(")
+            .expect("shadow_append call missing");
+        let stmt = &body[at..body[at..].find('\n').map(|i| at + i).unwrap_or(body.len())];
+        assert!(
+            !stmt.contains('?'),
+            "the shadow_append call propagates with `?`: {stmt:?}. A shadow that \
+             can fail a real write is a liability, not evidence."
+        );
+        assert!(
+            stmt.trim_end().ends_with(");"),
+            "expected a bare statement call, found {stmt:?} — if its result is \
+             now consumed, re-check that no failure can reach the caller."
+        );
+        // ⚠ The above cannot fail while `shadow_append` returns `()`, because a
+        // `?` on a unit value does not compile — a guard nothing can trip. So
+        // pin the property that makes it true: the signature itself. Change the
+        // return type to a `Result` and this fires, which is exactly the moment
+        // the call site could start propagating into the serving path.
+        let shadow_src = code_only(
+            include_str!("ehdb_embedded.rs")
+                .split("#[cfg(test)]")
+                .next()
+                .unwrap(),
+        );
+        let sig = shadow_src
+            .find("pub fn shadow_append(")
+            .expect("shadow_append signature not found — extraction broke");
+        let sig_line = &shadow_src[sig..shadow_src[sig..]
+            .find('{')
+            .map(|i| sig + i)
+            .unwrap_or(shadow_src.len())];
+        assert!(
+            !sig_line.contains("->"),
+            "shadow_append now returns a value ({sig_line:?}). It must return `()`: \
+             a fallible shadow on the write path can fail a real event, which is \
+             the liability this whole design forbids."
+        );
+    }
+
+    /// It must be called from exactly ONE place.
+    ///
+    /// With the CQRS gate on, an event passes `emit_events` and then reaches
+    /// `project_events` via the materializer. A hook in both would append the
+    /// same event twice and report a divergence the engine did not cause —
+    /// a self-inflicted finding on the one signal we armed to trust.
+    #[test]
+    fn the_shadow_has_exactly_one_call_site() {
+        // ⚠ The non-test region only. This guard's own assertions mention the
+        // call by name, so counting the whole file counts the guard — which
+        // first reported 6 call sites and failed for the wrong reason.
+        let event_write = code_only(
+            include_str!("event_write.rs")
+                .split("#[cfg(test)]")
+                .next()
+                .unwrap(),
+        );
+        let internal = code_only(
+            include_str!("../services/internal.rs")
+                .split("#[cfg(test)]")
+                .next()
+                .unwrap(),
+        );
+        assert!(
+            event_write.contains("pub async fn emit_events"),
+            "non-test slice of event_write.rs lost emit_events — extraction broke"
+        );
+        assert_eq!(
+            event_write.matches("ehdb_embedded::shadow_append(").count(),
+            1,
+            "expected exactly one call site in event_write.rs's non-test code"
+        );
+        assert_eq!(
+            internal.matches("ehdb_embedded::shadow_append(").count(),
+            0,
+            "services::internal::project_events still calls shadow_append. With the \
+             gate on it runs AFTER emit_events for the same event, so the batch is \
+             appended twice and the shadow reports a divergence it caused itself."
+        );
     }
 }
 

--- a/src/services/internal.rs
+++ b/src/services/internal.rs
@@ -699,19 +699,22 @@ pub async fn project_events(
         })
         .collect();
 
-    // noetl/ai-meta#332 step 5 — SHADOW ONLY.
+    // noetl/ai-meta#332 — the embedded shadow used to append HERE, and must not.
     //
-    // Append what Postgres just accepted to the embedded engine and compare the
-    // counts.  Nothing downstream reads this: `inserted` is returned unchanged,
-    // Postgres remains the system of record, and the flag defaults OFF so this
-    // whole block is unreachable until someone arms it.
+    // This is the materializer, reached only via `POST /api/internal/events/project`
+    // when the CQRS gate publishes.  Measured on prod 2026-09-08: across 25 minutes
+    // and a full hourly execution the shadow never opened, because
+    // `should_publish` excludes system executions by design and prod's scheduled
+    // traffic is `system/orchestrate` — so those events took the synchronous
+    // INSERT and never arrived here.  All six shadow series read 0, which is
+    // byte-identical to a healthy shadow on a quiet system.
     //
-    // ⚠ Errors are recorded and swallowed ON PURPOSE.  A shadow that can fail a
-    // real write is a liability, not evidence — the point is to learn whether the
-    // embedded engine agrees, at zero risk to serving.  The `append_failed`
-    // counter is how a silently-degraded shadow stays visible; a bare swallow
-    // here would be the `serve_ingest` mistake again.
-    crate::handlers::ehdb_embedded::shadow_append(inserted.as_slice());
+    // The hook now lives at `handlers::event_write::emit_events`, the one
+    // chokepoint every server-originated event passes through on BOTH sides of
+    // the gate.  ⚠ It must not also live here: with the gate on, an event passes
+    // through `emit_events` and then reaches this function via the materializer,
+    // so a second append would double-count it and manufacture a divergence the
+    // engine did not cause.
 
     Ok((projected, duplicates, inserted))
 }


### PR DESCRIPTION
## Why

The embedded EHDB shadow was armed on prod on 2026-09-08 and **never opened**.
Across 25 minutes and a full hourly execution, all six
`noetl_ehdb_embedded_shadow_total` series stayed at 0.

`shadow_append` was called only from `services::internal::project_events` — the
materializer, reached via `POST /api/internal/events/project` when the CQRS gate
publishes. But `should_publish` **excludes system executions by design**, and
prod's scheduled traffic is `system/orchestrate`, so those events took the
synchronous INSERT and never reached the materializer:

```
publish_skipped{gate_off}=0   {no_transport}=0   {system_execution}=22
published_total = ABSENT
```

⚠ **Why it went unnoticed is the substance of this PR.** An unreachable shadow
reports `agreed=0, diverged=0, append_failed=0` — byte-identical to a healthy
shadow on a quiet system. `opened` is the only series that separates them, and
five of six legitimately sit at 0 when healthy.

## What

The hook moves to `handlers::event_write::emit_events`, **beside `mirror_rows`**
and for the reasons that comment already gives:

- after terminal dedup and chain stamping ⇒ `rows` is exactly the set that
  becomes authoritative;
- **before** the publish/insert fork ⇒ one call site covers both branches, so
  the gate-off branch (the one prod does not exercise) cannot rot separately.

Removed from `project_events` rather than duplicated: with the gate on, an event
passes `emit_events` and *then* reaches the materializer, so two hooks would
append it twice and report a divergence the engine did not cause.

## Testing — mutation-gated

`emit_events` needs an `AppState` and a live pool, so it cannot be driven from a
unit test. And a test that calls `shadow_append` directly passes whether or not
anything on the write path calls it — the noetl/ai-meta#326 mistake exactly. So
the guards read the call site, and each was proven to fail when it should:

| mutation | result |
| :-- | :-- |
| M1 delete the call from `emit_events` | **CAUGHT** by 4 guards |
| M2 move it past the publish/insert fork | **CAUGHT** by the ordering guard |
| M3 give `shadow_append` a return type | **CAUGHT** by the serving-path guard |
| M4 re-add the second hook in `project_events` | **CAUGHT** by the one-call-site guard |
| control (unmutated) | green |

Zero compile errors — every mutation applied and built, so each result is a real
verdict rather than a build failure misread as a catch.

Each guard **asserts its own extraction first** (body size + presence of the
fork): a slice that silently came back empty would make every assertion pass
over zero bytes.

One guard needed fixing during this work and it is worth noting: the
one-call-site check initially counted **6** call sites, because it matched its
own assertion strings. It now counts only the non-test region.

`1046 tests pass`; clippy clean of new warnings (the remaining ones are
pre-existing, in files this PR does not touch); `rustfmt` verified per-file via
stdin against a HEAD baseline — `cargo fmt` is **not** run here because it
reformats unrelated `orchestrate-core` code.

## Doc correction

`shadow_append`'s comment claimed it appends *"the rows Postgres accepted"*.
Not true at the new call site: the write has not happened yet, so a batch whose
write then fails is counted by the shadow and not by the log. That is the same
property `mirror_rows` has one line above, accepted for the same reason, and it
is now written down.

Refs noetl/ai-meta#332
