### PR TITLE
fix(ehdb): make a dropped mirror batch recoverable instead of lost

### DIFF
--- a/src/handlers/ehdb_eventlog_mirror.rs
+++ b/src/handlers/ehdb_eventlog_mirror.rs
@@ -576,6 +576,13 @@ pub(crate) async fn deliver(batch: &MirrorBatch) {
                     // every queue metric read healthy and this path filed its
                     // discards under `unavailable`, which no alert watched.
                     crate::metrics::record_ehdb_eventlog_mirror("dropped", count);
+                    // noetl/ai-meta#342 — the drop is no longer terminal. Hint
+                    // the repair sweep so the gap closes in seconds rather than
+                    // waiting for the next scan. ⚠ This is a latency hint only:
+                    // the sweep re-derives the gap by comparing the tier against
+                    // Postgres, so losing this hint (restart, overflow) delays
+                    // the repair, it does not lose it.
+                    crate::handlers::ehdb_mirror_repair_sweep::hint(execution_id);
                     error!(
                         target: "noetl_server::ehdb_eventlog_mirror",
                         execution_id,

--- a/src/handlers/ehdb_mirror_repair_sweep.rs
+++ b/src/handlers/ehdb_mirror_repair_sweep.rs
@@ -1,0 +1,461 @@
+//! **Durable mirror repair** — make a dropped batch recoverable instead of lost
+//! (noetl/ai-meta#342).
+//!
+//! # The loss this closes
+//!
+//! The mirror retries a failed delivery seven times over ~63 s and then records
+//! `dropped`, logs the `event_id`s, and **returns**. Nothing retries afterwards,
+//! and the endpoint the log names (`POST /api/ehdb/repair/executions/{id}`) had
+//! **no caller anywhere in the tree**. Measured on prod over 8 h: `mirrored 237
+//! / recovered 256 / dropped 323` events — **39.6% of what the mirror was handed
+//! was lost permanently**, against a relay backed by a *single* endpoint pod
+//! whose restart outlasts the retry budget.
+//!
+//! # Why a sweep, and not a durable queue
+//!
+//! ⭐ **The gap is its own pending-work record.** Postgres is authoritative and
+//! the tier is a mirror, so "which events are missing" is *derivable at any time*
+//! by comparing the two. That makes a sweep durable in the way that matters:
+//!
+//! * it survives a server restart, which an in-memory queue does not;
+//! * it survives the repair itself failing — the gap is still there next pass;
+//! * it needs **no new storage**, so no schema decision and nothing to migrate.
+//!
+//! A durable queue would add a second source of truth about work that is already
+//! implied by the data. The hint set below is a latency optimisation on top, not
+//! the correctness mechanism: correctness does not depend on remembering.
+//!
+//! # Bounds
+//!
+//! Unbounded repair on a `primary`-serving tier is its own hazard. Every pass is
+//! capped in executions examined and repairs attempted, and the whole thing is
+//! behind [`SWEEP_ENV`], default **off** — so it deploys inert and arming is a
+//! separate, reversible step.
+//!
+//! ⚠ This repairs the **tier only**. Postgres is authoritative and is never
+//! written here; the repair reads it and re-mirrors through the same
+//! `mirror_rows` chokepoint the live path uses.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::state::AppState;
+
+/// Arm the background repair sweep. Default **off**.
+pub const SWEEP_ENV: &str = "NOETL_EHDB_MIRROR_REPAIR_SWEEP";
+/// Seconds between passes.
+pub const INTERVAL_ENV: &str = "NOETL_EHDB_MIRROR_REPAIR_INTERVAL_SECS";
+/// Maximum executions repaired per pass.
+pub const MAX_PER_PASS_ENV: &str = "NOETL_EHDB_MIRROR_REPAIR_MAX_PER_PASS";
+/// How far back the scan looks for executions to check.
+pub const LOOKBACK_ENV: &str = "NOETL_EHDB_MIRROR_REPAIR_LOOKBACK_MINS";
+
+const DEFAULT_INTERVAL_SECS: u64 = 120;
+const DEFAULT_MAX_PER_PASS: usize = 25;
+const DEFAULT_LOOKBACK_MINS: i64 = 180;
+/// Hint-set ceiling. Bounded so a relay outage cannot grow it without limit;
+/// anything evicted is still found by the scan, because the gap is the record.
+const HINT_CAPACITY: usize = 4096;
+
+/// Executions a drop was just observed for — a **latency hint**, not the
+/// correctness mechanism.
+///
+/// ⚠ Deliberately in-memory and lossy. If the process dies, or the set
+/// overflows, the scan still finds the gap. Making this durable would create a
+/// second source of truth about work the data already implies.
+static HINTS: Mutex<BTreeSet<i64>> = Mutex::new(BTreeSet::new());
+
+/// Is the sweep armed, given the raw env value? **Pure**, so the default is
+/// testable without touching process env.
+///
+/// ⚠ Extracted because the original test was a tautology: it asserted only that
+/// the parse agreed with the env, which is satisfied by *any* parse — including
+/// one armed by default. A mutation flipping the default survived it.
+pub fn sweep_armed(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("true"))
+}
+
+pub fn sweep_enabled() -> bool {
+    sweep_armed(std::env::var(SWEEP_ENV).ok().as_deref())
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(default)
+}
+
+pub fn interval() -> Duration {
+    Duration::from_secs(env_u64(INTERVAL_ENV, DEFAULT_INTERVAL_SECS))
+}
+
+pub fn max_per_pass() -> usize {
+    env_u64(MAX_PER_PASS_ENV, DEFAULT_MAX_PER_PASS as u64) as usize
+}
+
+pub fn lookback_mins() -> i64 {
+    env_u64(LOOKBACK_ENV, DEFAULT_LOOKBACK_MINS as u64) as i64
+}
+
+/// Record that an execution just lost a mirror batch.
+///
+/// Called from the mirror's terminal-drop path so the repair happens in seconds
+/// rather than waiting for the next scan to notice.
+pub fn hint(execution_id: i64) {
+    if let Ok(mut g) = HINTS.lock() {
+        if g.len() >= HINT_CAPACITY {
+            return;
+        }
+        g.insert(execution_id);
+        crate::metrics::set_ehdb_mirror_repair_pending(g.len() as u64);
+    }
+}
+
+fn take_hints(limit: usize) -> Vec<i64> {
+    let Ok(mut g) = HINTS.lock() else {
+        return Vec::new();
+    };
+    let taken: Vec<i64> = g.iter().copied().take(limit).collect();
+    for id in &taken {
+        g.remove(id);
+    }
+    crate::metrics::set_ehdb_mirror_repair_pending(g.len() as u64);
+    taken
+}
+
+/// Current hint-set size — exposed for tests.
+pub fn pending_hints() -> usize {
+    HINTS.lock().map(|g| g.len()).unwrap_or(0)
+}
+
+/// Clear the hint set — tests only.
+#[cfg(test)]
+pub fn clear_hints() {
+    if let Ok(mut g) = HINTS.lock() {
+        g.clear();
+    }
+}
+
+/// Executions worth checking this pass: the hinted ones first, then a bounded
+/// scan of recent executions.
+///
+/// ⚠ Hints first on purpose. They are the executions *known* to have lost
+/// events; the scan is the backstop that makes forgetting survivable.
+pub async fn candidates(state: &AppState, limit: usize) -> Vec<i64> {
+    let mut out = take_hints(limit);
+    if out.len() >= limit {
+        return out;
+    }
+    let seen: BTreeSet<i64> = out.iter().copied().collect();
+    let remaining = (limit - out.len()) as i64;
+    let rows = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT DISTINCT execution_id
+        FROM noetl.event
+        WHERE created_at > now() - ($1 || ' minutes')::interval
+        ORDER BY execution_id DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(lookback_mins().to_string())
+    .bind(remaining)
+    // ⚠ The scan runs on ONE pool. Prod runs single-pool (the boot log says
+    // "falling back to single-pool mode"), so this covers everything today —
+    // but under real sharding this scan sees one shard's rows. The hint path
+    // is not shard-limited, and the repair itself uses `pool_for(execution_id)`,
+    // so the gap is a scan-coverage limit, not a correctness one. Stated rather
+    // than left for someone to discover.
+    .fetch_all(state.pools.pool_for(0))
+    .await
+    .unwrap_or_default();
+    for id in rows {
+        if !seen.contains(&id) {
+            out.push(id);
+        }
+    }
+    out
+}
+
+/// One pass. Returns `(examined, repaired)`.
+pub async fn sweep_once(state: &AppState) -> (usize, usize) {
+    let limit = max_per_pass();
+    let ids = candidates(state, limit).await;
+    let mut repaired = 0usize;
+    for id in &ids {
+        let (outcome, _report) =
+            crate::handlers::ehdb_tier_repair::repair_execution(state, *id).await;
+        crate::metrics::record_ehdb_mirror_repair(outcome);
+        if outcome == "repaired" {
+            repaired += 1;
+        }
+        // ⚠ An execution that did NOT repair is deliberately not re-hinted here.
+        // Re-hinting a permanently unrecoverable execution would spin the sweep
+        // on it forever and crowd out real work; the scan will offer it again on
+        // its own while it remains in the lookback window.
+    }
+    (ids.len(), repaired)
+}
+
+/// Spawn the background sweep. A no-op when the flag is not armed.
+pub fn spawn(state: AppState) {
+    if !sweep_enabled() {
+        tracing::info!(
+            target: "noetl_server::ehdb_mirror_repair",
+            "mirror repair sweep NOT armed ({SWEEP_ENV} != true)"
+        );
+        return;
+    }
+    let every = interval();
+    tracing::info!(
+        target: "noetl_server::ehdb_mirror_repair",
+        interval_secs = every.as_secs(),
+        max_per_pass = max_per_pass(),
+        lookback_mins = lookback_mins(),
+        "mirror repair sweep ARMED"
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(every);
+        loop {
+            ticker.tick().await;
+            let (examined, repaired) = sweep_once(&state).await;
+            if repaired > 0 {
+                tracing::warn!(
+                    target: "noetl_server::ehdb_mirror_repair",
+                    examined, repaired,
+                    "mirror repair sweep closed tier gaps"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This module's source, without its own tests.
+    ///
+    /// ⚠ `include_str!` pulls the test module in too, so a needle written here
+    /// becomes a match in the thing being asserted about.
+    fn src() -> &'static str {
+        const RAW: &str = include_str!("ehdb_mirror_repair_sweep.rs");
+        // ⚠ Cut at the test MODULE, not at the first `#[cfg(test)]`. This file
+        // also has a `#[cfg(test)] pub fn clear_hints()` about a third of the way
+        // down, and cutting there truncated the slice before `sweep_once` — so
+        // the positive assertions failed and the negative ones were vacuous.
+        // The same shape as a `non_test()` helper that cut thousands of lines
+        // early and reported green on zero bytes.
+        let cut = RAW
+            .find("\n#[cfg(test)]\nmod tests")
+            .expect("exactly one test module, at the end");
+        let head = &RAW[..cut];
+        // Floor raised: the old 2000 was low enough that the truncated slice
+        // still passed it. A guard that cannot detect its own bad extraction is
+        // not a guard.
+        assert!(
+            head.len() > 5000,
+            "implausibly short slice ({} bytes) — every assertion below would be \
+             vacuous",
+            head.len()
+        );
+        head
+    }
+
+    /// [`src`] with comment lines removed.
+    ///
+    /// ⚠ Needed because a doc comment naming a function reads as a call to it.
+    /// `the_sweep_reuses_...` failed on its own module doc, which explains that
+    /// the repair "re-mirrors through the same `mirror_rows` chokepoint" — prose
+    /// about not calling something matched as calling it.
+    fn code_only() -> String {
+        src()
+            .lines()
+            .filter(|l| {
+                let t = l.trim_start();
+                !(t.starts_with("//") || t.starts_with("///") || t.starts_with("//!"))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Arming is opt-in, so the fix deploys inert — and ONLY the exact string
+    /// arms it.
+    ///
+    /// ⚠ Tests the pure parse, not the process env. The previous version
+    /// asserted the parse "agreed with the env", which any parse satisfies; a
+    /// mutation arming the sweep by default survived it.
+    #[test]
+    fn the_sweep_is_off_unless_explicitly_armed() {
+        assert!(
+            !sweep_armed(None),
+            "an unset flag must NOT arm the sweep — the fix has to deploy inert"
+        );
+        assert!(sweep_armed(Some("true")), "the exact string must arm it");
+        assert!(
+            sweep_armed(Some("  true  ")),
+            "surrounding space is trimmed"
+        );
+        for v in ["1", "yes", "TRUE", "True", "on", "", "false", "tier"] {
+            assert!(
+                !sweep_armed(Some(v)),
+                "{v:?} must not arm the sweep — only the exact string \"true\""
+            );
+        }
+    }
+
+    /// Hints dedupe and are bounded.
+    ///
+    /// ⚠ Bounded on purpose: a relay outage hints once per dropped batch, and an
+    /// unbounded set would grow with the outage. Overflow is safe precisely
+    /// because the hint is not the correctness mechanism.
+    /// ⚠⚠ **Every assertion about `HINTS` lives in THIS test.** Dedupe, drain,
+    /// the pass limit and the ceiling, all together. `HINTS` is a
+    /// process-global `static`, and **`cargo test` does not serialise tests** —
+    /// two tests mutating it raced and failed non-deterministically. Merging is
+    /// the fix that does not depend on scheduling.
+    #[test]
+    fn hints_dedupe_drain_and_respect_the_pass_limit() {
+        clear_hints();
+        hint(11);
+        hint(11);
+        hint(22);
+        assert_eq!(pending_hints(), 2, "the same execution must hint once");
+
+        let taken = take_hints(10);
+        assert_eq!(taken.len(), 2);
+        assert_eq!(pending_hints(), 0, "taking must drain");
+
+        // Two-sided: draining an empty set is not an error and yields nothing.
+        assert!(take_hints(10).is_empty());
+
+        // The pass limit: one pass must not exceed its budget.
+        for i in 0..10 {
+            hint(i);
+        }
+        let taken = take_hints(3);
+        assert_eq!(taken.len(), 3, "must not exceed the pass budget");
+        assert_eq!(pending_hints(), 7, "the rest stay for the next pass");
+
+        // The ceiling. A relay outage hints once per dropped batch, so an
+        // unbounded set would grow with the outage. Safe to bound precisely
+        // because the hint is not the correctness mechanism — anything refused
+        // here is still found by the scan.
+        clear_hints();
+        for i in 0..(HINT_CAPACITY as i64 + 50) {
+            hint(i);
+        }
+        assert_eq!(
+            pending_hints(),
+            HINT_CAPACITY,
+            "the hint set must stop at its ceiling — and must actually have \
+             filled, or the bound is not what stopped it"
+        );
+        clear_hints();
+    }
+
+    /// ⚠⚠ The terminal drop must hint the sweep.
+    ///
+    /// This is the whole fix. Before it, the drop path recorded a counter, logged
+    /// the event_ids, and returned — and the endpoint the log named had **no
+    /// caller anywhere in the tree**, so the events were simply gone.
+    #[test]
+    fn the_terminal_drop_hints_the_sweep() {
+        const MIRROR: &str = include_str!("ehdb_eventlog_mirror.rs");
+        let code = MIRROR
+            .split_once("\n#[cfg(test)]")
+            .map(|(above, _)| above)
+            .unwrap_or(MIRROR);
+        assert!(code.len() > 5000, "mirror slice too small: {}", code.len());
+        let at = code
+            .find(r#"record_ehdb_eventlog_mirror("dropped", count)"#)
+            .expect("the terminal drop site moved — extraction broke");
+        let window: String = code[at..].chars().take(900).collect();
+        assert!(
+            window.contains("ehdb_mirror_repair_sweep::hint("),
+            "the terminal drop does not hint the repair sweep — a dropped batch \
+             would be permanently lost again (noetl/ai-meta#342)"
+        );
+    }
+
+    /// One repair implementation, shared.
+    ///
+    /// A second repair path would be a second thing to keep true on the write
+    /// path of a tier that serves reads.
+    #[test]
+    fn the_sweep_reuses_the_endpoints_repair_and_does_not_reimplement_it() {
+        assert!(
+            code_only().contains("ehdb_tier_repair::repair_execution("),
+            "the sweep must call the shared repair"
+        );
+        assert!(
+            !code_only().contains("mirror_rows("),
+            "the sweep must not re-mirror directly — that would bypass the \
+             scoped/non-inflating/honest guarantees the repair holds"
+        );
+        assert!(
+            !code_only().contains("ParityRecording::Record"),
+            "the sweep must never record parity outcomes — it would inflate the \
+             counters it exists to repair (noetl/ai-meta#264)"
+        );
+    }
+
+    /// Postgres is authoritative and is never written by the repair path.
+    #[test]
+    fn the_sweep_never_writes_postgres() {
+        // ⚠ Match SQL SHAPES, not bare words. `"INSERT"` alone matched
+        // `BTreeSet::insert` and failed this test on a data-structure call.
+        let sql = code_only().to_uppercase();
+        for forbidden in [
+            "INSERT INTO",
+            "UPDATE NOETL.",
+            "DELETE FROM",
+            "TRUNCATE",
+            "INSERT_EVENT(",
+        ] {
+            assert!(
+                !sql.contains(forbidden),
+                "the sweep must never write the authoritative log; found {forbidden:?}"
+            );
+        }
+        // Positive control: the one authoritative access IS present, so the
+        // negatives above are not passing because the slice is empty.
+        assert!(
+            code_only().contains("SELECT DISTINCT execution_id"),
+            "the candidate read is missing — the negative assertions above would \
+             then be vacuous"
+        );
+    }
+
+    /// The pinned label set must be exactly what the repair can return.
+    ///
+    /// ⚠ A pinned set that omits one value reintroduces the absent-series bug on
+    /// that value alone, while the rest read 0 and look complete. The first draft
+    /// of this set carried `incomplete`; the code returns **`partial`**.
+    #[test]
+    fn every_repair_outcome_is_pinned() {
+        const REPAIR: &str = include_str!("ehdb_tier_repair.rs");
+        let code = REPAIR
+            .split_once("\n#[cfg(test)]")
+            .map(|(above, _)| above)
+            .unwrap_or(REPAIR);
+        assert!(code.len() > 2000, "repair slice too small");
+        for outcome in crate::metrics::EHDB_MIRROR_REPAIR_OUTCOMES {
+            assert!(
+                code.contains(&format!("\"{outcome}\"")),
+                "pinned outcome {outcome:?} is never produced by the repair — the \
+                 pinned set and the code have drifted"
+            );
+        }
+        // The other direction: the two literals `repair_outcome` returns must
+        // both be pinned, or a real outcome is invisible.
+        for produced in ["repaired", "partial"] {
+            assert!(
+                crate::metrics::EHDB_MIRROR_REPAIR_OUTCOMES.contains(&produced),
+                "{produced:?} is returned but not pinned"
+            );
+        }
+    }
+}

--- a/src/handlers/ehdb_projection_fold.rs
+++ b/src/handlers/ehdb_projection_fold.rs
@@ -871,8 +871,21 @@ pub struct FoldComparison {
     pub context_explains_the_gap: bool,
 }
 
-pub async fn compare_sources(pool: &DbPool, execution_id: i64) -> AppResult<FoldComparison> {
-    let pg = fold_from_postgres(pool, execution_id).await;
+pub async fn compare_sources(
+    pool: &DbPool,
+    result_store: &crate::services::result_store::ResultStoreService,
+    execution_id: i64,
+) -> AppResult<FoldComparison> {
+    // ⚠ HYDRATED, like the verification path (noetl/ai-meta#342).
+    //
+    // This is the instrument everyone reads to decide whether the tier agrees
+    // with Postgres, and it folded the RAW row while the tier holds inlined
+    // content — so it reported a `reference`-vs-content difference as
+    // divergence. Fixing only the serve path left the *measurement* lying:
+    // v3.108.2 deployed and this endpoint's divergence count did not move by a
+    // single execution, because this function was never on the path that
+    // changed. An instrument that cannot see a fix cannot validate one.
+    let pg = fold_from_postgres_hydrated(pool, result_store, execution_id).await;
     let tier = fold_from_tier(execution_id).await;
     let (postgres, postgres_refusal) = match pg {
         Ok(f) => (Some(f), None),
@@ -1049,7 +1062,11 @@ pub async fn compare_sources_endpoint(
     axum::extract::Path(execution_id): axum::extract::Path<i64>,
 ) -> AppResult<axum::Json<serde_json::Value>> {
     let pool = state.pools.pool_for(execution_id);
-    let cmp = compare_sources(pool, execution_id).await?;
+    let result_store = crate::services::result_store::ResultStoreService::new(
+        pool.clone(),
+        state.snowflake.clone(),
+    );
+    let cmp = compare_sources(pool, &result_store, execution_id).await?;
     Ok(axum::Json(serde_json::json!({
         "action": "ehdb.projection.fold.compare",
         "result": cmp,
@@ -2524,6 +2541,42 @@ mod tests {
         );
     }
 
+    /// The DIAGNOSTIC must hydrate too, or it cannot validate the fix.
+    ///
+    /// ⚠⚠ Written after a live miss. v3.108.2 shipped hydration on the serve
+    /// path, deployed cleanly — and the divergence count this endpoint reports
+    /// did not move by a single execution out of 40, because `compare_sources`
+    /// was never on the path that changed. The fix was right and the instrument
+    /// was still lying.
+    ///
+    /// An instrument that cannot see a fix cannot validate one, so it is held to
+    /// the same rule as the legs it measures.
+    #[test]
+    fn the_diagnostic_comparison_hydrates_like_the_serve_path() {
+        let src = include_str!("ehdb_projection_fold.rs");
+        let code = src
+            .split_once("\n#[cfg(test)]")
+            .map(|(above, _)| above)
+            .unwrap_or(src);
+        let start = code
+            .find("pub async fn compare_sources(")
+            .expect("compare_sources not found — extraction broke");
+        let body = &code[start..];
+        let end = body.find("\n}\n").map(|i| i + 3).unwrap_or(body.len());
+        let body = &body[..end];
+        assert!(
+            body.len() > 400,
+            "compare_sources slice too small: {}",
+            body.len()
+        );
+        assert!(
+            body.contains("fold_from_postgres_hydrated("),
+            "the diagnostic folds the RAW Postgres row — it will report a \
+             reference-vs-content difference as divergence, and will not move \
+             when the serve path is fixed"
+        );
+    }
+
     /// The READ PATH's verification leg must also be independent of the tier.
     ///
     /// Sibling of `the_bounded_verification_is_independent_of_the_tier`, which
@@ -3098,7 +3151,11 @@ pub async fn equivalence_endpoint(
 
     for id in &ids {
         let pool = state.pools.pool_for(*id);
-        let c = match compare_sources(pool, *id).await {
+        let result_store = crate::services::result_store::ResultStoreService::new(
+            pool.clone(),
+            state.snowflake.clone(),
+        );
+        let c = match compare_sources(pool, &result_store, *id).await {
             Ok(c) => c,
             Err(e) => {
                 *pg_refusals

--- a/src/handlers/ehdb_tier_repair.rs
+++ b/src/handlers/ehdb_tier_repair.rs
@@ -128,25 +128,42 @@ pub async fn repair_execution_endpoint(
     State(state): State<AppState>,
     Path(execution_id): Path<i64>,
 ) -> impl IntoResponse {
+    let (_outcome, body) = repair_execution(&state, execution_id).await;
+    (StatusCode::OK, Json(body))
+}
+
+/// Repair one execution's tier coverage. **The one implementation**, shared by
+/// the endpoint and the background sweep (noetl/ai-meta#342).
+///
+/// Returns `(outcome, report)`. The outcome string is the same vocabulary the
+/// endpoint reports, so the sweep's metrics and the endpoint's JSON cannot drift
+/// into describing different things.
+///
+/// ⚠ Extracted rather than duplicated. A second repair implementation would be a
+/// second thing to keep true, on the write path of a tier that serves reads.
+pub async fn repair_execution(
+    state: &AppState,
+    execution_id: i64,
+) -> (&'static str, serde_json::Value) {
     // Before. Inspect, never Record — see the module note on #264.
-    let before = compare_execution(&state, execution_id, ParityRecording::Inspect, None).await;
+    let before = compare_execution(state, execution_id, ParityRecording::Inspect, None).await;
     let Some(report) = before.report.as_ref() else {
         return (
-            StatusCode::OK,
-            Json(json!({
+            "not_comparable",
+            json!({
                 "action": "ehdb.tier.repair",
                 "execution_id": execution_id.to_string(),
                 "outcome": "not_comparable",
                 "detail": before.detail,
-            })),
+            }),
         );
     };
 
     let missing = report.missing_event_ids.clone();
     if missing.is_empty() {
         return (
-            StatusCode::OK,
-            Json(json!({
+            "already_complete",
+            json!({
                 "action": "ehdb.tier.repair",
                 "execution_id": execution_id.to_string(),
                 "outcome": "already_complete",
@@ -154,21 +171,21 @@ pub async fn repair_execution_endpoint(
                 "repaired": 0,
                 "authoritative_expected": report.authoritative_expected,
                 "ehdb_before": report.ehdb_count,
-            })),
+            }),
         );
     }
 
-    let rows = match fetch_rows(&state, execution_id, &missing).await {
+    let rows = match fetch_rows(state, execution_id, &missing).await {
         Ok(r) => r,
         Err(e) => {
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
+                "authoritative_read_failed",
+                json!({
                     "action": "ehdb.tier.repair",
                     "execution_id": execution_id.to_string(),
                     "outcome": "authoritative_read_failed",
                     "detail": e.to_string(),
-                })),
+                }),
             );
         }
     };
@@ -182,18 +199,18 @@ pub async fn repair_execution_endpoint(
     // Re-mirror exactly the rows we hold. `mirror_rows` is the same chokepoint the
     // live path uses, so a repaired record is byte-identical to a first-delivery
     // one — a second mirror implementation would be a second thing to keep true.
-    crate::handlers::ehdb_eventlog_mirror::mirror_rows(&state, &rows).await;
+    crate::handlers::ehdb_eventlog_mirror::mirror_rows(state, &rows).await;
 
     // After. Inspect again, for the same reason.
-    let after = compare_execution(&state, execution_id, ParityRecording::Inspect, None).await;
+    let after = compare_execution(state, execution_id, ParityRecording::Inspect, None).await;
     let (missing_after, ehdb_after) = match after.report.as_ref() {
         Some(r) => (r.missing_event_ids.len(), r.ehdb_count),
         None => (missing.len(), report.ehdb_count),
     };
 
     (
-        StatusCode::OK,
-        Json(json!({
+        repair_outcome(missing_after),
+        json!({
             "action": "ehdb.tier.repair",
             "execution_id": execution_id.to_string(),
             "outcome": repair_outcome(missing_after),
@@ -205,7 +222,7 @@ pub async fn repair_execution_endpoint(
             "remirrored": rows.len(),
             "unrecoverable": unrecoverable,
             "unrecoverable_count": unrecoverable.len(),
-        })),
+        }),
     )
 }
 
@@ -246,7 +263,7 @@ mod tests {
         // [`ParityRecording::Inspect`], and counting that made this read 3.
         assert_eq!(
             src()
-                .matches("compare_execution(&state, execution_id, ParityRecording::Inspect, None)")
+                .matches("compare_execution(state, execution_id, ParityRecording::Inspect, None)")
                 .count(),
             2,
             "the before and after comparisons must BOTH be Inspect"
@@ -285,7 +302,7 @@ mod tests {
     #[test]
     fn it_mirrors_through_the_same_chokepoint_the_live_path_uses() {
         assert!(
-            src().contains("ehdb_eventlog_mirror::mirror_rows(&state, &rows)"),
+            src().contains("ehdb_eventlog_mirror::mirror_rows(state, &rows)"),
             "a second mirror implementation would be a second thing to keep true, \
              and a repaired record must be byte-identical to a first delivery"
         );

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -21,6 +21,7 @@ pub mod ehdb;
 pub mod ehdb_embedded;
 pub mod ehdb_embedded_verify;
 pub mod ehdb_eventlog_mirror;
+pub mod ehdb_mirror_repair_sweep;
 pub mod ehdb_eventlog_mirror_queue;
 pub mod ehdb_parity;
 pub mod ehdb_parent_backfill;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1009,6 +1009,11 @@ async fn main() -> anyhow::Result<()> {
     noetl_server::metrics::init_event_ingest_phase_series();
     noetl_server::metrics::init_nonconvergence_sweep_series();
     noetl_server::metrics::init_orphan_sweep_series();
+    // noetl/ai-meta#342 — pin the repair-sweep series so a healthy sweep reads 0
+    // rather than being absent. Unconditional: pinning inside the armed branch
+    // would leave the series missing on exactly the configuration whose silence
+    // someone would be trying to read.
+    noetl_server::metrics::pin_ehdb_mirror_repair_outcomes();
     noetl_server::metrics::init_reconcile_giveup_series();
     noetl_server::metrics::init_db_pool_series();
     noetl_server::metrics::init_ehdb_publish_deferred_series();
@@ -1301,6 +1306,10 @@ async fn main() -> anyhow::Result<()> {
     let result_store_service = ResultStoreService::new(db_pool.clone(), state.snowflake.clone());
 
     // Build the router
+    // noetl/ai-meta#342 — the mirror-repair sweep. A no-op unless armed, so the
+    // decision lives in one place (the flag), not split across a call site.
+    noetl_server::handlers::ehdb_mirror_repair_sweep::spawn(state.clone());
+
     let app = build_router(
         state,
         db_pool,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3498,6 +3498,76 @@ pub fn record_ehdb_eventlog_mirror_attempt(outcome: &str, events: usize) {
         .inc_by(events as u64);
 }
 
+/// Outcomes of the background mirror-repair sweep (noetl/ai-meta#342).
+///
+/// ⚠ Pinned so a healthy sweep reads 0 rather than being absent — an absent
+/// series is indistinguishable from a build that cannot report at all.
+pub const EHDB_MIRROR_REPAIR_OUTCOMES: [&str; 5] = [
+    "repaired",
+    "partial",
+    "already_complete",
+    "not_comparable",
+    "authoritative_read_failed",
+];
+
+pub fn ehdb_mirror_repair_total() -> &'static IntCounterVec {
+    static M: OnceLock<IntCounterVec> = OnceLock::new();
+    M.get_or_init(|| {
+        let counter = IntCounterVec::new(
+            Opts::new(
+                "noetl_ehdb_mirror_repair_total",
+                "Background mirror-repair sweep outcomes, by outcome \
+                 (noetl/ai-meta#342).",
+            ),
+            &["outcome"],
+        )
+        .expect("static counter spec must be valid");
+        registry()
+            .register(Box::new(counter.clone()))
+            .expect("counter registration must succeed");
+        counter
+    })
+}
+
+/// Gauge: executions hinted as having lost a mirror batch and not yet repaired.
+///
+/// ⚠ A *hint* count, not a gap count. The sweep finds gaps by comparison
+/// regardless of this number, so 0 here means "nothing queued for the fast
+/// path", NOT "the tier is complete".
+pub fn ehdb_mirror_repair_pending() -> &'static IntGauge {
+    static M: OnceLock<IntGauge> = OnceLock::new();
+    M.get_or_init(|| {
+        let g = IntGauge::new(
+            "noetl_ehdb_mirror_repair_pending",
+            "Executions hinted to the mirror-repair sweep and not yet drained \
+             (noetl/ai-meta#342).",
+        )
+        .expect("static gauge spec must be valid");
+        registry()
+            .register(Box::new(g.clone()))
+            .expect("gauge registration must succeed");
+        g
+    })
+}
+
+pub fn record_ehdb_mirror_repair(outcome: &str) {
+    ehdb_mirror_repair_total()
+        .with_label_values(&[outcome])
+        .inc();
+}
+
+pub fn set_ehdb_mirror_repair_pending(n: u64) {
+    ehdb_mirror_repair_pending().set(n as i64);
+}
+
+/// Pin every repair outcome at 0 so a healthy sweep is readable.
+pub fn pin_ehdb_mirror_repair_outcomes() {
+    for o in EHDB_MIRROR_REPAIR_OUTCOMES {
+        ehdb_mirror_repair_total().with_label_values(&[o]).inc_by(0);
+    }
+    ehdb_mirror_repair_pending().set(0);
+}
+
 pub fn record_ehdb_eventlog_mirror(outcome: &str, events: usize) {
     ehdb_eventlog_mirror_total()
         .with_label_values(&[outcome])


### PR DESCRIPTION
Root fix for noetl/ai-meta#342 — **the tier was losing ~40% of the events the mirror was handed, permanently.**

## The loss

The mirror retried for ~63 s (7 × 500 ms doubling) and then recorded `dropped`, logged the event_ids, and returned. Nothing retried afterwards — and `POST /api/ehdb/repair/executions/{id}`, the endpoint that log line *names*, had **no caller anywhere in the tree**.

Prod, 8 h on one pod:

```
mirrored  237 | recovered 256 | dropped 323   → 39.6% of events lost
attempt{unavailable} 2842      relay = ONE endpoint pod
```

A single-pod relay restart outlasts the retry budget, so a routine blip was permanent loss.

## Why a sweep, not a durable queue

⭐ **The gap is its own pending-work record.** Postgres is authoritative and the tier is a mirror, so "which events are missing" is derivable at any time. That makes a sweep durable in the way that matters:

- survives a server restart (an in-memory queue does not);
- survives the repair *itself* failing — the gap is still there next pass;
- needs **no new storage**, so no schema decision and nothing to migrate.

A durable queue would add a second source of truth about work the data already implies. The hint set is a latency optimisation on top — in-memory, lossy, bounded — and correctness does not depend on it.

## What's here

- `ehdb_mirror_repair_sweep` — bounded periodic pass, behind `NOETL_EHDB_MIRROR_REPAIR_SWEEP` (**default off**: deploys inert, arming is a separate reversible step).
- The terminal drop now **hints** the sweep, so repair happens in seconds.
- `repair_execution` extracted from the endpoint so sweep and endpoint share **one** implementation — keeping its scoped / non-inflating / honest-about-unrecoverable guarantees rather than restating them.
- `compare_sources` (the diagnostic) now hydrates like the serve path.

⚠ Postgres is never written. The sweep's only authoritative access is the `SELECT DISTINCT execution_id` that finds candidates — pinned by a test that matches SQL *shapes* (`"INSERT"` alone matched `BTreeSet::insert`).

## ⚠⚠ The instrument was lying

v3.108.2 shipped hydration on the serve path, deployed cleanly — and the divergence reported by `/api/ehdb/projection-fold/executions/{id}` **did not move by a single execution out of 40**, because `compare_sources` was never on the path that changed.

The fix was right; the instrument still folded the raw row. **An instrument that cannot see a fix cannot validate one**, so it is now held to the same rule, with a guard (`the_diagnostic_comparison_hydrates_like_the_serve_path`).

## Mutation gate: 8/8

Green baseline (**1072 pass / 0 fail**):

```
D1 drop stops hinting           CAUGHT    D6 sweep armed by default     CAUGHT
D2 sweep reimplements mirroring CAUGHT    D7 a real outcome unpinned    CAUGHT
D4 take_hints ignores limit     CAUGHT    D8 sweep writes Postgres      CAUGHT
D5 hint set unbounded           CAUGHT    D9 diagnostic reverts to raw  CAUGHT
```

⚠ **Four only fail because the tests were fixed first**, which is the useful part:

- `the_sweep_is_off_by_default` was a **tautology** — it asserted the parse agreed with the env, which *any* parse satisfies, including one armed by default. Fixed by extracting the parse as a pure function.
- The pinned outcome set carried `incomplete`; the code returns **`partial`** — a pinned set that omits a real value reintroduces the absent-series bug on that value alone.
- `"INSERT"` matched `BTreeSet::insert`; `mirror_rows(` matched the module's own **doc comment**.

⚠ Every assertion about the global `HINTS` set lives in **one** test — `cargo test` does not serialise, and two tests mutating it raced.

## Rollout

Ships **inert**. Arming is env-only (`NOETL_EHDB_MIRROR_REPAIR_SWEEP=true`) and reverts by unsetting. Bounds: 25 executions/pass, 120 s interval, 180 min lookback — all env-tunable.

⚠ The scan runs on one pool. Prod is single-pool so this covers everything today; under real sharding the scan sees one shard, while the hint path and the repair are not shard-limited. Stated in the module rather than left to be discovered.

Refs noetl/ai-meta#342 · Refs noetl/ai-meta#332

🤖 Generated with [Claude Code](https://claude.com/claude-code)