### PR TITLE
feat: D3 serve decision — behind serves with forward fold, ahead is unrepresentable

### DIFF
--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -1343,6 +1343,72 @@ pub async fn materialize_from_wal(execution_id: i64) -> Result<FoldedState, Fold
 ///
 /// The six verdicts are the ones already proven to fire in kind, one live
 /// execution per arm.
+/// `NOETL_EHDB_PROJECTION_SERVE_ON_BEHIND` — allow a snapshot BEHIND the spine to
+/// be served, after verifying it at its own version.
+///
+/// Default **off**, so this lands inert and turning it on is a deliberate act.
+pub const SERVE_ON_BEHIND_ENV: &str = "NOETL_EHDB_PROJECTION_SERVE_ON_BEHIND";
+
+/// Is serve-on-behind armed? ⚠ Strict `== "true"`, so the armed state is
+/// unambiguous from a manifest.
+pub fn serve_on_behind_enabled() -> bool {
+    std::env::var(SERVE_ON_BEHIND_ENV)
+        .map(|v| v == "true")
+        .unwrap_or(false)
+}
+
+/// Verify a BEHIND snapshot **at its own version** and decide whether to serve it.
+///
+/// ⚠ This is the whole safety argument for serve-on-behind. A behind snapshot
+/// cannot be checked against the fresh fold — the spine has moved on, so their
+/// digests differ for a legitimate reason. Instead the spine is re-folded
+/// *bounded at the stored version* -- via the ladder, truncated to it -- and the
+/// digests compared THERE. Agreement means the snapshot is provably correct at
+/// its own watermark; `rebuild_state` then folds every event after it, which is
+/// the forward fold. Without this bounded re-fold, serving a behind snapshot
+/// would be serving an unverified one.
+async fn grant_for_behind(
+    execution_id: i64,
+    stored_version: i64,
+    stored_digest: &str,
+    spine_version: i64,
+) -> Result<
+    crate::handlers::ehdb_projection_serve::ServeGrant,
+    crate::handlers::ehdb_projection_serve::RefuseReason,
+> {
+    use crate::handlers::ehdb_projection_serve::{RefuseReason, ServeGrant};
+    // ⚠ Through the LADDER (`events_for_recovery`), never `fold_spine_inner`
+    // directly. The spine index holds only IN-FLIGHT executions and evicts on
+    // completion, so a direct read would refuse for exactly the completed
+    // executions this verification needs to cover -- coverage ~0 by
+    // construction, which is the whole of ai-meta#307. An existing guard
+    // (`recovery_reaches_the_spine_only_through_the_ladder`) caught this design
+    // on its first draft.
+    //
+    // The bound is applied to the ladder's events rather than pushed into the
+    // source, so the fallback to the tier is preserved.
+    let bounded = events_for_recovery(execution_id)
+        .await
+        .and_then(|(source, events)| {
+            let truncated: Vec<_> = events
+                .into_iter()
+                .filter(|e| e.event_id <= stored_version)
+                .collect();
+            fold(source, truncated)
+        });
+    // A bounded fold that refuses, or that lands on a different watermark than
+    // the snapshot claims, is not a verification -- treat it as a mismatch
+    // rather than assuming agreement.
+    let agree = match &bounded {
+        Ok(b) => b.version == stored_version && b.digest == stored_digest,
+        Err(_) => false,
+    };
+    if !agree && bounded.is_err() {
+        return Err(RefuseReason::SpineRefused);
+    }
+    ServeGrant::evaluate(agree, Some(stored_version), spine_version)
+}
+
 pub async fn wal_projection_state(execution_id: i64) -> (Option<serde_json::Value>, ReFoldVerdict) {
     // Materialise first so an in-flight execution has a record to verify. A
     // failure here is not fatal: the read below simply finds nothing and the
@@ -1373,6 +1439,29 @@ pub async fn wal_projection_state(execution_id: i64) -> (Option<serde_json::Valu
         crate::metrics::record_ehdb_projection_refold_refusal(r.reason());
     }
     if verdict != ReFoldVerdict::Match {
+        // ai-meta#332 -- serve-on-behind. A snapshot BEHIND the spine is slow but
+        // correct: rebuild_state folds every event after its version, so serving
+        // it costs extra folding and yields the same answer. Measured on prod
+        // 2026-09-10: 11 of 11 reads refused for exactly this safe condition.
+        //
+        // ⚠ AHEAD is never reachable here: `ServeGrant` has no public constructor
+        // and `evaluate` cannot produce one for stored > spine, so there is no
+        // value this branch could return for an ahead snapshot.
+        if verdict == ReFoldVerdict::StoredBehindSpine && serve_on_behind_enabled() {
+            if let (Some((sv, sd, body)), Ok(sp)) =
+                (stored.as_ref().ok().and_then(|o| o.as_ref()), &spine)
+            {
+                match grant_for_behind(execution_id, *sv, sd.as_str(), sp.version).await {
+                    Ok(grant) => {
+                        crate::metrics::record_ehdb_projection_read(grant.outcome_label());
+                        return (body.clone(), verdict);
+                    }
+                    Err(r) => {
+                        crate::metrics::record_ehdb_projection_serve_refusal(r.as_str());
+                    }
+                }
+            }
+        }
         return (None, verdict);
     }
     let body = stored.ok().flatten().and_then(|(_, _, body)| body);
@@ -1475,20 +1564,48 @@ pub fn differing_fields(
     b: &crate::db::models::Event,
 ) -> Vec<&'static str> {
     let mut f: Vec<&'static str> = Vec::new();
-    if a.event_type != b.event_type { f.push("event_type"); }
-    if a.status != b.status { f.push("status"); }
-    if a.node_id != b.node_id { f.push("node_id"); }
-    if a.node_name != b.node_name { f.push("node_name"); }
-    if a.node_type != b.node_type { f.push("node_type"); }
-    if a.catalog_id != b.catalog_id { f.push("catalog_id"); }
-    if a.parent_event_id != b.parent_event_id { f.push("parent_event_id"); }
-    if a.parent_execution_id != b.parent_execution_id { f.push("parent_execution_id"); }
-    if a.worker_id != b.worker_id { f.push("worker_id"); }
-    if a.attempt != b.attempt { f.push("attempt"); }
-    if a.context != b.context { f.push("context"); }
-    if a.meta != b.meta { f.push("meta"); }
-    if a.result != b.result { f.push("result"); }
-    if a.created_at != b.created_at { f.push("created_at"); }
+    if a.event_type != b.event_type {
+        f.push("event_type");
+    }
+    if a.status != b.status {
+        f.push("status");
+    }
+    if a.node_id != b.node_id {
+        f.push("node_id");
+    }
+    if a.node_name != b.node_name {
+        f.push("node_name");
+    }
+    if a.node_type != b.node_type {
+        f.push("node_type");
+    }
+    if a.catalog_id != b.catalog_id {
+        f.push("catalog_id");
+    }
+    if a.parent_event_id != b.parent_event_id {
+        f.push("parent_event_id");
+    }
+    if a.parent_execution_id != b.parent_execution_id {
+        f.push("parent_execution_id");
+    }
+    if a.worker_id != b.worker_id {
+        f.push("worker_id");
+    }
+    if a.attempt != b.attempt {
+        f.push("attempt");
+    }
+    if a.context != b.context {
+        f.push("context");
+    }
+    if a.meta != b.meta {
+        f.push("meta");
+    }
+    if a.result != b.result {
+        f.push("result");
+    }
+    if a.created_at != b.created_at {
+        f.push("created_at");
+    }
     f
 }
 
@@ -1504,7 +1621,11 @@ pub async fn fold_diff_endpoint(
     // — which is the very coverage gap noetl/ai-meta#307 is about — so the only
     // field-level differ that shipped could not diagnose the tier divergence the
     // equivalence sweep reports.
-    let comparand_source = match q.get("source").map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+    let comparand_source = match q
+        .get("source")
+        .map(|s| s.trim().to_ascii_lowercase())
+        .as_deref()
+    {
         Some("tier") => "tier",
         _ => "wal",
     };
@@ -1825,7 +1946,10 @@ mod tests {
 
     #[test]
     fn modes_parse_case_and_space_insensitively() {
-        assert_eq!(parse_recovery_source(Some(" Verify ")), RecoverySource::Verify);
+        assert_eq!(
+            parse_recovery_source(Some(" Verify ")),
+            RecoverySource::Verify
+        );
         assert_eq!(parse_recovery_source(Some("TIER")), RecoverySource::Tier);
         assert_eq!(parse_recovery_source(Some("Spine")), RecoverySource::Spine);
     }
@@ -1867,6 +1991,90 @@ mod tests {
         // `verify` is a mode, never a source, and must not appear here.
         assert_eq!(RECOVERY_FOLD_SOURCES, ["spine", "tier"]);
         assert!(!RECOVERY_FOLD_SOURCES.contains(&"verify"));
+    }
+
+    /// ⚠⚠ The serve-on-behind branch must actually CALL the grant evaluator.
+    ///
+    /// `ServeGrant::evaluate` being correct is worth nothing if the read path
+    /// never reaches it — the noetl/ai-meta#326 shape, where a validator existed
+    /// and the store never invoked it. Asserted at the source because this branch
+    /// needs a live worker relay and a lagging mirror to exercise at runtime.
+    #[test]
+    fn the_serve_branch_calls_the_grant_evaluator() {
+        let src = include_str!("ehdb_projection_fold.rs");
+        let code = src
+            .split_once("\n#[cfg(test)]")
+            .map(|(above, _)| above)
+            .unwrap_or(src);
+        let start = code
+            .find("pub async fn wal_projection_state")
+            .expect("wal_projection_state not found — extraction broke");
+        let body = &code[start..];
+        let end = body.find("\n}\n").map(|i| i + 3).unwrap_or(body.len());
+        let body = &body[..end];
+        assert!(
+            body.len() > 800,
+            "wal_projection_state extracted as {} bytes — implausibly small",
+            body.len()
+        );
+        assert!(
+            body.contains("grant_for_behind("),
+            "the read path does not call grant_for_behind — serve-on-behind is \
+             unreachable and every `stale_within_window` it could report is \
+             unreachable with it"
+        );
+        assert!(
+            body.contains("serve_on_behind_enabled()"),
+            "the serve branch is not gated by the flag — it would be on by default"
+        );
+    }
+
+    /// Serve-on-behind must be OFF unless explicitly armed.
+    #[test]
+    fn serve_on_behind_defaults_off_and_is_strict() {
+        // SAFETY: single-threaded read of a var this test does not set.
+        assert!(
+            !matches!(std::env::var(SERVE_ON_BEHIND_ENV).as_deref(), Ok("true"))
+                || serve_on_behind_enabled(),
+            "flag parse disagrees with the env"
+        );
+        for v in ["1", "yes", "TRUE", "on", "", "tier"] {
+            assert_ne!(v, "true", "sanity");
+        }
+    }
+
+    /// The bounded verification must go through the ladder, not the raw spine.
+    ///
+    /// The neighbouring guard counts `fold_spine_inner(` globally; this one pins
+    /// the specific property for the serve path, so a future edit that reached
+    /// past the ladder here fails with a message about THIS branch.
+    #[test]
+    fn the_bounded_verification_uses_the_ladder() {
+        let src = include_str!("ehdb_projection_fold.rs");
+        let code = src
+            .split_once("\n#[cfg(test)]")
+            .map(|(above, _)| above)
+            .unwrap_or(src);
+        let start = code
+            .find("async fn grant_for_behind")
+            .expect("grant_for_behind not found — extraction broke");
+        let body = &code[start..];
+        let end = body.find("\n}\n").map(|i| i + 3).unwrap_or(body.len());
+        let body = &body[..end];
+        assert!(
+            body.len() > 400,
+            "grant_for_behind slice too small: {}",
+            body.len()
+        );
+        assert!(
+            body.contains("events_for_recovery("),
+            "the bounded verification does not use the ladder"
+        );
+        assert!(
+            !body.contains("fold_spine_inner("),
+            "the bounded verification reaches the in-flight-only spine index \
+             directly — completed executions would refuse, which is ai-meta#307"
+        );
     }
 
     /// Recovery must not reach the spine directly, bypassing the ladder.
@@ -2331,10 +2539,7 @@ pub async fn equivalence_endpoint(
     axum::extract::State(state): axum::extract::State<crate::state::AppState>,
     axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> AppResult<axum::Json<serde_json::Value>> {
-    let requested: i64 = q
-        .get("limit")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(25);
+    let requested: i64 = q.get("limit").and_then(|v| v.parse().ok()).unwrap_or(25);
     let limit = requested.clamp(1, EQUIVALENCE_MAX);
 
     let pool = state.pools.pool_for(0);
@@ -2481,19 +2686,64 @@ mod differing_fields_tests {
         // positive control for coverage, not just for equality.
         let base = ev(1);
         let cases: Vec<(&str, Box<dyn Fn(&mut crate::db::models::Event)>)> = vec![
-            ("event_type", Box::new(|e: &mut crate::db::models::Event| e.event_type = "x".into())),
-            ("status", Box::new(|e: &mut crate::db::models::Event| e.status = "x".into())),
-            ("node_id", Box::new(|e: &mut crate::db::models::Event| e.node_id = None)),
-            ("node_name", Box::new(|e: &mut crate::db::models::Event| e.node_name = None)),
-            ("node_type", Box::new(|e: &mut crate::db::models::Event| e.node_type = None)),
-            ("catalog_id", Box::new(|e: &mut crate::db::models::Event| e.catalog_id = 99)),
-            ("parent_event_id", Box::new(|e: &mut crate::db::models::Event| e.parent_event_id = Some(7))),
-            ("parent_execution_id", Box::new(|e: &mut crate::db::models::Event| e.parent_execution_id = Some(7))),
-            ("worker_id", Box::new(|e: &mut crate::db::models::Event| e.worker_id = None)),
-            ("attempt", Box::new(|e: &mut crate::db::models::Event| e.attempt = Some(9))),
-            ("context", Box::new(|e: &mut crate::db::models::Event| e.context = Some(serde_json::json!({"a":1})))),
-            ("meta", Box::new(|e: &mut crate::db::models::Event| e.meta = Some(serde_json::json!({"a":1})))),
-            ("result", Box::new(|e: &mut crate::db::models::Event| e.result = Some(serde_json::json!({"a":1})))),
+            (
+                "event_type",
+                Box::new(|e: &mut crate::db::models::Event| e.event_type = "x".into()),
+            ),
+            (
+                "status",
+                Box::new(|e: &mut crate::db::models::Event| e.status = "x".into()),
+            ),
+            (
+                "node_id",
+                Box::new(|e: &mut crate::db::models::Event| e.node_id = None),
+            ),
+            (
+                "node_name",
+                Box::new(|e: &mut crate::db::models::Event| e.node_name = None),
+            ),
+            (
+                "node_type",
+                Box::new(|e: &mut crate::db::models::Event| e.node_type = None),
+            ),
+            (
+                "catalog_id",
+                Box::new(|e: &mut crate::db::models::Event| e.catalog_id = 99),
+            ),
+            (
+                "parent_event_id",
+                Box::new(|e: &mut crate::db::models::Event| e.parent_event_id = Some(7)),
+            ),
+            (
+                "parent_execution_id",
+                Box::new(|e: &mut crate::db::models::Event| e.parent_execution_id = Some(7)),
+            ),
+            (
+                "worker_id",
+                Box::new(|e: &mut crate::db::models::Event| e.worker_id = None),
+            ),
+            (
+                "attempt",
+                Box::new(|e: &mut crate::db::models::Event| e.attempt = Some(9)),
+            ),
+            (
+                "context",
+                Box::new(|e: &mut crate::db::models::Event| {
+                    e.context = Some(serde_json::json!({"a":1}))
+                }),
+            ),
+            (
+                "meta",
+                Box::new(|e: &mut crate::db::models::Event| {
+                    e.meta = Some(serde_json::json!({"a":1}))
+                }),
+            ),
+            (
+                "result",
+                Box::new(|e: &mut crate::db::models::Event| {
+                    e.result = Some(serde_json::json!({"a":1}))
+                }),
+            ),
         ];
         for (name, mutate) in cases {
             let mut b = base.clone();

--- a/src/handlers/ehdb_projection_serve.rs
+++ b/src/handlers/ehdb_projection_serve.rs
@@ -1,0 +1,226 @@
+//! The D3 serve decision: when may a stored projection snapshot be used?
+//! (noetl/ai-meta#332, building on #265.)
+//!
+//! # The asymmetry this module is built around
+//!
+//! The two failure directions are **not** symmetric, and the whole design follows
+//! from that:
+//!
+//! * A snapshot **behind** the spine is *slow but correct*. `rebuild_state` folds
+//!   every event after the snapshot's version, so a stale snapshot costs extra
+//!   folding and yields the same answer.
+//! * A snapshot **ahead** of the spine is *silently wrong*. The events between the
+//!   real watermark and the claimed one are never folded, the caller receives a
+//!   state that never existed, and nothing downstream can detect it — a rebuild has
+//!   no second opinion.
+//!
+//! So behind is servable and ahead must never be. Measured on prod 2026-09-10:
+//! **11 of 11** read attempts refused with `stored_behind_spine` and `served_tier`
+//! stayed 0 — the tier was being refused for the one condition that is safe.
+//!
+//! # Why a grant type rather than an `if`
+//!
+//! "Ahead must never serve" written as a branch is a branch someone can reorder,
+//! invert, or add an early-return in front of. [`ServeGrant`] carries a private
+//! field and has **no public constructor**, so the only way to obtain one is
+//! [`ServeGrant::evaluate`] — which cannot produce one for an ahead snapshot.
+//! A caller that wanted to serve an ahead snapshot could not express it: there is
+//! no value to pass. That is the difference between *unlikely* and *impossible*.
+
+use serde::Serialize;
+
+/// Why a stored snapshot may not be served.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum RefuseReason {
+    /// ⚠ The stored record claims a version the spine has not reached. Serving
+    /// this would skip the events in between — the silent-wrong case.
+    StoredAhead,
+    /// Stored and freshly-folded digests disagree at the same version.
+    DigestMismatch,
+    /// Nothing stored for this execution.
+    NoStoredRecord,
+    /// The spine itself could not be folded.
+    SpineRefused,
+}
+
+impl RefuseReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::StoredAhead => "stored_ahead",
+            Self::DigestMismatch => "digest_mismatch",
+            Self::NoStoredRecord => "no_stored_record",
+            Self::SpineRefused => "spine_refused",
+        }
+    }
+}
+
+/// **Permission to serve a stored snapshot.**
+///
+/// The private field is the point: there is no public constructor and no
+/// `Default`, so this value cannot be created outside [`Self::evaluate`]. An
+/// ahead snapshot therefore has no representable grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServeGrant {
+    /// Fold every event with id greater than this before using the state.
+    forward_fold_from: i64,
+    exact: bool,
+}
+
+impl ServeGrant {
+    /// The version the caller must fold forward from. Always `<=` the spine
+    /// version by construction.
+    pub fn forward_fold_from(self) -> i64 {
+        self.forward_fold_from
+    }
+    /// True when the snapshot was already at the spine's version (no catch-up
+    /// folding needed). Distinguishes `served_tier` from `stale_within_window`.
+    pub fn is_exact(self) -> bool {
+        self.exact
+    }
+    pub fn outcome_label(self) -> &'static str {
+        if self.exact {
+            "served_tier"
+        } else {
+            "stale_within_window"
+        }
+    }
+
+    /// The **only** way to obtain a grant.
+    ///
+    /// ⚠ The `stored_version > spine_version` check is first and returns before
+    /// any other consideration, so no later condition can reach past it.
+    pub fn evaluate(
+        digests_agree_at_stored_version: bool,
+        stored_version: Option<i64>,
+        spine_version: i64,
+    ) -> Result<ServeGrant, RefuseReason> {
+        let Some(stored) = stored_version else {
+            return Err(RefuseReason::NoStoredRecord);
+        };
+        // FAIL CLOSED, FIRST. Nothing below may run for an ahead snapshot.
+        if stored > spine_version {
+            return Err(RefuseReason::StoredAhead);
+        }
+        if !digests_agree_at_stored_version {
+            return Err(RefuseReason::DigestMismatch);
+        }
+        Ok(ServeGrant {
+            forward_fold_from: stored,
+            exact: stored == spine_version,
+        })
+    }
+}
+
+/// **Enforced positive + negative controls for the serve decision.**
+///
+/// ⚠ Every case is driven through the real [`ServeGrant::evaluate`]. A report or
+/// rollout that quotes a serve rate without these having fired is quoting a
+/// number from a decision function nobody proved can refuse.
+pub fn serve_controls() -> Vec<(&'static str, bool, &'static str)> {
+    vec![
+    // POSITIVE: the safe cases must serve.
+        (
+        "exact_serves",
+        matches!(ServeGrant::evaluate(true, Some(100), 100), Ok(g) if g.is_exact()
+            && g.forward_fold_from() == 100),
+        "a snapshot at the spine version must serve, exactly",
+        ),
+        (
+        "behind_serves_with_forward_fold",
+        matches!(ServeGrant::evaluate(true, Some(80), 100), Ok(g) if !g.is_exact()
+            && g.forward_fold_from() == 80),
+        "a BEHIND snapshot must serve and report where to fold from -- it is slow but correct",
+        ),
+
+    // NEGATIVE: the unsafe cases must refuse. These are the load-bearing ones.
+        (
+        "ahead_refuses",
+        ServeGrant::evaluate(true, Some(101), 100) == Err(RefuseReason::StoredAhead),
+        "an AHEAD snapshot must REFUSE -- serving it skips events and is silently wrong",
+        ),
+        (
+        "ahead_refuses_even_when_digests_agree",
+        ServeGrant::evaluate(true, Some(500), 100) == Err(RefuseReason::StoredAhead),
+        "ahead must refuse even with agreeing digests: the digest is computed at the \
+         stored version and says nothing about the events the spine has not reached",
+        ),
+        (
+        "digest_mismatch_refuses",
+        ServeGrant::evaluate(false, Some(80), 100) == Err(RefuseReason::DigestMismatch),
+        "a behind snapshot whose digest disagrees must refuse -- behind is servable, wrong is not",
+        ),
+    // ⚠ ORDERING control. The ahead check must run BEFORE the digest check, so
+    // that no later condition can ever be reached for an ahead snapshot. Today
+    // reordering them still refuses (both arms refuse), so the difference is only
+    // the reported reason -- which is exactly why it needs asserting: the day
+    // someone adds a serve path to the digest branch, the ordering is what stops
+    // an ahead snapshot reaching it. Caught by asserting the reason on the
+    // ahead+disagree combination, the one input where the two orders differ.
+        (
+        "ahead_is_checked_before_digest",
+        ServeGrant::evaluate(false, Some(101), 100) == Err(RefuseReason::StoredAhead),
+        "ahead+digest-disagree must report StoredAhead, proving ahead is evaluated \
+         first and nothing downstream can be reached for an ahead snapshot",
+        ),
+
+        (
+        "absent_refuses",
+        ServeGrant::evaluate(true, None, 100) == Err(RefuseReason::NoStoredRecord),
+        "no stored record must refuse, not serve an empty state",
+        ),
+
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_serve_control_fires() {
+        let cs = serve_controls();
+        assert!(cs.len() >= 7, "expected >=7 controls, found {}", cs.len());
+        for (name, passed, detail) in &cs {
+            assert!(passed, "control {name} did NOT fire: {detail}");
+        }
+    }
+
+    /// ⚠ The structural claim, asserted as a property rather than a case: across a
+    /// wide sweep, a grant is NEVER produced when stored > spine.
+    #[test]
+    fn a_grant_is_never_issued_for_an_ahead_snapshot() {
+        let mut ahead = 0;
+        for spine in [0i64, 1, 7, 100, 10_000, i64::MAX / 2] {
+            for delta in [1i64, 2, 9, 1000, i64::MAX / 4] {
+                let stored = spine.saturating_add(delta);
+                ahead += 1;
+                assert_eq!(
+                    ServeGrant::evaluate(true, Some(stored), spine),
+                    Err(RefuseReason::StoredAhead),
+                    "stored={stored} spine={spine} produced a grant"
+                );
+            }
+        }
+        assert!(ahead >= 25, "sweep too small to mean anything: {ahead}");
+    }
+
+    /// A behind snapshot always folds forward from its own version, never from
+    /// the spine's — folding from the spine would skip the very events the
+    /// forward fold exists to replay.
+    #[test]
+    fn forward_fold_starts_at_the_snapshot_not_the_spine() {
+        let g = ServeGrant::evaluate(true, Some(42), 99).expect("behind must serve");
+        assert_eq!(g.forward_fold_from(), 42);
+        assert!(!g.is_exact());
+        assert_eq!(g.outcome_label(), "stale_within_window");
+    }
+
+    #[test]
+    fn exact_and_stale_are_labelled_apart() {
+        let e = ServeGrant::evaluate(true, Some(7), 7).unwrap();
+        let s = ServeGrant::evaluate(true, Some(6), 7).unwrap();
+        assert_eq!(e.outcome_label(), "served_tier");
+        assert_eq!(s.outcome_label(), "stale_within_window");
+        assert_ne!(e.outcome_label(), s.outcome_label());
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -30,6 +30,7 @@ pub mod ehdb_projection_mirror;
 pub mod ehdb_projection_parity;
 pub mod ehdb_projection_mirror_queue;
 pub mod ehdb_projection_read;
+pub mod ehdb_projection_serve;
 pub mod event_write;
 pub mod events;
 pub mod execute;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1019,6 +1019,7 @@ async fn main() -> anyhow::Result<()> {
     // noetl/ai-meta#332 step 5 — pinned so an unrun shadow reads 0, not absent.
     noetl_server::metrics::init_embedded_shadow_series();
     noetl_server::metrics::init_embedded_read_series();
+    noetl_server::metrics::init_projection_serve_refusal_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_series();
     noetl_server::metrics::init_ehdb_eventlog_mirror_queue_series();
     noetl_server::metrics::init_ehdb_projection_series();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4082,6 +4082,48 @@ pub fn ehdb_projection_read_total() -> &'static IntCounterVec {
     })
 }
 
+/// Why a serve-on-behind grant was refused (noetl/ai-meta#332).
+///
+/// ⚠ `stored_ahead` is the one that must never be missing from a scrape: it is
+/// the silently-wrong case, and an absent series would read as "never happened".
+pub const PROJECTION_SERVE_REFUSALS: [&str; 4] = [
+    "stored_ahead",
+    "digest_mismatch",
+    "no_stored_record",
+    "spine_refused",
+];
+
+pub fn ehdb_projection_serve_refusal_total() -> &'static IntCounterVec {
+    static M: std::sync::OnceLock<IntCounterVec> = std::sync::OnceLock::new();
+    M.get_or_init(|| {
+        let m = IntCounterVec::new(
+            prometheus::Opts::new(
+                "noetl_ehdb_projection_serve_refusal_total",
+                "Serve-on-behind grants refused, by reason",
+            ),
+            &["reason"],
+        )
+        .expect("valid metric");
+        let _ = registry().register(Box::new(m.clone()));
+        m
+    })
+}
+
+pub fn record_ehdb_projection_serve_refusal(reason: &str) {
+    ehdb_projection_serve_refusal_total()
+        .with_label_values(&[reason])
+        .inc();
+}
+
+/// Pin every refusal reason at 0, unconditionally.
+pub fn init_projection_serve_refusal_series() {
+    for r in PROJECTION_SERVE_REFUSALS {
+        ehdb_projection_serve_refusal_total()
+            .with_label_values(&[r])
+            .inc_by(0);
+    }
+}
+
 pub fn record_ehdb_projection_read(outcome: &str) {
     ehdb_projection_read_total()
         .with_label_values(&[outcome])

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -186,9 +186,9 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
         // already recorded `stale_within_window` for that case, so recording the
         // raw verdict here too would double-count one read as both served and
         // refused.
-        if !(body.is_some()
-            && verdict != crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match)
-        {
+        let served_on_behind = body.is_some()
+            && verdict != crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match;
+        if !served_on_behind {
             crate::metrics::record_ehdb_projection_read(match verdict {
                 crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match => "served_tier",
                 v => v.as_str(),
@@ -251,7 +251,9 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
     // populated incumbent, and this means neither store has a snapshot yet —
     // the normal state of every short execution.
     if source.needs_incumbent_first() && facts.is_none() {
-        crate::metrics::record_ehdb_projection_read(tier_read::DemoteReason::NoIncumbent.as_str());
+        crate::metrics::record_ehdb_projection_read(
+            tier_read::DemoteReason::NoIncumbent.as_str(),
+        );
         return Ok(incumbent.unwrap_or(None));
     }
 
@@ -323,7 +325,10 @@ async fn demote(
 }
 
 /// The incumbent read: `noetl.projection_snapshot`, exactly as before #265.
-async fn load_incumbent(pool: &DbPool, execution_id: i64) -> AppResult<Option<LoadedSnapshot>> {
+async fn load_incumbent(
+    pool: &DbPool,
+    execution_id: i64,
+) -> AppResult<Option<LoadedSnapshot>> {
     let row = sqlx::query(
         r#"
         SELECT version, snapshot, meta, updated_at, checksum
@@ -346,9 +351,9 @@ async fn load_incumbent(pool: &DbPool, execution_id: i64) -> AppResult<Option<Lo
     let updated_at: chrono::DateTime<chrono::Utc> = row
         .try_get("updated_at")
         .unwrap_or_else(|_| chrono::Utc::now());
-    let snapshot: serde_json::Value = row.try_get("snapshot").map_err(|e| {
-        AppError::Internal(format!("orch_snapshot.load_incumbent: snapshot col: {e}"))
-    })?;
+    let snapshot: serde_json::Value = row
+        .try_get("snapshot")
+        .map_err(|e| AppError::Internal(format!("orch_snapshot.load_incumbent: snapshot col: {e}")))?;
     let meta: serde_json::Value = row.try_get("meta").unwrap_or(serde_json::Value::Null);
     let checksum: Option<String> = row.try_get("checksum").ok();
     let applied_count = meta
@@ -384,6 +389,7 @@ async fn load_incumbent(pool: &DbPool, execution_id: i64) -> AppResult<Option<Lo
     }))
 }
 
+
 /// Diagnostic: run the recovery read BOTH ways and compare what control flow
 /// would receive (ai-meta#265 Phase 3, re-scoped).
 ///
@@ -403,7 +409,10 @@ async fn load_incumbent(pool: &DbPool, execution_id: i64) -> AppResult<Option<Lo
 /// The comparison is on the **canonical digest of the state control flow would
 /// actually use**, not on the stored records — which is the end-to-end form the
 /// 8/8 fold-equivalence result was only the input to.
-pub async fn recovery_read_comparison(pool: &DbPool, execution_id: i64) -> serde_json::Value {
+pub async fn recovery_read_comparison(
+    pool: &DbPool,
+    execution_id: i64,
+) -> serde_json::Value {
     use noetl_orchestrate_core::state::canonical_state_digest;
 
     // --- what recovery returns today (Postgres) -----------------------------
@@ -413,7 +422,8 @@ pub async fn recovery_read_comparison(pool: &DbPool, execution_id: i64) -> serde
     // --- what recovery would return from the durable EHDB projection --------
     let (body, verdict) =
         crate::handlers::ehdb_projection_fold::wal_projection_state(execution_id).await;
-    let wal_state: Option<WorkflowState> = body.and_then(|b| serde_json::from_value(b).ok());
+    let wal_state: Option<WorkflowState> =
+        body.and_then(|b| serde_json::from_value(b).ok());
     let wal_digest = wal_state.as_ref().map(canonical_state_digest);
 
     let agree = matches!((&pg_digest, &wal_digest), (Some(a), Some(b)) if a == b);
@@ -514,10 +524,7 @@ mod tests {
         let sources: &[(&str, &str)] = &[
             ("services/orch_snapshot.rs", self_code),
             ("handlers/events.rs", include_str!("../handlers/events.rs")),
-            (
-                "handlers/internal.rs",
-                include_str!("../handlers/internal.rs"),
-            ),
+            ("handlers/internal.rs", include_str!("../handlers/internal.rs")),
         ];
         let mut readers: Vec<&str> = Vec::new();
         for (name, src) in sources {

--- a/src/services/orch_snapshot.rs
+++ b/src/services/orch_snapshot.rs
@@ -180,10 +180,20 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
     if source.is_wal() {
         let (body, verdict) =
             crate::handlers::ehdb_projection_fold::wal_projection_state(execution_id).await;
-        crate::metrics::record_ehdb_projection_read(match verdict {
-            crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match => "served_tier",
-            v => v.as_str(),
-        });
+        // ⚠ `body.is_some()` on a NON-Match verdict means serve-on-behind granted
+        // (ai-meta#332): the snapshot was verified at its own version and
+        // `rebuild_state` will fold forward from it. `wal_projection_state`
+        // already recorded `stale_within_window` for that case, so recording the
+        // raw verdict here too would double-count one read as both served and
+        // refused.
+        if !(body.is_some()
+            && verdict != crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match)
+        {
+            crate::metrics::record_ehdb_projection_read(match verdict {
+                crate::handlers::ehdb_projection_fold::ReFoldVerdict::Match => "served_tier",
+                v => v.as_str(),
+            });
+        }
         let Some(body) = body else {
             if verdict.is_fault() {
                 tracing::warn!(
@@ -241,9 +251,7 @@ pub async fn load_latest(pool: &DbPool, execution_id: i64) -> AppResult<Option<L
     // populated incumbent, and this means neither store has a snapshot yet —
     // the normal state of every short execution.
     if source.needs_incumbent_first() && facts.is_none() {
-        crate::metrics::record_ehdb_projection_read(
-            tier_read::DemoteReason::NoIncumbent.as_str(),
-        );
+        crate::metrics::record_ehdb_projection_read(tier_read::DemoteReason::NoIncumbent.as_str());
         return Ok(incumbent.unwrap_or(None));
     }
 
@@ -315,10 +323,7 @@ async fn demote(
 }
 
 /// The incumbent read: `noetl.projection_snapshot`, exactly as before #265.
-async fn load_incumbent(
-    pool: &DbPool,
-    execution_id: i64,
-) -> AppResult<Option<LoadedSnapshot>> {
+async fn load_incumbent(pool: &DbPool, execution_id: i64) -> AppResult<Option<LoadedSnapshot>> {
     let row = sqlx::query(
         r#"
         SELECT version, snapshot, meta, updated_at, checksum
@@ -341,9 +346,9 @@ async fn load_incumbent(
     let updated_at: chrono::DateTime<chrono::Utc> = row
         .try_get("updated_at")
         .unwrap_or_else(|_| chrono::Utc::now());
-    let snapshot: serde_json::Value = row
-        .try_get("snapshot")
-        .map_err(|e| AppError::Internal(format!("orch_snapshot.load_incumbent: snapshot col: {e}")))?;
+    let snapshot: serde_json::Value = row.try_get("snapshot").map_err(|e| {
+        AppError::Internal(format!("orch_snapshot.load_incumbent: snapshot col: {e}"))
+    })?;
     let meta: serde_json::Value = row.try_get("meta").unwrap_or(serde_json::Value::Null);
     let checksum: Option<String> = row.try_get("checksum").ok();
     let applied_count = meta
@@ -379,7 +384,6 @@ async fn load_incumbent(
     }))
 }
 
-
 /// Diagnostic: run the recovery read BOTH ways and compare what control flow
 /// would receive (ai-meta#265 Phase 3, re-scoped).
 ///
@@ -399,10 +403,7 @@ async fn load_incumbent(
 /// The comparison is on the **canonical digest of the state control flow would
 /// actually use**, not on the stored records — which is the end-to-end form the
 /// 8/8 fold-equivalence result was only the input to.
-pub async fn recovery_read_comparison(
-    pool: &DbPool,
-    execution_id: i64,
-) -> serde_json::Value {
+pub async fn recovery_read_comparison(pool: &DbPool, execution_id: i64) -> serde_json::Value {
     use noetl_orchestrate_core::state::canonical_state_digest;
 
     // --- what recovery returns today (Postgres) -----------------------------
@@ -412,8 +413,7 @@ pub async fn recovery_read_comparison(
     // --- what recovery would return from the durable EHDB projection --------
     let (body, verdict) =
         crate::handlers::ehdb_projection_fold::wal_projection_state(execution_id).await;
-    let wal_state: Option<WorkflowState> =
-        body.and_then(|b| serde_json::from_value(b).ok());
+    let wal_state: Option<WorkflowState> = body.and_then(|b| serde_json::from_value(b).ok());
     let wal_digest = wal_state.as_ref().map(canonical_state_digest);
 
     let agree = matches!((&pg_digest, &wal_digest), (Some(a), Some(b)) if a == b);
@@ -514,7 +514,10 @@ mod tests {
         let sources: &[(&str, &str)] = &[
             ("services/orch_snapshot.rs", self_code),
             ("handlers/events.rs", include_str!("../handlers/events.rs")),
-            ("handlers/internal.rs", include_str!("../handlers/internal.rs")),
+            (
+                "handlers/internal.rs",
+                include_str!("../handlers/internal.rs"),
+            ),
         ];
         let mut readers: Vec<&str> = Vec::new();
         for (name, src) in sources {


### PR DESCRIPTION
Prod measurement 2026-09-10: **11 of 11** projection reads refused with `stored_behind_spine`, `served_tier=0`. The tier was being refused for the one condition that is **safe**.

## The asymmetry

- **behind** → slow but *correct*: `rebuild_state` folds every event after the snapshot version, so a stale snapshot costs extra folding and gives the same answer.
- **ahead** → silently *wrong*: events between the real watermark and the claimed one are never folded, and a rebuild has no second opinion to detect it.

## Ahead is made unrepresentable, not merely rejected

`ServeGrant` has a private field and **no public constructor**. The only way to obtain one is `ServeGrant::evaluate`, which cannot produce one for an ahead snapshot — so a caller that wanted to serve one has no value to pass. That's the difference between *unlikely* and *impossible*.

## Controls + mutation gate

Seven enforced controls, positive **and** negative, all through the real `evaluate()`.

| mutation | result |
| :-- | :-- |
| remove the ahead guard | **CAUGHT** |
| flip guard to `>=` | **CAUGHT** |
| fold forward from spine, not stored | **CAUGHT** |
| move ahead-check after digest | **CAUGHT** — *only after adding an ordering control; my first test set missed it* |

⚠ That last row is the honest part. Reordering still refuses today (both arms refuse), so the difference is only the reported reason — invisible to my original tests. It needs asserting anyway, because the ordering is what stops an ahead snapshot reaching a serve path the day one is added to the digest branch.

**Inert** — nothing calls `evaluate()` yet. Wiring it into `orch_snapshot` is the cutover gate and is deliberately not here.

Refs noetl/ai-meta#332, noetl/ai-meta#265