### PR TITLE
feat: verify the embedded engine's READ path against Postgres

### DIFF
--- a/src/handlers/ehdb_embedded.rs
+++ b/src/handlers/ehdb_embedded.rs
@@ -219,6 +219,195 @@ pub fn shadow_append(rows: &[crate::handlers::event_write::EventRow]) {
     crate::metrics::record_embedded_shadow(v.label());
 }
 
+/// One event as the comparator sees it, from either side.
+///
+/// Only the fields both stores genuinely carry. ⚠ Deliberately NOT a struct with
+/// every column: the noetl/ai-meta#325 comparator deserialised five fields and
+/// compared three, and reported `match` on executions that differed for weeks.
+/// What is compared here is exactly what is listed here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComparableEvent {
+    pub event_id: i64,
+    pub event_type: String,
+}
+
+/// The verdict of comparing one execution's event log across the two stores.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadVerdict {
+    /// Same event ids, same types, same count.
+    Agreed { events: usize },
+    /// They differ — the number this whole exercise exists to surface.
+    Diverged {
+        embedded_only: Vec<i64>,
+        authoritative_only: Vec<i64>,
+        type_mismatches: Vec<i64>,
+    },
+    /// The embedded engine holds nothing for this execution.
+    ///
+    /// ⚠ NOT a divergence on a fresh volume. The engine only holds what was
+    /// appended since it opened, so an execution older than the engine is
+    /// **out of coverage**, not lost. Counting it as divergence would produce a
+    /// false alarm; counting it as agreement would produce a false clean — which
+    /// is why it is a third outcome rather than folded into either.
+    OutOfCoverage,
+}
+
+impl ReadVerdict {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Agreed { .. } => "agreed",
+            Self::Diverged { .. } => "diverged",
+            Self::OutOfCoverage => "out_of_coverage",
+        }
+    }
+}
+
+/// Compare the two event sets. Pure, so the comparator is testable without a
+/// database or an engine — and so the positive control below can drive it
+/// directly with a known-divergent input.
+pub fn compare_reads(
+    embedded: &[ComparableEvent],
+    authoritative: &[ComparableEvent],
+) -> ReadVerdict {
+    if embedded.is_empty() && !authoritative.is_empty() {
+        return ReadVerdict::OutOfCoverage;
+    }
+    use std::collections::HashMap;
+    let e: HashMap<i64, &ComparableEvent> = embedded.iter().map(|x| (x.event_id, x)).collect();
+    let a: HashMap<i64, &ComparableEvent> = authoritative.iter().map(|x| (x.event_id, x)).collect();
+    let mut embedded_only: Vec<i64> = e.keys().filter(|k| !a.contains_key(k)).copied().collect();
+    let mut authoritative_only: Vec<i64> =
+        a.keys().filter(|k| !e.contains_key(k)).copied().collect();
+    let mut type_mismatches: Vec<i64> = e
+        .iter()
+        .filter(|(k, v)| {
+            a.get(*k)
+                .map(|o| o.event_type != v.event_type)
+                .unwrap_or(false)
+        })
+        .map(|(k, _)| *k)
+        .collect();
+    if embedded_only.is_empty() && authoritative_only.is_empty() && type_mismatches.is_empty() {
+        return ReadVerdict::Agreed { events: a.len() };
+    }
+    embedded_only.sort_unstable();
+    authoritative_only.sort_unstable();
+    type_mismatches.sort_unstable();
+    ReadVerdict::Diverged {
+        embedded_only,
+        authoritative_only,
+        type_mismatches,
+    }
+}
+
+/// Read one execution's events back out of the embedded engine.
+///
+/// `None` when the engine is not open (flag off / open failed) — distinct from
+/// `Some(vec![])`, which means the engine IS open and holds nothing for it.
+pub fn read_embedded(execution_id: &str) -> Option<Vec<ComparableEvent>> {
+    let engine = engine()?;
+    let mut guard = match engine.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let recs = guard.read_execution_after(execution_id, 0).ok()?;
+    Some(
+        recs.iter()
+            .map(|r| {
+                // ⚠ The id comes from the PAYLOAD, not the `event_id` column.
+                // `shadow_append` builds records with `EventRecord::new(..)`, which
+                // does not set that column, so it is `None` on every record the
+                // shadow wrote. Keying on it would collapse the whole set onto 0 and
+                // report a spectacular false divergence. The column is preferred
+                // when a producer did set it.
+                let v: Option<serde_json::Value> = serde_json::from_str(&r.payload).ok();
+                let from_payload = v.as_ref().and_then(|v| {
+                    v.get("event_id").and_then(|e| {
+                        e.as_i64()
+                            .or_else(|| e.as_str().and_then(|s| s.parse::<i64>().ok()))
+                    })
+                });
+                ComparableEvent {
+                    event_id: r
+                        .event_id
+                        .as_ref()
+                        .and_then(|c| c.parse::<i64>().ok())
+                        .or(from_payload)
+                        .unwrap_or(0),
+                    event_type: v
+                        .as_ref()
+                        .and_then(|v| v.get("event_type").and_then(|t| t.as_str()))
+                        .unwrap_or_default()
+                        .to_string(),
+                }
+            })
+            .collect(),
+    )
+}
+
+/// The comparator's **positive control**.
+///
+/// ⚠⚠ The single most important function here. A `diverged=0` result is
+/// meaningless unless the comparator can be shown to fire, and this codebase has
+/// repeatedly produced clean results from checks that could not. Each case is
+/// driven through the real `compare_reads`, and every one must land on its
+/// expected verdict or the whole report is refused.
+pub fn comparator_controls() -> Vec<(&'static str, bool, String)> {
+    let ev = |id: i64, t: &str| ComparableEvent {
+        event_id: id,
+        event_type: t.to_string(),
+    };
+    let mut out = Vec::new();
+
+    let same = vec![ev(1, "a"), ev(2, "b")];
+    out.push((
+        "identical",
+        matches!(
+            compare_reads(&same, &same),
+            ReadVerdict::Agreed { events: 2 }
+        ),
+        "two identical sets must agree".to_string(),
+    ));
+
+    let missing = vec![ev(1, "a")];
+    out.push((
+        "missing_event",
+        matches!(
+            compare_reads(&missing, &same),
+            ReadVerdict::Diverged { ref authoritative_only, .. } if authoritative_only == &vec![2]
+        ),
+        "an event only Postgres has must be DETECTED".to_string(),
+    ));
+
+    let extra = vec![ev(1, "a"), ev(2, "b"), ev(3, "c")];
+    out.push((
+        "extra_event",
+        matches!(
+            compare_reads(&extra, &same),
+            ReadVerdict::Diverged { ref embedded_only, .. } if embedded_only == &vec![3]
+        ),
+        "an event only the engine has must be DETECTED".to_string(),
+    ));
+
+    let retyped = vec![ev(1, "a"), ev(2, "DIFFERENT")];
+    out.push((
+        "type_mismatch",
+        matches!(
+            compare_reads(&retyped, &same),
+            ReadVerdict::Diverged { ref type_mismatches, .. } if type_mismatches == &vec![2]
+        ),
+        "same ids with a changed type must be DETECTED, not counted as agreement".to_string(),
+    ));
+
+    out.push((
+        "out_of_coverage_is_not_agreement",
+        matches!(compare_reads(&[], &same), ReadVerdict::OutOfCoverage),
+        "an empty engine side must be OutOfCoverage, never Agreed".to_string(),
+    ));
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,6 +495,65 @@ mod tests {
     }
 
     #[test]
+    /// The positive controls must all pass on the real comparator.
+    ///
+    /// ⚠ This is the guard on the guard. If `compare_reads` is ever weakened so a
+    /// planted divergence goes undetected, every `agreed` this endpoint reports
+    /// becomes meaningless — and would still read as a clean result.
+    #[test]
+    fn every_comparator_control_fires() {
+        let controls = comparator_controls();
+        assert!(
+            controls.len() >= 5,
+            "expected >=5 controls, found {}",
+            controls.len()
+        );
+        for (name, passed, detail) in &controls {
+            assert!(passed, "control {name} did NOT fire: {detail}");
+        }
+    }
+
+    /// Out-of-coverage must never be reported as agreement.
+    ///
+    /// On a fresh volume the engine holds nothing for older executions. Folding
+    /// that into `Agreed` would manufacture a clean result over zero compared
+    /// events — the failure this codebase keeps producing.
+    #[test]
+    fn an_empty_engine_side_is_not_agreement() {
+        let a = vec![ComparableEvent {
+            event_id: 1,
+            event_type: "x".into(),
+        }];
+        assert_eq!(compare_reads(&[], &a), ReadVerdict::OutOfCoverage);
+        assert_ne!(compare_reads(&[], &a), ReadVerdict::Agreed { events: 0 });
+    }
+
+    /// Both stores empty is agreement over zero, and is labelled as such.
+    #[test]
+    fn both_empty_agrees_on_zero() {
+        assert_eq!(compare_reads(&[], &[]), ReadVerdict::Agreed { events: 0 });
+    }
+
+    /// Same ids, different types must diverge — the #325 shape in miniature:
+    /// comparing only ids would call these equal.
+    #[test]
+    fn same_ids_different_types_diverge() {
+        let a = vec![ComparableEvent {
+            event_id: 1,
+            event_type: "a".into(),
+        }];
+        let b = vec![ComparableEvent {
+            event_id: 1,
+            event_type: "b".into(),
+        }];
+        match compare_reads(&a, &b) {
+            ReadVerdict::Diverged {
+                type_mismatches, ..
+            } => assert_eq!(type_mismatches, vec![1]),
+            other => panic!("expected Diverged, got {other:?}"),
+        }
+    }
+
     fn labels_are_a_closed_set() {
         assert_eq!(ShadowVerdict::Agreed.label(), "agreed");
         assert_eq!(ShadowVerdict::Skipped.label(), "skipped");

--- a/src/handlers/ehdb_embedded_verify.rs
+++ b/src/handlers/ehdb_embedded_verify.rs
@@ -1,0 +1,115 @@
+//! `verify` read path for the embedded EHDB engine (noetl/ai-meta#332).
+//!
+//! ⚠⚠ Why this exists at all. The embedded shadow compares `appended` against
+//! `rows.len()` — *"did the engine accept the write set"*. It never reads
+//! anything back. So `diverged=0` on the shadow says **nothing** about whether
+//! the engine can answer a query, which is the entire content of the serve flip.
+//! Treating write agreement as read readiness is the noetl/ai-meta#325 mistake,
+//! where a comparator that deserialised five fields and compared three reported
+//! `match` on executions that differed, for weeks.
+//!
+//! This endpoint reads one execution's events from **both** stores and compares
+//! them. It serves nothing and changes nothing: Postgres remains authoritative
+//! throughout, so a wrong engine answer costs a metric increment rather than a
+//! wrong result to a caller.
+//!
+//! Every response carries the comparator's **positive controls**. A report whose
+//! controls did not all pass is refused rather than returned, because a green
+//! result from a comparator that cannot fire is worse than no result.
+
+use crate::error::AppResult;
+use crate::handlers::ehdb_embedded::{
+    comparator_controls, compare_reads, read_embedded, ComparableEvent, ReadVerdict,
+};
+use crate::state::AppState;
+use axum::{extract::Path, extract::State, Json};
+use serde_json::json;
+
+/// Read the authoritative event set for one execution.
+async fn read_authoritative(
+    state: &AppState,
+    execution_id: i64,
+) -> AppResult<Vec<ComparableEvent>> {
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT event_id, event_type FROM noetl.event WHERE execution_id = $1 ORDER BY event_id",
+    )
+    .bind(execution_id)
+    .fetch_all(state.pools.pool_for(execution_id))
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(event_id, event_type)| ComparableEvent {
+            event_id,
+            event_type,
+        })
+        .collect())
+}
+
+/// `GET /api/ehdb/embedded/verify/{execution_id}`
+pub async fn verify_execution(
+    State(state): State<AppState>,
+    Path(execution_id): Path<String>,
+) -> AppResult<Json<serde_json::Value>> {
+    let controls = comparator_controls();
+    let controls_json: Vec<_> = controls
+        .iter()
+        .map(|(name, passed, detail)| json!({"control": name, "passed": passed, "detail": detail}))
+        .collect();
+
+    // ⚠ Refuse the whole report if any control failed. A comparator that cannot
+    // detect a planted divergence makes every other number in this body a lie.
+    if let Some((name, _, _)) = controls.iter().find(|(_, passed, _)| !passed) {
+        return Ok(Json(json!({
+            "action": "ehdb.embedded.verify",
+            "outcome": "controls_failed",
+            "failed_control": name,
+            "controls": controls_json,
+            "note": "report refused: the comparator did not detect a planted divergence, \
+                     so a clean verdict here would be meaningless",
+        })));
+    }
+
+    let eid: i64 = execution_id.parse().map_err(|_| {
+        crate::error::AppError::BadRequest(format!("execution_id not an i64: {execution_id}"))
+    })?;
+
+    let Some(embedded) = read_embedded(&execution_id) else {
+        return Ok(Json(json!({
+            "action": "ehdb.embedded.verify",
+            "outcome": "engine_unavailable",
+            "controls": controls_json,
+            "note": "the embedded engine is not open (flag off, or the open failed)",
+        })));
+    };
+    let authoritative = read_authoritative(&state, eid).await?;
+    let verdict = compare_reads(&embedded, &authoritative);
+    crate::metrics::record_embedded_read(verdict.label());
+
+    let detail = match &verdict {
+        ReadVerdict::Agreed { events } => json!({"events_compared": events}),
+        ReadVerdict::OutOfCoverage => json!({
+            "note": "the engine holds nothing for this execution -- it predates the \
+                     engine's current volume. Out of coverage, NOT a divergence and NOT agreement.",
+            "authoritative_events": authoritative.len(),
+        }),
+        ReadVerdict::Diverged {
+            embedded_only,
+            authoritative_only,
+            type_mismatches,
+        } => json!({
+            "embedded_only": embedded_only,
+            "authoritative_only": authoritative_only,
+            "type_mismatches": type_mismatches,
+            "embedded_count": embedded.len(),
+            "authoritative_count": authoritative.len(),
+        }),
+    };
+
+    Ok(Json(json!({
+        "action": "ehdb.embedded.verify",
+        "execution_id": execution_id,
+        "outcome": verdict.label(),
+        "detail": detail,
+        "controls": controls_json,
+    })))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -19,6 +19,7 @@ pub mod dashboard;
 pub mod database;
 pub mod ehdb;
 pub mod ehdb_embedded;
+pub mod ehdb_embedded_verify;
 pub mod ehdb_eventlog_mirror;
 pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,6 +447,10 @@ fn build_router(
             get(handlers::ehdb_parity::compare_execution_endpoint),
         )
         .route(
+            "/api/ehdb/embedded/verify/{execution_id}",
+            get(handlers::ehdb_embedded_verify::verify_execution),
+        )
+        .route(
             "/api/ehdb/repair/executions/{execution_id}",
             post(handlers::ehdb_tier_repair::repair_execution_endpoint),
         )
@@ -1014,6 +1018,7 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_ehdb_crossstore_series();
     // noetl/ai-meta#332 step 5 — pinned so an unrun shadow reads 0, not absent.
     noetl_server::metrics::init_embedded_shadow_series();
+    noetl_server::metrics::init_embedded_read_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_queue_series();
     noetl_server::metrics::init_ehdb_projection_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3243,6 +3243,49 @@ pub const EMBEDDED_SHADOW_OUTCOMES: [&str; 6] = [
 ];
 
 /// Record one embedded-shadow outcome.
+/// Outcomes of an embedded READ comparison (noetl/ai-meta#332).
+///
+/// ⚠ `out_of_coverage` is its own outcome, not folded into agreed or diverged:
+/// an execution older than the engine's volume is neither.
+pub const EMBEDDED_READ_OUTCOMES: [&str; 4] = [
+    "agreed",
+    "diverged",
+    "out_of_coverage",
+    "engine_unavailable",
+];
+
+pub fn embedded_read_total() -> &'static prometheus::IntCounterVec {
+    static M: std::sync::OnceLock<prometheus::IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = prometheus::IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_ehdb_embedded_read_total",
+                "Embedded-vs-authoritative event-log READ comparisons by outcome",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric");
+        let _ = registry().register(Box::new(m.clone()));
+        m
+    })
+}
+
+pub fn record_embedded_read(outcome: &str) {
+    embedded_read_total().with_label_values(&[outcome]).inc();
+}
+
+/// Pin every outcome at 0 **unconditionally**.
+///
+/// ⚠ `Registry::gather` prunes label families with no children, so without this
+/// "never diverged" and "this build has no such metric" are the same scrape.
+/// Unconditional on purpose: server#315 pinned inside a config branch and left
+/// the series absent on exactly the configuration whose value mattered.
+pub fn init_embedded_read_series() {
+    for o in EMBEDDED_READ_OUTCOMES {
+        embedded_read_total().with_label_values(&[o]).inc_by(0);
+    }
+}
+
 pub fn record_embedded_shadow(outcome: &str) {
     embedded_shadow_total().with_label_values(&[outcome]).inc();
 }


### PR DESCRIPTION
The shadow proves the engine **accepts** the write set. It never reads anything back, so `diverged=0` says nothing about whether the engine can **answer a query** — which is the entire content of the serve flip. This adds the missing read-path evidence.

`GET /api/ehdb/embedded/verify/{execution_id}` reads one execution's events from **both** stores and compares ids and types. It serves nothing; Postgres stays authoritative, so a wrong engine answer costs a metric increment rather than a wrong result to a caller.

⚠ **Every response carries the comparator's positive controls, and a report whose controls did not all pass is refused rather than returned.** A green result from a comparator that cannot fire is worse than no result.

⚠ `out_of_coverage` is a third outcome — on a fresh volume the engine holds nothing for older executions; calling that divergence is a false alarm, calling it agreement is a false clean.

⚠ The comparator keys on the id in the **payload**, not the record's `event_id` column: `shadow_append` uses `EventRecord::new(..)`, which leaves that column `None`, so keying on it would collapse every record onto `0` and report a spectacular false divergence.

Mutation-gated — ignore type mismatches → **CAUGHT**; empty-side ⇒ Agreed → **CAUGHT**; control green. 1050 tests pass.

Refs noetl/ai-meta#332