### PR TITLE
fix: the embedded shadow must cover the emit-chokepoint BYPASS sites

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -1057,6 +1057,49 @@ mod tests {
     /// Checks the count, which is what actually goes wrong; the order is asserted
     /// on the tail the noetl/ai-meta#326 fix appended, where the risk is.
     #[test]
+    /// The embedded shadow must cover **every** site the mirror covers.
+    ///
+    /// ⚠ Both exist for the same reason: `emit_events` is NOT the only writer of
+    /// `noetl.event`. Two sites in `handlers::events` write the table directly,
+    /// in-transaction, on the branch `should_publish` takes when it returns false
+    /// -- the only branch a system-pool execution can take (noetl/ai-meta#263).
+    ///
+    /// Measured on prod 2026-09-09 before the fix: the embedded engine held 12 of
+    /// 14 events for an hourly `system/scheduled_cleanup`, missing exactly the
+    /// rows written at those sites. The write path could not see it -- every
+    /// append it made succeeded, so `append_failed` stayed 0. It surfaced only
+    /// when the READ comparison was built (noetl/ai-meta#332).
+    ///
+    /// Counting both, rather than naming the sites: a guard that names them
+    /// drifts the moment a third bypass is added, which is the failure class this
+    /// file already exists for.
+    #[test]
+    fn the_embedded_shadow_covers_every_site_the_mirror_covers() {
+        let src = include_str!("events.rs");
+        let code = src.split("#[cfg(test)]").next().unwrap();
+        assert!(
+            code.contains("pub async fn handle_event"),
+            "non-test slice lost handle_event -- the extraction broke and a guard \
+             measuring nothing passes"
+        );
+        let mirrors = code.matches("ehdb_eventlog_mirror::mirror_rows(").count();
+        let shadows = code.matches("ehdb_embedded::shadow_append(").count();
+        assert!(
+            mirrors >= 2,
+            "expected >=2 mirror sites in events.rs, found {mirrors} -- the slice \
+             is wrong or the bypass moved"
+        );
+        assert_eq!(
+            mirrors, shadows,
+            "events.rs mirrors {mirrors} direct-write site(s) but shadows {shadows}. \
+             Every site that writes noetl.event outside the emit chokepoint must \
+             append to the embedded engine too, or the engine silently holds an \
+             incomplete log for exactly the system-pool executions that take that \
+             branch -- invisible from the write side, because those appends never \
+             happen at all."
+        );
+    }
+
     fn insert_column_and_bind_counts_agree() {
         let src = include_str!("events.rs");
         let needle = format!("INSERT INTO noetl.event{}", "");

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1283,6 +1283,13 @@ pub async fn claim_command(
     // let alone mirrored, until this record is already in the tier.
     if let Some(ev) = claim_event_to_mirror {
         crate::handlers::ehdb_eventlog_mirror::mirror_rows(&state, std::slice::from_ref(&ev)).await;
+        // noetl/ai-meta#332 -- the embedded shadow rides the SAME bypass as the
+        // mirror. `emit_events` is not the only writer: this site writes
+        // `noetl.event` directly, in-transaction, on the branch `should_publish`
+        // takes when it returns false -- the only branch a system-pool execution
+        // can take. Measured on prod: the shadow held 12 of 14 events for an
+        // hourly `system/scheduled_cleanup`, missing exactly the rows written here.
+        crate::handlers::ehdb_embedded::shadow_append(std::slice::from_ref(&ev));
     }
 
     Ok(Json(ClaimResponse {
@@ -1469,6 +1476,8 @@ pub async fn handle_batch_events(
         // half of it would leave the tier's completeness dependent on which
         // ingest route a future system playbook happens to use.
         crate::handlers::ehdb_eventlog_mirror::mirror_rows(&state, &event_rows).await;
+        // noetl/ai-meta#332 -- same bypass, same reason as the claim site above.
+        crate::handlers::ehdb_embedded::shadow_append(&event_rows);
     }
 
     // Trigger orchestrator for any command.completed in the batch,


### PR DESCRIPTION
Found on prod by the read comparison from #421 — **not** by the write path.

An hourly `system/scheduled_cleanup` verified **DIVERGED**: Postgres 14 events, embedded 12. All five comparator controls passed, so the result is real.

## It is not a durability bug

The two missing rows were the last two written, which looks like a lost-buffer problem. It isn't. I tried to reproduce it at the storage layer and **could not**: an `ehdb-l0` engine appended 20 records, had its process killed **without `Drop`** (`std::mem::forget` — no flush, no seal), reopened, and returned all 20. Same with three interleaved executions at snowflake-scale sequences, 30 records each. `FlushPolicy::EveryAppend` fsyncs per append and `recover_active` recovers the intact frames.

**The records were never appended.**

## Root cause

`emit_events` is not the only writer of `noetl.event`. Two sites in `handlers::events` write the table directly, in-transaction, on the branch `should_publish` takes when it returns false — **the only branch a system-pool execution can take**. The mirror already carries this exact analysis (noetl/ai-meta#263), where it cost 11 of 13 events on the same hourly playbook. The shadow, hooked only at `emit_events`, inherited the identical gap.

⚠ **The write path cannot see this.** Every append the shadow made succeeded — `append_failed` stayed 0. A missing writer is invisible to a comparator that only sees the writers it hooks.

## Fix + guard

`shadow_append` at both bypass sites, beside the `mirror_rows` calls that are there for the same reason. The guard asserts the shadow's coverage **equals the mirror's**, counted rather than named — naming them drifts the moment a third bypass appears. Mutation-gated: dropping either call site is **CAUGHT**. 1051 tests pass.

Refs noetl/ai-meta#332, noetl/ai-meta#263